### PR TITLE
Replace default exports with named exports

### DIFF
--- a/client/eslint-rules/no-relative-component-imports.js
+++ b/client/eslint-rules/no-relative-component-imports.js
@@ -2,7 +2,7 @@ import { ESLintUtils } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(name => name);
 
-const noRelativeComponentImports = createRule({
+export const noRelativeComponentImports = createRule({
   name: "no-relative-component-imports",
   meta: {
     docs: {
@@ -35,5 +35,3 @@ const noRelativeComponentImports = createRule({
     };
   },
 });
-
-export default noRelativeComponentImports;

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,7 +1,7 @@
 import jsEslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import reactEslint from "eslint-plugin-react";
-import noRelativeComponentImports from "./eslint-rules/no-relative-component-imports.js";
+import {noRelativeComponentImports} from "./eslint-rules/no-relative-component-imports.js";
 
 const IGNORED_FILES = [ "eslint.config.js" ];
 

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,21 +1,18 @@
 import jsEslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import reactEslint from "eslint-plugin-react";
-import {noRelativeComponentImports} from "./eslint-rules/no-relative-component-imports.js";
+import { noRelativeComponentImports } from "./eslint-rules/no-relative-component-imports.js";
 
-const IGNORED_FILES = [ "eslint.config.js" ];
-
-export default tseslint.config(
+const eslintConfig = tseslint.config(
   jsEslint.configs.recommended,
   tseslint.configs.recommended,
   reactEslint.configs.flat.recommended,
   {
     settings: {
       react: {
-        version: "detect"
+        version: "detect",
       },
     },
-    ignores: IGNORED_FILES,
     plugins: {
       "no-relative-component-imports": {
         rules: { "no-relative-component-imports": noRelativeComponentImports },
@@ -35,3 +32,6 @@ export default tseslint.config(
     },
   }
 );
+
+// eslint-disable-next-line no-restricted-exports
+export default eslintConfig;

--- a/client/src/components/header/Avatar.tsx
+++ b/client/src/components/header/Avatar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Avatar: React.FC<{ character?: string }> = ({ character }) => {
+export const Avatar: React.FC<{ character?: string }> = ({ character }) => {
   return (
     <div
       id="profile-letter"
@@ -18,5 +18,3 @@ const Avatar: React.FC<{ character?: string }> = ({ character }) => {
     </div>
   );
 };
-
-export default Avatar;

--- a/client/src/components/header/Header.tsx
+++ b/client/src/components/header/Header.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import HeaderLower from "./HeaderLower";
-import HeaderUpper from "./HeaderUpper";
+import { HeaderLower } from "./HeaderLower";
+import { HeaderUpper } from "./HeaderUpper";
 
 export const Header: React.FC<{
   userId?: number;

--- a/client/src/components/header/HeaderLower.tsx
+++ b/client/src/components/header/HeaderLower.tsx
@@ -12,7 +12,7 @@ export const HEADER_LOWER_QUERY = gql`
   }
 `;
 
-const HeaderLower: React.FC<{ userId?: number }> = ({ userId }) => {
+export const HeaderLower: React.FC<{ userId?: number }> = ({ userId }) => {
   if (!userId) {
     return (
       <div className="w-full bg-blue-900 text-white px-4 py-1 flex items-center justify-between"/>
@@ -49,5 +49,3 @@ const HeaderLower: React.FC<{ userId?: number }> = ({ userId }) => {
     </div>
   );
 };
-
-export default HeaderLower;

--- a/client/src/components/header/HeaderUpper.tsx
+++ b/client/src/components/header/HeaderUpper.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import Logo from "./Logo";
-import QuickLinks from "./QuickLinks";
-import ProfileBlock from "./ProfileBlock";
+import { Logo } from "./Logo";
+import { QuickLinks } from "./QuickLinks";
+import { ProfileBlock } from "./ProfileBlock";
 
-const HeaderUpper: React.FC<{ userId?: number }> = ({ userId }) => {
+export const HeaderUpper: React.FC<{ userId?: number }> = ({ userId }) => {
   return (
     <header className="w-full flex items-stretch justify-between py-1 px-2 gap-1">
       <div id="header-upper-left">
@@ -18,5 +18,3 @@ const HeaderUpper: React.FC<{ userId?: number }> = ({ userId }) => {
     </header>
   );
 };
-
-export default HeaderUpper;

--- a/client/src/components/header/Logo.tsx
+++ b/client/src/components/header/Logo.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 
-const Logo: React.FC = () => {
+export const Logo: React.FC = () => {
   return (
     <a href="/"><img src="/img/logo.png" alt="Logo"/></a>
   );
 };
-
-export default Logo;

--- a/client/src/components/header/ProfileBlock.tsx
+++ b/client/src/components/header/ProfileBlock.tsx
@@ -1,6 +1,6 @@
 import { gql, useQuery } from "@apollo/client";
 import React, { useState } from "react";
-import Avatar from "./Avatar";
+import { Avatar } from "./Avatar";
 import { ChevronIcon } from "components/icons/ChevronIcon";
 
 export const PROFILE_BLOCK_QUERY = gql`
@@ -11,7 +11,7 @@ export const PROFILE_BLOCK_QUERY = gql`
   }
 `;
 
-const ProfileBlock: React.FC<{ userId?: number }> = ({ userId }) => {
+export const ProfileBlock: React.FC<{ userId?: number }> = ({ userId }) => {
   const [open, setOpen] = useState(false);
 
   if (!userId) {
@@ -69,5 +69,3 @@ const ProfileBlock: React.FC<{ userId?: number }> = ({ userId }) => {
 
   );
 };
-
-export default ProfileBlock;

--- a/client/src/components/header/QuickLinks.tsx
+++ b/client/src/components/header/QuickLinks.tsx
@@ -3,7 +3,7 @@ import { GearIcon } from "components/icons/GearIcon";
 import { LifeRaftIcon } from "components/icons/LifeRaftIcon";
 import React from "react";
 
-const QuickLinks: React.FC = () => {
+export const QuickLinks: React.FC = () => {
   return (
     <ul className="flex items-center gap-3">
       <li>
@@ -27,5 +27,3 @@ const QuickLinks: React.FC = () => {
     </ul>
   );
 };
-
-export default QuickLinks;

--- a/client/src/components/table/filters/ColumnFilterSelect.tsx
+++ b/client/src/components/table/filters/ColumnFilterSelect.tsx
@@ -70,5 +70,3 @@ export function ColumnFilterByDropdown<T extends object>({
     </div>
   );
 }
-
-export default ColumnFilterByDropdown;

--- a/client/src/components/table/pagination/PaginationControls.tsx
+++ b/client/src/components/table/pagination/PaginationControls.tsx
@@ -1,4 +1,3 @@
-// src/components/table/tables/PaginationControls.tsx
 import * as React from "react";
 
 export interface PaginationControlsProps {
@@ -101,5 +100,3 @@ export const PaginationControls: React.FC<PaginationControlsProps> = ({
     </div>
   );
 };
-
-export default PaginationControls;

--- a/client/src/components/table/tables/DemonstrationTable.tsx
+++ b/client/src/components/table/tables/DemonstrationTable.tsx
@@ -14,8 +14,8 @@ import {
   RowSelectionState
 } from "@tanstack/react-table";
 
-import PaginationControls from "components/table/pagination/PaginationControls";
-import ColumnFilterByDropdown from "components/table/filters/ColumnFilterSelect";
+import { PaginationControls } from "components/table/pagination/PaginationControls";
+import { ColumnFilterByDropdown } from "components/table/filters/ColumnFilterSelect";
 import { groupByDemoNumber, DemoWithSubRows } from "components/table/preproccessors/GroupByDemoNumber";
 import { DemonstrationColumns } from "components/table/columns/DemonstrationColumns";
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,7 +4,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
+export const config = defineConfig({
   plugins: [react(), tailwindcss(), tsconfigPaths()],
   server: { port: 3000 },
   test: {
@@ -21,3 +21,6 @@ export default defineConfig({
     },
   },
 });
+
+// eslint-disable-next-line no-restricted-exports
+export default config;

--- a/server/eslint-rules/validate-graphql-typescript-match.js
+++ b/server/eslint-rules/validate-graphql-typescript-match.js
@@ -153,7 +153,7 @@ const compareFieldTypes = (gqlFields, tsFields, tsNode, context) => {
   }
 }
 
-const validateGraphQLTypescriptMatch = createRule({
+export const validateGraphQLTypescriptMatch = createRule({
   name: "validate-graphql-typescript-match",
   meta: {
     docs: {
@@ -237,5 +237,3 @@ const validateGraphQLTypescriptMatch = createRule({
     };
   },
 });
-
-export default validateGraphQLTypescriptMatch;

--- a/server/eslint.config.js
+++ b/server/eslint.config.js
@@ -1,14 +1,11 @@
 import jsEslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
-import validateGraphQLTypescriptMatch from './eslint-rules/validate-graphql-typescript-match.js';
+import {validateGraphQLTypescriptMatch} from './eslint-rules/validate-graphql-typescript-match.js';
 
-const IGNORED_FILES = ["src/model/types.ts"];
-
-export default tseslint.config(
+const eslintConfig = tseslint.config(
   jsEslint.configs.recommended,
   tseslint.configs.recommended,
   {
-    ignores: IGNORED_FILES,
     plugins: {
       "validate-graphql-typescript-match": {
         rules: { "validate-graphql-typescript-match": validateGraphQLTypescriptMatch },
@@ -16,7 +13,11 @@ export default tseslint.config(
     },
     rules: {
       "eol-last": ["error", "always"], // Newline at the end of files
+      "no-restricted-exports": ["error", { "restrictDefaultExports": { "direct": true } }], // Disallow default exports
       "validate-graphql-typescript-match/validate-graphql-typescript-match": "error",
     }
   },
 );
+
+// eslint-disable-next-line no-restricted-exports
+export default eslintConfig;

--- a/server/src/auth/auth.util.ts
+++ b/server/src/auth/auth.util.ts
@@ -4,7 +4,6 @@ import { GraphQLResolveInfo, GraphQLError } from "graphql";
 import { IncomingMessage } from "http";
 import { PrismaClient, } from "@prisma/client";
 import { getAuthConfig } from "./auth.config.js";
-import { promiseHooks } from "v8";
 
 const prisma = new PrismaClient();
 const config = getAuthConfig();

--- a/server/src/model/permission/permission.ts
+++ b/server/src/model/permission/permission.ts
@@ -1,2 +1,0 @@
-import { Role } from "@prisma/client";
-


### PR DESCRIPTION
Replaces `export default` with `export {namedVariable}` and fixes a couple of linting rules in the server to get these ready for CI/CD (both just unused vars)

<img width="604" alt="image" src="https://github.com/user-attachments/assets/7e5e957b-8c20-4d88-a31c-30507bf83677" />
