### PR TITLE
Eslint: Fix comma-dangle config

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -27,7 +27,7 @@ const eslintConfig = tseslint.config(
       "no-trailing-spaces": "error", // Disallow trailing spaces
       "no-tabs": "error", // Disallow tabs for indentation
       "eol-last": ["error", "always"], // Newline at the end of files
-      // Trailing commas in multiline arrays and objects
+      // Trailing commas in multiline arrays, objects, imports, and exports
       "comma-dangle": [
         "error",
         {

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -27,10 +27,16 @@ const eslintConfig = tseslint.config(
       "no-trailing-spaces": "error", // Disallow trailing spaces
       "no-tabs": "error", // Disallow tabs for indentation
       "eol-last": ["error", "always"], // Newline at the end of files
+      // Trailing commas in multiline arrays and objects
       "comma-dangle": [
         "error",
-        { arrays: "always-multiline", objects: "always-multiline" },
-      ], // Trailing commas in multiline arrays and objects
+        {
+          arrays: "always-multiline",
+          objects: "always-multiline",
+          imports: "always-multiline",
+          exports: "always-multiline",
+        },
+      ],
       "no-restricted-exports": [
         "error",
         { restrictDefaultExports: { direct: true } },

--- a/client/src/components/auth/AuthButtons.tsx
+++ b/client/src/components/auth/AuthButtons.tsx
@@ -5,23 +5,19 @@ import { logout } from "router/cognitoConfig";
 
 export const SignoutButton = () => {
   const auth = useAuth();
+  const handleLogout = () => {
+    auth.removeUser();
+    logout();
+  };
 
-  return (
-    <PrimaryButton
-      onClick={() => {
-        auth.removeUser();
-        logout();
-      }}>Sign Out
-    </PrimaryButton>
-  );
+  return <PrimaryButton onClick={handleLogout}>Sign Out</PrimaryButton>;
 };
 
 export const SigninButton = () => {
   const auth = useAuth();
+  const handleSignin = () => {
+    auth.signinRedirect();
+  };
 
-  return (
-    <PrimaryButton
-      onClick={() => auth.signinRedirect()}>Sign In
-    </PrimaryButton>
-  );
+  return <PrimaryButton onClick={handleSignin}>Sign In</PrimaryButton>;
 };

--- a/client/src/components/button/ErrorButton.tsx
+++ b/client/src/components/button/ErrorButton.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import {
   BaseButton,
-  ButtonSize
+  ButtonSize,
 } from "./BaseButton";
 
 interface Props {

--- a/client/src/components/button/PrimaryButton.tsx
+++ b/client/src/components/button/PrimaryButton.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import {
   BaseButton,
-  ButtonSize
+  ButtonSize,
 } from "./BaseButton";
 
 interface Props {

--- a/client/src/components/button/TertiaryButton.tsx
+++ b/client/src/components/button/TertiaryButton.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import {
   BaseButton,
-  ButtonSize
+  ButtonSize,
 } from "./BaseButton";
 
 interface Props {

--- a/client/src/components/table/tables/DemonstrationTable.tsx
+++ b/client/src/components/table/tables/DemonstrationTable.tsx
@@ -11,7 +11,7 @@ import {
   ColumnFiltersState,
   ExpandedState,
   PaginationState,
-  RowSelectionState
+  RowSelectionState,
 } from "@tanstack/react-table";
 
 import { PaginationControls } from "components/table/pagination/PaginationControls";

--- a/client/src/layout/PrimaryLayout.tsx
+++ b/client/src/layout/PrimaryLayout.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from "react";
 import { SideNav } from "./SideNav";
-import { Footer, Header, ToastContainer, ToastProvider } from "components/index";
+import {
+  Footer,
+  Header,
+  ToastContainer,
+  ToastProvider,
+} from "components/index";
 
 interface PrimaryLayoutProps {
   children: React.ReactNode;
@@ -12,7 +17,7 @@ export const PrimaryLayout: React.FC<PrimaryLayoutProps> = ({ children }) => {
   return (
     <ToastProvider>
       <div className="h-screen flex flex-col">
-        <Header userId={2}/>
+        <Header userId={2} />
         <div className="flex flex-1 overflow-hidden">
           {/* Sidenav flex basis */}
           <div className={collapsed ? "w-20" : "w-64"}>

--- a/client/src/layout/SideNav.test.tsx
+++ b/client/src/layout/SideNav.test.tsx
@@ -6,19 +6,25 @@ import { SideNav } from "./SideNav";
 
 describe("SideNav", () => {
   it("renders all nav links", () => {
-    render(<SideNav collapsed={false} setCollapsed={() => { }} />, { wrapper: MemoryRouter });
+    render(<SideNav collapsed={false} setCollapsed={() => {}} />, {
+      wrapper: MemoryRouter,
+    });
     expect(screen.getByText("Demonstrations")).toBeInTheDocument();
   });
 
   it("toggles collapse when menu button is clicked", () => {
     const mockSetCollapsed = vi.fn();
-    render(<SideNav collapsed={false} setCollapsed={mockSetCollapsed} />, { wrapper: MemoryRouter });
+    render(<SideNav collapsed={false} setCollapsed={mockSetCollapsed} />, {
+      wrapper: MemoryRouter,
+    });
     fireEvent.click(screen.getByLabelText(/Collapse Menu/i));
     expect(mockSetCollapsed).toHaveBeenCalledWith(true);
   });
 
   it("shows only icons when collapsed", () => {
-    render(<SideNav collapsed={true} setCollapsed={() => { }} />, { wrapper: MemoryRouter });
+    render(<SideNav collapsed={true} setCollapsed={() => {}} />, {
+      wrapper: MemoryRouter,
+    });
     expect(screen.queryByText("Demonstrations")).not.toBeInTheDocument();
   });
 });

--- a/client/src/layout/SideNav.tsx
+++ b/client/src/layout/SideNav.tsx
@@ -11,7 +11,7 @@ import {
   ListIcon,
   MenuCollapseLeftIcon,
   MenuCollapseRightIcon,
-  ScaleIcon
+  ScaleIcon,
 } from "components/icons";
 
 interface NavLink {


### PR DESCRIPTION
The prettier config setting for `trailingComma: es5` was at odds with our `comma-dangle` config as imports need to be specifically declared as being expected to have a trailing comma where I thought this was covered by the `objects` key before.

Formatted some files while kicking the tires