### PR TITLE
Demos 295: Conditional MockedProvider / ApolloProvider

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/coverage-v8": "^3.1.2",
+        "demos-server": "file:../server",
         "eslint": "^9.25.1",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-react": "^7.37.5",
@@ -44,6 +45,43 @@
         "vite-bundle-visualizer": "^1.2.1",
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.1.4"
+      }
+    },
+    "../server": {
+      "name": "demos-server",
+      "version": "0.1.0",
+      "dev": true,
+      "dependencies": {
+        "@as-integrations/aws-lambda": "^3.1.0",
+        "@graphql-tools/merge": "^9.0.24",
+        "@prisma/client": "^6.7.0",
+        "depcheck": "^1.4.7",
+        "graphql-scalars": "^1.24.2",
+        "graphql-tools": "^9.0.18",
+        "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.2.0",
+        "prettier": "3.5.3",
+        "prisma-extension-random": "^0.2.2",
+        "react": "^19.1.0"
+      },
+      "devDependencies": {
+        "@apollo/server": "^4.12.2",
+        "@eslint/js": "^9.27.0",
+        "@faker-js/faker": "^9.8.0",
+        "@parcel/watcher": "^2.5.1",
+        "@types/jest": "^29.5.14",
+        "@types/node": "^22.14.1",
+        "artillery": "^2.0.23",
+        "concurrently": "^9.1.2",
+        "eslint": "^9.27.0",
+        "eslint-utils": "^3.0.0",
+        "graphql": "^16.11.0",
+        "jest": "^29.7.0",
+        "prisma": "^6.6.0",
+        "ts-jest": "^29.3.3",
+        "tsx": "^4.19.4",
+        "typescript": "^5.8.3",
+        "typescript-eslint": "^8.32.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3730,6 +3768,10 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/demos-server": {
+      "resolved": "../server",
+      "link": true
     },
     "node_modules/dequal": {
       "version": "2.0.3",

--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "devDependencies": {
+    "demos-server": "file:../server",
     "@apollo/client": "^3.13.8",
     "@eslint/js": "^9.26.0",
     "@faker-js/faker": "^9.8.0",
@@ -51,6 +52,7 @@
     "build": "vite build",
     "coverage": "vitest --coverage",
     "dev": "vite --host",
+    "dev:mocks": "VITE_USE_MOCKS=true npm run dev",
     "test": "vitest",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/client/src/components/header/Header.test.tsx
+++ b/client/src/components/header/Header.test.tsx
@@ -6,7 +6,7 @@ import { QuickLinks } from "./QuickLinks";
 import { HeaderLower } from "./HeaderLower";
 import { Avatar } from "./Avatar";
 import { MockedProvider } from "@apollo/client/testing";
-import { userMocks } from "hooks/userMocks";
+import { userMocks } from "mock-data/userMocks";
 
 describe("Header", async () => {
   it("renders the logo", () => {
@@ -17,28 +17,30 @@ describe("Header", async () => {
   it("renders all quick links", () => {
     render(<QuickLinks />);
     expect(screen.getByRole("link", { name: /Admin/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Notifications/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Notifications/i })
+    ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Help/i })).toBeInTheDocument();
   });
 
   it("renders the profile block", async () => {
     render(
       <MockedProvider mocks={userMocks} addTypename={false}>
-        <ProfileBlock userId={2}/>
+        <ProfileBlock userId={2} />
       </MockedProvider>
     );
     expect(await screen.findByText("John Doe")).toBeInTheDocument();
   });
 
   it("renders the avatar", () => {
-    render(<Avatar character={"J"}/>);
+    render(<Avatar character={"J"} />);
     expect(screen.getByText("J")).toBeInTheDocument();
   });
 
   it("renders the greeting", async () => {
     render(
       <MockedProvider mocks={userMocks} addTypename={false}>
-        <HeaderLower userId={2}/>
+        <HeaderLower userId={2} />
       </MockedProvider>
     );
     expect(await screen.findByText("Hello John Doe")).toBeInTheDocument();
@@ -48,10 +50,12 @@ describe("Header", async () => {
   it("renders the Create New button", async () => {
     render(
       <MockedProvider mocks={userMocks} addTypename={false}>
-        <HeaderLower userId={2}/>
+        <HeaderLower userId={2} />
       </MockedProvider>
     );
-    expect(await screen.findByRole("button", { name: /Create New/i })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: /Create New/i })
+    ).toBeInTheDocument();
   });
 
   it("toggles menu under Profile Block", async () => {

--- a/client/src/hooks/useUserOperations.test.tsx
+++ b/client/src/hooks/useUserOperations.test.tsx
@@ -1,23 +1,13 @@
-import React from "react";
 import { renderHook, act, waitFor } from "@testing-library/react";
-import { MockedProvider } from "@apollo/client/testing";
 import { useUserOperations } from "./useUserOperations";
-import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
-import { patrick, spongebob, squidward, userMocks } from "mock-data/userMocks";
-
-function withMocks({ children }: { children: ReactNode }) {
-  return (
-    <MockedProvider mocks={userMocks} addTypename={false}>
-      {children}
-    </MockedProvider>
-  );
-}
+import { patrick, spongebob, squidward } from "mock-data/userMocks";
+import { DemosApolloProvider } from "router/DemosApolloProvider";
 
 describe("useUserOperations", () => {
   it("can get a user by ID", async () => {
     const { result: userOperations } = renderHook(() => useUserOperations(), {
-      wrapper: withMocks,
+      wrapper: DemosApolloProvider,
     });
 
     // Get spongebob by ID
@@ -49,7 +39,7 @@ describe("useUserOperations", () => {
 
   it("can get all users", async () => {
     const { result: userOperations } = renderHook(() => useUserOperations(), {
-      wrapper: withMocks,
+      wrapper: DemosApolloProvider,
     });
 
     act(() => {

--- a/client/src/hooks/useUserOperations.test.tsx
+++ b/client/src/hooks/useUserOperations.test.tsx
@@ -4,15 +4,21 @@ import { MockedProvider } from "@apollo/client/testing";
 import { useUserOperations } from "./useUserOperations";
 import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
-import { patrick, spongebob, squidward, userMocks } from "./userMocks";
+import { patrick, spongebob, squidward, userMocks } from "mock-data/userMocks";
 
 function withMocks({ children }: { children: ReactNode }) {
-  return <MockedProvider mocks={userMocks} addTypename={false}>{children}</MockedProvider>;
+  return (
+    <MockedProvider mocks={userMocks} addTypename={false}>
+      {children}
+    </MockedProvider>
+  );
 }
 
 describe("useUserOperations", () => {
   it("can get a user by ID", async () => {
-    const { result: userOperations } = renderHook(() => useUserOperations(), { wrapper: withMocks });
+    const { result: userOperations } = renderHook(() => useUserOperations(), {
+      wrapper: withMocks,
+    });
 
     // Get spongebob by ID
     act(() => {
@@ -42,7 +48,9 @@ describe("useUserOperations", () => {
   });
 
   it("can get all users", async () => {
-    const { result: userOperations } = renderHook(() => useUserOperations(), { wrapper: withMocks });
+    const { result: userOperations } = renderHook(() => useUserOperations(), {
+      wrapper: withMocks,
+    });
 
     act(() => {
       userOperations.current.getAllUsers.trigger();
@@ -52,7 +60,11 @@ describe("useUserOperations", () => {
       expect(userOperations.current.getAllUsers.data).toBeDefined();
     });
 
-    expect(userOperations.current.getAllUsers.data).toEqual([spongebob, squidward, patrick]);
+    expect(userOperations.current.getAllUsers.data).toEqual([
+      spongebob,
+      squidward,
+      patrick,
+    ]);
     expect(userOperations.current.getAllUsers.loading).toBe(false);
     expect(userOperations.current.getAllUsers.error).toBeUndefined();
   });

--- a/client/src/hooks/useUserOperations.ts
+++ b/client/src/hooks/useUserOperations.ts
@@ -1,5 +1,5 @@
 import { gql, useLazyQuery } from "@apollo/client";
-import { User } from "models/index";
+import { User } from "demos-server";
 
 export const GET_ALL_USERS = gql`
   query GetUsers {

--- a/client/src/hooks/useUserOperations.ts
+++ b/client/src/hooks/useUserOperations.ts
@@ -4,8 +4,7 @@ import { User } from "demos-server";
 export const GET_ALL_USERS = gql`
   query GetUsers {
     users {
-      firstName
-      lastName
+      fullName
     }
   }
 `;
@@ -13,9 +12,7 @@ export const GET_ALL_USERS = gql`
 export const GET_USER_BY_ID = gql`
   query GetUser($id: ID!) {
     user(id: $id) {
-      id
-      firstName
-      lastName
+      fullName
     }
   }
 `;

--- a/client/src/mock-data/index.test.ts
+++ b/client/src/mock-data/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { print } from "graphql";
+import { ALL_MOCKS } from "./index";
+
+describe("ALL_MOCKS", () => {
+  it("should have a request and result for each mock", () => {
+    ALL_MOCKS.forEach((mock) => {
+      expect(mock.request).toBeDefined();
+      expect(mock.result).toBeDefined();
+    });
+  });
+
+  it("should not have overlapping queries", () => {
+    const queries = ALL_MOCKS.map((mock) => {
+      return {
+        query: print(mock.request.query),
+        variables: mock.request.variables,
+      };
+    });
+
+    const uniqueQueries = new Set(queries);
+    expect(uniqueQueries.size).toBe(queries.length);
+  });
+});

--- a/client/src/mock-data/index.ts
+++ b/client/src/mock-data/index.ts
@@ -1,0 +1,3 @@
+import { userMocks } from "./userMocks";
+
+export const ALL_MOCKS = [...userMocks];

--- a/client/src/mock-data/userMocks.ts
+++ b/client/src/mock-data/userMocks.ts
@@ -1,19 +1,16 @@
-import { User } from "models/index";
-import { GET_ALL_USERS, GET_USER_BY_ID } from "../hooks/useUserOperations";
+import { User } from "demos-server";
+import { GET_ALL_USERS, GET_USER_BY_ID } from "hooks/useUserOperations";
 import { HEADER_LOWER_QUERY } from "components/header/HeaderLower";
 import { PROFILE_BLOCK_QUERY } from "components/header/ProfileBlock";
 
 export const spongebob: Partial<User> = {
-  firstName: "spongebob",
-  lastName: "squarepants",
+  fullName: "spongebob squarepants",
 };
 export const squidward: Partial<User> = {
-  firstName: " squidward",
-  lastName: "tentacles",
+  fullName: " squidward tentacles",
 };
 export const patrick: Partial<User> = {
-  firstName: "patrick",
-  lastName: "star",
+  fullName: "patrick star",
 };
 
 export const userMocks = [

--- a/client/src/mock-data/userMocks.ts
+++ b/client/src/mock-data/userMocks.ts
@@ -1,11 +1,20 @@
 import { User } from "models/index";
-import { GET_ALL_USERS, GET_USER_BY_ID } from "./useUserOperations";
+import { GET_ALL_USERS, GET_USER_BY_ID } from "../hooks/useUserOperations";
 import { HEADER_LOWER_QUERY } from "components/header/HeaderLower";
 import { PROFILE_BLOCK_QUERY } from "components/header/ProfileBlock";
 
-export const spongebob: Partial<User> = { firstName: "spongebob", lastName: "squarepants" };
-export const squidward: Partial<User> = { firstName: " squidward", lastName: "tentacles" };
-export const patrick: Partial<User> = { firstName: "patrick", lastName: "star" };
+export const spongebob: Partial<User> = {
+  firstName: "spongebob",
+  lastName: "squarepants",
+};
+export const squidward: Partial<User> = {
+  firstName: " squidward",
+  lastName: "tentacles",
+};
+export const patrick: Partial<User> = {
+  firstName: "patrick",
+  lastName: "star",
+};
 
 export const userMocks = [
   {
@@ -46,7 +55,7 @@ export const userMocks = [
   {
     request: {
       query: HEADER_LOWER_QUERY,
-      variables: { "id": 1 },
+      variables: { id: 1 },
     },
     result: {
       data: {
@@ -59,7 +68,7 @@ export const userMocks = [
   {
     request: {
       query: PROFILE_BLOCK_QUERY,
-      variables: { "id": 1 },
+      variables: { id: 1 },
     },
     result: {
       data: {
@@ -72,7 +81,7 @@ export const userMocks = [
   {
     request: {
       query: HEADER_LOWER_QUERY,
-      variables: { "id": 2 },
+      variables: { id: 2 },
     },
     result: {
       data: {
@@ -85,7 +94,7 @@ export const userMocks = [
   {
     request: {
       query: PROFILE_BLOCK_QUERY,
-      variables: { "id": 2 },
+      variables: { id: 2 },
     },
     result: {
       data: {

--- a/client/src/pages/debug/TestHooks.tsx
+++ b/client/src/pages/debug/TestHooks.tsx
@@ -1,7 +1,5 @@
 import React from "react";
-import { MockedProvider } from "@apollo/client/testing";
-import { useUserOperations } from "../../hooks/useUserOperations";
-import { userMocks } from "mock-data/userMocks";
+import { useUserOperations } from "hooks/useUserOperations";
 import { PrimaryButton } from "components/button/PrimaryButton";
 import { TextInput } from "components";
 
@@ -58,8 +56,4 @@ const TestUserOperationsHook: React.FC = () => {
   );
 };
 
-export const TestHooks: React.FC = () => (
-  <MockedProvider mocks={userMocks} addTypename={false}>
-    <TestUserOperationsHook />
-  </MockedProvider>
-);
+export const TestHooks: React.FC = () => <TestUserOperationsHook />;

--- a/client/src/pages/debug/TestHooks.tsx
+++ b/client/src/pages/debug/TestHooks.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { MockedProvider } from "@apollo/client/testing";
 import { useUserOperations } from "../../hooks/useUserOperations";
-import { userMocks } from "hooks/userMocks";
+import { userMocks } from "mock-data/userMocks";
 import { PrimaryButton } from "components/button/PrimaryButton";
 import { TextInput } from "components";
 
@@ -10,22 +10,35 @@ const TestUserOperationsHook: React.FC = () => {
 
   return (
     <div className="p-md flex gap-sm">
-      <TextInput label="ID (try initials of spongebob characters)" name="userId"/>
-      <PrimaryButton onClick={() => userOperations.getUserById.trigger((document.getElementsByName("userId")[0] as HTMLInputElement).value)}>
+      <TextInput
+        label="ID (try initials of spongebob characters)"
+        name="userId"
+      />
+      <PrimaryButton
+        onClick={() =>
+          userOperations.getUserById.trigger(
+            (document.getElementsByName("userId")[0] as HTMLInputElement).value
+          )
+        }
+      >
         Get User By ID
       </PrimaryButton>
       <PrimaryButton onClick={() => userOperations.getAllUsers.trigger()}>
-      Get All Users
+        Get All Users
       </PrimaryButton>
       <div>
         Get User By ID Response:
         {userOperations.getUserById.data ? (
           <div>
-            <pre>{JSON.stringify(userOperations.getUserById.data, null, 2)}</pre>
+            <pre>
+              {JSON.stringify(userOperations.getUserById.data, null, 2)}
+            </pre>
           </div>
         ) : (
           <div>
-            No user found with ID {(document.getElementsByName("userId")[0] as HTMLInputElement)?.value || ""}
+            No user found with ID{" "}
+            {(document.getElementsByName("userId")[0] as HTMLInputElement)
+              ?.value || ""}
           </div>
         )}
       </div>
@@ -33,12 +46,12 @@ const TestUserOperationsHook: React.FC = () => {
         Get All Users Response:
         {userOperations.getAllUsers.data ? (
           <div>
-            <pre>{JSON.stringify(userOperations.getAllUsers.data, null, 2)}</pre>
+            <pre>
+              {JSON.stringify(userOperations.getAllUsers.data, null, 2)}
+            </pre>
           </div>
         ) : (
-          <div>
-            No users found!
-          </div>
+          <div>No users found!</div>
         )}
       </div>
     </div>

--- a/client/src/router/DemosApolloProvider.tsx
+++ b/client/src/router/DemosApolloProvider.tsx
@@ -17,19 +17,6 @@ const createApolloClient = (uri: string) => {
   });
 };
 
-// TODO: This will grab a graphQL URI based on the environment such as
-// dev, test, impl, production - not sure the name of this variable yet.
-// This should be encapsulated in an "env" file when we have more of this setup.
-const getGraphQLUri = () => {
-  if (process.env.NODE_ENV === "development") {
-    return GRAPHQL_ENDPOINT;
-  }
-
-  throw new Error(
-    "GraphQL URI not defined for production or impl environments. Please set the environment variable."
-  );
-};
-
 export const DemosApolloProvider = ({
   children,
 }: {
@@ -50,7 +37,7 @@ export const DemosApolloProvider = ({
       </MockedProvider>
     );
   } else {
-    const apolloClient = createApolloClient(getGraphQLUri());
+    const apolloClient = createApolloClient(GRAPHQL_ENDPOINT);
 
     return <ApolloProvider client={apolloClient}>{children}</ApolloProvider>;
   }

--- a/client/src/router/DemosApolloProvider.tsx
+++ b/client/src/router/DemosApolloProvider.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import {
+  ApolloClient,
+  InMemoryCache,
+  ApolloProvider,
+  createHttpLink,
+} from "@apollo/client";
+import { MockedProvider } from "@apollo/client/testing";
+import { ALL_MOCKS } from "mock-data";
+
+const createApolloClient = () => {
+  const httpLink = createHttpLink({
+    uri:
+      process.env.NODE_ENV === "development"
+        ? "http://localhost:4000" // Local GraphQL server
+        : "/graphql", // Production API Gateway endpoint
+  });
+
+  return new ApolloClient({
+    link: httpLink,
+    cache: new InMemoryCache(),
+    defaultOptions: {
+      watchQuery: {
+        errorPolicy: "all",
+      },
+      query: {
+        errorPolicy: "all",
+      },
+    },
+  });
+};
+
+export const DemosApolloProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const useMocks =
+    process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
+
+  if (useMocks) {
+    return (
+      <MockedProvider mocks={ALL_MOCKS} addTypename={false}>
+        {children}
+      </MockedProvider>
+    );
+  } else {
+    const client = createApolloClient();
+    return <ApolloProvider client={client}>{children}</ApolloProvider>;
+  }
+};

--- a/client/src/router/DemosRouter.tsx
+++ b/client/src/router/DemosRouter.tsx
@@ -6,10 +6,9 @@ import { LandingPage } from "pages";
 import { ComponentLibrary, TestHooks } from "pages/debug";
 import { AuthComponent } from "components/auth/AuthComponent";
 import { PrimaryLayout } from "layout/PrimaryLayout";
-import { MockedProvider } from "@apollo/client/testing";
-import { userMocks } from "hooks/userMocks";
 import { Demonstrations } from "pages/Demonstrations";
 import { IconLibrary } from "pages/debug/IconLibrary";
+import { DemosApolloProvider } from "./DemosApolloProvider";
 
 export const DemosRouter = () => {
   // TODO: When we know what IDM integration looks like
@@ -19,7 +18,7 @@ export const DemosRouter = () => {
 
   return (
     <AuthProvider {...cognitoConfig}>
-      <MockedProvider mocks={userMocks} addTypename={false}>
+      <DemosApolloProvider>
         <BrowserRouter>
           <Routes>
             <Route
@@ -45,7 +44,7 @@ export const DemosRouter = () => {
             </Route>
           </Routes>
         </BrowserRouter>
-      </MockedProvider>
+      </DemosApolloProvider>
     </AuthProvider>
   );
 };

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -14,6 +14,7 @@
       "pages/*": ["pages/*"],
       "models/*": ["../../server/src/model/*"],
       "hooks/*": ["hooks/*"],
+      "mock-data/*": ["mock-data/*"]
     }
   },
   "exclude": ["node_modules"]

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -12,7 +12,6 @@
     "paths": {
       "components/*": ["components/*"],
       "pages/*": ["pages/*"],
-      "models/*": ["../../server/src/model/*"],
       "hooks/*": ["hooks/*"],
       "mock-data/*": ["mock-data/*"]
     }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -6,7 +6,16 @@ import react from "@vitejs/plugin-react";
 
 export const config = defineConfig({
   plugins: [react(), tailwindcss(), tsconfigPaths()],
-  server: { port: 3000 },
+  server: {
+    port: 3000,
+    // Proxy /graphql requests to the server running on port 4000 to avoid CORS issues
+    proxy: {
+      "/graphql": {
+        target: "http://localhost:4000",
+        changeOrigin: true,
+      },
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",

--- a/server/package.json
+++ b/server/package.json
@@ -2,6 +2,11 @@
   "name": "demos-server",
   "version": "0.1.0",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/types.d.ts"
+    }
+  },
   "prisma": {
     "schema": "./src/model"
   },

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,0 +1,36 @@
+// Export types for use in the client code
+export type {
+  User,
+  AddUserInput,
+  UpdateUserInput,
+} from "./model/user/userSchema.js";
+
+export type {
+  Demonstration,
+  AddDemonstrationInput,
+  UpdateDemonstrationInput,
+} from "./model/demonstration/demonstrationSchema.js";
+
+export type {
+  DemonstrationStatus,
+  AddDemonstrationStatusInput,
+  UpdateDemonstrationStatusInput,
+} from "./model/demonstrationStatus/demonstrationStatusSchema.js";
+
+export type {
+  State,
+  AddStateInput,
+  UpdateStateInput,
+} from "./model/state/stateSchema.js";
+
+export type {
+  Role,
+  AddRoleInput,
+  UpdateRoleInput,
+} from "./model/role/roleSchema.js";
+
+export type {
+  Permission,
+  AddPermissionInput,
+  UpdatePermissionInput,
+} from "./model/permission/permissionSchema.js";

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -10,6 +10,8 @@
     "types": ["node"],
     "strict": true,
     "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true
   },
-  "include": ["src/**/*.ts"], 
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
This change adds support for conditionally using Apollo's `MockedProvider` versus the main `ApolloProvider` depending on environment and a new environment variable: `VITE_USE_MOCKS`

- Test: Always use mocks
- Dev: Use mocks if VITE_USE_MOCKS is true
- Prod: Never use mocks