### PR TITLE
DEMOS-74-fix-small-test-error

### DIFF
--- a/data/research/duckdb_exporter/tests/test_duckdb_exporter.py
+++ b/data/research/duckdb_exporter/tests/test_duckdb_exporter.py
@@ -302,4 +302,4 @@ class TestDuckDBExporter():
         mocker.patch("builtins.open", mocked_open)
         duckdb_exporter.save_ddl("tbl1", "this is a test line")
         mocked_open.assert_called_once_with("ddls/tbl1.sql", "w")
-        mocked_open.return_value.write.assert_called_once_with("this is a test line")
+        mocked_open.return_value.write.assert_called_once_with("this is a test line\n")


### PR DESCRIPTION
Oops - forgot to fix this test when I fixed the newlines at the end of the DDLs. 🤦🏻 Confirming now that it is working correctly:

```
[2025-06-17 12:29:52-0400] 43229 in ~/git-repos/demos/data/research/duckdb_exporter using demos-data on DEMOS-74-fix-small-test-error
λ> ./run_checks.sh

ruff
====
All checks passed!

pytest
======
============================================================================= test session starts =============================================================================
platform darwin -- Python 3.13.3, pytest-8.4.0, pluggy-1.6.0
rootdir: /Users/43229/git-repos/demos/data
configfile: pyproject.toml
plugins: cov-6.2.1, mocha-0.4.0, mock-3.14.1
collected 27 items

A class for the tests for the duckdb_exporter.py file. :: research/duckdb_exporter/tests/test_duckdb_exporter.py
    Test duckdb_exporter.py functions.
        parse_config
            ✓ It should invoke the config parser with the correct argument.
        create_duckdb_conn
            ✓ It should invoke an in-memory database.
            ✓ It should install the MySQL and PostgreSQL extensions.
            ✓ It should connect to PostgreSQL.
            ✓ It should connect to MySQL.
        get_table_list
            ✓ It should query the schema table names.
        get_column_details
            ✓ It should make a copy of the columns table locally.
            ✓ It should query the column table for every table requested.
        make_column_definition
            ✓ It should convert column types from MySQL to PostgreSQL.[int]
            ✓ It should convert column types from MySQL to PostgreSQL.[int unsigned]
            ✓ It should convert column types from MySQL to PostgreSQL.[char(30)]
            ✓ It should convert column types from MySQL to PostgreSQL.[decimal(15,2)]
            ✓ It should convert column types from MySQL to PostgreSQL.[date]
            ✓ It should convert column types from MySQL to PostgreSQL.[datetime]
            ✓ It should convert column types from MySQL to PostgreSQL.[float]
            ✓ It should convert column types from MySQL to PostgreSQL.[longtext]
            ✓ It should convert column types from MySQL to PostgreSQL.[mediumtext]
            ✓ It should convert column types from MySQL to PostgreSQL.[smallint]
            ✓ It should convert column types from MySQL to PostgreSQL.[smallint unsigned]
            ✓ It should convert column types from MySQL to PostgreSQL.[timestamp]
            ✓ It should convert column types from MySQL to PostgreSQL.[varchar(2048)]
        sanitize_table_name
            ✓ If given a table name with dashes, it should quote it.
        generate_postgres_ddl
            ✓ It should make a column definition for each argument.
            ✓ It should return expected DDLs for the given inputs.
        transfer_table
            ✓ It should properly execute transfer SQL.
            ✓ It should properly escape unusual table names.
        save_ddl
            ✓ It should open a file and save the DDL to it.
=============================================================================== tests coverage ================================================================================
______________________________________________________________ coverage: platform darwin, python 3.13.3-final-0 _______________________________________________________________

Name                 Stmts   Miss  Cover   Missing
--------------------------------------------------
duckdb_exporter.py     119     14    88%   271-288
--------------------------------------------------
TOTAL                  119     14    88%
Coverage HTML written to dir .cov.html
Required test coverage of 80% reached. Total coverage: 88.24%
============================================================================= 27 passed in 0.20s ==============================================================================

pydocstyle
==========

pydoclint
=========

mypy
====
Success: no issues found in 4 source files

radon cyclomatic complexity
=====
duckdb_exporter.py
    F 269:0 main - A (4)
    F 51:0 parse_config - A (2)
    F 113:0 get_table_list - A (2)
    F 131:0 get_column_details - A (2)
    F 188:0 sanitize_table_name - A (2)
    F 205:0 generate_postgres_ddl - A (2)
    F 73:0 create_duckdb_conn - A (1)
    F 169:0 make_column_definition - A (1)
    F 231:0 save_ddl - A (1)
    F 245:0 transfer_table - A (1)
    F 291:0 custom_excepthook - A (1)

radon maintainability index
===========================
duckdb_exporter.py - A
[2025-06-17 12:29:56-0400] 43229 in ~/git-repos/demos/data/research/duckdb_exporter using demos-data on DEMOS-74-fix-small-test-error
λ>
```