### PR TITLE
DEMOS-301: Add ALLOW_SEED and a connection string for local development

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,2 +1,3 @@
-DATABASE_URL=""
+DATABASE_URL="postgresql://postgres@localhost:5432/postgres"
 BYPASS_AUTH=true
+ALLOW_SEED=true

--- a/server/src/seeder.ts
+++ b/server/src/seeder.ts
@@ -1,7 +1,15 @@
 import { faker } from "@faker-js/faker";
 import { prisma } from "./prismaClient";
 
+function checkIfAllowed() {
+  if(process.env.ALLOW_SEED !== "true") {
+    throw new Error("Database seeding is not allowed. Set ALLOW_SEED=true to use this feature.");
+  }
+}
+
 export function clearDatabase() {
+  checkIfAllowed();
+
   return prisma.$transaction([
     prisma.rolePermission.deleteMany(),
     prisma.userRole.deleteMany(),
@@ -17,6 +25,8 @@ export function clearDatabase() {
 }
 
 async function seedDatabase() {
+  checkIfAllowed();
+  
   clearDatabase();
 
 


### PR DESCRIPTION
Added ALLOW_SEED to the .env.example that must be set to true to use the seed functions.

Also added a default connection string to the devcontainer postgres.