### PR TITLE
Demos 186 - Fixes ESM imports and adds esbuild

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive  && apt-get -y install python3 python3-pip && pip3 install pre-commit --break-system-packages
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive  && apt-get -y install python3 python3-pip python-is-python3 && pip3 install pre-commit --break-system-packages
 
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/.vscode/**
 **/.DS_Store
 **/dist/**
+**/build/**
 **/node_modules/**
 
 cdk.out/

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,3 @@
-DATABASE_URL="postgresql://postgres@localhost:5432/postgres"
+DATABASE_URL="postgresql://postgres@localhost:5432/demos"
 BYPASS_AUTH=true
 ALLOW_SEED=true

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -27,6 +27,7 @@
         "artillery": "^2.0.23",
         "concurrently": "^9.1.2",
         "depcheck": "^1.4.7",
+        "esbuild": "^0.25.5",
         "eslint": "^9.27.0",
         "eslint-utils": "^3.0.0",
         "graphql": "^16.11.0",
@@ -35,6 +36,7 @@
         "prettier": "^3.5.3",
         "prisma": "^6.6.0",
         "ts-jest": "^29.3.3",
+        "tsc-watch": "^7.1.1",
         "tsx": "^4.19.4",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.32.1"
@@ -11491,6 +11493,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -12138,6 +12147,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -12719,6 +12744,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fromentries": {
       "version": "1.3.2",
@@ -15805,6 +15837,12 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
+      "dev": true
+    },
     "node_modules/matcher-collection": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
@@ -16415,6 +16453,13 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-cleanup": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
+      "integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
       "dev": true,
       "license": "MIT"
     },
@@ -17246,6 +17291,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -17853,6 +17911,22 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-stream": "=3.3.4"
+      },
+      "bin": {
+        "ps-tree": "bin/ps-tree.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.2",
@@ -19114,6 +19188,19 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -19180,6 +19267,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -19188,6 +19285,16 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-length": {
@@ -19818,6 +19925,13 @@
         "async-limiter": "~1.0.0"
       }
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -20069,6 +20183,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tsc-watch": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-7.1.1.tgz",
+      "integrity": "sha512-r6t37Dkk4vK44HwxOe+OzjpE/gDamZAwqXhtcAJD/hPVblcjJK45NxbK0HcDASXG0U4pEnCh640JZbeDVSC6yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "node-cleanup": "^2.1.2",
+        "ps-tree": "^1.2.0",
+        "string-argv": "^0.3.2"
+      },
+      "bin": {
+        "tsc-watch": "dist/lib/tsc-watch.js"
+      },
+      "engines": {
+        "node": ">=12.12.0"
+      },
+      "peerDependencies": {
+        "typescript": "*"
       }
     },
     "node_modules/tsconfig-paths": {

--- a/server/package.json
+++ b/server/package.json
@@ -11,24 +11,25 @@
     "schema": "./src/model"
   },
   "dependencies": {
+    "@apollo/server": "^4.12.2",
     "@as-integrations/aws-lambda": "^3.1.0",
     "@prisma/client": "^6.7.0",
     "graphql-scalars": "^1.24.2",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.2.0",
     "prisma-extension-random": "^0.2.2",
-    "@apollo/server": "^4.12.2",
     "react": "^19.1.0"
   },
   "scripts": {
-    "build": "npm install; rm -rf dist; npx tsc",
-    "build:ci": "npm ci; npx prisma generate; rm -rf dist; npx tsc -p ./tsconfig-ci.json; npm ci --omit=dev; cp -R node_modules dist",
-    "dev": "npm run build && node ./dist/index.js",
+    "clean": "rm -rf dist; npm ci",
+    "build": "tsc; esbuild dist/server.js --bundle --platform=node --outfile=build/server.cjs --minify",
+    "build:ci": "npm ci; prisma generate; rm -rf dist; tsc -p ./tsconfig-ci.json; npm ci --omit=dev; cp -R node_modules dist",
+    "dev": "node ./dist/index.js",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
-    "watch": "concurrently \"tsx watch --clear-screen=false src/index.ts\" \"npx prisma generate --watch\"",
-    "seed": "npx prisma db push --force-reset && tsx --inspect ./src/seeder.ts",
-    "depcheck": "npx depcheck"
+    "watch": "concurrently \"tsx watch --clear-screen=false src/index.ts\" \"prisma generate --watch\"",
+    "seed": "prisma db push --force-reset && tsx --inspect ./src/seeder.ts",
+    "depcheck": "depcheck"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",
@@ -40,6 +41,7 @@
     "artillery": "^2.0.23",
     "concurrently": "^9.1.2",
     "depcheck": "^1.4.7",
+    "esbuild": "^0.25.5",
     "eslint": "^9.27.0",
     "eslint-utils": "^3.0.0",
     "graphql": "^16.11.0",
@@ -48,6 +50,7 @@
     "prettier": "^3.5.3",
     "prisma": "^6.6.0",
     "ts-jest": "^29.3.3",
+    "tsc-watch": "^7.1.1",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.32.1"

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -1,9 +1,9 @@
 import { Demonstration } from "@prisma/client";
-import { prisma } from "../../prismaClient";
+import { prisma } from "../../prismaClient.js";
 import {
   AddDemonstrationInput,
   UpdateDemonstrationInput,
-} from "./demonstrationSchema";
+} from "./demonstrationSchema.js";
 
 export const demonstrationResolvers = {
   Query: {

--- a/server/src/model/demonstration/demonstrationSchema.ts
+++ b/server/src/model/demonstration/demonstrationSchema.ts
@@ -1,7 +1,7 @@
 import { gql } from "graphql-tag";
-import { DemonstrationStatus } from "../demonstrationStatus/demonstrationStatusSchema";
-import { State } from "../state/stateSchema";
-import { User } from "../user/userSchema";
+import { DemonstrationStatus } from "../demonstrationStatus/demonstrationStatusSchema.js";
+import { State } from "../state/stateSchema.js";
+import { User } from "../user/userSchema.js";
 
 export const demonstrationSchema = gql`
   type Demonstration {

--- a/server/src/model/demonstrationStatus/demonstrationStatusResolvers.ts
+++ b/server/src/model/demonstrationStatus/demonstrationStatusResolvers.ts
@@ -1,9 +1,9 @@
 import { DemonstrationStatus } from "@prisma/client";
-import { prisma } from "../../prismaClient";
+import { prisma } from "../../prismaClient.js";
 import {
   AddDemonstrationStatusInput,
   UpdateDemonstrationStatusInput,
-} from "./demonstrationStatusSchema";
+} from "./demonstrationStatusSchema.js";
 
 export const demonstrationStatusResolvers = {
   Query: {

--- a/server/src/model/demonstrationStatus/demonstrationStatusSchema.ts
+++ b/server/src/model/demonstrationStatus/demonstrationStatusSchema.ts
@@ -1,5 +1,5 @@
 import { gql } from "graphql-tag";
-import { Demonstration } from "../demonstration/demonstrationSchema";
+import { Demonstration } from "../demonstration/demonstrationSchema.js";
 
 export const demonstrationStatusSchema = gql`
   type DemonstrationStatus {

--- a/server/src/model/graphql.ts
+++ b/server/src/model/graphql.ts
@@ -1,20 +1,20 @@
-import { demonstrationSchema } from "./demonstration/demonstrationSchema";
-import { demonstrationResolvers } from "./demonstration/demonstrationResolvers";
+import { demonstrationSchema } from "./demonstration/demonstrationSchema.js";
+import { demonstrationResolvers } from "./demonstration/demonstrationResolvers.js";
 
-import { demonstrationStatusSchema } from "./demonstrationStatus/demonstrationStatusSchema";
-import { demonstrationStatusResolvers } from "./demonstrationStatus/demonstrationStatusResolvers";
+import { demonstrationStatusSchema } from "./demonstrationStatus/demonstrationStatusSchema.js";
+import { demonstrationStatusResolvers } from "./demonstrationStatus/demonstrationStatusResolvers.js";
 
-import { permissionSchema } from "./permission/permissionSchema";
-import { permissionResolvers } from "./permission/permissionResolvers";
+import { permissionSchema } from "./permission/permissionSchema.js";
+import { permissionResolvers } from "./permission/permissionResolvers.js";
 
-import { roleSchema } from "./role/roleSchema";
-import { roleResolvers } from "./role/roleResolvers";
+import { roleSchema } from "./role/roleSchema.js";
+import { roleResolvers } from "./role/roleResolvers.js";
 
-import { stateSchema } from "./state/stateSchema";
-import { stateResolvers } from "./state/stateResolvers";
+import { stateSchema } from "./state/stateSchema.js";
+import { stateResolvers } from "./state/stateResolvers.js";
 
-import { userSchema } from "./user/userSchema";
-import { userResolvers } from "./user/userResolvers";
+import { userSchema } from "./user/userSchema.js";
+import { userResolvers } from "./user/userResolvers.js";
 
 import {
   JSONObjectDefinition,

--- a/server/src/model/permission/permissionResolvers.ts
+++ b/server/src/model/permission/permissionResolvers.ts
@@ -1,6 +1,6 @@
 import { Permission } from "@prisma/client";
-import { prisma } from "../../prismaClient";
-import { AddPermissionInput, UpdatePermissionInput } from "./permissionSchema";
+import { prisma } from "../../prismaClient.js";
+import { AddPermissionInput, UpdatePermissionInput } from "./permissionSchema.js";
 
 export const permissionResolvers = {
   Query: {

--- a/server/src/model/permission/permissionSchema.ts
+++ b/server/src/model/permission/permissionSchema.ts
@@ -1,5 +1,5 @@
 import { gql } from "graphql-tag";
-import { Role } from "../role/roleSchema";
+import { Role } from "../role/roleSchema.js";
 
 export const permissionSchema = gql`
   type Permission {

--- a/server/src/model/role/roleResolvers.ts
+++ b/server/src/model/role/roleResolvers.ts
@@ -1,6 +1,6 @@
 import { Role } from "@prisma/client";
-import { prisma } from "../../prismaClient";
-import { AddRoleInput, UpdateRoleInput } from "./roleSchema";
+import { prisma } from "../../prismaClient.js";
+import { AddRoleInput, UpdateRoleInput } from "./roleSchema.js";
 
 export const roleResolvers = {
   Query: {

--- a/server/src/model/role/roleSchema.ts
+++ b/server/src/model/role/roleSchema.ts
@@ -1,6 +1,6 @@
 import { gql } from "graphql-tag";
-import { User } from "../user/userSchema";
-import { Permission } from "../permission/permissionSchema";
+import { User } from "../user/userSchema.js";
+import { Permission } from "../permission/permissionSchema.js";
 
 export const roleSchema = gql`
   type Role {

--- a/server/src/model/state/stateResolvers.ts
+++ b/server/src/model/state/stateResolvers.ts
@@ -1,6 +1,6 @@
 import { State } from "@prisma/client";
-import { prisma } from "../../prismaClient";
-import { AddStateInput, UpdateStateInput } from "./stateSchema";
+import { prisma } from "../../prismaClient.js";
+import { AddStateInput, UpdateStateInput } from "./stateSchema.js";
 
 export const stateResolvers = {
   Query: {

--- a/server/src/model/state/stateSchema.ts
+++ b/server/src/model/state/stateSchema.ts
@@ -1,6 +1,6 @@
 import { gql } from "graphql-tag";
-import { Demonstration } from "../demonstration/demonstrationSchema";
-import { User } from "../user/userSchema";
+import { Demonstration } from "../demonstration/demonstrationSchema.js";
+import { User } from "../user/userSchema.js";
 
 export const stateSchema = gql`
   type State {

--- a/server/src/model/user/userResolvers.ts
+++ b/server/src/model/user/userResolvers.ts
@@ -1,7 +1,7 @@
 import { User } from "@prisma/client";
-import { prisma } from "../../prismaClient";
-import { AddUserInput } from "./userSchema";
-import { requireRole } from "../../auth/auth.util";
+import { prisma } from "../../prismaClient.js";
+import { AddUserInput } from "./userSchema.js";
+import { requireRole } from "../../auth/auth.util.js";
 
 export const userResolvers = {
   Query: {

--- a/server/src/model/user/userSchema.ts
+++ b/server/src/model/user/userSchema.ts
@@ -1,7 +1,7 @@
 import { gql } from "graphql-tag";
-import { State } from "../state/stateSchema";
-import { Role } from "../role/roleSchema";
-import { Demonstration } from "../demonstration/demonstrationSchema";
+import { State } from "../state/stateSchema.js";
+import { Role } from "../role/roleSchema.js";
+import { Demonstration } from "../demonstration/demonstrationSchema.js";
 
 export const userSchema = gql`
   type User {

--- a/server/src/seeder.ts
+++ b/server/src/seeder.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { prisma } from "./prismaClient";
+import { prisma } from "./prismaClient.js";
 
 function checkIfAllowed() {
   if(process.env.ALLOW_SEED !== "true") {


### PR DESCRIPTION
Apparently ESM imports are supported natively now, but browsers weren't going to open random files so  you need the file extension.  TS is smart enough to know that when you import a .js file to look for the .ts file at compile time. 

This PR adds in the missing .js to the imports and cleans up the run commands in the package.json file.  

Also sets the default postgres database to demos and not public 😄 

Updates the devcontainer to alias python to python3 for Tom

Also adds ESBuild to try and pack the /dist folder for the lambda.  I'm hoping Jesse can test it.

Also npx is needed in the scripts in the package.json, npm will added it magically. 