### PR TITLE
DEMOS-263 add DemonstrationDetail page, make lowerHeader context sens…

### DIFF
--- a/client/src/components/header/DefaultHeaderLower.test.tsx
+++ b/client/src/components/header/DefaultHeaderLower.test.tsx
@@ -1,4 +1,4 @@
-// src/components/HeaderLower.test.tsx
+// src/components/DefaultHeaderLower.test.tsx
 import React from "react";
 
 import { vi } from "vitest";
@@ -10,7 +10,7 @@ import {
   screen,
 } from "@testing-library/react";
 
-import { HeaderLower } from "./HeaderLower";
+import { DefaultHeaderLower } from "./DefaultHeaderLower";
 
 // Mock Apollo
 vi.mock("@apollo/client", async () => {
@@ -39,14 +39,14 @@ vi.mock("components/modal/AddDocumentModal", () => ({
   ),
 }));
 
-describe("HeaderLower", () => {
+describe("DefaultHeaderLower", () => {
   afterEach(() => {
     vi.resetAllMocks();
   });
 
   it("renders empty bar when no userId is passed", () => {
     (useQuery as unknown as import("vitest").Mock).mockReturnValue({});
-    const { container } = render(<HeaderLower />);
+    const { container } = render(<DefaultHeaderLower />);
     expect(container.firstChild?.childNodes.length).toBe(0);
   });
 
@@ -56,7 +56,7 @@ describe("HeaderLower", () => {
       error: null,
       data: null,
     });
-    render(<HeaderLower userId={1} />);
+    render(<DefaultHeaderLower userId={1} />);
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
@@ -66,7 +66,7 @@ describe("HeaderLower", () => {
       error: { message: "fail" },
       data: null,
     });
-    render(<HeaderLower userId={2} />);
+    render(<DefaultHeaderLower userId={2} />);
     expect(screen.getByText("Error: fail")).toBeInTheDocument();
   });
 
@@ -76,7 +76,7 @@ describe("HeaderLower", () => {
       error: null,
       data: { user: null },
     });
-    const { container } = render(<HeaderLower userId={3} />);
+    const { container } = render(<DefaultHeaderLower userId={3} />);
     expect(container.firstChild).toBeNull();
   });
 
@@ -86,7 +86,7 @@ describe("HeaderLower", () => {
       error: null,
       data: { user: { fullName: "John Test" } },
     });
-    render(<HeaderLower userId={4} />);
+    render(<DefaultHeaderLower userId={4} />);
     expect(screen.getByText("Hello John Test")).toBeInTheDocument();
   });
 
@@ -96,7 +96,7 @@ describe("HeaderLower", () => {
       error: null,
       data: { user: { fullName: "X" } },
     });
-    render(<HeaderLower userId={5} />);
+    render(<DefaultHeaderLower userId={5} />);
     const button = screen.getByText("Create New");
     fireEvent.click(button);
     expect(screen.getByText("Demonstration")).toBeInTheDocument();
@@ -110,7 +110,7 @@ describe("HeaderLower", () => {
       error: null,
       data: { user: { fullName: "X" } },
     });
-    render(<HeaderLower userId={6} />);
+    render(<DefaultHeaderLower userId={6} />);
     fireEvent.click(screen.getByText("Create New"));
     fireEvent.click(screen.getByText("Demonstration"));
     expect(screen.getByTestId("create-modal")).toBeInTheDocument();
@@ -124,7 +124,7 @@ describe("HeaderLower", () => {
       error: null,
       data: { user: { fullName: "X" } },
     });
-    render(<HeaderLower userId={7} />);
+    render(<DefaultHeaderLower userId={7} />);
     fireEvent.click(screen.getByText("Create New"));
     fireEvent.click(screen.getByText("Add New Document"));
     expect(screen.getByTestId("add-document-modal")).toBeInTheDocument();
@@ -138,7 +138,7 @@ describe("HeaderLower", () => {
       error: null,
       data: { user: { fullName: "X" } },
     });
-    render(<HeaderLower userId={8} />);
+    render(<DefaultHeaderLower userId={8} />);
     fireEvent.click(screen.getByText("Create New"));
 
     fireEvent.click(screen.getByText("Amendment"));

--- a/client/src/components/header/DefaultHeaderLower.tsx
+++ b/client/src/components/header/DefaultHeaderLower.tsx
@@ -20,7 +20,7 @@ export const HEADER_LOWER_QUERY = gql`
   }
 `;
 
-export const HeaderLower: React.FC<{ userId?: number }> = ({ userId }) => {
+export const DefaultHeaderLower: React.FC<{ userId?: number }> = ({ userId }) => {
   const [showDropdown, setShowDropdown] = useState(false);
   const [modalType, setModalType] = useState<"create" | "document" | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);

--- a/client/src/components/header/Header.test.tsx
+++ b/client/src/components/header/Header.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { Header } from "./Header";
 import { ProfileBlock } from "./ProfileBlock";
 import { QuickLinks } from "./QuickLinks";
-import { HeaderLower } from "./HeaderLower";
+import { DefaultHeaderLower } from "./DefaultHeaderLower";
 import { Avatar } from "./Avatar";
 import { MockedProvider } from "@apollo/client/testing";
 import { userMocks } from "mock-data/userMocks";
@@ -40,7 +40,7 @@ describe("Header", async () => {
   it("renders the greeting", async () => {
     render(
       <MockedProvider mocks={userMocks} addTypename={false}>
-        <HeaderLower userId={2} />
+        <DefaultHeaderLower userId={2} />
       </MockedProvider>
     );
     expect(await screen.findByText("Hello John Doe")).toBeInTheDocument();
@@ -50,7 +50,7 @@ describe("Header", async () => {
   it("renders the Create New button", async () => {
     render(
       <MockedProvider mocks={userMocks} addTypename={false}>
-        <HeaderLower userId={2} />
+        <DefaultHeaderLower userId={2} />
       </MockedProvider>
     );
     expect(

--- a/client/src/components/header/Header.tsx
+++ b/client/src/components/header/Header.tsx
@@ -1,13 +1,20 @@
 import React from "react";
 import { HeaderUpper } from "./HeaderUpper";
+import { useHeaderConfig } from "./HeaderConfigContext";
 
 export const Header: React.FC<{
   userId?: number;
 }> = ({ userId }) => {
+  const { effectiveContent } = useHeaderConfig();
+
   return (
     <div id="header-container" className="top-0 left-0 w-full z-11">
       <HeaderUpper userId={userId} />
-      {/* HeaderLower is now rendered by HeaderConfigProvider */}
+      {effectiveContent && (
+        <div className="w-full">
+          {effectiveContent}
+        </div>
+      )}
     </div>
   );
 };

--- a/client/src/components/header/Header.tsx
+++ b/client/src/components/header/Header.tsx
@@ -11,7 +11,7 @@ export const Header: React.FC<{
     <div id="header-container" className="top-0 left-0 w-full z-11">
       <HeaderUpper userId={userId} />
       {effectiveContent && (
-        <div className="w-full">
+        <div className="flex w-full min-h-[6rem]">
           {effectiveContent}
         </div>
       )}

--- a/client/src/components/header/Header.tsx
+++ b/client/src/components/header/Header.tsx
@@ -8,7 +8,7 @@ export const Header: React.FC<{
   return (
     <div id="header-container" className="top-0 left-0 w-full z-11">
       <HeaderUpper userId={userId} />
-      <HeaderLower userId={userId} />
+      {/* HeaderLower is now rendered by HeaderConfigProvider */}
     </div>
   );
 };

--- a/client/src/components/header/Header.tsx
+++ b/client/src/components/header/Header.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { HeaderLower } from "./HeaderLower";
 import { HeaderUpper } from "./HeaderUpper";
 
 export const Header: React.FC<{

--- a/client/src/components/header/HeaderConfigContext.test.tsx
+++ b/client/src/components/header/HeaderConfigContext.test.tsx
@@ -2,41 +2,49 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HeaderConfigProvider, useHeaderConfig } from "./HeaderConfigContext";
+import { Header } from "./Header";
 
+// Test component that updates the header content
 const TestConsumer = () => {
   const { setHeaderConfig } = useHeaderConfig();
 
   return (
-    <>
-      <button onClick={() => setHeaderConfig({ lowerContent: <div>Updated Content</div> })}>
-        Update Header
-      </button>
-    </>
+    <button
+      onClick={() =>
+        setHeaderConfig({ lowerContent: <div data-testid="updated">Updated Content</div> })
+      }
+    >
+      Update Header
+    </button>
   );
 };
 
 describe("HeaderConfigProvider", () => {
-  it("renders defaultLowerContent initially", () => {
+  it("renders defaultLowerContent initially inside Header", () => {
     render(
-      <HeaderConfigProvider defaultLowerContent={<div>Default Content</div>}>
-        <TestConsumer />
+      <HeaderConfigProvider defaultLowerContent={<div data-testid="default">Default Content</div>}>
+        <Header />
       </HeaderConfigProvider>
     );
-    expect(screen.getByText("Default Content")).toBeInTheDocument();
+
+    expect(screen.getByTestId("default")).toHaveTextContent("Default Content");
   });
 
-  it("updates content when setHeaderConfig is called", async () => {
+  it("updates content in Header when setHeaderConfig is called", async () => {
     const user = userEvent.setup();
+
     render(
-      <HeaderConfigProvider defaultLowerContent={<div>Default Content</div>}>
+      <HeaderConfigProvider defaultLowerContent={<div data-testid="default">Default Content</div>}>
+        <Header />
         <TestConsumer />
       </HeaderConfigProvider>
     );
 
-    expect(screen.getByText("Default Content")).toBeInTheDocument();
+    expect(screen.getByTestId("default")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /Update Header/i }));
 
-    expect(screen.getByText("Updated Content")).toBeInTheDocument();
+    expect(screen.getByTestId("updated")).toHaveTextContent("Updated Content");
+    expect(screen.queryByTestId("default")).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/header/HeaderConfigContext.test.tsx
+++ b/client/src/components/header/HeaderConfigContext.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HeaderConfigProvider, useHeaderConfig } from "./HeaderConfigContext";
+
+const TestConsumer = () => {
+  const { setHeaderConfig } = useHeaderConfig();
+
+  return (
+    <>
+      <button onClick={() => setHeaderConfig({ lowerContent: <div>Updated Content</div> })}>
+        Update Header
+      </button>
+    </>
+  );
+};
+
+describe("HeaderConfigProvider", () => {
+  it("renders defaultLowerContent initially", () => {
+    render(
+      <HeaderConfigProvider defaultLowerContent={<div>Default Content</div>}>
+        <TestConsumer />
+      </HeaderConfigProvider>
+    );
+    expect(screen.getByText("Default Content")).toBeInTheDocument();
+  });
+
+  it("updates content when setHeaderConfig is called", async () => {
+    const user = userEvent.setup();
+    render(
+      <HeaderConfigProvider defaultLowerContent={<div>Default Content</div>}>
+        <TestConsumer />
+      </HeaderConfigProvider>
+    );
+
+    expect(screen.getByText("Default Content")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Update Header/i }));
+
+    expect(screen.getByText("Updated Content")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/header/HeaderConfigContext.tsx
+++ b/client/src/components/header/HeaderConfigContext.tsx
@@ -18,9 +18,9 @@ export const HeaderConfigProvider: React.FC<{
   children: React.ReactNode;
   defaultLowerContent: React.ReactNode;
 }> = ({ children, defaultLowerContent }) => {
-  const [headerConfig, setHeaderConfig] = useState<HeaderConfig | null>(null);```
+  const [headerConfig, setHeaderConfig] = useState<HeaderConfig | null>(null);
 
-  const effectiveContent = headerConfig.lowerContent ?? defaultLowerContent;
+  const effectiveContent = headerConfig?.lowerContent ?? defaultLowerContent;
 
   return (
     <HeaderConfigContext.Provider value={{ setHeaderConfig, effectiveContent }}>

--- a/client/src/components/header/HeaderConfigContext.tsx
+++ b/client/src/components/header/HeaderConfigContext.tsx
@@ -6,8 +6,10 @@ interface HeaderConfig {
 
 const HeaderConfigContext = createContext<{
   setHeaderConfig: (config: HeaderConfig) => void;
+  effectiveContent: ReactNode;
     }>({
       setHeaderConfig: () => {},
+      effectiveContent: null,
     });
 
 export const useHeaderConfig = () => useContext(HeaderConfigContext);
@@ -21,11 +23,8 @@ export const HeaderConfigProvider: React.FC<{
   const effectiveContent = headerConfig.lowerContent ?? defaultLowerContent;
 
   return (
-    <HeaderConfigContext.Provider value={{ setHeaderConfig }}>
+    <HeaderConfigContext.Provider value={{ setHeaderConfig, effectiveContent }}>
       {children}
-      <div className="absolute top-12 w-full z-10">
-        {effectiveContent}
-      </div>
     </HeaderConfigContext.Provider>
   );
 };

--- a/client/src/components/header/HeaderConfigContext.tsx
+++ b/client/src/components/header/HeaderConfigContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useState, ReactNode } from "react";
+
+interface HeaderConfig {
+  lowerContent?: ReactNode;
+}
+
+const HeaderConfigContext = createContext<{
+  setHeaderConfig: (config: HeaderConfig) => void;
+}>({
+  setHeaderConfig: () => {},
+});
+
+export const useHeaderConfig = () => useContext(HeaderConfigContext);
+
+export const HeaderConfigProvider: React.FC<{
+  children: React.ReactNode;
+  defaultLowerContent: React.ReactNode;
+}> = ({ children, defaultLowerContent }) => {
+  const [headerConfig, setHeaderConfig] = useState<HeaderConfig>({});
+
+  const effectiveContent = headerConfig.lowerContent ?? defaultLowerContent;
+
+  return (
+    <HeaderConfigContext.Provider value={{ setHeaderConfig }}>
+      {children}
+      <div className="absolute top-12 w-full z-10">
+        {effectiveContent}
+      </div>
+    </HeaderConfigContext.Provider>
+  );
+};

--- a/client/src/components/header/HeaderConfigContext.tsx
+++ b/client/src/components/header/HeaderConfigContext.tsx
@@ -6,9 +6,9 @@ interface HeaderConfig {
 
 const HeaderConfigContext = createContext<{
   setHeaderConfig: (config: HeaderConfig) => void;
-}>({
-  setHeaderConfig: () => {},
-});
+    }>({
+      setHeaderConfig: () => {},
+    });
 
 export const useHeaderConfig = () => useContext(HeaderConfigContext);
 

--- a/client/src/components/header/HeaderConfigContext.tsx
+++ b/client/src/components/header/HeaderConfigContext.tsx
@@ -18,7 +18,7 @@ export const HeaderConfigProvider: React.FC<{
   children: React.ReactNode;
   defaultLowerContent: React.ReactNode;
 }> = ({ children, defaultLowerContent }) => {
-  const [headerConfig, setHeaderConfig] = useState<HeaderConfig>({});
+  const [headerConfig, setHeaderConfig] = useState<HeaderConfig | null>(null);```
 
   const effectiveContent = headerConfig.lowerContent ?? defaultLowerContent;
 

--- a/client/src/hooks/usePageHeader.test.tsx
+++ b/client/src/hooks/usePageHeader.test.tsx
@@ -1,40 +1,48 @@
-// src/hooks/usePageHeader.test.tsx
 import React from "react";
 import { renderHook, waitFor } from "@testing-library/react";
 import { usePageHeader } from "./usePageHeader";
 import { HeaderConfigProvider } from "components/header/HeaderConfigContext";
+import { Header } from "components/header/Header";
 
+// Include Header so we can see the output of setHeaderConfig
 const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <HeaderConfigProvider defaultLowerContent={null}>{children}</HeaderConfigProvider>
+  <HeaderConfigProvider defaultLowerContent={null}>
+    <Header />
+    {children}
+  </HeaderConfigProvider>
 );
 
 describe("usePageHeader hook", () => {
-  it("sets header content on mount and clears on unmount", async () => {
+  it("sets header content on mount, updates on rerender, and clears on unmount", async () => {
     const { rerender, unmount } = renderHook(
       ({ content }) => usePageHeader(content),
       {
-        initialProps: { content: <div>Test Header Content</div> },
+        initialProps: { content: <div data-testid="header-content">Test Header Content</div> },
         wrapper,
       }
     );
 
-    // Wait for initial header content to appear
+    // Wait for initial header content
     await waitFor(() => {
-      expect(document.body.textContent).toContain("Test Header Content");
+      expect(document.querySelector("[data-testid='header-content']")?.textContent).toBe(
+        "Test Header Content"
+      );
     });
 
-    // Rerender with new header content
-    rerender({ content: <div>New Header Content</div> });
+    // Rerender with new content
+    rerender({ content: <div data-testid="header-content">New Header Content</div> });
 
     await waitFor(() => {
-      expect(document.body.textContent).toContain("New Header Content");
+      expect(document.querySelector("[data-testid='header-content']")?.textContent).toBe(
+        "New Header Content"
+      );
     });
 
-    // Unmount hook and expect header content to be cleared
+    // Unmount the hook and verify the header content is cleared
     unmount();
 
     await waitFor(() => {
-      expect(document.body.textContent).not.toContain("New Header Content");
+      expect(document.querySelector("[data-testid='header-content']")).not.toBeInTheDocument();
     });
   });
 });

--- a/client/src/hooks/usePageHeader.test.tsx
+++ b/client/src/hooks/usePageHeader.test.tsx
@@ -1,0 +1,40 @@
+// src/hooks/usePageHeader.test.tsx
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { usePageHeader } from "./usePageHeader";
+import { HeaderConfigProvider } from "components/header/HeaderConfigContext";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <HeaderConfigProvider defaultLowerContent={null}>{children}</HeaderConfigProvider>
+);
+
+describe("usePageHeader hook", () => {
+  it("sets header content on mount and clears on unmount", async () => {
+    const { rerender, unmount } = renderHook(
+      ({ content }) => usePageHeader(content),
+      {
+        initialProps: { content: <div>Test Header Content</div> },
+        wrapper,
+      }
+    );
+
+    // Wait for initial header content to appear
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("Test Header Content");
+    });
+
+    // Rerender with new header content
+    rerender({ content: <div>New Header Content</div> });
+
+    await waitFor(() => {
+      expect(document.body.textContent).toContain("New Header Content");
+    });
+
+    // Unmount hook and expect header content to be cleared
+    unmount();
+
+    await waitFor(() => {
+      expect(document.body.textContent).not.toContain("New Header Content");
+    });
+  });
+});

--- a/client/src/hooks/usePageHeader.ts
+++ b/client/src/hooks/usePageHeader.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useHeaderConfig } from "components/header/HeaderConfigContext";
+
+export const usePageHeader = (lowerContent: React.ReactNode) => {
+  const { setHeaderConfig } = useHeaderConfig();
+
+  useEffect(() => {
+    setHeaderConfig({ lowerContent });
+
+    return () => {
+      setHeaderConfig({ lowerContent: undefined });
+    };
+  }, [lowerContent, setHeaderConfig]);
+};

--- a/client/src/layout/PrimaryLayout.tsx
+++ b/client/src/layout/PrimaryLayout.tsx
@@ -6,6 +6,8 @@ import {
   ToastContainer,
   ToastProvider,
 } from "components/index";
+import { HeaderLower } from "../components/header/HeaderLower"; // import your default header lower
+import { HeaderConfigProvider } from "../components/header/HeaderConfigContext";
 
 interface PrimaryLayoutProps {
   children: React.ReactNode;
@@ -16,21 +18,20 @@ export const PrimaryLayout: React.FC<PrimaryLayoutProps> = ({ children }) => {
 
   return (
     <ToastProvider>
-      <div className="h-screen flex flex-col">
-        <Header userId={2} />
-        <div className="flex flex-1 overflow-hidden">
-          {/* Sidenav flex basis */}
-          <div className={collapsed ? "w-20" : "w-64"}>
-            <SideNav collapsed={collapsed} setCollapsed={setCollapsed} />
+      <HeaderConfigProvider defaultLowerContent={<HeaderLower userId={2} />}>
+        <div className="h-screen flex flex-col">
+          <Header userId={2} />
+          <div className="flex flex-1 overflow-hidden">
+            <div className={collapsed ? "w-20" : "w-64"}>
+              <SideNav collapsed={collapsed} setCollapsed={setCollapsed} />
+            </div>
+            <main className="flex-1 overflow-auto p-6 bg-gray-50 transition-all duration-300">
+              {children}
+            </main>
           </div>
-
-          {/* Page Content */}
-          <main className="flex-1 overflow-auto p-6 bg-gray-50 transition-all duration-300">
-            {children}
-          </main>
+          <Footer />
         </div>
-        <Footer />
-      </div>
+      </HeaderConfigProvider>
       <ToastContainer />
     </ToastProvider>
   );

--- a/client/src/layout/PrimaryLayout.tsx
+++ b/client/src/layout/PrimaryLayout.tsx
@@ -6,8 +6,8 @@ import {
   ToastContainer,
   ToastProvider,
 } from "components/index";
-import { HeaderLower } from "../components/header/HeaderLower"; // import your default header lower
-import { HeaderConfigProvider } from "../components/header/HeaderConfigContext";
+import { DefaultHeaderLower } from "components/header/DefaultHeaderLower"; // import your default header lower
+import { HeaderConfigProvider } from "components/header/HeaderConfigContext";
 
 interface PrimaryLayoutProps {
   children: React.ReactNode;
@@ -18,7 +18,7 @@ export const PrimaryLayout: React.FC<PrimaryLayoutProps> = ({ children }) => {
 
   return (
     <ToastProvider>
-      <HeaderConfigProvider defaultLowerContent={<HeaderLower userId={2} />}>
+      <HeaderConfigProvider defaultLowerContent={<DefaultHeaderLower userId={2} />}>
         <div className="h-screen flex flex-col">
           <Header userId={2} />
           <div className="flex flex-1 overflow-hidden">

--- a/client/src/layout/PrimaryLayout.tsx
+++ b/client/src/layout/PrimaryLayout.tsx
@@ -6,7 +6,7 @@ import {
   ToastContainer,
   ToastProvider,
 } from "components/index";
-import { DefaultHeaderLower } from "components/header/DefaultHeaderLower"; // import your default header lower
+import { DefaultHeaderLower } from "components/header/DefaultHeaderLower";
 import { HeaderConfigProvider } from "components/header/HeaderConfigContext";
 
 interface PrimaryLayoutProps {

--- a/client/src/mock-data/userMocks.ts
+++ b/client/src/mock-data/userMocks.ts
@@ -1,6 +1,6 @@
 import { User } from "demos-server";
 import { GET_ALL_USERS, GET_USER_BY_ID } from "hooks/useUserOperations";
-import { HEADER_LOWER_QUERY } from "components/header/HeaderLower";
+import { HEADER_LOWER_QUERY } from "components/header/DefaultHeaderLower";
 import { PROFILE_BLOCK_QUERY } from "components/header/ProfileBlock";
 import { MockedResponse } from "@apollo/client/testing";
 

--- a/client/src/pages/DemonstrationDetail.tsx
+++ b/client/src/pages/DemonstrationDetail.tsx
@@ -37,7 +37,7 @@ export const DemonstrationDetail = () => {
           <span className="block text-sm">
             State/Territory: {data.state.stateCode}
             <span className="mx-1">|</span>
-            Project Officer {data.description}
+            Project Officer: {data.description}
           </span>
         </div>
         <div className="relative">

--- a/client/src/pages/DemonstrationDetail.tsx
+++ b/client/src/pages/DemonstrationDetail.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useDemonstration } from "hooks/useDemonstration";
+
+import { DeleteIcon, EditIcon, EllipsisIcon } from "components/icons";
+import { CircleButton } from "components/button/CircleButton";
+import { usePageHeader } from "hooks/usePageHeader";
+
+
+export const DemonstrationDetail = () => {
+  const { id } = useParams<{ id: string }>();
+  const [showButtons, setShowButtons] = useState(false);
+  const { getDemonstrationById } = useDemonstration();
+  const { trigger, data, loading, error } = getDemonstrationById;
+
+  useEffect(() => {
+    if (id) trigger(id);
+  }, [id]);
+
+  // Build dynamic header content
+  const headerContent = useMemo(() => {
+    if (loading) {
+      return <div className="w-full bg-[var(--color-brand)] text-white px-4 py-1 flex items-center justify-between">Loading demonstration...</div>;
+    }
+
+    if (error || !data) {
+      return <div className="w-full bg-[var(--color-brand)] text-white px-4 py-1 flex items-center justify-between">Failed to load demonstration</div>;
+    }
+
+    return (
+      <div className="w-full bg-[var(--color-brand)] text-white px-4 py-1 flex items-center justify-between">
+        <div>
+          {/* TODO: Replace with breadcrumb */}
+          <span className="-ml-2 block text-sm">Demonstration List {">"} {data.id} </span>
+          <span className="font-bold block">{data.name}</span>
+          <span className="block text-sm">State/Territory: {`${data.state}`}</span>
+        </div>
+        <div className="relative">
+          { showButtons && (
+            <span className="mr-0.75">
+              <CircleButton
+                aria-label="Delete demonstration"
+                className="cursor-pointer flex items-center gap-1 px-1 py-1 mr-0.75"
+                data-testid="delete-button"
+              >
+                <DeleteIcon width="24" height="24" />
+              </CircleButton>
+              <CircleButton
+                aria-label="Edit demonstration"
+                className="cursor-pointer flex items-center gap-1 px-1 py-1"
+                data-testid="edit-button"
+              >
+                <EditIcon width="24" height="24" />
+              </CircleButton>
+            </span>
+          )}
+          <CircleButton
+            className="cursor-pointer flex items-center gap-1 px-1 py-1"
+            aria-label="Toggle more options"
+            data-testid="toggle-ellipsis-button"
+            onClick={() => setShowButtons((prev) => !prev)}
+          >
+            <span
+              className={`transform transition-transform duration-200 ease-in-out ${
+                showButtons ? "rotate-90" : "rotate-0"
+              }`}
+            >
+              <EllipsisIcon width="24" height="24" />
+            </span>
+          </CircleButton>
+        </div>
+      </div>
+    );
+  }, [data, loading, error, showButtons]);
+
+  usePageHeader(headerContent);
+
+  return (
+    <div className="p-4">
+      {loading && <p>Loading...</p>}
+      {error && <p>Error loading demonstration</p>}
+      {data && (
+        <>
+          Demonstration Detail Content
+        </>
+      )}
+    </div>
+  );
+};

--- a/client/src/pages/DemonstrationDetail.tsx
+++ b/client/src/pages/DemonstrationDetail.tsx
@@ -31,7 +31,7 @@ export const DemonstrationDetail = () => {
       <div className="w-full bg-[var(--color-brand)] text-white px-4 py-1 flex items-center justify-between">
         <div>
           {/* TODO: Replace with breadcrumb */}
-          <span className="-ml-2 block text-sm"><a className="underline decoration-gray-400 decoration-1 decoration-opacity-40" href="/demonstrations">Demonstration List</a> {">"} {data.id}</span>
+          <span className="-ml-2 block text-sm"><a className="underline underline-offset-2 decoration-gray-400 decoration-1 decoration-opacity-40" href="/demonstrations">Demonstration List</a> {">"} {data.id}</span>
           <span className="font-bold block">{data.name}</span>
           <span className="block text-sm">State/Territory: {`${data.state.stateCode}`}</span>
         </div>

--- a/client/src/pages/DemonstrationDetail.tsx
+++ b/client/src/pages/DemonstrationDetail.tsx
@@ -35,7 +35,7 @@ export const DemonstrationDetail = () => {
           <span className="font-bold block">{data.name}</span>
           {/* TODO: Replace Project Officer with correct value */}
           <span className="block text-sm">
-            State/Territory: {data.state.stateCode} 
+            State/Territory: {data.state.stateCode}
             <span className="mx-1">|</span>
             Project Officer {data.description}
           </span>

--- a/client/src/pages/DemonstrationDetail.tsx
+++ b/client/src/pages/DemonstrationDetail.tsx
@@ -31,9 +31,9 @@ export const DemonstrationDetail = () => {
       <div className="w-full bg-[var(--color-brand)] text-white px-4 py-1 flex items-center justify-between">
         <div>
           {/* TODO: Replace with breadcrumb */}
-          <span className="-ml-2 block text-sm">Demonstration List {">"} {data.id} </span>
+          <span className="-ml-2 block text-sm"><a className="underline decoration-gray-400 decoration-1 decoration-opacity-40" href="/demonstrations">Demonstration List</a> {">"} {data.id}</span>
           <span className="font-bold block">{data.name}</span>
-          <span className="block text-sm">State/Territory: {`${data.state}`}</span>
+          <span className="block text-sm">State/Territory: {`${data.state.stateCode}`}</span>
         </div>
         <div className="relative">
           { showButtons && (

--- a/client/src/pages/DemonstrationDetail.tsx
+++ b/client/src/pages/DemonstrationDetail.tsx
@@ -33,7 +33,12 @@ export const DemonstrationDetail = () => {
           {/* TODO: Replace with breadcrumb */}
           <span className="-ml-2 block text-sm"><a className="underline underline-offset-2 decoration-gray-400 decoration-1 decoration-opacity-40" href="/demonstrations">Demonstration List</a> {">"} {data.id}</span>
           <span className="font-bold block">{data.name}</span>
-          <span className="block text-sm">State/Territory: {`${data.state.stateCode}`}</span>
+          {/* TODO: Replace Project Officer with correct value */}
+          <span className="block text-sm">
+            State/Territory: {data.state.stateCode} 
+            <span className="mx-1">|</span>
+            Project Officer {data.description}
+          </span>
         </div>
         <div className="relative">
           { showButtons && (

--- a/client/src/router/DemosRouter.tsx
+++ b/client/src/router/DemosRouter.tsx
@@ -7,6 +7,7 @@ import { ComponentLibrary, TestHooks } from "pages/debug";
 import { AuthComponent } from "components/auth/AuthComponent";
 import { PrimaryLayout } from "layout/PrimaryLayout";
 import { Demonstrations } from "pages/Demonstrations";
+import { DemonstrationDetail } from "pages/DemonstrationDetail";
 import { IconLibrary } from "pages/debug/IconLibrary";
 import { DemosApolloProvider } from "./DemosApolloProvider";
 import { isDevelopmentMode } from "config/env";
@@ -33,6 +34,7 @@ export const DemosRouter = () => {
               {/* TODO: is the Demonstration page just the landing page? */}
               <Route path="/" element={<LandingPage />} />
               <Route path="demonstrations" element={<Demonstrations />} />
+              <Route path="demonstrations/:id" element={<DemonstrationDetail />} />
               {/* Debug routes, only available in development mode */}
               {isDevelopmentMode() && (
                 <>


### PR DESCRIPTION
…itive

- Adds "usePageHeader" hook to set the page level header
- Adds demonstrationDetail route, with initial setup for viewing demonstration details in header

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/b213bacd-738b-483a-85ef-9834291c52c0" />
