### PR TITLE
DEMOS-423-add-lambda-secretsmanager-items

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,13 @@
 FROM mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive  && apt-get -y install python3 python3-pip python-is-python3 && pip3 install pre-commit --break-system-packages
+RUN apt-get update && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y install \
+        python3 \
+        python3-pip \
+        python-is-python3 \
+        awscli && \
+    pip3 install pre-commit --break-system-packages
 
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,10 +19,10 @@
 
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // This can be used to network with other containers or with the host.
-    "forwardPorts": [3000, 4000, 5432, 9092, 9093],
+    "forwardPorts": [3000, 4000, 4566, 5432, 9092, 9093],
 
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "pre-commit install",
+    "postCreateCommand": "zsh .devcontainer/post_create.sh",
 
     // Configure tool-specific properties.
     // "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,16 +17,16 @@
     // Features to add to the dev container. More info: https://containers.dev/features.
     // "features": {},
 
-    // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    // This can be used to network with other containers or with the host.
-    "forwardPorts": [3000, 4000, 4566, 5432, 9092, 9093],
-
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "zsh .devcontainer/post_create.sh",
+    "postCreateCommand": "bash .devcontainer/post_create.sh",
 
     // Configure tool-specific properties.
     // "customizations": {},
 
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-    "remoteUser": "root"
+    "remoteUser": "root",
+
+    "otherPortsAttributes": {
+        "onAutoForward": "ignore"
+    }
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,7 +8,9 @@ services:
     volumes:
       - ../..:/workspaces:cached
     command: sleep infinity # Overrides default command so things don't shut down after the process ends.
-    network_mode: service:db # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    ports:
+      - "3000:3000"
+      - "4000:4000"
 
   db:
     image: postgres:latest
@@ -20,11 +22,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_DB: demos
     ports:
-      - "3000:3000"
-      - "4000:4000"
-      - "4566:4566"
       - "5432:5432"
-      - "9092:9093"
 
   kafka-mock:
     image: apache/kafka:latest
@@ -40,11 +38,11 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-    network_mode: service:db
+    ports:
+      - "9092:9093"
 
   localstack:
     image: localstack/localstack:latest
-    network_mode: service:db
     environment:
       - DEBUG=${DEBUG:-0}
       - DOCKER_HOST=unix:///var/run/docker.sock
@@ -53,6 +51,8 @@ services:
     volumes:
       - "localstack-data:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
+    ports:
+      - "4566:4566"
 
 volumes:
   postgres-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     volumes:
       - ../..:/workspaces:cached
     command: sleep infinity # Overrides default command so things don't shut down after the process ends.
+    environment:
+      AWS_PAGER: ""
     ports:
       - "3000:3000"
       - "4000:4000"
@@ -44,10 +46,10 @@ services:
   localstack:
     image: localstack/localstack:latest
     environment:
-      - DEBUG=${DEBUG:-0}
-      - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOSTNAME_EXTERNAL=localstack
-      - SERVICES=s3,lambda,apigateway,secretsmanager
+      DEBUG: ${DEBUG:-0}
+      DOCKER_HOST: unix:///var/run/docker.sock
+      HOSTNAME_EXTERNAL: localstack
+      SERVICES: s3,lambda,apigateway,secretsmanager
     volumes:
       - "localstack-data:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,18 +5,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-
     volumes:
       - ../..:/workspaces:cached
-      
-    # Overrides default command so things don't shut down after the process ends.
-    command: sleep infinity
-
-    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
-    network_mode: service:db
-
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
+    command: sleep infinity # Overrides default command so things don't shut down after the process ends.
+    network_mode: service:db # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
 
   db:
     image: postgres:latest
@@ -27,15 +19,18 @@ services:
       POSTGRES_PASSWORD: postgres # pragma: allowlist secret
       POSTGRES_USER: postgres
       POSTGRES_DB: demos
+    ports:
+      - "3000:3000"
+      - "4000:4000"
+      - "4566:4566"
+      - "5432:5432"
+      - "9092:9093"
 
-    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
-  
   kafka-mock:
-    image: apache/kafka:latest    
+    image: apache/kafka:latest
     environment:
       KAFKA_NODE_ID: 1
-      KAFKA_PROCESS_ROLES:  broker,controller
+      KAFKA_PROCESS_ROLES: broker,controller
       KAFKA_LISTENERS: PLAINTEXT://localhost:9092,CONTROLLER://localhost:9093
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
@@ -44,8 +39,21 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0      
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
     network_mode: service:db
+
+  localstack:
+    image: localstack/localstack:latest
+    network_mode: service:db
+    environment:
+      - DEBUG=${DEBUG:-0}
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - HOSTNAME_EXTERNAL=localstack
+      - SERVICES=s3,lambda,apigateway,secretsmanager
+    volumes:
+      - "localstack-data:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
 
 volumes:
   postgres-data:
+  localstack-data:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       DEBUG: ${DEBUG:-0}
       DOCKER_HOST: unix:///var/run/docker.sock
       HOSTNAME_EXTERNAL: localstack
-      SERVICES: s3,lambda,apigateway,secretsmanager
+      SERVICES: s3,lambda,apigateway,secretsmanager,logs
     volumes:
       - "localstack-data:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+pre-commit install
+
+aws configure set aws_access_key_id test
+aws configure set aws_secret_access_key test # pragma: allowlist secret
+aws configure set region us-east-1
+
+# The ENDPOINT_URL setting is broken in all contexts except on the command line
+# Add this alias to handle it
+echo "alias aws='aws --endpoint-url=http://localhost:4566'" >> ~/.bashrc
+echo "alias aws='aws --endpoint-url=http://localhost:4566'" >> ~/.zshrc

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -7,5 +7,5 @@ aws configure set region us-east-1
 
 # The ENDPOINT_URL setting is broken in all contexts except on the command line
 # Add this alias to handle it
-echo "alias aws='aws --endpoint-url=http://localhost:4566'" >> ~/.bashrc
-echo "alias aws='aws --endpoint-url=http://localhost:4566'" >> ~/.zshrc
+echo "alias aws='aws --endpoint-url=http://localstack:4566'" >> ~/.bashrc
+echo "alias aws='aws --endpoint-url=http://localstack:4566'" >> ~/.zshrc

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 
 cdk.out/
 cdk.context.json
+
+server/localstack/demos-server.zip

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,3 @@
-DATABASE_URL="postgresql://postgres@localhost:5432/demos?schema=demos_app"
+DATABASE_URL="postgresql://postgres:postgres@db:5432/demos?schema=demos_app" # pragma: allowlist secret
 BYPASS_AUTH=true
 ALLOW_SEED=true

--- a/server/localstack/localstack.sh
+++ b/server/localstack/localstack.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/bash
+
+# Static variables
+ENDPOINT="--endpoint-url=http://localstack:4566"
+PACKAGE_NAME="demos-server"
+PACKAGE_VERSION="0.1.0"
+DEPLOY_BUCKET="${PACKAGE_NAME}-deployment"
+API_NAME="${PACKAGE_NAME}-api"
+
+# Convert exit codes to booleans for easy processing
+clean_exit() {
+  if [ $? -eq 0 ]; then echo true; else echo false; fi
+}
+
+# Checking for existing items
+aws ${ENDPOINT} s3api head-bucket --bucket ${DEPLOY_BUCKET} >/dev/null 2>&1
+BUCKET_EXISTS=$(clean_exit)
+aws ${ENDPOINT} lambda get-function --function-name ${PACKAGE_NAME} >/dev/null 2>&1
+LAMBDA_EXISTS=$(clean_exit)
+
+API_ID=$(aws apigateway get-rest-apis \
+  ${ENDPOINT} \
+  --query "items[?name=='${API_NAME}'].id" \
+  --output text)
+API_EXISTS=$([ -n "${API_ID}" ] && echo true || echo false)
+
+echo "Bucket exists in localstack: ${BUCKET_EXISTS}"
+echo "Lambda exists in localstack: ${LAMBDA_EXISTS}"
+echo "Gateway exists in localstack: ${API_EXISTS}"
+
+# Clean up old stuff in localstack
+if [[ ${BUCKET_EXISTS} == true ]]; then
+  aws ${ENDPOINT} s3 rb s3://${DEPLOY_BUCKET} --force
+fi
+if [[ ${LAMBDA_EXISTS} == true ]]; then
+  aws ${ENDPOINT} lambda delete-function --function-name ${PACKAGE_NAME}
+fi
+if [[ ${API_EXISTS} == true ]]; then
+  aws ${ENDPOINT} apigateway delete-rest-api --rest-api-id ${API_ID}
+fi
+
+# Build file
+npm run build
+cp ../build/server.cjs .
+zip ${PACKAGE_NAME}.zip server.cjs
+rm server.cjs
+
+# Make a bucket and upload the zip
+aws ${ENDPOINT} s3 mb s3://${DEPLOY_BUCKET}
+aws ${ENDPOINT} s3 cp ${PACKAGE_NAME}.zip s3://${DEPLOY_BUCKET}/${PACKAGE_NAME}.zip
+
+# Create a function
+aws lambda create-function \
+  ${ENDPOINT} \
+  --function-name ${PACKAGE_NAME} \
+  --code S3Bucket=${DEPLOY_BUCKET},S3Key=${PACKAGE_NAME}.zip \
+  --handler server.graphqlHandler \
+  --runtime nodejs22.x \
+  --role arn:aws:iam::000000000000:role/${PACKAGE_NAME}-localstack-lambda
+
+# Add Lambda permission for API Gateway
+aws lambda add-permission \
+  ${ENDPOINT} \
+  --function-name ${PACKAGE_NAME} \
+  --statement-id apigateway-invoke \
+  --action lambda:InvokeFunction \
+  --principal apigateway.amazonaws.com
+
+# Create an API gateway
+API_ID=$(aws apigateway create-rest-api \
+  ${ENDPOINT} \
+  --name ${API_NAME} \
+  --description "${API_NAME} Localstack Version" \
+  --query "id" \
+  --output text)
+
+# Get the root resource ID
+ROOT_RESOURCE_ID=$(aws ${ENDPOINT} apigateway get-resources \
+  --rest-api-id ${API_ID} \
+  --query "items[?path=='/'].id" \
+  --output text)
+
+# Adding POST method
+aws apigateway put-method \
+  ${ENDPOINT} \
+  --rest-api-id ${API_ID} \
+  --resource-id ${ROOT_RESOURCE_ID} \
+  --http-method POST \
+  --authorization-type NONE
+
+# Integrate POST method with Lambda
+aws apigateway put-integration \
+  ${ENDPOINT} \
+  --rest-api-id ${API_ID} \
+  --resource-id ${ROOT_RESOURCE_ID} \
+  --http-method POST \
+  --type AWS_PROXY \
+  --integration-http-method POST \
+  --uri "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:${PACKAGE_NAME}/invocations"
+
+# Deploy the API
+aws apigateway create-deployment \
+  ${ENDPOINT} \
+  --rest-api-id ${API_ID} \
+  --stage-name local
+
+# Output the API Gateway URL
+echo "API Gateway URL: http://localhost:4566/_aws/execute-api/${API_ID}/local"

--- a/server/localstack/localstack.sh
+++ b/server/localstack/localstack.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/bash
 
 # Static variables
+# Note, using escaped quotes for the SECRET_VALUE because of needing to double-quote it later
 ENDPOINT="--endpoint-url=http://localstack:4566"
 PACKAGE_NAME="demos-server"
 PACKAGE_VERSION="0.1.0"
 DEPLOY_BUCKET="${PACKAGE_NAME}-deployment"
 API_NAME="${PACKAGE_NAME}-api"
 SECRET_NAME="${PACKAGE_NAME}-database-url"
+SECRET_VALUE="{\"DATABASE_URL\":\"postgresql://postgres:postgres@db:5432/demos?schema=demos_app\"}" # pragma: allowlist secret
 
 # Convert exit codes to booleans for easy processing
 clean_exit() {
@@ -68,7 +70,7 @@ aws ${ENDPOINT} s3 cp ${PACKAGE_NAME}.zip s3://${DEPLOY_BUCKET}/${PACKAGE_NAME}.
 SECRET_ARN=$(aws secretsmanager create-secret \
   ${ENDPOINT} \
   --name "${SECRET_NAME}" \
-  --secret-string '{"DATABASE_URL":"postgresql://postgres:postgres@db:5432/demos?schema=demos_app"}' \ # pragma: allowlist secret \
+  --secret-string "${SECRET_VALUE}" \
   --query "ARN" \
   --output text)
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@apollo/server": "^4.12.2",
         "@as-integrations/aws-lambda": "^3.1.0",
+        "@aws-sdk/client-secrets-manager": "^3.840.0",
         "@prisma/client": "^6.7.0",
         "graphql-scalars": "^1.24.2",
         "jsonwebtoken": "^9.0.2",
@@ -617,7 +618,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -633,7 +633,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -646,7 +645,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -660,7 +658,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -674,7 +671,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -689,7 +685,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -699,7 +694,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
@@ -711,7 +705,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -724,7 +717,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -738,7 +730,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -850,6 +841,480 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.840.0.tgz",
+      "integrity": "sha512-oUcoZT4YJc/WUoxydfzSE3o89dBvdzan75XOLXg3JVg64os4ao8SUkIphR3YXmjmHz8qwaVNXVF4MpR3IxGPCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/credential-provider-node": "3.840.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.840.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.840.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.840.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.6.0",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.13",
+        "@smithy/middleware-retry": "^4.1.14",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.21",
+        "@smithy/util-defaults-mode-node": "^4.0.21",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sso": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.840.0.tgz",
+      "integrity": "sha512-3Zp+FWN2hhmKdpS0Ragi5V2ZPsZNScE3jlbgoJjzjI/roHZqO+e3/+XFN4TlM0DsPKYJNp+1TAjmhxN6rOnfYA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.840.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.840.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.840.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.6.0",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.13",
+        "@smithy/middleware-retry": "^4.1.14",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.21",
+        "@smithy/util-defaults-mode-node": "^4.0.21",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/core": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.840.0.tgz",
+      "integrity": "sha512-x3Zgb39tF1h2XpU+yA4OAAQlW6LVEfXNlSedSYJ7HGKXqA/E9h3rWQVpYfhXXVVsLdYXdNw5KBUkoAoruoZSZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/xml-builder": "3.821.0",
+        "@smithy/core": "^3.6.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/signature-v4": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.840.0.tgz",
+      "integrity": "sha512-EzF6VcJK7XvQ/G15AVEfJzN2mNXU8fcVpXo4bRyr1S6t2q5zx6UPH/XjDbn18xyUmOq01t+r8gG+TmHEVo18fA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.840.0.tgz",
+      "integrity": "sha512-wbnUiPGLVea6mXbUh04fu+VJmGkQvmToPeTYdHE8eRZq3NRDi3t3WltT+jArLBKD/4NppRpMjf2ju4coMCz91g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-stream": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.840.0.tgz",
+      "integrity": "sha512-7F290BsWydShHb+7InXd+IjJc3mlEIm9I0R57F/Pjl1xZB69MdkhVGCnuETWoBt4g53ktJd6NEjzm/iAhFXFmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/credential-provider-env": "3.840.0",
+        "@aws-sdk/credential-provider-http": "3.840.0",
+        "@aws-sdk/credential-provider-process": "3.840.0",
+        "@aws-sdk/credential-provider-sso": "3.840.0",
+        "@aws-sdk/credential-provider-web-identity": "3.840.0",
+        "@aws-sdk/nested-clients": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.840.0.tgz",
+      "integrity": "sha512-KufP8JnxA31wxklLm63evUPSFApGcH8X86z3mv9SRbpCm5ycgWIGVCTXpTOdgq6rPZrwT9pftzv2/b4mV/9clg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.840.0",
+        "@aws-sdk/credential-provider-http": "3.840.0",
+        "@aws-sdk/credential-provider-ini": "3.840.0",
+        "@aws-sdk/credential-provider-process": "3.840.0",
+        "@aws-sdk/credential-provider-sso": "3.840.0",
+        "@aws-sdk/credential-provider-web-identity": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.840.0.tgz",
+      "integrity": "sha512-HkDQWHy8tCI4A0Ps2NVtuVYMv9cB4y/IuD/TdOsqeRIAT12h8jDb98BwQPNLAImAOwOWzZJ8Cu0xtSpX7CQhMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.840.0.tgz",
+      "integrity": "sha512-2qgdtdd6R0Z1y0KL8gzzwFUGmhBHSUx4zy85L2XV1CXhpRNwV71SVWJqLDVV5RVWVf9mg50Pm3AWrUC0xb0pcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.840.0",
+        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/token-providers": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.840.0.tgz",
+      "integrity": "sha512-dpEeVXG8uNZSmVXReE4WP0lwoioX2gstk4RnUgrdUE3YaPq8A+hJiVAyc3h+cjDeIqfbsQbZm9qFetKC2LF9dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/nested-clients": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.840.0.tgz",
+      "integrity": "sha512-ub+hXJAbAje94+Ya6c6eL7sYujoE8D4Bumu1NUI8TXjUhVVn0HzVWQjpRLshdLsUp1AW7XyeJaxyajRaJQ8+Xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.840.0.tgz",
+      "integrity": "sha512-lSV8FvjpdllpGaRspywss4CtXV8M7NNNH+2/j86vMH+YCOZ6fu2T/TyFd/tHwZ92vDfHctWkRbQxg0bagqwovA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.840.0.tgz",
+      "integrity": "sha512-Gu7lGDyfddyhIkj1Z1JtrY5NHb5+x/CRiB87GjaSrKxkDaydtX2CU977JIABtt69l9wLbcGDIQ+W0uJ5xPof7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.840.0.tgz",
+      "integrity": "sha512-hiiMf7BP5ZkAFAvWRcK67Mw/g55ar7OCrvrynC92hunx/xhMkrgSLM0EXIZ1oTn3uql9kH/qqGF0nqsK6K555A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.840.0",
+        "@smithy/core": "^3.6.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.840.0.tgz",
+      "integrity": "sha512-LXYYo9+n4hRqnRSIMXLBb+BLz+cEmjMtTudwK1BF6Bn2RfdDv29KuyeDRrPCS3TwKl7ZKmXUmE9n5UuHAPfBpA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.840.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.840.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.840.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.6.0",
+        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.13",
+        "@smithy/middleware-retry": "^4.1.14",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.5",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.21",
+        "@smithy/util-defaults-mode-node": "^4.0.21",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.840.0.tgz",
+      "integrity": "sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/token-providers": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.840.0.tgz",
+      "integrity": "sha512-6BuTOLTXvmgwjK7ve7aTg9JaWFdM5UoMolLVPMyh3wTv9Ufalh8oklxYHUBIxsKkBGO2WiHXytveuxH6tAgTYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.840.0",
+        "@aws-sdk/nested-clients": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/types": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
+      "integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.840.0.tgz",
+      "integrity": "sha512-eqE9ROdg/Kk0rj3poutyRCFauPDXIf/WSvCqFiRDDVi6QOnCv/M0g2XW8/jSvkJlOyaXkNCptapIp6BeeFFGYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-endpoints": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz",
+      "integrity": "sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.840.0.tgz",
+      "integrity": "sha512-Fy5JUEDQU1tPm2Yw/YqRYYc27W5+QD/J4mYvQvdWjUGZLB5q3eLFMGD35Uc28ZFoGMufPr4OCxK/bRfWROBRHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-sso": {
@@ -1278,7 +1743,6 @@
       "version": "3.821.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.821.0.tgz",
       "integrity": "sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -1308,7 +1772,6 @@
       "version": "3.804.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.804.0.tgz",
       "integrity": "sha512-zVoRfpmBVPodYlnMjgVjfGoEZagyRF5IPn3Uo6ZvOZp24chnW/FRstH7ESDHDDRga4z3V+ElUQHKpFDXWyBW5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1359,7 +1822,6 @@
       "version": "3.821.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.821.0.tgz",
       "integrity": "sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6277,7 +6739,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.4.tgz",
       "integrity": "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6291,7 +6752,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.4.tgz",
       "integrity": "sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
@@ -6305,10 +6765,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.5.1.tgz",
-      "integrity": "sha512-xSw7bZEFKwOKrm/iv8e2BLt2ur98YZdrRD6nII8ditQeUsY2Q1JmIQ0rpILOhaLKYxxG2ivnoOpokzr9qLyDWA==",
-      "dev": true,
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-Pgvfb+TQ4wUNLyHzvgCP4aYZMh16y7GcfF59oirRHcgGgkH1e/s9C0nv/v3WP+Quymyr5je71HeFQCwh+44XLg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.0.8",
@@ -6329,7 +6788,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz",
       "integrity": "sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
@@ -6346,7 +6804,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz",
       "integrity": "sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.2",
@@ -6363,7 +6820,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.4.tgz",
       "integrity": "sha512-qnbTPUhCVnCgBp4z4BUJUhOEkVwxiEi1cyFM+Zj6o+aY8OFGxUQleKWq8ltgp3dujuhXojIvJWdoqpm6dVO3lQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6379,7 +6835,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.4.tgz",
       "integrity": "sha512-bNYMi7WKTJHu0gn26wg8OscncTt1t2b8KcsZxvOv56XA6cyXtOAAAaNP7+m45xfppXfOatXF3Sb1MNsLUgVLTw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6393,7 +6848,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
       "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6428,7 +6882,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.4.tgz",
       "integrity": "sha512-F7gDyfI2BB1Kc+4M6rpuOLne5LOcEknH1n6UQB69qv+HucXBR1rkzXBnQTB2q46sFy1PM/zuSJOB532yc8bg3w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.2",
@@ -6440,13 +6893,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.9.tgz",
-      "integrity": "sha512-AjDgX4UjORLltD/LZCBQTwjQqEfyrx/GeDTHcYLzIgf87pIT70tMWnN87NQpJru1K4ITirY2htSOxNECZJCBOg==",
-      "dev": true,
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.13.tgz",
+      "integrity": "sha512-xg3EHV/Q5ZdAO5b0UiIMj3RIOCobuS40pBBODguUDVdko6YK6QIzCVRrHTogVuEKglBWqWenRnZ71iZnLL3ZAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.5.1",
+        "@smithy/core": "^3.6.0",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -6460,19 +6912,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.10.tgz",
-      "integrity": "sha512-RyhcA3sZIIvAo6r48b2Nx2qfg0OnyohlaV0fw415xrQyx5HQ2bvHl9vs/WBiDXIP49mCfws5wX4308c9Pi/isw==",
-      "dev": true,
+      "version": "4.1.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.14.tgz",
+      "integrity": "sha512-eoXaLlDGpKvdmvt+YBfRXE7HmIEtFF+DJCbTPwuLunP0YUnrydl+C4tS+vEM0+nyxXrX3PSUFqC+lP1+EHB1Tw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/service-error-classification": "^4.0.5",
-        "@smithy/smithy-client": "^4.4.1",
+        "@smithy/service-error-classification": "^4.0.6",
+        "@smithy/smithy-client": "^4.4.5",
         "@smithy/types": "^4.3.1",
         "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
+        "@smithy/util-retry": "^4.0.6",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -6484,7 +6935,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.8.tgz",
       "integrity": "sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.2",
@@ -6499,7 +6949,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.4.tgz",
       "integrity": "sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6513,7 +6962,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.3.tgz",
       "integrity": "sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.4",
@@ -6529,7 +6977,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz",
       "integrity": "sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.0.4",
@@ -6546,7 +6993,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.4.tgz",
       "integrity": "sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6560,7 +7006,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.2.tgz",
       "integrity": "sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6574,7 +7019,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.4.tgz",
       "integrity": "sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6589,7 +7033,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz",
       "integrity": "sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6600,10 +7043,9 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.5.tgz",
-      "integrity": "sha512-LvcfhrnCBvCmTee81pRlh1F39yTS/+kYleVeLCwNtkY8wtGg8V/ca9rbZZvYIl8OjlMtL6KIjaiL/lgVqHD2nA==",
-      "dev": true,
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.6.tgz",
+      "integrity": "sha512-RRoTDL//7xi4tn5FrN2NzH17jbgmnKidUqd4KvquT0954/i6CXXkh1884jBiunq24g9cGtPBEXlU40W6EpNOOg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1"
@@ -6616,7 +7058,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz",
       "integrity": "sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6630,7 +7071,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.2.tgz",
       "integrity": "sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
@@ -6647,14 +7087,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.1.tgz",
-      "integrity": "sha512-XPbcHRfd0iwx8dY5XCBCGyI7uweMW0oezYezxXcG8ANgvZ5YPuC6Ylh+n0bTHpdU3SCMZOnhzgVklYz+p3fIhw==",
-      "dev": true,
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.5.tgz",
+      "integrity": "sha512-+lynZjGuUFJaMdDYSTMnP/uPBBXXukVfrJlP+1U/Dp5SFTEI++w6NMga8DjOENxecOF71V9Z2DllaVDYRnGlkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.5.1",
-        "@smithy/middleware-endpoint": "^4.1.9",
+        "@smithy/core": "^3.6.0",
+        "@smithy/middleware-endpoint": "^4.1.13",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
@@ -6669,7 +7108,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
       "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6682,7 +7120,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.4.tgz",
       "integrity": "sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/querystring-parser": "^4.0.4",
@@ -6697,7 +7134,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
       "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
@@ -6712,7 +7148,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
       "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6725,7 +7160,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
       "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6738,7 +7172,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
       "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
@@ -6752,7 +7185,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
       "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6762,14 +7194,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.17.tgz",
-      "integrity": "sha512-HXq5181qnXmIwB7VrwqwP8rsJybHMoYuJnNoXy4PROs2pfSI4sWDMASF2i+7Lo+u64Y6xowhegcdxczowgJtZg==",
-      "dev": true,
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.21.tgz",
+      "integrity": "sha512-wM0jhTytgXu3wzJoIqpbBAG5U6BwiubZ6QKzSbP7/VbmF1v96xlAbX2Am/mz0Zep0NLvLh84JT0tuZnk3wmYQA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.1",
+        "@smithy/smithy-client": "^4.4.5",
         "@smithy/types": "^4.3.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -6779,17 +7210,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.17.tgz",
-      "integrity": "sha512-RfU2A5LjFhEHw4Nwl1GZNitK4AUWu5jGtigAUDoQtfDUvYHpQxcuLw2QGAdKDtKRflIiHSZ8wXBDR36H9R2Ang==",
-      "dev": true,
+      "version": "4.0.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.21.tgz",
+      "integrity": "sha512-/F34zkoU0GzpUgLJydHY8Rxu9lBn8xQC/s/0M0U9lLBkYbA1htaAFjWYJzpzsbXPuri5D1H8gjp2jBum05qBrA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.1.4",
         "@smithy/credential-provider-imds": "^4.0.6",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.1",
+        "@smithy/smithy-client": "^4.4.5",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
@@ -6801,7 +7231,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.6.tgz",
       "integrity": "sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
@@ -6816,7 +7245,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
       "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6829,7 +7257,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.4.tgz",
       "integrity": "sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
@@ -6840,13 +7267,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.5.tgz",
-      "integrity": "sha512-V7MSjVDTlEt/plmOFBn1762Dyu5uqMrV2Pl2X0dYk4XvWfdWJNe9Bs5Bzb56wkCuiWjSfClVMGcsuKrGj7S/yg==",
-      "dev": true,
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.6.tgz",
+      "integrity": "sha512-+YekoF2CaSMv6zKrA6iI/N9yva3Gzn4L6n35Luydweu5MMPYpiGZlWqehPHDHyNbnyaYlz/WJyYAZnC+loBDZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.5",
+        "@smithy/service-error-classification": "^4.0.6",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
@@ -6858,7 +7284,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.2.tgz",
       "integrity": "sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.0.4",
@@ -6878,7 +7303,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
       "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6891,7 +7315,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
       "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
@@ -8055,6 +8478,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -9632,7 +10061,6 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -12411,7 +12839,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
       "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19421,7 +19848,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
       "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@apollo/server": "^4.12.2",
     "@as-integrations/aws-lambda": "^3.1.0",
+    "@aws-sdk/client-secrets-manager": "^3.840.0",
     "@prisma/client": "^6.7.0",
     "graphql-scalars": "^1.24.2",
     "jsonwebtoken": "^9.0.2",

--- a/server/src/model/demonstrationStatus/demonstrationStatusSchema.ts
+++ b/server/src/model/demonstrationStatus/demonstrationStatusSchema.ts
@@ -1,4 +1,5 @@
 import { gql } from "graphql-tag";
+import { Demonstration } from "../demonstration/demonstrationSchema.js";
 
 export const demonstrationStatusSchema = gql`
   type DemonstrationStatus {
@@ -7,7 +8,7 @@ export const demonstrationStatusSchema = gql`
     description: String!
     createdAt: DateTime!
     updatedAt: DateTime!
-    demonstrationIds: [ID!]
+    demonstrations: [Demonstration!]!
   }
 
   input AddDemonstrationStatusInput {
@@ -45,7 +46,7 @@ export interface DemonstrationStatus {
   description: string;
   createdAt: DateTime;
   updatedAt: DateTime;
-  demonstrationIds?: string[];
+  demonstrations: Demonstration[];
 }
 
 export interface AddDemonstrationStatusInput {

--- a/server/src/model/state/stateSchema.ts
+++ b/server/src/model/state/stateSchema.ts
@@ -1,10 +1,14 @@
 import { gql } from "graphql-tag";
+import { Demonstration } from "../demonstration/demonstrationSchema.js";
+import { User } from "../user/userSchema.js";
 
 export const stateSchema = gql`
   type State {
     id: ID!
     stateCode: String!
     stateName: String!
+    users: [User!]!
+    demonstrations: [Demonstration!]!
   }
 
   input AddStateInput {
@@ -37,6 +41,8 @@ export interface State {
   id: string;
   stateCode: string;
   stateName: string;
+  users: User[];
+  demonstrations: Demonstration[];
 }
 
 export interface AddStateInput {

--- a/server/src/model/user/userSchema.ts
+++ b/server/src/model/user/userSchema.ts
@@ -1,5 +1,7 @@
 import { gql } from "graphql-tag";
+import { State } from "../state/stateSchema.js";
 import { Role } from "../role/roleSchema.js";
+import { Demonstration } from "../demonstration/demonstrationSchema.js";
 
 export const userSchema = gql`
   type User {
@@ -11,7 +13,9 @@ export const userSchema = gql`
     displayName: String!
     createdAt: DateTime!
     updatedAt: DateTime!
+    states: [State!]!
     roles: [Role!]!
+    demonstrations: [Demonstration!]!
   }
 
   input AddUserInput {
@@ -58,7 +62,9 @@ export interface User {
   displayName: string;
   createdAt: DateTime;
   updatedAt: DateTime;
+  states: State[];
   roles: Role[];
+  demonstrations: Demonstration[];
 }
 
 export interface AddUserInput {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,14 +7,21 @@ import { typeDefs, resolvers } from "./model/graphql.js";
 import {
     getCognitoUserInfoForLambda,
     getUserRoles,
+    getDatabaseUrl
 } from "./auth/auth.util.js";
 
+const databaseUrlPromise = getDatabaseUrl().then(url => {
+    process.env.DATABASE_URL = url;
+    return url;
+}).catch(error => {
+    console.error("Failed to get database URL:", error);
+    throw error;
+});
 
 const server = new ApolloServer<BaseContext>({
     typeDefs,
     resolvers
 });
-
 
 export const graphqlHandler = startServerAndCreateLambdaHandler(
     server,
@@ -22,6 +29,8 @@ export const graphqlHandler = startServerAndCreateLambdaHandler(
     {
         context: async ({ event, context }) => {
             // Add any shared context here, e.g., user authentication
+            await databaseUrlPromise;
+
             const { sub, email } = await getCognitoUserInfoForLambda(event.headers);
             const roles = await getUserRoles(sub);
             return {


### PR DESCRIPTION
This PR is essentially two features in one: updating our local development environment to use `localstack` for the server, and adding support to the server Lambda to get the authentication details from SecretsManager and use them to talk to the database. I'm writing a bit more here just for context.

# Devcontainer Changes

This changes the devcontainer setup in a few ways.

- Installs the `awscli` package, which is used by the `localstack` setup.
- Removes port forwarding from the actual devcontainer setup and moves it to the Docker compose.
- Adds a proper post-create script, needed for AWS configuration. In that script, we set up the `awscli` profile for `localstack` and alias the `aws` command to include the endpoint (for some reason, none of the other ways of setting that up are honored).
- Adds a setting regarding auto forwarding of ports to the devcontainer. This just makes the VSCode interface less cluttered with extra ports added.

# Localstack Implementation

Localstack is set up using the script `server/localstack/localstack.sh`. Most of this is pretty straightforward configuration of the `localstack` environment.

- It checks to see if the deployment bucket, the Lambda function, the API Gateway, and the secret exist, and if they do, it drops them and recreates them.
- Note that in the build process, it is necessary to grab both the minified JSON file, _and_ the binaries used by Prisma; these do not exist in the Lambda runtime, and so that is the reason to grab them from the `server/node_modules/.prisma/client` folder.

When running `localstack.sh`, the last thing output is the URL of the API endpoint. Putting this into Bruno or something similar will allow access to run queries. Note that if you were using it from _inside_ the `app` machine, you would want to make the URL `localstack`.

# Lambda Implementation

The changes to the server code add a new function to retrieve a secret from SecretsManager, and then modify the Lambda to set the `DATABASE_URL` environment variable.

Note that at the time of Lambda startup, Prisma will be unhappy if there is not _some_ value of `DATABASE_URL` set - this is why the `localstack.sh` file sets it to `postgres://placeholder`. Note also that Prisma will be unhappy if the value doesn't start with `postgres://` which is why the version above is used.

The function that retrieves the secret performs very basic caching of the secret with a 1-hour timeout. This will only be necessary if the Lambda context is reused, where it will decrease the amount of calls to SecretsManager that we'll need to make. We may want to think about what will happen when secrets rotate, as a cached value could remain incorrect for up to an hour depending.

In the Lambda, the `getDatabaseUrl` function is used to create the `databaseUrlPromise` which basically just sets the `DATABASE_URL` environment variable. Arguably, there's no need to return the `url` value there in the anonymous function on Line 15 - not sure if we want to remove that or not. Then, we just await the `databaseUrlPromise` in the Lambda setup.

# Other Changes

The changes to these three files revert a previous change which had broken the server from working. This still needs attention per comments from @connor-parke-icf, but just was not in scope for this ticket.

- `server/src/model/demonstrationStatus/demonstrationStatusSchema.ts`
- `server/src/model/state/stateSchema.ts`
- `server/src/model/user/userSchema.ts`