### PR TITLE
DEMOS-481: Rename CfnOutputs to include stage name

### DIFF
--- a/deployment/build.js
+++ b/deployment/build.js
@@ -93,10 +93,10 @@ async function buildClient(environment) {
     cwd: clientPath,
     env: {
       ...process.env,
-      VITE_COGNITO_AUTHORITY: coreOutputData[`demos-${environment}-core`].cognitoAuthority,
-      VITE_COGNITO_DOMAIN: coreOutputData[`demos-${environment}-core`].cognitoDomain,
-      VITE_COGNITO_CLIENT_ID: coreOutputData[`demos-${environment}-core`].cognitoClientId,
-      VITE_BASE_URL: coreOutputData[`demos-${environment}-core`].baseUrl,
+      VITE_COGNITO_AUTHORITY: coreOutputData[`demos-${environment}-core`][`${environment}CognitoAuthority`],
+      VITE_COGNITO_DOMAIN: coreOutputData[`demos-${environment}-core`][`${environment}CognitoDomain`],
+      VITE_COGNITO_CLIENT_ID: coreOutputData[`demos-${environment}-core`][`${environment}CognitoClientId`],
+      VITE_BASE_URL: coreOutputData[`demos-${environment}-core`][`${environment}BaseUrl`],
       VITE_API_URL_PREFIX: "/api/graphql",
     },
   });

--- a/deployment/stacks/api.ts
+++ b/deployment/stacks/api.ts
@@ -115,6 +115,7 @@ export class ApiStack extends Stack {
 
     new CfnOutput(this, "ApiUrl", {
       value: apigateway_outputs.apiGatewayRestApiUrl,
+      exportName: `${commonProps.stage}ApiGWUrl`
     });
   }
 }

--- a/deployment/stacks/core.ts
+++ b/deployment/stacks/core.ts
@@ -105,17 +105,17 @@ export class CoreStack extends Stack {
 
     new CfnOutput(this, "cognitoAuthority", {
       value: cognito_outputs.authority,
-      exportName: "cognitoAuthority",
+      exportName: `${commonProps.stage}CognitoAuthority`,
     });
 
     new CfnOutput(this, "cognitoDomain", {
       value: cognito_outputs.domain,
-      exportName: "cognitoDomain"
+      exportName: `${commonProps.stage}CognitoDomain`
     })
 
     new CfnOutput(this, "cognitoClientId", {
       value: cognito_outputs.userPoolClientId,
-      exportName: "cognitoClientId"
+      exportName: `${commonProps.stage}CognitoClientId`
     })
 
     this.cloudVpnSecurityGroup = aws_ec2.SecurityGroup.fromLookupByName(

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -232,7 +232,7 @@ export class UiStack extends Stack {
 
     new CfnOutput(this, "Cloudfront URL", {
       value: applicationEndpointUrl,
-      exportName: "cloudfrontUrl",
+      exportName: `${commonProps.stage}CloudfrontUrl`,
     });
   }
 }


### PR DESCRIPTION
This avoids conflicts between multiple environments in the same account.

None of these outputs are currently used by the CDK code, so there are no conflicts to work through