### PR TITLE
Demos 303 - Add project officer to demonstrations and fix a few gql bugs

### DIFF
--- a/server/src/model/demonstration/demonstration.prisma
+++ b/server/src/model/demonstration/demonstration.prisma
@@ -11,6 +11,7 @@ model Demonstration {
   state                     State                    @relation(fields: [stateId], references: [id])
   stateId                   String                   @map("state_id") @db.Uuid
   userStateDemonstrations   UserStateDemonstration[]
+  projectOfficer            String                   @map("project_officer_user_id") @db.Uuid
 
   @@map("demonstration")
 }

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -34,13 +34,13 @@ export const demonstrationResolvers = {
           },
           ...(userIds &&
             stateId && {
-              userStateDemonstrations: {
-                create: userIds.map((userId: string) => ({
-                  userId,
-                  stateId,
-                })),
-              },
-            }),
+            userStateDemonstrations: {
+              create: userIds.map((userId: string) => ({
+                userId,
+                stateId,
+              })),
+            },
+          }),
         },
       });
     },
@@ -49,7 +49,7 @@ export const demonstrationResolvers = {
       _: undefined,
       { id, input }: { id: string; input: UpdateDemonstrationInput },
     ) => {
-      const { demonstrationStatusId, userIds, stateId, ...rest } = input;      
+      const { demonstrationStatusId, userIds, stateId, ...rest } = input;
 
       // If stateId is not provided, use the demonstration's existing stateId
       let existingStateId = stateId;
@@ -78,18 +78,18 @@ export const demonstrationResolvers = {
           }),
           ...(userIds &&
             existingStateId && {
-              userStateDemonstrations: {
-                create: userIds.map((userId: string) => ({
-                  userId,
-                  stateId: existingStateId,
-                })),
-              },
-            }),
+            userStateDemonstrations: {
+              create: userIds.map((userId: string) => ({
+                userId,
+                stateId: existingStateId,
+              })),
+            },
+          }),
         },
       });
     },
 
-    deleteDemonstration: async (_: undefined, { id }: { id: string }) => {      
+    deleteDemonstration: async (_: undefined, { id }: { id: string }) => {
       return await prisma.demonstration.delete({
         where: { id: id },
       });
@@ -127,7 +127,7 @@ export const demonstrationResolvers = {
       );
     },
 
-    projectOfficer: async (parent: Demonstration) => {            
+    projectOfficer: async (parent: Demonstration) => {
       if (!parent) return null;
       return await prisma.user.findUnique({
         where: { id: parent.projectOfficer },

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -1,4 +1,4 @@
-import { Demonstration } from "@prisma/client";
+import { Demonstration, User } from "@prisma/client";
 import { prisma } from "../../prismaClient.js";
 import {
   AddDemonstrationInput,
@@ -121,6 +121,13 @@ export const demonstrationResolvers = {
       return userStateDemonstrations.map(
         (userStateDemonstration) => userStateDemonstration.user,
       );
+    },
+
+    projectOfficer: async (parent: User) => {            
+      if (!parent) return null;
+      return await prisma.user.findUnique({
+        where: { id: parent.id },
+      });
     },
   },
 };

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -49,7 +49,7 @@ export const demonstrationResolvers = {
       _: undefined,
       { id, input }: { id: string; input: UpdateDemonstrationInput },
     ) => {
-      const { demonstrationStatusId, userIds, stateId, ...rest } = input;
+      const { demonstrationStatusId, userIds, stateId, ...rest } = input;      
 
       // If stateId is not provided, use the demonstration's existing stateId
       let existingStateId = stateId;
@@ -89,7 +89,7 @@ export const demonstrationResolvers = {
       });
     },
 
-    deleteDemonstration: async (_: undefined, { id }: { id: string }) => {
+    deleteDemonstration: async (_: undefined, { id }: { id: string }) => {      
       return await prisma.demonstration.delete({
         where: { id: id },
       });
@@ -118,15 +118,19 @@ export const demonstrationResolvers = {
           },
         });
 
+      interface UserStateDemonstrationWithUser {
+        user: User;
+      }
+
       return userStateDemonstrations.map(
-        (userStateDemonstration) => userStateDemonstration.user,
+        (userStateDemonstration: UserStateDemonstrationWithUser) => userStateDemonstration.user,
       );
     },
 
-    projectOfficer: async (parent: User) => {            
+    projectOfficer: async (parent: Demonstration) => {            
       if (!parent) return null;
       return await prisma.user.findUnique({
-        where: { id: parent.id },
+        where: { id: parent.projectOfficer },
       });
     },
   },

--- a/server/src/model/demonstration/demonstrationSchema.ts
+++ b/server/src/model/demonstration/demonstrationSchema.ts
@@ -15,6 +15,7 @@ export const demonstrationSchema = gql`
     demonstrationStatus: DemonstrationStatus!
     state: State!
     users: [User!]!
+    projectOfficer: User!
   }
 
   input AddDemonstrationInput {
@@ -25,6 +26,7 @@ export const demonstrationSchema = gql`
     demonstrationStatusId: ID!
     stateId: ID!
     userIds: [ID!]
+    projectOfficer: String!
   }
 
   input UpdateDemonstrationInput {
@@ -35,6 +37,7 @@ export const demonstrationSchema = gql`
     demonstrationStatusId: ID
     stateId: ID
     userIds: [ID!]
+    projectOfficer: String
   }
 
   type Mutation {
@@ -61,6 +64,7 @@ export interface Demonstration {
   demonstrationStatus: DemonstrationStatus;
   state: State;
   users: User[];
+  projectOfficer: User;
 }
 
 export interface AddDemonstrationInput {
@@ -71,6 +75,7 @@ export interface AddDemonstrationInput {
   demonstrationStatusId: string;
   stateId: string;
   userIds?: string[];
+  projectOfficer: string; 
 }
 
 export interface UpdateDemonstrationInput {
@@ -81,4 +86,5 @@ export interface UpdateDemonstrationInput {
   demonstrationStatusId?: string;
   stateId?: string;
   userIds?: string[];
+  projectOfficer?: string; 
 }

--- a/server/src/model/demonstration/demonstrationSchema.ts
+++ b/server/src/model/demonstration/demonstrationSchema.ts
@@ -42,7 +42,7 @@ export const demonstrationSchema = gql`
 
   type Mutation {
     addDemonstration(input: AddDemonstrationInput!): Demonstration
-    updateDemonstration(input: UpdateDemonstrationInput!): Demonstration
+    updateDemonstration(id: ID!, input: UpdateDemonstrationInput!): Demonstration
     deleteDemonstration(id: ID!): Demonstration
   }
 

--- a/server/src/model/migrations/20250623155458_init_baseline/migration.sql
+++ b/server/src/model/migrations/20250623155458_init_baseline/migration.sql
@@ -90,6 +90,7 @@ CREATE TABLE "demonstration" (
     "updated_at" TIMESTAMPTZ NOT NULL,
     "demonstration_status_id" UUID NOT NULL,
     "state_id" UUID NOT NULL,
+    "project_officer_user_id" UUID NOT NULL,
 
     CONSTRAINT "demonstration_pkey" PRIMARY KEY ("id")
 );
@@ -108,6 +109,7 @@ CREATE TABLE "demonstration_history" (
     "updated_at" TIMESTAMPTZ NOT NULL,
     "demonstration_status_id" UUID NOT NULL,
     "state_id" UUID NOT NULL,
+    "project_officer_user_id" UUID NOT NULL,
 
     CONSTRAINT "demonstration_history_pkey" PRIMARY KEY ("revision_id")
 );
@@ -274,3 +276,9 @@ ALTER TABLE "demonstration" ADD CONSTRAINT "demonstration_demonstration_status_i
 
 -- AddForeignKey
 ALTER TABLE "demonstration" ADD CONSTRAINT "demonstration_state_id_fkey" FOREIGN KEY ("state_id") REFERENCES "state"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "demonstration" ADD CONSTRAINT "demonstration_project_officer_user_id_fkey" FOREIGN KEY ("project_officer_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "demonstration_history" ADD CONSTRAINT "demonstration_history_project_officer_id_fkey" FOREIGN KEY ("project_officer_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/src/model/migrations/20250623155513_add_history_triggers/migration.sql
+++ b/server/src/model/migrations/20250623155513_add_history_triggers/migration.sql
@@ -172,7 +172,8 @@ BEGIN
             created_at,
             updated_at,
             demonstration_status_id,
-            state_id
+            state_id,
+            project_officer_user_id
         )
         VALUES (
             CASE TG_OP
@@ -187,7 +188,8 @@ BEGIN
             NEW.created_at,
             NEW.updated_at,
             NEW.demonstration_status_id,
-            NEW.state_id
+            NEW.state_id,
+            NEW.project_officer_user_id
         );
         RETURN NEW;
     ELSIF TG_OP = 'DELETE' THEN
@@ -201,7 +203,8 @@ BEGIN
             created_at,
             updated_at,
             demonstration_status_id,
-            state_id
+            state_id,
+            project_officer_user_id
         )
         VALUES (
             'D'::demos_app.revision_type_enum,
@@ -213,7 +216,8 @@ BEGIN
             OLD.created_at,
             OLD.updated_at,
             OLD.demonstration_status_id,
-            OLD.state_id
+            OLD.state_id,
+            OLD.project_officer_user_id
         );
         RETURN OLD;
     END IF;

--- a/server/src/seeder.ts
+++ b/server/src/seeder.ts
@@ -107,6 +107,7 @@ async function seedDatabase() {
         evaluationPeriodEndDate: faker.date.future({ years: 1 }),
         demonstrationStatusId: (await prisma.demonstrationStatus.findRandom())!.id,
         stateId: (await prisma.state.findRandom())!.id,
+        projectOfficer: (await prisma.user.findRandom())!.id,
       },
     });
   }


### PR DESCRIPTION
This PR adds a project officer to the demonstration.  Also fixes a missing arg (id) in the update demonstration mutation.

Tested with the following operations:
```
query ExampleQuery {
  demonstrations {
    projectOfficer {
      id
      username
      email
      fullName
      displayName
 
    }
    id
    name
    createdAt
    demonstrationStatus {
      id
    }
    users {
      id
      username
    }
  }  
}

query ExampleQuery($updateDemonstrationId: ID!) {
  demonstration(id: $updateDemonstrationId) {
    projectOfficer {
      id
      username
      email
      fullName
      displayName
 
    }
    id
    name  
  }
  }

mutation DeleteDemonstration($deleteDemonstrationId: ID!) {
  deleteDemonstration(id: $deleteDemonstrationId) {
    id
  }
}


mutation AddDemonstration($addDemonstrationInput2: AddDemonstrationInput!) {
  addDemonstration(input: $addDemonstrationInput2) {
    id
  }
}

mutation UpdateDemonstration($updateDemonstrationId: ID!, $input: UpdateDemonstrationInput!) {
  updateDemonstration(id: $updateDemonstrationId, input: $input) {
    id
  }
}
```

With the variables 
```
{
  "deleteDemonstrationId": "91537ca2-4084-4e5d-ab40-8ad5cf7bba80",
  "updateDemonstrationId":"d09cfc3f-b4ac-4d83-8b9e-a64e0e45c24f",
  "input": {    
    "projectOfficer": "6e112013-8756-4af5-a665-d5835f238d09"
  },
  "addDemonstrationInput2": {
    "name": "James Test",
    "description": "test",
    "evaluationPeriodStartDate":"2025-07-07T17:51:44.415Z",
    "evaluationPeriodEndDate": "2025-07-07T17:51:44.415Z",
    "demonstrationStatusId": "9eda8b7c-893a-40d5-9f52-ac0e0215cba0",
    "stateId": "7632bac4-f98b-4310-9074-b62871e8fd47",
    "userIds": ["9d025caa-703f-4a04-b498-0db8a7aa87f5"],
    "projectOfficer": "9d025caa-703f-4a04-b498-0db8a7aa87f5"
  }
}
```
(you will need to update uuid's from your seed)

