### PR TITLE
Demos-503: Add non-prod private hosted zones

### DIFF
--- a/deployment/app.ts
+++ b/deployment/app.ts
@@ -60,6 +60,10 @@ async function main() {
   if (stage == "bootstrap") {
     new BootstrapStack(app, `${config.project}-${stage}`, {
       ...config,
+      env: {
+        account: process.env.CDK_DEFAULT_ACCOUNT,
+        region: process.env.CDK_DEFAULT_REGION,
+      },
     });
     return;
   }


### PR DESCRIPTION
There are 2 changes here:

1. This adds the private hosted zones for all non-prod environments. These will be synced with CMS Infoblox so that they can be resolved while on ZScaler. Since these will never change and will likely be shared between main and ephemeral environments, I put them in the bootstrap stack that is only run at the account level
2. There is another change included for a Jenkins role. This is the role assumed by the Jenkins pipelines and has been in use, but the changes were never pr'd