### PR TITLE
task/fix-project-officer-addition

### DIFF
--- a/data/utilities/scripts/history_trigger_generator.py
+++ b/data/utilities/scripts/history_trigger_generator.py
@@ -153,18 +153,18 @@ def get_prisma_lines(folder: str) -> List[str]:
     return prisma_lines
 
 
-def main(migration: str) -> None:
+def main(migration: str, folders: List[str] = TBL_FOLDERS) -> None:
     """Execute main program function.
 
     Args:
         migration (str): The migration folder where the SQL should be placed.
     """
     queries = []
-    for x in TBL_FOLDERS:
+    for x in folders:
         prisma_lines = get_prisma_lines(x)
         queries.append(get_trigger_code(prisma_lines) + "\n\n")
 
-    with open(f"../../../server/src/model/migrations/{migration}/migration.sql", "w") as query_file:
+    with open(f"../../../server/src/model/migrations/{migration}/migration.sql", "a") as query_file:
         query_file.writelines(queries)
 
 
@@ -173,5 +173,12 @@ if __name__ == "__main__":
         description="Generate history table triggers from models in the server folder."
     )
     parser.add_argument("migration", help="The migration folder where the output should be written.")
+    parser.add_argument(
+        "-m",
+        "--models",
+        nargs="+",
+        choices=TBL_FOLDERS,
+        help="A list of models to process, which must be found in TBL_FOLDERS."
+    )
     args = parser.parse_args()
-    main(args.migration)
+    main(args.migration, args.models if args.models is not None else TBL_FOLDERS)

--- a/server/src/model/_rolePermission/rolePermissionHistory.prisma
+++ b/server/src/model/_rolePermission/rolePermissionHistory.prisma
@@ -1,5 +1,5 @@
 model RolePermissionHistory {
-  revisionId   Int          @id @map("revision_id") @default(autoincrement())
+  revisionId   Int          @id @default(autoincrement()) @map("revision_id")
   revisionType RevisionType @map("revision_type")
   modifiedAt   DateTime     @default(now()) @map("modified_at") @db.Timestamptz()
   roleId       String       @map("role_id") @db.Uuid

--- a/server/src/model/_userRole/userRoleHistory.prisma
+++ b/server/src/model/_userRole/userRoleHistory.prisma
@@ -1,5 +1,5 @@
 model UserRoleHistory {
-  revisionId   Int          @id @map("revision_id") @default(autoincrement())
+  revisionId   Int          @id @default(autoincrement()) @map("revision_id")
   revisionType RevisionType @map("revision_type")
   modifiedAt   DateTime     @default(now()) @map("modified_at") @db.Timestamptz()
   userId       String       @map("user_id") @db.Uuid

--- a/server/src/model/_userState/userStateHistory.prisma
+++ b/server/src/model/_userState/userStateHistory.prisma
@@ -1,5 +1,5 @@
 model UserStateHistory {
-  revisionId   Int          @id @map("revision_id") @default(autoincrement())
+  revisionId   Int          @id @default(autoincrement()) @map("revision_id")
   revisionType RevisionType @map("revision_type")
   modifiedAt   DateTime     @default(now()) @map("modified_at") @db.Timestamptz()
   userId       String       @map("user_id") @db.Uuid

--- a/server/src/model/_userStateDemonstration/userStateDemonstration.prisma
+++ b/server/src/model/_userStateDemonstration/userStateDemonstration.prisma
@@ -1,10 +1,11 @@
 model UserStateDemonstration {
-  userState       UserState     @relation(fields: [userId, stateId], references: [userId, stateId])
-  user            User          @relation(fields: [userId], references: [id])
-  userId          String        @map("user_id") @db.Uuid
-  stateId         String        @map("state_id") @db.Uuid
-  demonstration   Demonstration @relation(fields: [demonstrationId], references: [id])
-  demonstrationId String        @map("demonstration_id") @db.Uuid
+  userId          String @map("user_id") @db.Uuid
+  stateId         String @map("state_id") @db.Uuid
+  demonstrationId String @map("demonstration_id") @db.Uuid
+
+  user               User          @relation(fields: [userId], references: [id])
+  userState          UserState     @relation(fields: [userId, stateId], references: [userId, stateId])
+  demonstrationState Demonstration @relation(fields: [demonstrationId, stateId], references: [id, stateId])
 
   @@id([userId, stateId, demonstrationId])
   @@map("user_state_demonstration")

--- a/server/src/model/_userStateDemonstration/userStateDemonstration.prisma
+++ b/server/src/model/_userStateDemonstration/userStateDemonstration.prisma
@@ -5,7 +5,7 @@ model UserStateDemonstration {
 
   user               User          @relation(fields: [userId], references: [id])
   userState          UserState     @relation(fields: [userId, stateId], references: [userId, stateId])
-  demonstrationState Demonstration @relation(fields: [demonstrationId, stateId], references: [id, stateId])
+  demonstration      Demonstration @relation(fields: [demonstrationId, stateId], references: [id, stateId])
 
   @@id([userId, stateId, demonstrationId])
   @@map("user_state_demonstration")

--- a/server/src/model/_userStateDemonstration/userStateDemonstrationHistory.prisma
+++ b/server/src/model/_userStateDemonstration/userStateDemonstrationHistory.prisma
@@ -1,5 +1,5 @@
 model UserStateDemonstrationHistory {
-  revisionId      Int          @id @map("revision_id") @default(autoincrement())
+  revisionId      Int          @id @default(autoincrement()) @map("revision_id")
   revisionType    RevisionType @map("revision_type")
   modifiedAt      DateTime     @default(now()) @map("modified_at") @db.Timestamptz()
   userId          String       @map("user_id") @db.Uuid

--- a/server/src/model/demonstration/demonstration.prisma
+++ b/server/src/model/demonstration/demonstration.prisma
@@ -1,17 +1,20 @@
 model Demonstration {
-  id                        String                   @id @default(uuid()) @db.Uuid
+  id                        String   @id @default(uuid()) @db.Uuid
   name                      String
   description               String
-  evaluationPeriodStartDate DateTime                 @map("evaluation_period_start_date") @db.Date
-  evaluationPeriodEndDate   DateTime                 @map("evaluation_period_end_date") @db.Date
-  createdAt                 DateTime                 @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt                 DateTime                 @updatedAt @map("updated_at") @db.Timestamptz()
-  demonstrationStatus       DemonstrationStatus      @relation(fields: [demonstrationStatusId], references: [id])
-  demonstrationStatusId     String                   @map("demonstration_status_id") @db.Uuid
-  state                     State                    @relation(fields: [stateId], references: [id])
-  stateId                   String                   @map("state_id") @db.Uuid
-  userStateDemonstrations   UserStateDemonstration[]
-  projectOfficer            String                   @map("project_officer_user_id") @db.Uuid
+  evaluationPeriodStartDate DateTime @map("evaluation_period_start_date") @db.Date
+  evaluationPeriodEndDate   DateTime @map("evaluation_period_end_date") @db.Date
+  createdAt                 DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt                 DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+  demonstrationStatusId     String   @map("demonstration_status_id") @db.Uuid
+  stateId                   String   @map("state_id") @db.Uuid
+  projectOfficerUserId      String   @map("project_officer_user_id") @db.Uuid
 
+  demonstrationStatus     DemonstrationStatus      @relation(fields: [demonstrationStatusId], references: [id])
+  state                   State                    @relation(fields: [stateId], references: [id])
+  projectOfficer          User                     @relation(fields: [projectOfficerUserId], references: [id])
+  userStateDemonstrations UserStateDemonstration[]
+
+  @@unique([id, stateId])
   @@map("demonstration")
 }

--- a/server/src/model/demonstration/demonstrationHistory.prisma
+++ b/server/src/model/demonstration/demonstrationHistory.prisma
@@ -1,5 +1,5 @@
 model DemonstrationHistory {
-  revisionId                Int          @id @map("revision_id") @default(autoincrement())
+  revisionId                Int          @id @default(autoincrement()) @map("revision_id")
   revisionType              RevisionType @map("revision_type")
   modifiedAt                DateTime     @default(now()) @map("modified_at") @db.Timestamptz()
   id                        String       @db.Uuid
@@ -11,6 +11,7 @@ model DemonstrationHistory {
   updatedAt                 DateTime     @map("updated_at") @db.Timestamptz()
   demonstrationStatusId     String       @map("demonstration_status_id") @db.Uuid
   stateId                   String       @map("state_id") @db.Uuid
+  projectOfficerUserId      String       @map("project_officer_user_id") @db.Uuid
 
   @@map("demonstration_history")
 }

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -22,7 +22,7 @@ export const demonstrationResolvers = {
       _: undefined,
       { input }: { input: AddDemonstrationInput },
     ) => {
-      const { demonstrationStatusId, stateId, userIds, ...rest } = input;
+      const { demonstrationStatusId, stateId, userIds, projectOfficerUserId, ...rest } = input;
       return await prisma().demonstration.create({
         data: {
           ...rest,
@@ -41,6 +41,9 @@ export const demonstrationResolvers = {
               })),
             },
           }),
+          projectOfficer: {
+            connect: { id: projectOfficerUserId },
+          },
         },
       });
     },
@@ -49,7 +52,7 @@ export const demonstrationResolvers = {
       _: undefined,
       { id, input }: { id: string; input: UpdateDemonstrationInput },
     ) => {
-      const { demonstrationStatusId, userIds, stateId, ...rest } = input;
+      const { demonstrationStatusId, userIds, stateId, projectOfficerUserId, ...rest } = input;
 
       // If stateId is not provided, use the demonstration's existing stateId
       let existingStateId = stateId;
@@ -83,6 +86,11 @@ export const demonstrationResolvers = {
                 userId,
                 stateId: existingStateId,
               })),
+            },
+          }),
+          ...(projectOfficerUserId && {
+            projectOfficer: {
+              connect: { id: projectOfficerUserId },
             },
           }),
         },
@@ -130,7 +138,7 @@ export const demonstrationResolvers = {
     projectOfficer: async (parent: Demonstration) => {
       if (!parent) return null;
       return await prisma().user.findUnique({
-        where: { id: parent.projectOfficer },
+        where: { id: parent.projectOfficerUserId },
       });
     },
   },

--- a/server/src/model/demonstration/demonstrationSchema.ts
+++ b/server/src/model/demonstration/demonstrationSchema.ts
@@ -26,7 +26,7 @@ export const demonstrationSchema = gql`
     demonstrationStatusId: ID!
     stateId: ID!
     userIds: [ID!]
-    projectOfficer: String!
+    projectOfficerUserId: String!
   }
 
   input UpdateDemonstrationInput {
@@ -37,7 +37,7 @@ export const demonstrationSchema = gql`
     demonstrationStatusId: ID
     stateId: ID
     userIds: [ID!]
-    projectOfficer: String
+    projectOfficerUserId: String
   }
 
   type Mutation {
@@ -75,7 +75,7 @@ export interface AddDemonstrationInput {
   demonstrationStatusId: string;
   stateId: string;
   userIds?: string[];
-  projectOfficer: string; 
+  projectOfficerUserId: string; 
 }
 
 export interface UpdateDemonstrationInput {
@@ -86,5 +86,5 @@ export interface UpdateDemonstrationInput {
   demonstrationStatusId?: string;
   stateId?: string;
   userIds?: string[];
-  projectOfficer?: string; 
+  projectOfficerUserId?: string; 
 }

--- a/server/src/model/demonstrationStatus/demonstrationStatusHistory.prisma
+++ b/server/src/model/demonstrationStatus/demonstrationStatusHistory.prisma
@@ -1,5 +1,5 @@
 model DemonstrationStatusHistory {
-  revisionId   Int          @id @map("revision_id") @default(autoincrement())
+  revisionId   Int          @id @default(autoincrement()) @map("revision_id")
   revisionType RevisionType @map("revision_type")
   modifiedAt   DateTime     @default(now()) @map("modified_at") @db.Timestamptz()
   id           String       @db.Uuid

--- a/server/src/model/migrations/20250623155458_init_baseline/migration.sql
+++ b/server/src/model/migrations/20250623155458_init_baseline/migration.sql
@@ -242,6 +242,9 @@ CREATE TABLE "users_history" (
 );
 
 -- CreateIndex
+CREATE UNIQUE INDEX "demonstration_id_state_id_key" ON "demonstration"("id", "state_id");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "users_cognito_subject_key" ON "users"("cognito_subject");
 
 -- AddForeignKey
@@ -263,13 +266,13 @@ ALTER TABLE "user_state" ADD CONSTRAINT "user_state_user_id_fkey" FOREIGN KEY ("
 ALTER TABLE "user_state" ADD CONSTRAINT "user_state_state_id_fkey" FOREIGN KEY ("state_id") REFERENCES "state"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "user_state_demonstration" ADD CONSTRAINT "user_state_demonstration_user_id_state_id_fkey" FOREIGN KEY ("user_id", "state_id") REFERENCES "user_state"("user_id", "state_id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
 ALTER TABLE "user_state_demonstration" ADD CONSTRAINT "user_state_demonstration_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "user_state_demonstration" ADD CONSTRAINT "user_state_demonstration_demonstration_id_fkey" FOREIGN KEY ("demonstration_id") REFERENCES "demonstration"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "user_state_demonstration" ADD CONSTRAINT "user_state_demonstration_user_id_state_id_fkey" FOREIGN KEY ("user_id", "state_id") REFERENCES "user_state"("user_id", "state_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_state_demonstration" ADD CONSTRAINT "user_state_demonstration_demonstration_id_state_id_fkey" FOREIGN KEY ("demonstration_id", "state_id") REFERENCES "demonstration"("id", "state_id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "demonstration" ADD CONSTRAINT "demonstration_demonstration_status_id_fkey" FOREIGN KEY ("demonstration_status_id") REFERENCES "demonstration_status"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
@@ -278,7 +281,4 @@ ALTER TABLE "demonstration" ADD CONSTRAINT "demonstration_demonstration_status_i
 ALTER TABLE "demonstration" ADD CONSTRAINT "demonstration_state_id_fkey" FOREIGN KEY ("state_id") REFERENCES "state"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "demonstration" ADD CONSTRAINT "demonstration_project_officer_user_id_fkey" FOREIGN KEY ("project_officer_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "demonstration_history" ADD CONSTRAINT "demonstration_history_project_officer_id_fkey" FOREIGN KEY ("project_officer_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "demonstration" ADD CONSTRAINT "demonstration_project_officer_user_id_fkey" FOREIGN KEY ("project_officer_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/src/model/permission/permissionHistory.prisma
+++ b/server/src/model/permission/permissionHistory.prisma
@@ -1,5 +1,5 @@
 model PermissionHistory {
-  revisionId   Int          @id @map("revision_id") @default(autoincrement())
+  revisionId   Int          @id @default(autoincrement()) @map("revision_id")
   revisionType RevisionType @map("revision_type")
   modifiedAt   DateTime     @default(now()) @map("modified_at") @db.Timestamptz()
   id           String       @db.Uuid

--- a/server/src/model/role/roleHistory.prisma
+++ b/server/src/model/role/roleHistory.prisma
@@ -1,5 +1,5 @@
 model RoleHistory {
-  revisionId   Int          @id @map("revision_id") @default(autoincrement())
+  revisionId   Int          @id @default(autoincrement()) @map("revision_id")
   revisionType RevisionType @map("revision_type")
   modifiedAt   DateTime     @default(now()) @map("modified_at") @db.Timestamptz()
   id           String       @db.Uuid

--- a/server/src/model/schema.prisma
+++ b/server/src/model/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
-  output   = "../../node_modules/.prisma/client"
+  provider      = "prisma-client-js"
+  output        = "../../node_modules/.prisma/client"
   binaryTargets = ["rhel-openssl-3.0.x", "native"]
 }
 

--- a/server/src/model/state/stateHistory.prisma
+++ b/server/src/model/state/stateHistory.prisma
@@ -1,5 +1,5 @@
 model StateHistory {
-  revisionId   Int          @id @map("revision_id") @default(autoincrement())
+  revisionId   Int          @id @default(autoincrement()) @map("revision_id")
   revisionType RevisionType @map("revision_type")
   modifiedAt   DateTime     @default(now()) @map("modified_at") @db.Timestamptz()
   id           String       @db.Uuid

--- a/server/src/model/user/user.prisma
+++ b/server/src/model/user/user.prisma
@@ -1,15 +1,17 @@
 model User {
-  id                      String                   @id @default(uuid()) @db.Uuid
-  cognitoSubject          String                   @unique @map("cognito_subject") @db.Uuid
-  username                String
-  email                   String
-  fullName                String                   @map("full_name")
-  displayName             String                   @map("display_name")
-  createdAt               DateTime                 @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt               DateTime                 @updatedAt @map("updated_at") @db.Timestamptz()
-  userRoles               UserRole[]
-  userStates              UserState[]
-  userStateDemonstrations UserStateDemonstration[]
+  id             String   @id @default(uuid()) @db.Uuid
+  cognitoSubject String   @unique @map("cognito_subject") @db.Uuid
+  username       String
+  email          String
+  fullName       String   @map("full_name")
+  displayName    String   @map("display_name")
+  createdAt      DateTime @default(now()) @map("created_at") @db.Timestamptz()
+  updatedAt      DateTime @updatedAt @map("updated_at") @db.Timestamptz()
+
+  userRoles                    UserRole[]
+  userStates                   UserState[]
+  userStateDemonstrations      UserStateDemonstration[]
+  projectOfficerDemonstrations Demonstration[]
 
   @@map("users") // user is a reserved word in PostgreSQL; users is not, which is why this is plural
 }

--- a/server/src/model/user/userHistory.prisma
+++ b/server/src/model/user/userHistory.prisma
@@ -1,5 +1,5 @@
 model UserHistory {
-  revisionId     Int          @id @map("revision_id") @default(autoincrement())
+  revisionId     Int          @id @default(autoincrement()) @map("revision_id")
   revisionType   RevisionType @map("revision_type")
   modifiedAt     DateTime     @default(now()) @map("modified_at") @db.Timestamptz()
   id             String       @db.Uuid
@@ -11,5 +11,5 @@ model UserHistory {
   createdAt      DateTime     @map("created_at") @db.Timestamptz()
   updatedAt      DateTime     @map("updated_at") @db.Timestamptz()
 
-  @@map("users_history")  // user is a reserved word in PostgreSQL; users is not, which is why this is plural
+  @@map("users_history") // user is a reserved word in PostgreSQL; users is not, which is why this is plural
 }

--- a/server/src/seeder.ts
+++ b/server/src/seeder.ts
@@ -107,7 +107,7 @@ async function seedDatabase() {
         evaluationPeriodEndDate: faker.date.future({ years: 1 }),
         demonstrationStatusId: (await prisma().demonstrationStatus.findRandom())!.id,
         stateId: (await prisma().state.findRandom())!.id,
-        projectOfficer: (await prisma().user.findRandom())!.id,
+        projectOfficerUserId: (await prisma().user.findRandom())!.id,
       },
     });
   }


### PR DESCRIPTION
This PR fixes how the project officer field was originally added to the data models and resolves assorted Typescript issues associated with it. It also adds a constraint for the `user_state_demonstration` table.

This is a functioning version of the server and database, and it is highly recommended that further development be based off this to avoid chasing down gremlins that are unrelated to your code changes.