### PR TITLE
Fix Error: Query.event defined in resolvers, but not in schema

### DIFF
--- a/server/src/model/event/eventResolvers.ts
+++ b/server/src/model/event/eventResolvers.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../prismaClient.js';
-import { Event } from '@prisma/client';
 import { LogEventInput } from './eventSchema.js';
+import { Event } from '@prisma/client';
 import { GraphQLContext, getCurrentUserId, getCurrentUserRoleId } from '../../auth/auth.util.js';
 export const eventResolvers = {
   Query: {


### PR DESCRIPTION
I removed these unused query types and the GQL server was yelling at me because the resolvers still exist