### PR TITLE
DEMOS-564: Add synkScan jenkins library function

### DIFF
--- a/pipelines/lib/vars/kubeBlock.groovy
+++ b/pipelines/lib/vars/kubeBlock.groovy
@@ -43,6 +43,13 @@ def call(Map params = [:]) {
     limits:
       cpu: 3000m
       memory: 4Gi
+""",
+      'snyk': """
+- name: snyk
+  image: ${opts.SCANNER_IMAGE ?: 'artifactory.cloud.cms.gov/docker/snyk/snyk:alpine'}
+  command:
+  - cat
+  tty: true
 """
     ]
 

--- a/pipelines/lib/vars/snykScan.groovy
+++ b/pipelines/lib/vars/snykScan.groovy
@@ -1,0 +1,24 @@
+def call(Map params) {
+
+  def containerName = params.containerName ?: 'snyk'
+  def dirName = params.dir ?: './'
+  def severityThreshold = params.severityThreshold ?: 'high'
+
+  dir(dirName) {
+    container(containerName) {
+      withCredentials([
+        string(credentialsId: 'demos-snyk-sa', variable: 'SNYK_TOKEN'),
+        string(credentialsId: 'demos-snyk-org-id', variable: 'SNYK_CFG_ORG')
+      ]) {
+        sh """
+          snyk test --severity-threshold=${severityThreshold} --strict-out-of-sync=true
+        """
+      }
+    }
+  }
+}
+
+def call(String dirName, Map params = [:]) {
+  Map mergedParams = params + [dir: dirName]
+  call(mergedParams)
+}


### PR DESCRIPTION
This adds a new library function for running Snyk scans in the Jenkins pipelines. 

This PR is to add the functionality itself, and then a second PR will be opened to use the function within the pipelines. (The library is mapped to the `main` branch, so a single PR creating the function and using it can't be added together without ad hoc changes that I'd prefer to stay away from)