### PR TITLE
DEMOS-578: Update jenkins library to support sonarqube changes

### DIFF
--- a/pipelines/lib/vars/kubeBlock.groovy
+++ b/pipelines/lib/vars/kubeBlock.groovy
@@ -38,11 +38,11 @@ def call(Map params = [:]) {
   tty: true
   resources:
     requests:
-      cpu: 750m
-      memory: 1Gi
-    limits:
       cpu: 1500m
       memory: 2Gi
+    limits:
+      cpu: 3000m
+      memory: 4Gi
 """
     ]
 

--- a/pipelines/lib/vars/sonarQubeScan.groovy
+++ b/pipelines/lib/vars/sonarQubeScan.groovy
@@ -30,14 +30,14 @@ def call(Map params) {
   def formattedFlags = (sonarqubeCliFlags.findAll { k, v -> v != null }).collect { k, v -> "-Dsonar.${k}=${v}" }.join(" ")
 
   withCredentials([string(credentialsId: "${credentialsId}", variable: 'TOKEN')]) {
-    withSonarQubeEnv('SonarQube') {
+      container('scanner') {
         sh """
-          ${scannerHome}/bin/sonar-scanner \
+          sonar-scanner \
             -Dsonar.projectKey=${projectKey} \
             -Dsonar.projectBaseDir=${projectBaseDir} \
             -Dsonar.host.url=https://sonarqube.cloud.cms.gov \
             -Dsonar.qualitygate.wait=true \
-            -Dsonar.login=\$TOKEN \
+            -Dsonar.token=\$TOKEN \
             ${formattedFlags} \
             -X
         """


### PR DESCRIPTION
With the changes to SonarQube made by the cloud team (upgrading to version 2025.1) the sonar-scanner is pulling updated binaries that require more RAM to run. The previous installation used the sonar-scanner Jenkins plugin, this change uses the sonar-scanner-cli image with additional RAM.