### PR TITLE
DEMOS-577-gql-list-return-types

### DIFF
--- a/server/src/model/demonstration/demonstrationSchema.ts
+++ b/server/src/model/demonstration/demonstrationSchema.ts
@@ -54,7 +54,7 @@ export const demonstrationSchema = gql`
   }
 
   type Query {
-    demonstrations: [Demonstration]!
+    demonstrations: [Demonstration!]!
     demonstration(id: ID!): Demonstration
   }
 `;

--- a/server/src/model/demonstrationStatus/demonstrationStatusSchema.ts
+++ b/server/src/model/demonstrationStatus/demonstrationStatusSchema.ts
@@ -36,7 +36,7 @@ export const demonstrationStatusSchema = gql`
   }
 
   type Query {
-    demonstrationStatuses: [DemonstrationStatus]!
+    demonstrationStatuses: [DemonstrationStatus!]!
     demonstrationStatus(id: String!): DemonstrationStatus
   }
 `;

--- a/server/src/model/document/documentSchema.ts
+++ b/server/src/model/document/documentSchema.ts
@@ -71,7 +71,7 @@ export const documentSchema = gql`
   }
 
   type Query {
-    documents(bundleTypeId: String): [Document]!
+    documents(bundleTypeId: String): [Document!]!
     document(id: ID!): Document
   }
 `;

--- a/server/src/model/documentType/documentTypeSchema.ts
+++ b/server/src/model/documentType/documentTypeSchema.ts
@@ -32,7 +32,7 @@ export const documentTypeSchema = gql`
   }
 
   type Query {
-    documentTypes: [DocumentType]!
+    documentTypes: [DocumentType!]!
     documentType(id: String!): DocumentType
   }
 `;

--- a/server/src/model/event/eventSchema.ts
+++ b/server/src/model/event/eventSchema.ts
@@ -18,7 +18,7 @@ export const eventSchema = gql`
   }
 
   type Query {
-    events: [Event]!
+    events: [Event!]!
   }
   
   type Mutation {

--- a/server/src/model/modification/modificationSchema.ts
+++ b/server/src/model/modification/modificationSchema.ts
@@ -46,7 +46,7 @@ export const modificationSchema = gql`
   }
 
   type Query {
-    amendments: [Amendment]!
+    amendments: [Amendment!]!
     amendment(id: ID!): Amendment
   }
 `;

--- a/server/src/model/modificationStatus/modificationStatusSchema.ts
+++ b/server/src/model/modificationStatus/modificationStatusSchema.ts
@@ -32,7 +32,7 @@ export const modificationStatusSchema = gql`
   }
 
   type Query {
-    amendmentStatuses: [AmendmentStatus]!
+    amendmentStatuses: [AmendmentStatus!]!
     amendmentStatus(id: String!): AmendmentStatus
   }
 `;

--- a/server/src/model/permission/permissionSchema.ts
+++ b/server/src/model/permission/permissionSchema.ts
@@ -31,7 +31,7 @@ export const permissionSchema = gql`
   }
 
   type Query {
-    permissions: [Permission]!
+    permissions: [Permission!]!
     permission(id: ID!): Permission
   }
 `;

--- a/server/src/model/role/roleSchema.ts
+++ b/server/src/model/role/roleSchema.ts
@@ -35,7 +35,7 @@ export const roleSchema = gql`
   }
 
   type Query {
-    roles: [Role]!
+    roles: [Role!]!
     role(id: ID!): Role
   }
 `;

--- a/server/src/model/state/stateSchema.ts
+++ b/server/src/model/state/stateSchema.ts
@@ -11,7 +11,7 @@ export const stateSchema = gql`
   }
 
   type Query {
-    states: [State]!
+    states: [State!]!
     state(id: String!): State
   }
 `;

--- a/server/src/model/user/userSchema.ts
+++ b/server/src/model/user/userSchema.ts
@@ -51,7 +51,7 @@ export const userSchema = gql`
   }
 
   type Query {
-    users: [User]!
+    users: [User!]!
     user(id: ID!): User
   }
 `;


### PR DESCRIPTION
Very simple PR that just changes the query returns in the GraphQL schemas to use `[Thing!]!` instead of `[Thing]!`. This is a small tweak, but makes the results more consistent with the other types throughout the system. `[Thing]!` means that an array is always returned, but that the elements can either be `Thing` or `null`. `[Thing!]!` means that the array must have only non-null elements. Both allow for empty arrays, to be clear.

Unless there's an actual reason to expect / return null elements from a query (i.e. the null values communicate some meaning), everything I've seen indicates the `[Thing!]!` type is more appropriate in GQL.