### PR TITLE
DEMOS-602: Add WAF to api gateway

### DIFF
--- a/deployment/config.ts
+++ b/deployment/config.ts
@@ -16,6 +16,7 @@ export interface DeploymentConfigProperties {
   zScalerIps: string[];
   hostUserPoolId?: string;
   idmMetadataEndpoint?: string;
+  cloudfrontWafHeaderValue?: string;
 }
 
 export const determineDeploymentConfig = async (


### PR DESCRIPTION
The major change in this PR is a new WAF ACL for the api gateway. By default, the API gateway URL is publicly available since this is a public API, however, we want all traffic to be routed through our Cloudfront distribution (<domain>/api/)

With standard resource policies, there is no way to restrict things to Cloudfront. So, the solution here, though not 100% foolproof, is to use WAF to enforce a specific header with a hard-to-guess value. The value itself is not truly a secret and is not treated as such on the AWS console or in CDK, but it will be sufficient for our needs. The graphql endpoint on the API is protected by the authorizer regardless of the entry point.

Additional changes:
- adds a custom response to the Cloudfront WAF when attempting to access the site from outside the ZScaler VPN
- adds a name and identifying description to the CloudFront distribution