### PR TITLE
DEMOS-604: Handle authorizer errors and deny request

### DIFF
--- a/lambda_authorizer/index.mjs
+++ b/lambda_authorizer/index.mjs
@@ -13,18 +13,25 @@ function getKey(header, callback) {
   });
 }
 
-export const handler = async (event, context, callback) => {
+export const handler = async (event) => {
   const token = event.authorizationToken.split(" ")[1];
   console.log("starting validation");
 
   if (!token) {
     console.log("no token");
-    return callback("unauthorized");
+    return generatePolicy("unknown", "Deny", event.methodArn, {});
   }
 
   console.log("token found");
 
-  const decoded = await verifyToken(token);
+  let decoded;
+  try {
+    decoded = await verifyToken(token);
+  } catch (decoded) {
+    const sub = decoded?.sub || "unknown";
+    console.log(`user sub [${sub}] rejected with invalid token`);
+    return generatePolicy(sub, "Deny", event.methodArn, {});
+  }
   const roles = decoded["custom:roles"];
 
   if (!roles) {
@@ -55,7 +62,7 @@ const verifyToken = (token) => {
     jwt.verify(token, getKey, {}, (err, decoded) => {
       if (err) {
         console.log("validation error:", err);
-        return reject(new Error("User is not authenticated"));
+        return reject(decoded);
       }
       resolve(decoded);
     });


### PR DESCRIPTION
Previously, the authorizer would throw an error if the JWT was invalid. This would prevent the user from accessing the API but would result in a 500 response to the client. This change updates the response to always use a Deny policy so a proper 403 response is returned for all issues.