### PR TITLE
DEMOS-606: Only invalidate cloudfront when necessary

### DIFF
--- a/deployment/lib/ui-deploy.ts
+++ b/deployment/lib/ui-deploy.ts
@@ -2,6 +2,7 @@ import {
   aws_cloudfront,
   aws_iam,
   aws_s3,
+  aws_s3_assets,
   aws_s3_deployment,
   custom_resources,
   Duration,
@@ -72,6 +73,10 @@ export function create(props: UIDeploymentProps) {
       role: deploymentRole,
     }
   );
+  const buildAsset = new aws_s3_assets.Asset(props.scope, "uiBuildAsset", {
+    path: buildOutputPath
+  })
+
 
   const invalidateCloudfront = new custom_resources.AwsCustomResource(
     props.scope,
@@ -89,7 +94,7 @@ export function create(props: UIDeploymentProps) {
               Quantity: 1,
               Items: ["/*"],
             },
-            CallerReference: new Date().toISOString(),
+            CallerReference: `invalidate-${buildAsset.assetHash}`,
           },
         },
         physicalResourceId: custom_resources.PhysicalResourceId.of(


### PR DESCRIPTION
Currently, every time there is a CDK deploy, it will show a diff for the CloudFront invalidation because a timestamp is being used. This PR updates the process to use a hash of the UI code so the cache is only invalidated when necessary.