### PR TITLE
DEMOS-603: Update logging and log retention values

### DIFF
--- a/deployment/lib/lambda.ts
+++ b/deployment/lib/lambda.ts
@@ -16,6 +16,7 @@ import {
   ServicePrincipal,
 } from "aws-cdk-lib/aws-iam";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
+import { DemosLogGroup } from "./logGroup";
 
 interface LambdaProps extends CommonProps {
   additionalPolicies?: PolicyStatement[];
@@ -61,6 +62,12 @@ export class Lambda extends Construct {
       memorySize = 1024,
       asCode = false,
     } = props;
+
+    const logGroup = new DemosLogGroup(this, "LogGroup", {
+      name: `lambda/${id}`,
+      isEphemeral: props.isEphemeral,
+      stage: props.stage
+    })
 
     const role = new Role(this, `${id}LambdaExecutionRole`, {
       assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
@@ -123,6 +130,7 @@ export class Lambda extends Construct {
       environment: props.environment,
       vpc: props.vpc,
       vpcSubnets: props.vpc ? { subnets: props.vpc.privateSubnets } : undefined,
+      logGroup: logGroup.logGroup
     });
 
     let alias;

--- a/deployment/lib/logGroup.ts
+++ b/deployment/lib/logGroup.ts
@@ -1,0 +1,50 @@
+import { aws_lambda, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { LogGroup, RetentionDays, SubscriptionFilter, FilterPattern } from "aws-cdk-lib/aws-logs";
+import { LambdaDestination } from "aws-cdk-lib/aws-logs-destinations";
+import { Construct } from "constructs";
+
+interface DemosLogGroupProps {
+  isEphemeral: boolean;
+  name?: string;
+  stage: string;
+  overrideFullName?: string;
+}
+
+export class DemosLogGroup extends Construct {
+  public readonly logGroup: LogGroup;
+
+  constructor(scope: Construct, id: string, props: DemosLogGroupProps) {
+    super(scope, id);
+
+    if (!props.name && !props.overrideFullName) {
+      throw new Error("you must specify `name` or `overrideFullName` for the log group")
+    }
+
+    this.logGroup = new LogGroup(this, "LogGroup", {
+      logGroupName: props.overrideFullName ?? `/demos/${props.stage}/${props.name}`,
+      retention: !props.isEphemeral ? RetentionDays.THREE_MONTHS : RetentionDays.ONE_WEEK,
+      removalPolicy: !props.isEphemeral ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
+    })
+
+
+    new SubscriptionFilter(this, "SubscriptionFilter", {
+      logGroup: this.logGroup,
+      destination: new LambdaDestination(DemosLogGroup.getSubscriptionLambda(this)),
+      filterPattern: FilterPattern.allEvents(),
+      filterName: "logs-to-cms-splunk"
+    })
+
+  }
+
+  private static getSubscriptionLambda(scope: Construct): aws_lambda.IFunction {
+    const stack = Stack.of(scope);
+    const id = "CMSCloudLoggingLambda";
+
+    const existing = stack.node.tryFindChild(id)
+    if (existing) {
+      return existing as aws_lambda.IFunction
+    }
+
+    return aws_lambda.Function.fromFunctionName(stack, id, "cms-cloud-logging-cloudwatch-to-splunk")
+  }
+}

--- a/deployment/types/props.ts
+++ b/deployment/types/props.ts
@@ -10,6 +10,7 @@ export interface CommonProps {
   iamPath?: string;
   iamPermissionsBoundary?: IManagedPolicy;
   isLocalstack: boolean;
+  isEphemeral: boolean;
   zScalerIps: string[];
   idmMetadataEndpoint?: string;
 }


### PR DESCRIPTION
This PR updates the logging setup. It incorporates a new construct for generating log groups with a subscription for the CMS process for sending logs to splunk. It also sets the retention policies to 90 days (or lower) rather than the default "never-expire". 