### PR TITLE
DEMOS-288: Add fields to DemonstrationModal

### DIFF
--- a/client/src/components/header/DefaultHeaderLower.test.tsx
+++ b/client/src/components/header/DefaultHeaderLower.test.tsx
@@ -7,11 +7,11 @@ import { useQuery } from "@apollo/client";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 import { DefaultHeaderLower } from "./DefaultHeaderLower";
+import { DemosApolloProvider } from "router/DemosApolloProvider";
 
 // Mock Apollo
 vi.mock("@apollo/client", async () => {
-  const actual =
-    await vi.importActual<typeof import("@apollo/client")>("@apollo/client");
+  const actual = await vi.importActual<typeof import("@apollo/client")>("@apollo/client");
   return {
     ...actual,
     useQuery: vi.fn(),
@@ -28,14 +28,12 @@ vi.mock("components/modal/document/DocumentModal", () => ({
   ),
 }));
 
+vi.mock("components/modal/DemonstrationModal", () => ({
+  DemonstrationModal: () => <div>DemonstrationModal</div>,
+}));
+
 vi.mock("components/modal/CreateNewModal", () => ({
-  CreateNewModal: ({
-    mode,
-    onClose,
-  }: {
-    mode: string;
-    onClose: () => void;
-  }) => (
+  CreateNewModal: ({ mode, onClose }: { mode: string; onClose: () => void }) => (
     <div data-testid={`modal-${mode}`}>
       CreateNewModal ({mode})<button onClick={onClose}>Close</button>
     </div>
@@ -112,18 +110,21 @@ describe("DefaultHeaderLower", () => {
     expect(screen.queryByText("Demonstration")).not.toBeInTheDocument();
   });
 
-  it("opens CreateNewModal for demonstration", () => {
+  it("opens DemonstrationModal when demonstration modal is clicked", () => {
     (useQuery as unknown as import("vitest").Mock).mockReturnValue({
       loading: false,
       error: null,
       data: { user: { fullName: "X" } },
     });
-    render(<DefaultHeaderLower userId={6} />);
+
+    render(
+      <DemosApolloProvider>
+        <DefaultHeaderLower userId={"6"} />
+      </DemosApolloProvider>
+    );
     fireEvent.click(screen.getByText("Create New"));
     fireEvent.click(screen.getByText("Demonstration"));
-    expect(screen.getByTestId("modal-demonstration")).toBeInTheDocument();
-    fireEvent.click(screen.getByText("Close"));
-    expect(screen.queryByTestId("modal-demonstration")).not.toBeInTheDocument();
+    expect(screen.queryByText("DemonstrationModal")).toBeInTheDocument();
   });
 
   it("opens AddDocumentModal", () => {

--- a/client/src/components/header/DefaultHeaderLower.tsx
+++ b/client/src/components/header/DefaultHeaderLower.tsx
@@ -1,11 +1,8 @@
-import React, {
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import { SecondaryButton } from "components/button/SecondaryButton";
 import { AddNewIcon } from "components/icons";
+import { DemonstrationModal } from "components/modal/DemonstrationModal";
 import { CreateNewModal } from "components/modal/CreateNewModal";
 import { AddDocumentModal } from "components/modal/document/DocumentModal";
 import { gql } from "graphql-tag";
@@ -23,16 +20,15 @@ export const HEADER_LOWER_QUERY = gql`
 
 export const DefaultHeaderLower: React.FC<{ userId?: string }> = ({ userId }) => {
   const [showDropdown, setShowDropdown] = useState(false);
-  const [modalType, setModalType] = useState<"create" | "document" | "amendment" | "extension" | null>(null);
+  const [modalType, setModalType] = useState<
+    "create" | "document" | "amendment" | "extension" | null
+  >(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Close dropdown on outside click
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setShowDropdown(false);
       }
     };
@@ -112,18 +108,15 @@ export const DefaultHeaderLower: React.FC<{ userId?: string }> = ({ userId }) =>
       </div>
 
       {modalType === "create" && (
-        <CreateNewModal mode="demonstration" onClose={() => setModalType(null)} />
+        <DemonstrationModal mode="add" onClose={() => setModalType(null)} />
       )}
-      {modalType === "document" && (
-        <AddDocumentModal onClose={() => setModalType(null)} />
-      )}
+      {modalType === "document" && <AddDocumentModal onClose={() => setModalType(null)} />}
       {modalType === "amendment" && (
         <CreateNewModal mode="amendment" onClose={() => setModalType(null)} />
       )}
       {modalType === "extension" && (
         <CreateNewModal mode="extension" onClose={() => setModalType(null)} />
       )}
-
     </div>
   );
 };

--- a/client/src/components/input/select/SelectCMCSDivision.test.tsx
+++ b/client/src/components/input/select/SelectCMCSDivision.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SelectCMCSDivision } from "./SelectCMCSDivision";
+import { CMCS_DIVISION } from "demos-server-constants";
+
+const onSelect = vi.fn();
+
+describe("SelectCMCSDivision", () => {
+  it("renders division options with proper labels", () => {
+    render(<SelectCMCSDivision onSelect={onSelect} />);
+    const select = screen.getByLabelText("CMCS Division");
+    fireEvent.mouseDown(select);
+    CMCS_DIVISION.forEach((division) => {
+      expect(screen.getByText(division)).toBeInTheDocument();
+    });
+  });
+
+  it("calls onSelect when an option is selected", () => {
+    render(<SelectCMCSDivision onSelect={onSelect} />);
+    const select = screen.getByLabelText("CMCS Division");
+    fireEvent.mouseDown(select);
+    fireEvent.change(select, { target: { value: CMCS_DIVISION[0] } });
+    expect(onSelect).toHaveBeenCalledWith(CMCS_DIVISION[0]);
+  });
+});

--- a/client/src/components/input/select/SelectCMCSDivision.test.tsx
+++ b/client/src/components/input/select/SelectCMCSDivision.test.tsx
@@ -21,6 +21,7 @@ describe("SelectCMCSDivision", () => {
     const select = screen.getByLabelText("CMCS Division");
     fireEvent.mouseDown(select);
     fireEvent.change(select, { target: { value: CMCS_DIVISION[0] } });
+    expect(select).toHaveValue(CMCS_DIVISION[0]);
     expect(onSelect).toHaveBeenCalledWith(CMCS_DIVISION[0]);
   });
 });

--- a/client/src/components/input/select/SelectCMCSDivision.tsx
+++ b/client/src/components/input/select/SelectCMCSDivision.tsx
@@ -8,11 +8,16 @@ const options: Option[] = CMCS_DIVISION.map((division) => ({
 }));
 
 export const SelectCMCSDivision = ({ onSelect }: { onSelect: (value: string) => void }) => {
+  const [cmcsDivision, setCmcsDivision] = React.useState("");
   return (
     <Select
+      value={cmcsDivision}
       options={options}
       placeholder="Select CMCS Division"
-      onSelect={onSelect}
+      onSelect={(value) => {
+        setCmcsDivision(value);
+        onSelect(value);
+      }}
       id="cmcs-division-select"
       label="CMCS Division"
     />

--- a/client/src/components/input/select/SelectCMCSDivision.tsx
+++ b/client/src/components/input/select/SelectCMCSDivision.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { CMCS_DIVISION } from "demos-server-constants";
+import { Option, Select } from "./Select";
+
+const options: Option[] = CMCS_DIVISION.map((division) => ({
+  value: division,
+  label: division,
+}));
+
+export const SelectCMCSDivision = ({ onSelect }: { onSelect: (value: string) => void }) => {
+  return (
+    <Select
+      options={options}
+      placeholder="Select CMCS Division"
+      onSelect={onSelect}
+      id="cmcs-division-select"
+      label="CMCS Division"
+    />
+  );
+};

--- a/client/src/components/input/select/SelectSignatureLevel.test.tsx
+++ b/client/src/components/input/select/SelectSignatureLevel.test.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SelectSignatureLevel } from "./SelectSignatureLevel";
+import { SIGNATURE_LEVEL } from "demos-server-constants";
+
+const onSelect = vi.fn();
+
+describe("SelectSignatureLevel", () => {
+  it("renders all signature level options with explicit labels", () => {
+    render(<SelectSignatureLevel onSelect={onSelect} />);
+    const select = screen.getByLabelText("Signature Level");
+    fireEvent.mouseDown(select);
+    expect(screen.getByText("OA - Office of the Administrator")).toBeInTheDocument();
+    expect(screen.getByText("OCD - Office of the Center Director")).toBeInTheDocument();
+    expect(screen.getByText("OGD - Office of the Group Director")).toBeInTheDocument();
+  });
+
+  it("calls onSelect when an option is selected", () => {
+    render(<SelectSignatureLevel onSelect={onSelect} />);
+    const select = screen.getByLabelText("Signature Level");
+    fireEvent.change(select, { target: { value: SIGNATURE_LEVEL[0] } });
+    expect(onSelect).toHaveBeenCalledWith(SIGNATURE_LEVEL[0]);
+  });
+});

--- a/client/src/components/input/select/SelectSignatureLevel.test.tsx
+++ b/client/src/components/input/select/SelectSignatureLevel.test.tsx
@@ -20,6 +20,7 @@ describe("SelectSignatureLevel", () => {
     render(<SelectSignatureLevel onSelect={onSelect} />);
     const select = screen.getByLabelText("Signature Level");
     fireEvent.change(select, { target: { value: SIGNATURE_LEVEL[0] } });
+    expect(select).toHaveValue(SIGNATURE_LEVEL[0]);
     expect(onSelect).toHaveBeenCalledWith(SIGNATURE_LEVEL[0]);
   });
 });

--- a/client/src/components/input/select/SelectSignatureLevel.tsx
+++ b/client/src/components/input/select/SelectSignatureLevel.tsx
@@ -15,11 +15,16 @@ const options: Option[] = SIGNATURE_LEVEL.map((level) => ({
 }));
 
 export const SelectSignatureLevel = ({ onSelect }: { onSelect: (value: string) => void }) => {
+  const [signatureLevel, setSignatureLevel] = React.useState("");
   return (
     <Select
+      value={signatureLevel}
       options={options}
       placeholder="Select Signature Level"
-      onSelect={onSelect}
+      onSelect={(value) => {
+        setSignatureLevel(value);
+        onSelect(value);
+      }}
       id="signature-level-select"
       label="Signature Level"
     />

--- a/client/src/components/input/select/SelectSignatureLevel.tsx
+++ b/client/src/components/input/select/SelectSignatureLevel.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { SIGNATURE_LEVEL } from "demos-server-constants";
+import { Option, Select } from "./Select";
+import { SignatureLevel } from "demos-server";
+
+const labelMap: Record<SignatureLevel, string> = {
+  OA: "OA - Office of the Administrator",
+  OCD: "OCD - Office of the Center Director",
+  OGD: "OGD - Office of the Group Director",
+};
+
+const options: Option[] = SIGNATURE_LEVEL.map((level) => ({
+  value: level,
+  label: labelMap[level] || level,
+}));
+
+export const SelectSignatureLevel = ({ onSelect }: { onSelect: (value: string) => void }) => {
+  return (
+    <Select
+      options={options}
+      placeholder="Select Signature Level"
+      onSelect={onSelect}
+      id="signature-level-select"
+      label="Signature Level"
+    />
+  );
+};

--- a/client/src/components/modal/DemonstrationModal.test.tsx
+++ b/client/src/components/modal/DemonstrationModal.test.tsx
@@ -4,12 +4,7 @@ import { ToastProvider } from "components/toast/ToastContext";
 import { Demonstration } from "demos-server";
 import { vi } from "vitest";
 
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { DemonstrationModal } from "./DemonstrationModal";
 
@@ -35,7 +30,6 @@ vi.mock("hooks/useDemonstration", () => ({
   })),
 }));
 
-
 // Mock the SelectUSAStates component
 vi.mock("components/input/select/SelectUSAStates", () => ({
   SelectUSAStates: ({
@@ -47,10 +41,7 @@ vi.mock("components/input/select/SelectUSAStates", () => ({
   }) => (
     <div>
       <label>{label}</label>
-      <select
-        data-testid="state-select"
-        onChange={(e) => onStateChange(e.target.value)}
-      >
+      <select data-testid="state-select" onChange={(e) => onStateChange(e.target.value)}>
         <option value="">Select a state</option>
         <option value="1">California</option>
         <option value="2">Texas</option>
@@ -70,10 +61,7 @@ vi.mock("components/input/select/SelectUsers", () => ({
   }) => (
     <div>
       <label>{label}</label>
-      <select
-        data-testid="user-select"
-        onChange={(e) => onStateChange(e.target.value)}
-      >
+      <select data-testid="user-select" onChange={(e) => onStateChange(e.target.value)}>
         <option value="">Select a user</option>
         <option value="1">John Doe</option>
         <option value="2">Jane Smith</option>
@@ -94,9 +82,7 @@ if (!HTMLFormElement.prototype.requestSubmit) {
       return;
     }
 
-    this.dispatchEvent(
-      new SubmitEvent("submit", { bubbles: true, cancelable: true })
-    );
+    this.dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
   };
 }
 
@@ -127,9 +113,7 @@ describe("DemonstrationModal", () => {
   it("opens cancel confirmation when clicking Cancel button", () => {
     renderModal();
     fireEvent.click(screen.getByText("Cancel"));
-    expect(
-      screen.getByText("Are you sure you want to cancel?")
-    ).toBeInTheDocument();
+    expect(screen.getByText("Are you sure you want to cancel?")).toBeInTheDocument();
   });
 
   it("closes modal when clicking Yes in cancel confirmation", () => {
@@ -143,9 +127,7 @@ describe("DemonstrationModal", () => {
     renderModal();
     fireEvent.click(screen.getByText("Cancel"));
     fireEvent.click(screen.getByText("No"));
-    expect(
-      screen.queryByText("Are you sure you want to cancel?")
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Are you sure you want to cancel?")).not.toBeInTheDocument();
   });
 
   it("validates expiration date cannot be before effective date", async () => {
@@ -217,6 +199,8 @@ describe("DemonstrationModal", () => {
         stateId: "1",
         userIds: ["1"],
         projectOfficerUserId: "1",
+        cmcsDivision: "",
+        signatureLevel: "",
       });
     });
   });
@@ -319,6 +303,8 @@ describe("DemonstrationModal", () => {
         stateId: "1",
         userIds: ["1"],
         projectOfficerUserId: "1",
+        cmcsDivision: "",
+        signatureLevel: "",
       });
     });
   });

--- a/client/src/components/modal/DemonstrationModal.tsx
+++ b/client/src/components/modal/DemonstrationModal.tsx
@@ -1,23 +1,21 @@
-import React, {
-  useEffect,
-  useState,
-} from "react";
+import React, { useEffect, useState } from "react";
 
-import {
-  PrimaryButton,
-  SecondaryButton,
-} from "components/button";
+import { PrimaryButton, SecondaryButton } from "components/button";
 import { SelectUSAStates } from "components/input/select/SelectUSAStates";
 import { SelectUsers } from "components/input/select/SelectUsers";
 import { TextInput } from "components/input/TextInput";
 import { BaseModal } from "components/modal/BaseModal";
 import { useToast } from "components/toast";
 import {
+  CmcsDivision,
   CreateDemonstrationInput,
   Demonstration,
+  SignatureLevel,
 } from "demos-server";
 import { useDemonstration } from "hooks/useDemonstration";
 import { tw } from "tags/tw";
+import { SelectCMCSDivision } from "components/input/select/SelectCMCSDivision";
+import { SelectSignatureLevel } from "components/input/select/SelectSignatureLevel";
 
 const LABEL_CLASSES = tw`text-text-font font-bold text-field-label flex gap-0-5`;
 const DATE_INPUT_CLASSES = tw`w-full border rounded px-1 py-1 text-sm`;
@@ -37,6 +35,8 @@ export const DemonstrationModal: React.FC<Props> = ({ onClose, demonstration, mo
   const [effectiveDate, setEffectiveDate] = useState("");
   const [expirationDate, setExpirationDate] = useState("");
   const [description, setDescription] = useState("");
+  const [cmcsDivision, setCmcsDivision] = useState("");
+  const [signatureLevel, setSignatureLevel] = useState("");
   const [expirationError, setExpirationError] = useState("");
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const [formStatus, setFormStatus] = useState<"idle" | "pending">("idle");
@@ -54,6 +54,8 @@ export const DemonstrationModal: React.FC<Props> = ({ onClose, demonstration, mo
       setEffectiveDate(new Date(demonstration.effectiveDate).toISOString().slice(0, 10));
       setExpirationDate(new Date(demonstration.expirationDate).toISOString().slice(0, 10));
       setDescription(demonstration.description || "");
+      setCmcsDivision(demonstration.cmcsDivision || "");
+      setSignatureLevel(demonstration.signatureLevel || "");
     }
   }, [demonstration]);
 
@@ -66,6 +68,8 @@ export const DemonstrationModal: React.FC<Props> = ({ onClose, demonstration, mo
     stateId: state,
     userIds: [projectOfficer],
     projectOfficerUserId: projectOfficer,
+    cmcsDivision: cmcsDivision as CmcsDivision,
+    signatureLevel: signatureLevel as SignatureLevel,
   });
 
   const handleSubmit = async () => {
@@ -207,9 +211,10 @@ export const DemonstrationModal: React.FC<Props> = ({ onClose, demonstration, mo
           <input
             id="expiration-date"
             type="date"
-            className={`${DATE_INPUT_CLASSES} ${expirationError
-              ? "border-border-warn focus:ring-border-warn"
-              : "border-border-fields focus:ring-border-focus"
+            className={`${DATE_INPUT_CLASSES} ${
+              expirationError
+                ? "border-border-warn focus:ring-border-warn"
+                : "border-border-fields focus:ring-border-focus"
             }`}
             value={expirationDate}
             min={effectiveDate || undefined}
@@ -238,6 +243,11 @@ export const DemonstrationModal: React.FC<Props> = ({ onClose, demonstration, mo
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <SelectCMCSDivision onSelect={setCmcsDivision} />
+        <SelectSignatureLevel onSelect={setSignatureLevel} />
       </div>
     </BaseModal>
   );


### PR DESCRIPTION
DEMOS-288 - adds the `CMCSDivision` and `SignatureLevel` dropdown fields to the `DemonstrationModal`

**Actual**
<img width="847" height="739" alt="image" src="https://github.com/user-attachments/assets/79e6caa4-62a8-425f-9528-7c1399fce9bc" />

**Mocks**
<img width="722" height="637" alt="Created Demo Modal_Updated" src="https://github.com/user-attachments/assets/a973349a-9b83-4829-aec6-3c722a1677e3" />