### PR TITLE
Update guard duty role name by stage

### DIFF
--- a/deployment/lib/guardDutyS3.ts
+++ b/deployment/lib/guardDutyS3.ts
@@ -109,7 +109,7 @@ export class GuardDutyS3 extends Construct {
       this,
       "GuardDutyMalwareProtectionPassRole",
       {
-        roleName: `GuardDutyMalwareProtectionPassRole-${props.account}`,
+        roleName: `GuardDutyMalwareProtectionPassRole-${props.stage}`,
         assumedBy: new aws_iam.ServicePrincipal(
           "malware-protection-plan.guardduty.amazonaws.com"
         ),


### PR DESCRIPTION
This change updates the role name of the guard duty role to use the name of the stage rather than the account number in order to allow for unique role names per environment within the same account