### PR TITLE
DEMOS-699-fix-document-resolver

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -21,8 +21,8 @@
   },
   "scripts": {
     "clean": "rm -rf dist; npm ci",
-    "build": "prisma generate; tsc; esbuild dist/server.js --bundle --platform=node --outfile=build/server.cjs --minify",
-    "build:ci": "prisma generate; tsc; esbuild dist/server.js --bundle --platform=node --outfile=build/server.cjs --minify; mkdir -p build/node_modules/.prisma/client/ && cp node_modules/.prisma/client/libquery_engine-rhel-openssl-3.0.x.so.node build/node_modules/.prisma/client/",
+    "build": "prisma generate && tsc && esbuild dist/server.js --bundle --platform=node --outfile=build/server.cjs --minify",
+    "build:ci": "prisma generate && tsc && esbuild dist/server.js --bundle --platform=node --outfile=build/server.cjs --minify && mkdir -p build/node_modules/.prisma/client/ && cp node_modules/.prisma/client/libquery_engine-rhel-openssl-3.0.x.so.node build/node_modules/.prisma/client/",
     "depcheck": "depcheck",
     "dev": "node ./dist/index.js",
     "local": "tsx watch --inspect=9229 --clear-screen=false src/local-server.ts",

--- a/server/src/model/document/documentSchema.ts
+++ b/server/src/model/document/documentSchema.ts
@@ -32,7 +32,6 @@ export const documentSchema = gql`
   input UpdateDocumentInput {
     title: String
     description: String
-    s3Path: String
     ownerUserId: ID
     documentTypeId: String
     bundleId: ID
@@ -75,7 +74,6 @@ export interface UploadDocumentInput {
 export interface UpdateDocumentInput {
   title?: string;
   description?: string;
-  s3Path?: string;
   ownerUserId?: string;
   documentTypeId?: string;
   bundleId?: string;

--- a/server/src/model/document/documentSchema.ts
+++ b/server/src/model/document/documentSchema.ts
@@ -24,20 +24,24 @@ export const documentSchema = gql`
   input UploadDocumentInput {
     title: String!
     description: String!
-    documentType: String!
+    ownerUserId: ID!
+    documentTypeId: String!
+    bundleId: ID!
   }
 
   input UpdateDocumentInput {
-    id: ID!
     title: String
     description: String
-    documentType: String
+    s3Path: String
+    ownerUserId: ID
+    documentTypeId: String
+    bundleId: ID
   }
 
   type Mutation {
     uploadDocument(input: UploadDocumentInput!): Document
-    updateDocument(input: UpdateDocumentInput!): Document
-    deleteDocuments(ids: [ID!]!): [ID!]!
+    updateDocument(id: ID!, input: UpdateDocumentInput!): Document
+    deleteDocuments(ids: [ID!]!): Int!
   }
 
   type Query {
@@ -63,12 +67,16 @@ export interface Document {
 export interface UploadDocumentInput {
   title: string;
   description: string;
-  documentType: string;
+  ownerUserId: string;
+  documentTypeId: string;
+  bundleId: string;
 }
 
 export interface UpdateDocumentInput {
-  id: string;
   title?: string;
   description?: string;
-  documentType?: string;
+  s3Path?: string;
+  ownerUserId?: string;
+  documentTypeId?: string;
+  bundleId?: string;
 }


### PR DESCRIPTION
This PR addresses a bug discovered in the Document resolver where certain required fields were absent from the resolver code. It also fixes the `deleteDocuments` mutator to correctly return the count of deleted records (it does not return a list of IDs).

This also changes `package.json` so that in the future, running `npm run build` or `npm run build:ci` will properly give a non-zero error code if `tsc` fails. This will ensure that at least after merge, an error will be raised (one was not presently). @cms-jesse is going to add a PR check that runs the build as well.

In just cleaning up, I pulled out the check for whether a bundle type was implemented or not, since they're all implemented now.

I validated that this worked by running it locally and using the mutators to do a number of document-related tasks.