### PR TITLE
DEMOS-711: Add a delay lambda and use it for guard duty

### DIFF
--- a/deployment/lib/guardDutyS3.ts
+++ b/deployment/lib/guardDutyS3.ts
@@ -72,19 +72,6 @@ export class GuardDutyS3 extends Construct {
           actions: ["s3:GetObject", "s3:GetObjectVersion"],
           resources: [`${props.bucket.bucketArn}/*`],
         }),
-        // new aws_iam.PolicyStatement({
-        //   sid: "AllowDecryptForMalwareScan",
-        //   effect: aws_iam.Effect.ALLOW,
-        //   actions: ["kms:GenerateDataKey", "kms:Decrypt"],
-        //   resources: [
-        //     `${S3MalwareProtectedBucketStack.kmsEncryptionKey.keyArn}`,
-        //   ],
-        //   conditions: {
-        //     StringLike: {
-        //       "kms:ViaService": "s3.*.amazonaws.com",
-        //     },
-        //   },
-        // }),
       ],
     });
 

--- a/deployment/lib/guardDutyS3.ts
+++ b/deployment/lib/guardDutyS3.ts
@@ -1,164 +1,136 @@
 import { aws_events, aws_events_targets, aws_guardduty, aws_iam, aws_s3, aws_sqs } from "aws-cdk-lib";
 import { Construct } from "constructs";
+import { Wait } from "./wait";
 
 interface GuardDutyS3Props {
   bucket: aws_s3.IBucket;
   region: string;
   account: string;
   stage: string;
-  uploadQueue: aws_sqs.IQueue
+  uploadQueue: aws_sqs.IQueue;
 }
 
 export class GuardDutyS3 extends Construct {
-
   constructor(scope: Construct, id: string, props: GuardDutyS3Props) {
-
-    super(scope, id)
+    super(scope, id);
 
     const rolePolicy = new aws_iam.Policy(this, "GuardDutyMalwareProtectionRolePolicy", {
       statements: [
-          new aws_iam.PolicyStatement({
-            sid: "AllowManagedRuleToSendS3EventsToGuardDuty",
-            effect: aws_iam.Effect.ALLOW,
-            actions: [
-              "events:PutRule",
-              "events:DeleteRule",
-              "events:PutTargets",
-              "events:RemoveTargets",
-            ],
-            resources: [
-              `arn:aws:events:${props.region}:${props.account}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*`,
-            ],
-            conditions: {
-              StringLike: {
-                "events:ManagedBy":
-                  "malware-protection-plan.guardduty.amazonaws.com",
-              },
+        new aws_iam.PolicyStatement({
+          sid: "AllowManagedRuleToSendS3EventsToGuardDuty",
+          effect: aws_iam.Effect.ALLOW,
+          actions: ["events:PutRule", "events:DeleteRule", "events:PutTargets", "events:RemoveTargets"],
+          resources: [
+            `arn:aws:events:${props.region}:${props.account}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*`,
+          ],
+          conditions: {
+            StringLike: {
+              "events:ManagedBy": "malware-protection-plan.guardduty.amazonaws.com",
             },
-          }),
-          new aws_iam.PolicyStatement({
-            sid: "AllowGuardDutyToMonitorEventBridgeManagedRule",
-            effect: aws_iam.Effect.ALLOW,
-            actions: ["events:DescribeRule", "events:ListTargetsByRule"],
-            resources: [
-              `arn:aws:events:${props.region}:${props.account}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*`,
-            ],
-          }),
-          new aws_iam.PolicyStatement({
-            sid: "AllowPostScanTag",
-            effect: aws_iam.Effect.ALLOW,
-            actions: [
-              "s3:PutObjectTagging",
-              "s3:GetObjectTagging",
-              "s3:PutObjectVersionTagging",
-              "s3:GetObjectVersionTagging",
-            ],
-            resources: [
-              `${props.bucket.bucketArn}/*`,
-            ],
-          }),
-          new aws_iam.PolicyStatement({
-            sid: "AllowEnableS3EventBridgeEvents",
-            effect: aws_iam.Effect.ALLOW,
-            actions: ["s3:PutBucketNotification", "s3:GetBucketNotification"],
-            resources: [
-              `${props.bucket.bucketArn}`,
-            ],
-          }),
-          new aws_iam.PolicyStatement({
-            sid: "AllowPutValidationObject",
-            effect: aws_iam.Effect.ALLOW,
-            actions: ["s3:PutObject"],
-            resources: [
-              `${props.bucket.bucketArn}/malware-protection-resource-validation-object`,
-            ],
-          }),
-          new aws_iam.PolicyStatement({
-            sid: "AllowCheckBucketOwnership",
-            effect: aws_iam.Effect.ALLOW,
-            actions: ["s3:ListBucket", "s3:GetBucketLocation"],
-            resources: [
-              `${props.bucket.bucketArn}`,
-            ],
-          }),
-          new aws_iam.PolicyStatement({
-            sid: "AllowMalwareScan",
-            effect: aws_iam.Effect.ALLOW,
-            actions: ["s3:GetObject", "s3:GetObjectVersion"],
-            resources: [
-              `${props.bucket.bucketArn}/*`,
-            ],
-          }),
-          // new aws_iam.PolicyStatement({
-          //   sid: "AllowDecryptForMalwareScan",
-          //   effect: aws_iam.Effect.ALLOW,
-          //   actions: ["kms:GenerateDataKey", "kms:Decrypt"],
-          //   resources: [
-          //     `${S3MalwareProtectedBucketStack.kmsEncryptionKey.keyArn}`,
-          //   ],
-          //   conditions: {
-          //     StringLike: {
-          //       "kms:ViaService": "s3.*.amazonaws.com",
-          //     },
-          //   },
-          // }),
-      ]
-    })
+          },
+        }),
+        new aws_iam.PolicyStatement({
+          sid: "AllowGuardDutyToMonitorEventBridgeManagedRule",
+          effect: aws_iam.Effect.ALLOW,
+          actions: ["events:DescribeRule", "events:ListTargetsByRule"],
+          resources: [
+            `arn:aws:events:${props.region}:${props.account}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*`,
+          ],
+        }),
+        new aws_iam.PolicyStatement({
+          sid: "AllowPostScanTag",
+          effect: aws_iam.Effect.ALLOW,
+          actions: [
+            "s3:PutObjectTagging",
+            "s3:GetObjectTagging",
+            "s3:PutObjectVersionTagging",
+            "s3:GetObjectVersionTagging",
+          ],
+          resources: [`${props.bucket.bucketArn}/*`],
+        }),
+        new aws_iam.PolicyStatement({
+          sid: "AllowEnableS3EventBridgeEvents",
+          effect: aws_iam.Effect.ALLOW,
+          actions: ["s3:PutBucketNotification", "s3:GetBucketNotification"],
+          resources: [`${props.bucket.bucketArn}`],
+        }),
+        new aws_iam.PolicyStatement({
+          sid: "AllowPutValidationObject",
+          effect: aws_iam.Effect.ALLOW,
+          actions: ["s3:PutObject"],
+          resources: [`${props.bucket.bucketArn}/malware-protection-resource-validation-object`],
+        }),
+        new aws_iam.PolicyStatement({
+          sid: "AllowCheckBucketOwnership",
+          effect: aws_iam.Effect.ALLOW,
+          actions: ["s3:ListBucket", "s3:GetBucketLocation"],
+          resources: [`${props.bucket.bucketArn}`],
+        }),
+        new aws_iam.PolicyStatement({
+          sid: "AllowMalwareScan",
+          effect: aws_iam.Effect.ALLOW,
+          actions: ["s3:GetObject", "s3:GetObjectVersion"],
+          resources: [`${props.bucket.bucketArn}/*`],
+        }),
+        // new aws_iam.PolicyStatement({
+        //   sid: "AllowDecryptForMalwareScan",
+        //   effect: aws_iam.Effect.ALLOW,
+        //   actions: ["kms:GenerateDataKey", "kms:Decrypt"],
+        //   resources: [
+        //     `${S3MalwareProtectedBucketStack.kmsEncryptionKey.keyArn}`,
+        //   ],
+        //   conditions: {
+        //     StringLike: {
+        //       "kms:ViaService": "s3.*.amazonaws.com",
+        //     },
+        //   },
+        // }),
+      ],
+    });
 
-    const guardDutyPassRole = new aws_iam.Role(
-      this,
-      "GuardDutyMalwareProtectionPassRole",
-      {
-        roleName: `GuardDutyMalwareProtectionPassRole-${props.stage}`,
-        assumedBy: new aws_iam.ServicePrincipal(
-          "malware-protection-plan.guardduty.amazonaws.com"
-        ),
-        description:
-          "An iam pass role for guardduty malware protection service to assume",
-      }
-    );
+    const guardDutyPassRole = new aws_iam.Role(this, "GuardDutyMalwareProtectionPassRole", {
+      roleName: `GuardDutyMalwareProtectionPassRole-${props.stage}`,
+      assumedBy: new aws_iam.ServicePrincipal("malware-protection-plan.guardduty.amazonaws.com"),
+      description: "An iam pass role for guardduty malware protection service to assume",
+    });
 
     rolePolicy.attachToRole(guardDutyPassRole);
 
+    const roleWait = Wait.forSeconds(this, "guardDutyRoleWait", 30);
+    roleWait.node.addDependency(guardDutyPassRole);
+
     const protectionPlan = new aws_guardduty.CfnMalwareProtectionPlan(this, "guardDutyS3Protection", {
-          protectedResource: {
-            s3Bucket: {
-              bucketName: props.bucket.bucketName,
-            }
-          },
-          role: guardDutyPassRole.roleArn,
-          actions: {
-            tagging: {
-              status: "ENABLED"
-            }
-          }
-        })
-
-    protectionPlan.node.addDependency(guardDutyPassRole)
-
-
-     const GuardDutyCopyS3ObjectRule = new aws_events.Rule(
-      this,
-      "GuardDutyCopyS3ObjectRule",
-      {
-        ruleName: `demos-${props.stage}-guardduty-scan`,
-        description: `Copy GuardDuty scanned S3 objects from: ${props.bucket.bucketName} to clean`,
-        eventPattern: {
-          source: ["aws.guardduty"],
-          detailType: ["GuardDuty Malware Protection Object Scan Result"],
-          detail: {
-            scanStatus: ["COMPLETED","DONE"],
-            resourceType: ["S3_OBJECT"],
-            s3ObjectDetails: {
-              bucketName: [props.bucket.bucketName]
-            }
-          }
+      protectedResource: {
+        s3Bucket: {
+          bucketName: props.bucket.bucketName,
         },
-      }
-    );
+      },
+      role: guardDutyPassRole.roleArn,
+      actions: {
+        tagging: {
+          status: "ENABLED",
+        },
+      },
+    });
 
-      GuardDutyCopyS3ObjectRule.addTarget(
-      new aws_events_targets.SqsQueue(props.uploadQueue)
-    );
+    protectionPlan.node.addDependency(roleWait);
+
+    const GuardDutyCopyS3ObjectRule = new aws_events.Rule(this, "GuardDutyCopyS3ObjectRule", {
+      ruleName: `demos-${props.stage}-guardduty-scan`,
+      description: `Copy GuardDuty scanned S3 objects from: ${props.bucket.bucketName} to clean`,
+      eventPattern: {
+        source: ["aws.guardduty"],
+        detailType: ["GuardDuty Malware Protection Object Scan Result"],
+        detail: {
+          scanStatus: ["COMPLETED", "DONE"],
+          resourceType: ["S3_OBJECT"],
+          s3ObjectDetails: {
+            bucketName: [props.bucket.bucketName],
+          },
+        },
+      },
+    });
+
+    GuardDutyCopyS3ObjectRule.addTarget(new aws_events_targets.SqsQueue(props.uploadQueue));
   }
 }

--- a/deployment/lib/wait.ts
+++ b/deployment/lib/wait.ts
@@ -1,0 +1,14 @@
+import { Aws, aws_lambda, CustomResource } from "aws-cdk-lib";
+import { Construct } from "constructs";
+
+export class Wait {
+  // private static readonly LAMBDA_KEY = "SharedWaitLambda";
+
+  public static forSeconds(scope: Construct, id: string, seconds: number): CustomResource {
+    const waitLambda = aws_lambda.Function.fromFunctionName(scope, "SharedWaitLambda", `cdk-wait-${Aws.ACCOUNT_ID}`);
+    return new CustomResource(scope, id, {
+      serviceToken: waitLambda.functionArn,
+      properties: { WaitTimeSeconds: seconds },
+    });
+  }
+}

--- a/deployment/stacks/bootstrap.ts
+++ b/deployment/stacks/bootstrap.ts
@@ -1,15 +1,11 @@
-import { Stack, StackProps, aws_iam, aws_apigateway, aws_ec2 } from "aws-cdk-lib";
+import { Stack, StackProps, aws_iam, aws_apigateway, aws_ec2, aws_lambda, Duration } from "aws-cdk-lib";
 import { Construct } from "constructs";
 
 import { DeploymentConfigProperties } from "../config";
 import { PrivateHostedZone } from "aws-cdk-lib/aws-route53";
 
 export class BootstrapStack extends Stack {
-  constructor(
-    scope: Construct,
-    id: string,
-    props: StackProps & DeploymentConfigProperties
-  ) {
+  constructor(scope: Construct, id: string, props: StackProps & DeploymentConfigProperties) {
     super(scope, id, {
       ...props,
       terminationProtection: false,
@@ -20,28 +16,20 @@ export class BootstrapStack extends Stack {
       scope: this,
       iamPermissionsBoundary:
         props.iamPermissionsBoundaryArn != null
-          ? aws_iam.ManagedPolicy.fromManagedPolicyArn(
-              this,
-              "iamPermissionsBoundary",
-              props.iamPermissionsBoundaryArn
-            )
+          ? aws_iam.ManagedPolicy.fromManagedPolicyArn(this, "iamPermissionsBoundary", props.iamPermissionsBoundaryArn)
           : undefined,
     };
 
-    const apiGwCloudWatchRole = new aws_iam.Role(
-      commonProps.scope,
-      "ApiGatewayCloudWatchRole",
-      {
-        assumedBy: new aws_iam.ServicePrincipal("apigateway.amazonaws.com"),
-        managedPolicies: [
-          aws_iam.ManagedPolicy.fromAwsManagedPolicyName(
-            "service-role/AmazonAPIGatewayPushToCloudWatchLogs" // pragma: allowlist secret
-          ),
-        ],
-        permissionsBoundary: commonProps.iamPermissionsBoundary,
-        path: commonProps.iamPath,
-      }
-    );
+    const apiGwCloudWatchRole = new aws_iam.Role(commonProps.scope, "ApiGatewayCloudWatchRole", {
+      assumedBy: new aws_iam.ServicePrincipal("apigateway.amazonaws.com"),
+      managedPolicies: [
+        aws_iam.ManagedPolicy.fromAwsManagedPolicyName(
+          "service-role/AmazonAPIGatewayPushToCloudWatchLogs" // pragma: allowlist secret
+        ),
+      ],
+      permissionsBoundary: commonProps.iamPermissionsBoundary,
+      path: commonProps.iamPath,
+    });
 
     new aws_apigateway.CfnAccount(commonProps.scope, "cloudwatchRole", {
       cloudWatchRoleArn: apiGwCloudWatchRole.roleArn,
@@ -50,60 +38,41 @@ export class BootstrapStack extends Stack {
     const githubRepo = "Enterprise-CMCS/demos";
 
     // GITHUB
-    const oidcProvider = new aws_iam.OpenIdConnectProvider(
-      commonProps.scope,
-      "DemosGithubOIDCProvider",
-      {
-        url: "https://token.actions.githubusercontent.com",
-        clientIds: ["sts.amazonaws.com"],
-        thumbprints: [
-          "6938fd4d98bab03faadb97b34396831e3780aea1", // pragma: allowlist secret
-          "1c58a3a8518e8759bf075b76b750d4f2df264fcd", // pragma: allowlist secret
-        ], // https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
-      }
-    );
+    const oidcProvider = new aws_iam.OpenIdConnectProvider(commonProps.scope, "DemosGithubOIDCProvider", {
+      url: "https://token.actions.githubusercontent.com",
+      clientIds: ["sts.amazonaws.com"],
+      thumbprints: [
+        "6938fd4d98bab03faadb97b34396831e3780aea1", // pragma: allowlist secret
+        "1c58a3a8518e8759bf075b76b750d4f2df264fcd", // pragma: allowlist secret
+      ], // https://github.blog/changelog/2023-06-27-github-actions-update-on-oidc-integration-with-aws/
+    });
 
-    const githubActionsRole = new aws_iam.Role(
-      commonProps.scope,
-      "GithubActionsOIDCRole",
-      {
-        roleName: `${commonProps.project}-github-actions-oidc-role`,
-        permissionsBoundary: commonProps.iamPermissionsBoundary,
-        path: commonProps.iamPath,
-        assumedBy: new aws_iam.WebIdentityPrincipal(
-          oidcProvider.openIdConnectProviderArn,
-          {
-            StringEquals: {
-              "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-            },
-            StringLike: {
-              "token.actions.githubusercontent.com:sub": `repo:${githubRepo}:*`,
-            },
-          }
-        ),
-        managedPolicies: [
-          aws_iam.ManagedPolicy.fromAwsManagedPolicyName("ReadOnlyAccess"),
-        ],
-        description: "Role assumed by github actions",
-      }
-    );
+    const githubActionsRole = new aws_iam.Role(commonProps.scope, "GithubActionsOIDCRole", {
+      roleName: `${commonProps.project}-github-actions-oidc-role`,
+      permissionsBoundary: commonProps.iamPermissionsBoundary,
+      path: commonProps.iamPath,
+      assumedBy: new aws_iam.WebIdentityPrincipal(oidcProvider.openIdConnectProviderArn, {
+        StringEquals: {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+        },
+        StringLike: {
+          "token.actions.githubusercontent.com:sub": `repo:${githubRepo}:*`,
+        },
+      }),
+      managedPolicies: [aws_iam.ManagedPolicy.fromAwsManagedPolicyName("ReadOnlyAccess")],
+      description: "Role assumed by github actions",
+    });
 
-    const jenkinsRole = new aws_iam.Role(
-      commonProps.scope,
-      "jenkinsRole",
-      {
-        roleName: `${commonProps.project}-jenkins-role`,
-        permissionsBoundary: commonProps.iamPermissionsBoundary,
-        path: commonProps.iamPath,
-        assumedBy: new aws_iam.ArnPrincipal("arn:aws:iam::478919403635:role/cbc-demos"),
-        managedPolicies: [
-          aws_iam.ManagedPolicy.fromAwsManagedPolicyName("ReadOnlyAccess"),
-        ],
-        description: "Role assumed by github actions",
-      }
-    );
+    const jenkinsRole = new aws_iam.Role(commonProps.scope, "jenkinsRole", {
+      roleName: `${commonProps.project}-jenkins-role`,
+      permissionsBoundary: commonProps.iamPermissionsBoundary,
+      path: commonProps.iamPath,
+      assumedBy: new aws_iam.ArnPrincipal("arn:aws:iam::478919403635:role/cbc-demos"),
+      managedPolicies: [aws_iam.ManagedPolicy.fromAwsManagedPolicyName("ReadOnlyAccess")],
+      description: "Role assumed by github actions",
+    });
 
-    const cbcJenkinsRole = aws_iam.Role.fromRoleName(commonProps.scope, "cbcJenkinsRole", "jenkins-role")
+    const cbcJenkinsRole = aws_iam.Role.fromRoleName(commonProps.scope, "cbcJenkinsRole", "jenkins-role");
 
     const policy = new aws_iam.Policy(commonProps.scope, "actionsPolicy", {
       statements: [
@@ -117,51 +86,69 @@ export class BootstrapStack extends Stack {
         }),
         new aws_iam.PolicyStatement({
           actions: ["ec2:DescribeManagedPrefixLists", "ec2:GetManagedPrefixListEntries"],
-          resources: ["*"]
+          resources: ["*"],
         }),
         new aws_iam.PolicyStatement({
           actions: ["sts:AssumeRole"],
           resources: ["*"],
           conditions: {
             "ForAnyValue:StringEquals": {
-              "iam:ResourceTag/aws-cdk:bootstrap-role": [
-                "deploy",
-                "lookup",
-                "file-publishing",
-                "image-publishing",
-              ],
+              "iam:ResourceTag/aws-cdk:bootstrap-role": ["deploy", "lookup", "file-publishing", "image-publishing"],
             },
           },
         }),
         new aws_iam.PolicyStatement({
-          actions: ["cognito-idp:ListUserPools","cognito-idp:DescribeUserPoolClient", "cognito-idp:UpdateUserPoolClient"],
-          resources: ["*"]
+          actions: [
+            "cognito-idp:ListUserPools",
+            "cognito-idp:DescribeUserPoolClient",
+            "cognito-idp:UpdateUserPoolClient",
+          ],
+          resources: ["*"],
         }),
       ],
     });
 
     githubActionsRole.attachInlinePolicy(policy);
     jenkinsRole.attachInlinePolicy(policy);
-    cbcJenkinsRole.attachInlinePolicy(policy);  
-  
+    cbcJenkinsRole.attachInlinePolicy(policy);
+
     // Private Hosted Zones
-    
-    createPHZ(commonProps.scope, "dev")
-    createPHZ(commonProps.scope, "test")
-    createPHZ(commonProps.scope, "impl")
+
+    createPHZ(commonProps.scope, "dev");
+    createPHZ(commonProps.scope, "test");
+    createPHZ(commonProps.scope, "impl");
+
+    // Wait function
+    new aws_lambda.SingletonFunction(commonProps.scope, "SharedWaitLambda", {
+      functionName: `cdk-wait-${commonProps.scope.account}`,
+      uuid: "c0d7adea-b43d-4022-a438-551724eb7e0f",
+      runtime: aws_lambda.Runtime.NODEJS_22_X,
+      handler: "index.handler",
+      timeout: Duration.minutes(5),
+      code: aws_lambda.Code.fromInline(`
+        var response = require('cfn-response');
+        exports.handler = async (event, context) => {
+          console.log("event", event)
+          const waitTime = event.ResourceProperties.WaitTimeSeconds || 30;
+          console.log('Waiting for ' + waitTime + ' seconds...');
+          await new Promise(resolve => setTimeout(resolve, waitTime * 1000));
+          await response.send(event, context, response.SUCCESS, {wait: waitTime * 1000});
+        }
+      `),
+    });
   }
 }
 
 function createPHZ(scope: Construct, env: string) {
-  const dnsSuffix = "demos.internal.cms.gov"
+  const dnsSuffix = "demos.internal.cms.gov";
 
-    const devVpc = aws_ec2.Vpc.fromLookup(scope, `${env}Vpc`, {
-          tags: {
-            Name: `demos-east-${env}`,
-          },
-        });
-    new PrivateHostedZone(scope, `${env}PrivateZone`, {
-      zoneName: `${env}.${dnsSuffix}`,
-      vpc: devVpc,
-    })
+  const devVpc = aws_ec2.Vpc.fromLookup(scope, `${env}Vpc`, {
+    tags: {
+      Name: `demos-east-${env}`,
+    },
+  });
+  new PrivateHostedZone(scope, `${env}PrivateZone`, {
+    zoneName: `${env}.${dnsSuffix}`,
+    vpc: devVpc,
+  });
 }


### PR DESCRIPTION
This change adds a new lambda at the account level that can be used by any stack to wait for a certain number of seconds. The "wait" resource can set a dependency to start the timer, then other resources can add the wait as a dependency so they aren't created until the timer is up. The number of seconds to wait can be set within the stack up to 5 minutes.

This is used along with the guard duty S3 scanning in order to avoid the race condition between it and the role creation