### PR TITLE
DEMOS-726: Update deployment packages

### DIFF
--- a/deployment/package-lock.json
+++ b/deployment/package-lock.json
@@ -8,11 +8,12 @@
       "name": "deployment",
       "version": "0.1.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity-provider": "^3.844.0",
-        "@aws-sdk/client-ec2": "^3.830.0",
-        "@aws-sdk/client-secrets-manager": "^3.812.0",
-        "aws-cdk-lib": "^2.197.0",
-        "cdk-nag": "^2.35.105",
+        "@aws-sdk/client-cognito-identity-provider": "^3.848.0",
+        "@aws-sdk/client-ec2": "^3.854.0",
+        "@aws-sdk/client-secrets-manager": "^3.848.0",
+        "aws-cdk": "^2.1028.0",
+        "aws-cdk-lib": "^2.214.0",
+        "cdk-nag": "^2.36.46",
         "chalk": "^5.4.1",
         "constructs": "^10.0.0",
         "pg": "^8.16.3"
@@ -25,7 +26,6 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^22.15.21",
         "@types/pg": "^8.15.5",
-        "aws-cdk": "2.1010.0",
         "aws-cdk-local": "^3.0.1",
         "eslint": "^9.27.0",
         "jest": "^29.7.0",
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.236",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.236.tgz",
-      "integrity": "sha512-BjqQVGYsVuS4VXdrezDapSd6P7soEdWJoXl1S8X7l0uLtVX9WvpmCylZKOJDrJblK5MNe1Vq9wUI91LBzzOi8A==",
+      "version": "2.2.242",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz",
+      "integrity": "sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -63,9 +63,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "41.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
-      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
+      "version": "48.7.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-48.7.0.tgz",
+      "integrity": "sha512-NQjyv9Sq9U/LfXf/QkgcGOoOZlZ47KoIzmY6ZBvlcojHRU2XCl1tQLs83YfbG3VQOhoF6cmak8/cIbdEXvfagQ==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -73,10 +73,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.1"
+        "semver": "^7.7.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
@@ -88,7 +88,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.1",
+      "version": "7.7.2",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -224,45 +224,45 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.844.0.tgz",
-      "integrity": "sha512-/8AebJNrkBmnou/5wMtL/lmDcDg7xBsC3WQzXuudGCoeuhrI62hkteRDqar/byQFiO/6H0qXiMry/eq0cMwhYA==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.848.0.tgz",
+      "integrity": "sha512-P/CURVHkOahwUBy9X+uBK/cIOZ7aRfEnZunctNttcfGXToe6RKHvSv8izD8GjWSB/KCYPYbJZKxA9ro8rcimxQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.844.0",
-        "@aws-sdk/credential-provider-node": "3.844.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
         "@aws-sdk/middleware-host-header": "3.840.0",
         "@aws-sdk/middleware-logger": "3.840.0",
         "@aws-sdk/middleware-recursion-detection": "3.840.0",
-        "@aws-sdk/middleware-user-agent": "3.844.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
         "@aws-sdk/region-config-resolver": "3.840.0",
         "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.844.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
         "@aws-sdk/util-user-agent-browser": "3.840.0",
-        "@aws-sdk/util-user-agent-node": "3.844.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
         "@smithy/config-resolver": "^4.1.4",
         "@smithy/core": "^3.7.0",
         "@smithy/fetch-http-handler": "^5.1.0",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.14",
-        "@smithy/middleware-retry": "^4.1.15",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/node-http-handler": "^4.1.0",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.6",
+        "@smithy/smithy-client": "^4.4.7",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.22",
-        "@smithy/util-defaults-mode-node": "^4.0.22",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.6",
@@ -273,45 +273,151 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/client-sso": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.844.0.tgz",
-      "integrity": "sha512-FktodSx+pfUfIqMjoNwZ6t1xqq/G3cfT7I4JJ0HKHoIIZdoCHQB52x0OzKDtHDJAnEQPInasdPS8PorZBZtHmg==",
+    "node_modules/@aws-sdk/client-ec2": {
+      "version": "3.854.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.854.0.tgz",
+      "integrity": "sha512-HLR4d7YcQLyHslePFlnAQmgOXZ+q9qpnGO6MUl53CUdQvGPso8EcDaK4DwMPcDcAPCBA1hozYpjrQBb+fYgnew==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
         "@aws-sdk/middleware-host-header": "3.840.0",
         "@aws-sdk/middleware-logger": "3.840.0",
         "@aws-sdk/middleware-recursion-detection": "3.840.0",
-        "@aws-sdk/middleware-user-agent": "3.844.0",
+        "@aws-sdk/middleware-sdk-ec2": "3.845.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
         "@aws-sdk/region-config-resolver": "3.840.0",
         "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.844.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
         "@aws-sdk/util-user-agent-browser": "3.840.0",
-        "@aws-sdk/util-user-agent-node": "3.844.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
         "@smithy/config-resolver": "^4.1.4",
         "@smithy/core": "^3.7.0",
         "@smithy/fetch-http-handler": "^5.1.0",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.14",
-        "@smithy/middleware-retry": "^4.1.15",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/node-http-handler": "^4.1.0",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.6",
+        "@smithy/smithy-client": "^4.4.7",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.22",
-        "@smithy/util-defaults-mode-node": "^4.0.22",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.6",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.848.0.tgz",
+      "integrity": "sha512-T1SRQrBvUD8KGArFpWeVuXD1Qh2zqMErayRvJiTvVMy8ru1jXDr58MVdoIDnRVLQFeE4k9f0jtPbUXJsRIoGIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.848.0.tgz",
+      "integrity": "sha512-mD+gOwoeZQvbecVLGoCmY6pS7kg02BHesbtIxUj+PeBqYoZV5uLvjUOmuGfw1SfoSobKvS11urxC9S7zxU/Maw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.6",
@@ -322,10 +428,10 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/core": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.844.0.tgz",
-      "integrity": "sha512-pfpI54bG5Xf2NkqrDBC2REStXlDXNCw/whORhkEs+Tp5exU872D5QKguzjPA6hH+8Pvbq1qgt5zXMbduISTHJw==",
+    "node_modules/@aws-sdk/core": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.846.0.tgz",
+      "integrity": "sha512-7CX0pM906r4WSS68fCTNMTtBCSkTtf3Wggssmx13gD40gcWEZXsU00KzPp1bYheNRyPlAq3rE22xt4wLPXbuxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.840.0",
@@ -335,7 +441,7 @@
         "@smithy/property-provider": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/signature-v4": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.6",
+        "@smithy/smithy-client": "^4.4.7",
         "@smithy/types": "^4.3.1",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
@@ -348,13 +454,13 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.844.0.tgz",
-      "integrity": "sha512-WB94Ox86MqcZ4CnRjKgopzaSuZH4hMP0GqdOxG4s1it1lRWOIPOHOC1dPiM0Zbj1uqITIhbXUQVXyP/uaJeNkw==",
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.846.0.tgz",
+      "integrity": "sha512-QuCQZET9enja7AWVISY+mpFrEIeHzvkx/JEEbHYzHhUkxcnC2Kq2c0bB7hDihGD0AZd3Xsm653hk1O97qu69zg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/core": "3.846.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/types": "^4.3.1",
@@ -364,19 +470,19 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.844.0.tgz",
-      "integrity": "sha512-e+efVqfkhpM8zxYeiLNgTUlX+tmtXzVm3bw1A02U9Z9cWBHyQNb8pi90M7QniLoqRURY1B0C2JqkOE61gd4KNg==",
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.846.0.tgz",
+      "integrity": "sha512-Jh1iKUuepdmtreMYozV2ePsPcOF5W9p3U4tWhi3v6nDvz0GsBjzjAROW+BW8XMz9vAD3I9R+8VC3/aq63p5nlw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/core": "3.846.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/fetch-http-handler": "^5.1.0",
         "@smithy/node-http-handler": "^4.1.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.6",
+        "@smithy/smithy-client": "^4.4.7",
         "@smithy/types": "^4.3.1",
         "@smithy/util-stream": "^4.2.3",
         "tslib": "^2.6.2"
@@ -385,19 +491,19 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.844.0.tgz",
-      "integrity": "sha512-jc5ArGz2HfAx5QPXD+Ep36+QWyCKzl2TG6Vtl87/vljfLhVD0gEHv8fRsqWEp3Rc6hVfKnCjLW5ayR2HYcow9w==",
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.848.0.tgz",
+      "integrity": "sha512-r6KWOG+En2xujuMhgZu7dzOZV3/M5U/5+PXrG8dLQ3rdPRB3vgp5tc56KMqLwm/EXKRzAOSuw/UE4HfNOAB8Hw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.844.0",
-        "@aws-sdk/credential-provider-env": "3.844.0",
-        "@aws-sdk/credential-provider-http": "3.844.0",
-        "@aws-sdk/credential-provider-process": "3.844.0",
-        "@aws-sdk/credential-provider-sso": "3.844.0",
-        "@aws-sdk/credential-provider-web-identity": "3.844.0",
-        "@aws-sdk/nested-clients": "3.844.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-env": "3.846.0",
+        "@aws-sdk/credential-provider-http": "3.846.0",
+        "@aws-sdk/credential-provider-process": "3.846.0",
+        "@aws-sdk/credential-provider-sso": "3.848.0",
+        "@aws-sdk/credential-provider-web-identity": "3.848.0",
+        "@aws-sdk/nested-clients": "3.848.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/credential-provider-imds": "^4.0.6",
         "@smithy/property-provider": "^4.0.4",
@@ -409,18 +515,18 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.844.0.tgz",
-      "integrity": "sha512-pUqB0StTNyW0R03XjTA3wrQZcie/7FJKSXlYHue921ZXuhLOZpzyDkLNfdRsZTcEoYYWVPSmyS+Eu/g5yVsBNA==",
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.848.0.tgz",
+      "integrity": "sha512-AblNesOqdzrfyASBCo1xW3uweiSro4Kft9/htdxLeCVU1KVOnFWA5P937MNahViRmIQm2sPBCqL8ZG0u9lnh5g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.844.0",
-        "@aws-sdk/credential-provider-http": "3.844.0",
-        "@aws-sdk/credential-provider-ini": "3.844.0",
-        "@aws-sdk/credential-provider-process": "3.844.0",
-        "@aws-sdk/credential-provider-sso": "3.844.0",
-        "@aws-sdk/credential-provider-web-identity": "3.844.0",
+        "@aws-sdk/credential-provider-env": "3.846.0",
+        "@aws-sdk/credential-provider-http": "3.846.0",
+        "@aws-sdk/credential-provider-ini": "3.848.0",
+        "@aws-sdk/credential-provider-process": "3.846.0",
+        "@aws-sdk/credential-provider-sso": "3.848.0",
+        "@aws-sdk/credential-provider-web-identity": "3.848.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/credential-provider-imds": "^4.0.6",
         "@smithy/property-provider": "^4.0.4",
@@ -432,13 +538,13 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.844.0.tgz",
-      "integrity": "sha512-VCI8XvIDt2WBfk5Gi/wXKPcWTS3OkAbovB66oKcNQalllH8ESDg4SfLNhchdnN8A5sDGj6tIBJ19nk+dQ6GaqQ==",
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.846.0.tgz",
+      "integrity": "sha512-mEpwDYarJSH+CIXnnHN0QOe0MXI+HuPStD6gsv3z/7Q6ESl8KRWon3weFZCDnqpiJMUVavlDR0PPlAFg2MQoPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/core": "3.846.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -449,15 +555,15 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.844.0.tgz",
-      "integrity": "sha512-UNp/uWufGlb5nWa4dpc6uQnDOB/9ysJJFG95ACowNVL9XWfi1LJO7teKrqNkVhq0CzSJS1tCt3FvX4UfM+aN1g==",
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.848.0.tgz",
+      "integrity": "sha512-pozlDXOwJZL0e7w+dqXLgzVDB7oCx4WvtY0sk6l4i07uFliWF/exupb6pIehFWvTUcOvn5aFTTqcQaEzAD5Wsg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.844.0",
-        "@aws-sdk/core": "3.844.0",
-        "@aws-sdk/token-providers": "3.844.0",
+        "@aws-sdk/client-sso": "3.848.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/token-providers": "3.848.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -468,14 +574,14 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.844.0.tgz",
-      "integrity": "sha512-iDmX4pPmatjttIScdspZRagaFnCjpHZIEEwTyKdXxUaU0iAOSXF8ecrCEvutETvImPOC86xdrq+MPacJOnMzUA==",
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.848.0.tgz",
+      "integrity": "sha512-D1fRpwPxtVDhcSc/D71exa2gYweV+ocp4D3brF0PgFd//JR3XahZ9W24rVnTQwYEcK9auiBZB89Ltv+WbWN8qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.844.0",
-        "@aws-sdk/nested-clients": "3.844.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/nested-clients": "3.848.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/types": "^4.3.1",
@@ -485,7 +591,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-host-header": {
+    "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.840.0.tgz",
       "integrity": "sha512-ub+hXJAbAje94+Ya6c6eL7sYujoE8D4Bumu1NUI8TXjUhVVn0HzVWQjpRLshdLsUp1AW7XyeJaxyajRaJQ8+Xg==",
@@ -500,7 +606,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-logger": {
+    "node_modules/@aws-sdk/middleware-logger": {
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.840.0.tgz",
       "integrity": "sha512-lSV8FvjpdllpGaRspywss4CtXV8M7NNNH+2/j86vMH+YCOZ6fu2T/TyFd/tHwZ92vDfHctWkRbQxg0bagqwovA==",
@@ -514,7 +620,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-recursion-detection": {
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.840.0.tgz",
       "integrity": "sha512-Gu7lGDyfddyhIkj1Z1JtrY5NHb5+x/CRiB87GjaSrKxkDaydtX2CU977JIABtt69l9wLbcGDIQ+W0uJ5xPof7g==",
@@ -529,15 +635,34 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.844.0.tgz",
-      "integrity": "sha512-SIbDNUL6ZYXPj5Tk0qEz05sW9kNS1Gl3/wNWEmH+AuUACipkyIeKKWzD6z5433MllETh73vtka/JQF3g7AuZww==",
+    "node_modules/@aws-sdk/middleware-sdk-ec2": {
+      "version": "3.845.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.845.0.tgz",
+      "integrity": "sha512-AATrRHKPzvHdTHbDhOHKvVhOlkrdVmPY00gP/dSBRu2im2Hr694aCcnvf/RLJVlw9fdkJFIFH7TVgPeSO2AUOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.844.0",
         "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.844.0",
+        "@aws-sdk/util-format-url": "3.840.0",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/signature-v4": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.848.0.tgz",
+      "integrity": "sha512-rjMuqSWJEf169/ByxvBqfdei1iaduAnfolTshsZxwcmLIUtbYrFUmts0HrLQqsAG8feGPpDLHA272oPl+NTCCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
         "@smithy/core": "^3.7.0",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
@@ -547,45 +672,45 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.844.0.tgz",
-      "integrity": "sha512-p2XILWc7AcevUSpBg2VtQrk79eWQC4q2JsCSY7HxKpFLZB4mMOfmiTyYkR1gEA6AttK/wpCOtfz+hi1/+z2V1A==",
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.848.0.tgz",
+      "integrity": "sha512-joLsyyo9u61jnZuyYzo1z7kmS7VgWRAkzSGESVzQHfOA1H2PYeUFek6vLT4+c9xMGrX/Z6B0tkRdzfdOPiatLg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/core": "3.846.0",
         "@aws-sdk/middleware-host-header": "3.840.0",
         "@aws-sdk/middleware-logger": "3.840.0",
         "@aws-sdk/middleware-recursion-detection": "3.840.0",
-        "@aws-sdk/middleware-user-agent": "3.844.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
         "@aws-sdk/region-config-resolver": "3.840.0",
         "@aws-sdk/types": "3.840.0",
-        "@aws-sdk/util-endpoints": "3.844.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
         "@aws-sdk/util-user-agent-browser": "3.840.0",
-        "@aws-sdk/util-user-agent-node": "3.844.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
         "@smithy/config-resolver": "^4.1.4",
         "@smithy/core": "^3.7.0",
         "@smithy/fetch-http-handler": "^5.1.0",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.14",
-        "@smithy/middleware-retry": "^4.1.15",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/node-http-handler": "^4.1.0",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.6",
+        "@smithy/smithy-client": "^4.4.7",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.22",
-        "@smithy/util-defaults-mode-node": "^4.0.22",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.6",
@@ -596,7 +721,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/region-config-resolver": {
+    "node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.840.0.tgz",
       "integrity": "sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA==",
@@ -613,14 +738,14 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/token-providers": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.844.0.tgz",
-      "integrity": "sha512-Kh728FEny0fil+LeH8U1offPJCTd/EDh8liBAvLtViLHt2WoX2xC8rk98D38Q5p79aIUhHb3Pf4n9IZfTu/Kog==",
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.848.0.tgz",
+      "integrity": "sha512-oNPyM4+Di2Umu0JJRFSxDcKQ35+Chl/rAwD47/bS0cDPI8yrao83mLXLeDqpRPHyQW4sXlP763FZcuAibC0+mg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.844.0",
-        "@aws-sdk/nested-clients": "3.844.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/nested-clients": "3.848.0",
         "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -631,7 +756,7 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/types": {
+    "node_modules/@aws-sdk/types": {
       "version": "3.840.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
       "integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
@@ -644,1023 +769,16 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.844.0.tgz",
-      "integrity": "sha512-1DHh0WTUmxlysz3EereHKtKoxVUG9UC5BsfAw6Bm4/6qDlJiqtY3oa2vebkYN23yltKdfsCK65cwnBRU59mWVg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.840.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-endpoints": "^3.0.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.840.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz",
-      "integrity": "sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.840.0",
-        "@smithy/types": "^4.3.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.844.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.844.0.tgz",
-      "integrity": "sha512-0eTpURp9Gxbyyeqr78ogARZMSWS5KUMZuN+XMHxNpQLmn2S+J3g+MAyoklCcwhKXlbdQq2aMULEiy0mqIWytuw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.844.0",
-        "@aws-sdk/types": "3.840.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^2.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity-provider/node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@aws-sdk/client-ec2": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.830.0.tgz",
-      "integrity": "sha512-5rPRmw/Q9F9Q8aAaJaQJx0Py7vo9HoFQWyDwFIMK4BRrVVu4DjqZB/fTOmWiZrwGsgAVdCj5CbFPe4lkc1af1A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-node": "3.830.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-sdk-ec2": "3.826.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.5",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/client-sso": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.830.0.tgz",
-      "integrity": "sha512-5zCEpfI+zwX2SIa258L+TItNbBoAvQQ6w74qdFM6YJufQ1F9tvwjTX8T+eSTT9nsFIvfYnUaGalWwJVfmJUgVQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/core": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.826.0.tgz",
-      "integrity": "sha512-BGbQYzWj3ps+dblq33FY5tz/SsgJCcXX0zjQlSC07tYvU1jHTUvsefphyig+fY38xZ4wdKjbTop+KUmXUYrOXw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/xml-builder": "3.821.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/signature-v4": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-utf8": "^4.0.0",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.826.0.tgz",
-      "integrity": "sha512-DK3pQY8+iKK3MGDdC3uOZQ2psU01obaKlTYhEwNu4VWzgwQL4Vi3sWj4xSWGEK41vqZxiRLq6fOq7ysRI+qEZA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.826.0.tgz",
-      "integrity": "sha512-N+IVZBh+yx/9GbMZTKO/gErBi/FYZQtcFRItoLbY+6WU+0cSWyZYfkoeOxHmQV3iX9k65oljERIWUmL9x6OSQg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.830.0.tgz",
-      "integrity": "sha512-zeQenzvh8JRY5nULd8izdjVGoCM1tgsVVsrLSwDkHxZTTW0hW/bmOmXfvdaE0wDdomXW7m2CkQDSmP7XdvNXZg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.830.0",
-        "@aws-sdk/credential-provider-web-identity": "3.830.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.830.0.tgz",
-      "integrity": "sha512-X/2LrTgwtK1pkWrvofxQBI8VTi6QVLtSMpsKKPPnJQ0vgqC0e4czSIs3ZxiEsOkCBaQ2usXSiKyh0ccsQ6k2OA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-ini": "3.830.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.830.0",
-        "@aws-sdk/credential-provider-web-identity": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.826.0.tgz",
-      "integrity": "sha512-kURrc4amu3NLtw1yZw7EoLNEVhmOMRUTs+chaNcmS+ERm3yK0nKjaJzmKahmwlTQTSl3wJ8jjK7x962VPo+zWw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.830.0.tgz",
-      "integrity": "sha512-+VdRpZmfekzpySqZikAKx6l5ndnLGluioIgUG4ZznrButgFD/iogzFtGmBDFB3ZLViX1l4pMXru0zFwJEZT21Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.830.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/token-providers": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.830.0.tgz",
-      "integrity": "sha512-hPYrKsZeeOdLROJ59T6Y8yZ0iwC/60L3qhZXjapBFjbqBtMaQiMTI645K6xVXBioA6vxXq7B4aLOhYqk6Fy/Ww==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.821.0.tgz",
-      "integrity": "sha512-xSMR+sopSeWGx5/4pAGhhfMvGBHioVBbqGvDs6pG64xfNwM5vq5s5v6D04e2i+uSTj4qGa71dLUs5I0UzAK3sw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.821.0.tgz",
-      "integrity": "sha512-0cvI0ipf2tGx7fXYEEN5fBeZDz2RnHyb9xftSgUsEq7NBxjV0yTZfLJw6Za5rjE6snC80dRN8+bTNR1tuG89zA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.821.0.tgz",
-      "integrity": "sha512-efmaifbhBoqKG3bAoEfDdcM8hn1psF+4qa7ykWuYmfmah59JBeqHLfz5W9m9JoTwoKPkFcVLWZxnyZzAnVBOIg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.828.0.tgz",
-      "integrity": "sha512-nixvI/SETXRdmrVab4D9LvXT3lrXkwAWGWk2GVvQvzlqN1/M/RfClj+o37Sn4FqRkGH9o9g7Fqb1YqZ4mqDAtA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.830.0.tgz",
-      "integrity": "sha512-5N5YTlBr1vtxf7+t+UaIQ625KEAmm7fY9o1e3MgGOi/paBoI0+axr3ud24qLIy0NSzFlAHEaxUSWxcERNjIoZw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.821.0.tgz",
-      "integrity": "sha512-t8og+lRCIIy5nlId0bScNpCkif8sc0LhmtaKsbm0ZPm3sCa/WhCbSZibjbZ28FNjVCV+p0D9RYZx0VDDbtWyjw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/token-providers": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.830.0.tgz",
-      "integrity": "sha512-aJ4guFwj92nV9D+EgJPaCFKK0I3y2uMchiDfh69Zqnmwfxxxfxat6F79VA7PS0BdbjRfhLbn+Ghjftnomu2c1g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/types": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.821.0.tgz",
-      "integrity": "sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.828.0.tgz",
-      "integrity": "sha512-RvKch111SblqdkPzg3oCIdlGxlQs+k+P7Etory9FmxPHyPDvsP1j1c74PmgYqtzzMWmoXTjd+c9naUHh9xG8xg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-endpoints": "^3.0.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.821.0.tgz",
-      "integrity": "sha512-irWZHyM0Jr1xhC+38OuZ7JB6OXMLPZlj48thElpsO1ZSLRkLZx5+I7VV6k3sp2yZ7BYbKz/G2ojSv4wdm7XTLw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.828.0.tgz",
-      "integrity": "sha512-LdN6fTBzTlQmc8O8f1wiZN0qF3yBWVGis7NwpWK7FUEzP9bEZRxYfIkV9oV9zpt6iNRze1SedK3JQVB/udxBoA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.812.0.tgz",
-      "integrity": "sha512-RyGzi7kkacjPd0QgVjw6OYvZVvuqtd1wRwG0Aek32dPUYu8eOs9FDaqBsDnNIqdw+lAqC/pKIOPYWtLu2OxE0Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.812.0",
-        "@aws-sdk/credential-provider-node": "3.812.0",
-        "@aws-sdk/middleware-host-header": "3.804.0",
-        "@aws-sdk/middleware-logger": "3.804.0",
-        "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.812.0",
-        "@aws-sdk/region-config-resolver": "3.808.0",
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.808.0",
-        "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.812.0",
-        "@smithy/config-resolver": "^4.1.2",
-        "@smithy/core": "^3.3.3",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.6",
-        "@smithy/middleware-retry": "^4.1.7",
-        "@smithy/middleware-serde": "^4.0.5",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.6",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.14",
-        "@smithy/util-defaults-mode-node": "^4.0.14",
-        "@smithy/util-endpoints": "^3.0.4",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.3",
-        "@smithy/util-utf8": "^4.0.0",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.812.0.tgz",
-      "integrity": "sha512-O//smQRj1+RXELB7xX54s5pZB0V69KHXpUZmz8V+8GAYO1FKTHfbpUgK+zyMNb+lFZxG9B69yl8pWPZ/K8bvxA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.812.0",
-        "@aws-sdk/middleware-host-header": "3.804.0",
-        "@aws-sdk/middleware-logger": "3.804.0",
-        "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.812.0",
-        "@aws-sdk/region-config-resolver": "3.808.0",
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.808.0",
-        "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.812.0",
-        "@smithy/config-resolver": "^4.1.2",
-        "@smithy/core": "^3.3.3",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.6",
-        "@smithy/middleware-retry": "^4.1.7",
-        "@smithy/middleware-serde": "^4.0.5",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.6",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.14",
-        "@smithy/util-defaults-mode-node": "^4.0.14",
-        "@smithy/util-endpoints": "^3.0.4",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.3",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.812.0.tgz",
-      "integrity": "sha512-myWA9oHMBVDObKrxG+puAkIGs8igcWInQ1PWCRTS/zN4BkhUMFjjh/JPV/4Vzvtvj5E36iujq2WtlrDLl1PpOw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/core": "^3.3.3",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/signature-v4": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.6",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.812.0.tgz",
-      "integrity": "sha512-Ge7IEu06ANurGBZx39q9CNN/ncqb1K8lpKZCY969uNWO0/7YPhnplrRJGMZYIS35nD2mBm3ortEKjY/wMZZd5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.812.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.812.0.tgz",
-      "integrity": "sha512-Vux2U42vPGXeE407Lp6v3yVA65J7hBO9rB67LXshyGVi7VZLAYWc4mrZxNJNqabEkjcDEmMQQakLPT6zc5SvFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.812.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.6",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-stream": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.812.0.tgz",
-      "integrity": "sha512-oltqGvQ488xtPY5wrNjbD+qQYYkuCjn30IDE1qKMxJ58EM6UVTQl3XV44Xq07xfF5gKwVJQkfIyOkRAguOVybg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.812.0",
-        "@aws-sdk/credential-provider-env": "3.812.0",
-        "@aws-sdk/credential-provider-http": "3.812.0",
-        "@aws-sdk/credential-provider-process": "3.812.0",
-        "@aws-sdk/credential-provider-sso": "3.812.0",
-        "@aws-sdk/credential-provider-web-identity": "3.812.0",
-        "@aws-sdk/nested-clients": "3.812.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/credential-provider-imds": "^4.0.4",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.812.0.tgz",
-      "integrity": "sha512-SnvSWBP6cr9nqx784eETnL2Zl7ZnMB/oJgFVEG1aejAGbT1H9gTpMwuUsBXk4u/mEYe3f1lh1Wqo+HwDgNkfrg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.812.0",
-        "@aws-sdk/credential-provider-http": "3.812.0",
-        "@aws-sdk/credential-provider-ini": "3.812.0",
-        "@aws-sdk/credential-provider-process": "3.812.0",
-        "@aws-sdk/credential-provider-sso": "3.812.0",
-        "@aws-sdk/credential-provider-web-identity": "3.812.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/credential-provider-imds": "^4.0.4",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.812.0.tgz",
-      "integrity": "sha512-YI8bb153XeEOb59F9KtTZEwDAc14s2YHZz58+OFiJ2udnKsPV87mNiFhJPW6ba9nmOLXVat5XDcwtVT1b664wg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.812.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.812.0.tgz",
-      "integrity": "sha512-ODsPcNhgiO6GOa82TVNskM97mml9rioe9Cbhemz48lkfDQPv1u06NaCR0o3FsvprX1sEhMvJTR3sE1fyEOzvJQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.812.0",
-        "@aws-sdk/core": "3.812.0",
-        "@aws-sdk/token-providers": "3.812.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.812.0.tgz",
-      "integrity": "sha512-E9Bmiujvm/Hp9DM/Vc1S+D0pQbx8/x4dR/zyAEZU9EoRq0duQOQ1reWYWbebYmL1OklcVpTfKV0a/VCwuAtGSg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.812.0",
-        "@aws-sdk/nested-clients": "3.812.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.804.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.804.0.tgz",
-      "integrity": "sha512-bum1hLVBrn2lJCi423Z2fMUYtsbkGI2s4N+2RI2WSjvbaVyMSv/WcejIrjkqiiMR+2Y7m5exgoKeg4/TODLDPQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.804.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.804.0.tgz",
-      "integrity": "sha512-w/qLwL3iq0KOPQNat0Kb7sKndl9BtceigINwBU7SpkYWX9L/Lem6f8NPEKrC9Tl4wDBht3Yztub4oRTy/horJA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.804.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.804.0.tgz",
-      "integrity": "sha512-zqHOrvLRdsUdN/ehYfZ9Tf8svhbiLLz5VaWUz22YndFv6m9qaAcijkpAOlKexsv3nLBMJdSdJ6GUTAeIy3BZzw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-ec2": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.826.0.tgz",
-      "integrity": "sha512-qonwFJddYtVTXEj+GGjqHWqlSYDmKI4ZIf7iozNgucBzP5+zdFuyjvdQIAFLAv/joQphGv4P799PK2Elb5ZzpA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-format-url": "3.821.0",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/signature-v4": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@aws-sdk/types": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.821.0.tgz",
-      "integrity": "sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.812.0.tgz",
-      "integrity": "sha512-r+HFwtSvnAs6Fydp4mijylrTX0og9p/xfxOcKsqhMuk3HpZAIcf9sSjRQI6MBusYklg7pnM4sGEnPAZIrdRotA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.812.0",
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.808.0",
-        "@smithy/core": "^3.3.3",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.812.0.tgz",
-      "integrity": "sha512-FS/fImbEpJU3cXtBGR9fyVd+CP51eNKlvTMi3f4/6lSk3RmHjudNC9yEF/og3jtpT3O+7vsNOUW9mHco5IjdQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.812.0",
-        "@aws-sdk/middleware-host-header": "3.804.0",
-        "@aws-sdk/middleware-logger": "3.804.0",
-        "@aws-sdk/middleware-recursion-detection": "3.804.0",
-        "@aws-sdk/middleware-user-agent": "3.812.0",
-        "@aws-sdk/region-config-resolver": "3.808.0",
-        "@aws-sdk/types": "3.804.0",
-        "@aws-sdk/util-endpoints": "3.808.0",
-        "@aws-sdk/util-user-agent-browser": "3.804.0",
-        "@aws-sdk/util-user-agent-node": "3.812.0",
-        "@smithy/config-resolver": "^4.1.2",
-        "@smithy/core": "^3.3.3",
-        "@smithy/fetch-http-handler": "^5.0.2",
-        "@smithy/hash-node": "^4.0.2",
-        "@smithy/invalid-dependency": "^4.0.2",
-        "@smithy/middleware-content-length": "^4.0.2",
-        "@smithy/middleware-endpoint": "^4.1.6",
-        "@smithy/middleware-retry": "^4.1.7",
-        "@smithy/middleware-serde": "^4.0.5",
-        "@smithy/middleware-stack": "^4.0.2",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/node-http-handler": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.0",
-        "@smithy/smithy-client": "^4.2.6",
-        "@smithy/types": "^4.2.0",
-        "@smithy/url-parser": "^4.0.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.14",
-        "@smithy/util-defaults-mode-node": "^4.0.14",
-        "@smithy/util-endpoints": "^3.0.4",
-        "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.3",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.808.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.808.0.tgz",
-      "integrity": "sha512-9x2QWfphkARZY5OGkl9dJxZlSlYM2l5inFeo2bKntGuwg4A4YUe5h7d5yJ6sZbam9h43eBrkOdumx03DAkQF9A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.812.0.tgz",
-      "integrity": "sha512-dbVBaKxrxE708ub5uH3w+cmKIeRQas+2Xf6rpckhohYY+IiflGOdK6aLrp3T6dOQgr/FJ37iQtcYNonAG+yVBQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/nested-clients": "3.812.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/property-provider": "^4.0.2",
-        "@smithy/shared-ini-file-loader": "^4.0.2",
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/types": {
-      "version": "3.804.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.804.0.tgz",
-      "integrity": "sha512-A9qnsy9zQ8G89vrPPlNG9d1d8QcKRGqJKqwyGgS0dclJpwy6d1EWgQLIolKPl6vcFpLoe6avLOLxr+h8ur5wpg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.808.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.808.0.tgz",
-      "integrity": "sha512-N6Lic98uc4ADB7fLWlzx+1uVnq04VgVjngZvwHoujcRg9YDhIg9dUDiTzD5VZv13g1BrPYmvYP1HhsildpGV6w==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
+      "integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/types": "^4.2.0",
-        "@smithy/util-endpoints": "^3.0.4",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-endpoints": "^3.0.6",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1668,26 +786,13 @@
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.821.0.tgz",
-      "integrity": "sha512-h+xqmPToxDrZ0a7rxE1a8Oh4zpWfZe9oiQUphGtfiGFA6j75UiURH5J3MmGHa/G4t15I3iLLbYtUXxvb1i7evg==",
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.840.0.tgz",
+      "integrity": "sha512-VB1PWyI1TQPiPvg4w7tgUGGQER1xxXPNUqfh3baxUSFi1Oh8wHrDnFywkxLm3NMmgDmnLnSZ5Q326qAoyqKLSg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/querystring-builder": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.821.0.tgz",
-      "integrity": "sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
@@ -1708,27 +813,27 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.804.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.804.0.tgz",
-      "integrity": "sha512-KfW6T6nQHHM/vZBBdGn6fMyG/MgX5lq82TDdX4HRQRRuHKLgBWGpKXqqvBwqIaCdXwWHgDrg2VQups6GqOWW2A==",
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz",
+      "integrity": "sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.812.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.812.0.tgz",
-      "integrity": "sha512-8pt+OkHhS2U0LDwnzwRnFxyKn8sjSe752OIZQCNv263odud8jQu9pYO2pKqb2kRBk9h9szynjZBDLXfnvSQ7Bg==",
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.848.0.tgz",
+      "integrity": "sha512-Zz1ft9NiLqbzNj/M0jVNxaoxI2F4tGXN0ZbZIj+KJ+PbJo+w5+Jo6d0UDAtbj3AEd79pjcCaP4OA9NTVzItUdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.812.0",
-        "@aws-sdk/types": "3.804.0",
-        "@smithy/node-config-provider": "^4.1.1",
-        "@smithy/types": "^4.2.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3467,12 +2572,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.4.tgz",
-      "integrity": "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.5.tgz",
+      "integrity": "sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3480,15 +2585,15 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.4.tgz",
-      "integrity": "sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.5.tgz",
+      "integrity": "sha512-viuHMxBAqydkB0AfWwHIdwf/PRH2z5KHGUzqyRtS/Wv+n3IHI993Sk76VCA7dD/+GzgGOmlJDITfPcJC1nIVIw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-middleware": "^4.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3496,35 +2601,37 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-7ov8hu/4j0uPZv8b27oeOFtIBtlFmM3ibrPv/Omx1uUdoXvcpJ00U+H/OWWC/keAguLlcqwtyL2/jTlSnApgNQ==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.9.2.tgz",
+      "integrity": "sha512-H7H+dnfyHa/XXmZB3+IcqB1snIvbXaeGbV7//PMY69YKMOfGtuHPg6aukxsD0TyqmIU+bcX5nitR+nf/19nTlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-stream": "^4.2.3",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-stream": "^4.2.4",
         "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz",
-      "integrity": "sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.7.tgz",
+      "integrity": "sha512-dDzrMXA8d8riFNiPvytxn0mNwR4B3h8lgrQ5UjAGu6T9z/kRg/Xncf4tEQHE/+t25sY8IH3CowcmWi+1U5B1Gw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3532,14 +2639,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.0.tgz",
-      "integrity": "sha512-mADw7MS0bYe2OGKkHYMaqarOXuDwRbO6ArD91XhHcl2ynjGCFF+hvqf0LyQcYxkA1zaWjefSkU7Ne9mqgApSgQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
+      "integrity": "sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/querystring-builder": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/querystring-builder": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-base64": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -3602,18 +2709,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.14.tgz",
-      "integrity": "sha512-+BGLpK5D93gCcSEceaaYhUD/+OCGXM1IDaq/jKUQ+ujB0PTWlWN85noodKw/IPFZhIKFCNEe19PGd/reUMeLSQ==",
+      "version": "4.1.21",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.21.tgz",
+      "integrity": "sha512-VCFE6LGSbnXs6uxLTdtar6dbkOHa9mrj692pZJx1mQVEzk0gvckAX9WB9BzlONUpv92QBWGezROz/+yEitQjAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.7.0",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/core": "^3.9.2",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-middleware": "^4.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3621,18 +2728,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.15.tgz",
-      "integrity": "sha512-iKYUJpiyTQ33U2KlOZeUb0GwtzWR3C0soYcKuCnTmJrvt6XwTPQZhMfsjJZNw7PpQ3TU4Ati1qLSrkSJxnnSMQ==",
+      "version": "4.1.22",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.22.tgz",
+      "integrity": "sha512-mb6/wn4ixnSJCkKVLs51AKAyknbSTvwrHCM7cqgwGfYQ7/J6Qvv+49cBHe6Rl8Q0m3fROVYcSvM6bBiQtuhYWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/service-error-classification": "^4.0.6",
-        "@smithy/smithy-client": "^4.4.6",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.6",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/service-error-classification": "^4.0.7",
+        "@smithy/smithy-client": "^4.5.2",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@types/uuid": "^9.0.1",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -3641,13 +2749,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.8.tgz",
-      "integrity": "sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.9.tgz",
+      "integrity": "sha512-uAFFR4dpeoJPGz8x9mhxp+RPjo5wW0QEEIPPPbLXiRRWeCATf/Km3gKIVR5vaP8bN1kgsPhcEeh+IZvUlBv6Xg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3655,12 +2763,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.4.tgz",
-      "integrity": "sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.5.tgz",
+      "integrity": "sha512-/yoHDXZPh3ocRVyeWQFvC44u8seu3eYzZRveCMfgMOBcNKnAmOvjbL9+Cp5XKSIi9iYA9PECUuW2teDAk8T+OQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3668,14 +2776,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.3.tgz",
-      "integrity": "sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.4.tgz",
+      "integrity": "sha512-+UDQV/k42jLEPPHSn39l0Bmc4sB1xtdI9Gd47fzo/0PbXzJ7ylgaOByVjF5EeQIumkepnrJyfx86dPa9p47Y+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3683,15 +2791,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.0.tgz",
-      "integrity": "sha512-vqfSiHz2v8b3TTTrdXi03vNz1KLYYS3bhHCDv36FYDqxT7jvTll1mMnCrkD+gOvgwybuunh/2VmvOMqwBegxEg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.1.tgz",
+      "integrity": "sha512-RHnlHqFpoVdjSPPiYy/t40Zovf3BBHc2oemgD7VsVTFFZrU5erFFe0n52OANZZ/5sbshgD93sOh5r6I35Xmpaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/querystring-builder": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/abort-controller": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/querystring-builder": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3699,12 +2807,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.4.tgz",
-      "integrity": "sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.5.tgz",
+      "integrity": "sha512-R/bswf59T/n9ZgfgUICAZoWYKBHcsVDurAGX88zsiUtOTA/xUAPyiT+qkNCPwFn43pZqN84M4MiUsbSGQmgFIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3712,12 +2820,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.2.tgz",
-      "integrity": "sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
+      "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3725,12 +2833,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.4.tgz",
-      "integrity": "sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
+      "integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-uri-escape": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -3739,12 +2847,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz",
-      "integrity": "sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.5.tgz",
+      "integrity": "sha512-6SV7md2CzNG/WUeTjVe6Dj8noH32r4MnUeFKZrnVYsQxpGSIcphAanQMayi8jJLZAWm6pdM9ZXvKCpWOsIGg0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3752,24 +2860,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.6.tgz",
-      "integrity": "sha512-RRoTDL//7xi4tn5FrN2NzH17jbgmnKidUqd4KvquT0954/i6CXXkh1884jBiunq24g9cGtPBEXlU40W6EpNOOg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.7.tgz",
+      "integrity": "sha512-XvRHOipqpwNhEjDf2L5gJowZEm5nsxC16pAZOeEcsygdjv9A2jdOh3YoDQvOXBGTsaJk6mNWtzWalOB9976Wlg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1"
+        "@smithy/types": "^4.3.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz",
-      "integrity": "sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.5.tgz",
+      "integrity": "sha512-YVVwehRDuehgoXdEL4r1tAAzdaDgaC9EQvhK0lEbfnbrd0bd5+CTQumbdPryX3J2shT7ZqQE+jPW4lmNBAB8JQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3796,17 +2904,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.6.tgz",
-      "integrity": "sha512-3wfhywdzB/CFszP6moa5L3lf5/zSfQoH0kvVSdkyK2az5qZet0sn2PAHjcTDiq296Y4RP5yxF7B6S6+3oeBUCQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.5.2.tgz",
+      "integrity": "sha512-WRdTJ7aNSJY0WuGpxrvVgRaFKGiuvtXX1Txhnu2BdynraSlH2bcP75riQ4SiQfawU1HNEKaPI5gf/ePm+Ro/Cw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.7.0",
-        "@smithy/middleware-endpoint": "^4.1.14",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.3",
+        "@smithy/core": "^3.9.2",
+        "@smithy/middleware-endpoint": "^4.1.21",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-stream": "^4.2.4",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3814,9 +2922,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
-      "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
+      "integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3826,13 +2934,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.4.tgz",
-      "integrity": "sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.5.tgz",
+      "integrity": "sha512-j+733Um7f1/DXjYhCbvNXABV53NyCRRA54C7bNEIxNPs0YjfRxeMKjjgm2jvTYrciZyCjsicHwQ6Q0ylo+NAUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/querystring-parser": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3903,14 +3011,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.22",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.22.tgz",
-      "integrity": "sha512-hjElSW18Wq3fUAWVk6nbk7pGrV7ZT14DL1IUobmqhV3lxcsIenr5FUsDe2jlTVaS8OYBI3x+Og9URv5YcKb5QA==",
+      "version": "4.0.29",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.29.tgz",
+      "integrity": "sha512-awrIb21sWml3OMRhqf8e5GPLuZAcH3PRAHXVOPof/rBOKLxc6N01ZRs25154Ww6Ygm9oNP6G0tVvhcy8ktYXtw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.6",
-        "@smithy/types": "^4.3.1",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/smithy-client": "^4.5.2",
+        "@smithy/types": "^4.3.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -3919,17 +3027,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.22",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.22.tgz",
-      "integrity": "sha512-7B8mfQBtwwr2aNRRmU39k/bsRtv9B6/1mTMrGmmdJFKmLAH+KgIiOuhaqfKOBGh9sZ/VkZxbvm94rI4MMYpFjQ==",
+      "version": "4.0.29",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.29.tgz",
+      "integrity": "sha512-DxBWCC059GwOQXc5nxVudhdGQLZHTDhU4rkK4rvaBQn8IWBw8G+3H2hWk897LaNv6zwwhh7kpfqF0rJ77DvlSg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.6",
-        "@smithy/types": "^4.3.1",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/smithy-client": "^4.5.2",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3963,12 +3071,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.4.tgz",
-      "integrity": "sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
+      "integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3976,13 +3084,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.6.tgz",
-      "integrity": "sha512-+YekoF2CaSMv6zKrA6iI/N9yva3Gzn4L6n35Luydweu5MMPYpiGZlWqehPHDHyNbnyaYlz/WJyYAZnC+loBDZg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.7.tgz",
+      "integrity": "sha512-TTO6rt0ppK70alZpkjwy+3nQlTiqNfoXja+qwuAchIEAIoSZW8Qyd76dvBv3I5bCpE38APafG23Y/u270NspiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.6",
-        "@smithy/types": "^4.3.1",
+        "@smithy/service-error-classification": "^4.0.7",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3990,14 +3098,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.3.tgz",
-      "integrity": "sha512-cQn412DWHHFNKrQfbHY8vSFI3nTROY1aIKji9N0tpp8gUABRilr7wdf8fqBbSlXresobM+tQFNk6I+0LXK/YZg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.4.tgz",
+      "integrity": "sha512-vSKnvNZX2BXzl0U2RgCLOwWaAP9x/ddd/XobPK02pCbzRm5s55M53uwb1rl/Ts7RXZvdJZerPkA+en2FDghLuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.1.0",
-        "@smithy/node-http-handler": "^4.1.0",
-        "@smithy/types": "^4.3.1",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/types": "^4.3.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-hex-encoding": "^4.0.0",
@@ -4034,13 +3142,13 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.5.tgz",
-      "integrity": "sha512-4QvC49HTteI1gfemu0I1syWovJgPvGn7CVUoN9ZFkdvr/cCFkrEL7qNCdx/2eICqDWEGnnr68oMdSIPCLAriSQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.7.tgz",
+      "integrity": "sha512-mYqtQXPmrwvUljaHyGxYUIIRI3qjBTEb/f5QFi3A6VlxhpmZd5mWXn9W+qUkf2pVE1Hv3SqxefiZOPGdxmO64A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/abort-controller": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4597,25 +3705,24 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1010.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1010.0.tgz",
-      "integrity": "sha512-kYNzBXVUZoRrTuYxRRA2Loz/Uvay0MqHobg8KPZaWylIbw/meUDgtoATRNt+stOdJ9PHODTjWmlDKI+2/KoF+w==",
-      "dev": true,
+      "version": "2.1028.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1028.0.tgz",
+      "integrity": "sha512-PcWyjrLiTfhWiqI/R6JmiLO57riONGMhZ2SsdjHuDZ3wSlsz8WtDblohHqaUaylkF1aasYfM6LCnoZFv7eHkNw==",
       "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.0.0"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.197.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.197.0.tgz",
-      "integrity": "sha512-P+Ed5YPmwNT/Y6W813VQq56pH4B5p/gB0DrhatpUrMxgeIpvqRzSY0YPHyeV4/Dr/fzhIstL7s4pDpAMrlEP2g==",
+      "version": "2.214.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.214.0.tgz",
+      "integrity": "sha512-Mj9GSJkkXj8wjiy2pKARquOsiiHsu7tK1WDfdA8Db39hIznWWP+/KscI2iqnntDMeEmcj1QX25PbYT+6rq8zkw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -4631,12 +3738,12 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.236",
+        "@aws-cdk/asset-awscli-v1": "2.2.242",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^41.2.0",
+        "@aws-cdk/cloud-assembly-schema": "^48.6.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.0",
+        "fs-extra": "^11.3.1",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
@@ -4647,7 +3754,7 @@
         "yaml": "1.10.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.0.0"
       },
       "peerDependencies": {
         "constructs": "^10.0.0"
@@ -4709,7 +3816,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4757,7 +3864,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.0.6",
+      "version": "3.1.0",
       "funding": [
         {
           "type": "github",
@@ -4772,7 +3879,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.0",
+      "version": "11.3.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4811,7 +3918,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
+      "version": "6.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5260,9 +4367,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.35.105",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.105.tgz",
-      "integrity": "sha512-hlA4801/vRb8w2rJCJg/ImpHz3oHfA73WlLZ0c4P54E3sFROz/nwkVYsdax5R/Tj7xD0r4JpTW9vMZzteEPGDw==",
+      "version": "2.36.46",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.36.46.tgz",
+      "integrity": "sha512-3k1ZT9eRleLPWYlVnWLTqcE5nZhgIp8Q2TTZAzd+kWvjImkQ3/fBYU2Uavz55X9RrGF07F+yiXyf29rVPMELDw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",
@@ -5992,22 +5099,18 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^2.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6138,7 +5241,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8502,9 +7604,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
       "funding": [
         {
           "type": "github",

--- a/deployment/package.json
+++ b/deployment/package.json
@@ -20,7 +20,6 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.15.21",
     "@types/pg": "^8.15.5",
-    "aws-cdk": "2.1010.0",
     "aws-cdk-local": "^3.0.1",
     "eslint": "^9.27.0",
     "jest": "^29.7.0",
@@ -31,11 +30,12 @@
     "typescript-eslint": "^8.32.1"
   },
   "dependencies": {
-    "@aws-sdk/client-cognito-identity-provider": "^3.844.0",
-    "@aws-sdk/client-ec2": "^3.830.0",
-    "@aws-sdk/client-secrets-manager": "^3.812.0",
-    "aws-cdk-lib": "^2.197.0",
-    "cdk-nag": "^2.35.105",
+    "@aws-sdk/client-cognito-identity-provider": "^3.848.0",
+    "@aws-sdk/client-ec2": "^3.854.0",
+    "@aws-sdk/client-secrets-manager": "^3.848.0",
+    "aws-cdk": "^2.1028.0",
+    "aws-cdk-lib": "^2.214.0",
+    "cdk-nag": "^2.36.46",
     "chalk": "^5.4.1",
     "constructs": "^10.0.0",
     "pg": "^8.16.3"


### PR DESCRIPTION
Update deployment packages to cover the changes requested by Snyk. This was mainly done because of the failure on PR checks on the CDK lib update, but I figured I might as well combine everything