### PR TITLE
DEMOS-709: Phase Selector Polish

### DIFF
--- a/client/src/components/application/ApplicationWorkflow.tsx
+++ b/client/src/components/application/ApplicationWorkflow.tsx
@@ -14,7 +14,7 @@ export const ApplicationWorkflow = ({
   demonstration: ApplicationWorkflowDemonstration;
 }) => {
   return (
-    <div className="flex flex-col gap-sm">
+    <div className="flex flex-col gap-sm p-md">
       <div className="flex w-full">
         <h3 className="text-brand text-2xl font-bold">APPLICATION</h3>
         <DemonstrationStatusBadge demonstrationStatus={demonstration.status} />

--- a/client/src/components/application/phase-selector/PhaseSelector.tsx
+++ b/client/src/components/application/phase-selector/PhaseSelector.tsx
@@ -38,7 +38,7 @@ const PHASE_COMPONENTS_LOOKUP: Record<PhaseName, React.ComponentType> = {
 };
 
 const PhaseGroups = () => {
-  const leftBorderStyles = "border-l-1 border-surface-placeholder pl-1";
+  const leftBorderStyles = "border-l-1 border-surface-placeholder pl-2 -ml-sm";
   return (
     <>
       <span className="col-span-1">Pre-Submission</span>
@@ -89,7 +89,7 @@ export const PhaseSelector = (props: PhaseSelectorProps) => {
 
   return (
     <>
-      <div className="grid grid-cols-8 gap-md p-1">
+      <div className="grid grid-cols-8 gap-md">
         <PhaseGroups />
         {PHASE_NAMES.map((phaseName, idx) => (
           <PhaseBox

--- a/client/src/components/application/phase-selector/PhaseSelector.tsx
+++ b/client/src/components/application/phase-selector/PhaseSelector.tsx
@@ -38,12 +38,13 @@ const PHASE_COMPONENTS_LOOKUP: Record<PhaseName, React.ComponentType> = {
 };
 
 const PhaseGroups = () => {
+  const leftBorderStyles = "border-l-1 border-surface-placeholder pl-1";
   return (
     <>
       <span className="col-span-1">Pre-Submission</span>
-      <span className="col-span-3">Submission</span>
-      <span className="col-span-3">Approval</span>
-      <span className="col-span-1">Post-Approval</span>
+      <span className={`col-span-3 ${leftBorderStyles}`}>Submission</span>
+      <span className={`col-span-3 ${leftBorderStyles}`}>Approval</span>
+      <span className={`col-span-1 ${leftBorderStyles}`}>Post-Approval</span>
     </>
   );
 };
@@ -88,7 +89,7 @@ export const PhaseSelector = (props: PhaseSelectorProps) => {
 
   return (
     <>
-      <div className="grid grid-cols-8 gap-sm">
+      <div className="grid grid-cols-8 gap-md p-1">
         <PhaseGroups />
         {PHASE_NAMES.map((phaseName, idx) => (
           <PhaseBox


### PR DESCRIPTION
For DEMOS-709, had some conversations with Michael and polished  some of the phase selector components to more closely fit the mocks 🖼️ - Main differences are the dividers between the "categories" and the scaling of the phase boxes. There are some other differences in the mocks related to the number of the phases, those are outside the scope of this ticket

Code:
<img width="1546" height="345" alt="Screenshot 2025-09-04 142957" src="https://github.com/user-attachments/assets/7d954ad6-b0ec-45f9-abc4-cbd14ee64a79" />

Figma:
<img width="1170" height="330" alt="Screenshot 2025-09-04 143133" src="https://github.com/user-attachments/assets/ca9e840b-bed7-43fe-b5c8-df9734e763b4" />
