### PR TITLE
DEMOS-753-fix-placement-of-user-roles

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data
+      - ./postgres-init:/docker-entrypoint-initdb.d
     environment:
       POSTGRES_PASSWORD: postgres # pragma: allowlist secret
       POSTGRES_USER: postgres

--- a/.devcontainer/postgres-init/create_base_roles.sql
+++ b/.devcontainer/postgres-init/create_base_roles.sql
@@ -1,0 +1,3 @@
+CREATE ROLE demos_read;
+CREATE ROLE demos_write;
+CREATE ROLE demos_delete;

--- a/server/src/model/migrations/20250909154217_add_default_groups_and_views/migration.sql
+++ b/server/src/model/migrations/20250909154217_add_default_groups_and_views/migration.sql
@@ -1,4 +1,70 @@
--- Make views first
+-- Easy way to revoke schema permissions
+CREATE OR REPLACE FUNCTION revoke_all_on_schema(schema_name TEXT, user_name TEXT) 
+RETURNS VOID
+AS $$
+DECLARE
+    proper_user_name TEXT;
+BEGIN
+    -- Handle passing in the PUBLIC user
+    IF upper(user_name) = 'PUBLIC' THEN
+        proper_user_name := 'PUBLIC';
+    ELSE
+        proper_user_name := format('%I', user_name);
+    END IF;
+
+    -- Revoke privileges on the schema itself
+    EXECUTE format('REVOKE ALL PRIVILEGES ON SCHEMA %I FROM %s', schema_name, proper_user_name);
+
+    -- Revoke privileges on objects within the schema
+    EXECUTE format('REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA %I FROM %s', schema_name, proper_user_name);
+    EXECUTE format('REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I FROM %s', schema_name, proper_user_name);
+    EXECUTE format('REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA %I FROM %s', schema_name, proper_user_name);
+
+    -- Revoke default privileges
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I REVOKE ALL ON TABLES FROM %s', schema_name, proper_user_name);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I REVOKE ALL ON SEQUENCES FROM %s', schema_name, proper_user_name);
+    EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I REVOKE ALL ON FUNCTIONS FROM %s', schema_name, proper_user_name);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Permission settings
+-- Revoke all access to start
+SELECT revoke_all_on_schema('public', 'PUBLIC');
+SELECT revoke_all_on_schema('demos_app', 'PUBLIC');
+SELECT revoke_all_on_schema('public', 'demos_read');
+SELECT revoke_all_on_schema('demos_app', 'demos_read');
+SELECT revoke_all_on_schema('public', 'demos_write');
+SELECT revoke_all_on_schema('demos_app', 'demos_write');
+SELECT revoke_all_on_schema('public', 'demos_delete');
+SELECT revoke_all_on_schema('demos_app', 'demos_delete');
+
+-- Grant usage on schemas
+GRANT USAGE ON SCHEMA public TO PUBLIC;
+GRANT USAGE ON SCHEMA demos_app TO demos_read;
+GRANT USAGE ON SCHEMA demos_app TO demos_write;
+GRANT USAGE ON SCHEMA demos_app TO demos_delete;
+
+-- Give table access appropriately
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO PUBLIC;
+GRANT SELECT ON ALL TABLES IN SCHEMA demos_app TO demos_read;
+GRANT INSERT, UPDATE ON ALL TABLES IN SCHEMA demos_app TO demos_write;
+GRANT DELETE ON ALL TABLES IN SCHEMA demos_app TO demos_delete;
+
+-- Grant sequence usage for writing
+GRANT USAGE ON ALL SEQUENCES IN SCHEMA demos_app TO demos_write;
+
+-- Update default privileges for future tables / drops and reloads
+-- Eventually, all alter default privileges commands need to be executed by the table owners
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO PUBLIC;
+ALTER DEFAULT PRIVILEGES IN SCHEMA demos_app GRANT SELECT ON TABLES TO demos_read;
+ALTER DEFAULT PRIVILEGES IN SCHEMA demos_app GRANT INSERT, UPDATE ON TABLES TO demos_write;
+ALTER DEFAULT PRIVILEGES IN SCHEMA demos_app GRANT DELETE ON TABLES TO demos_delete;
+ALTER DEFAULT PRIVILEGES IN SCHEMA demos_app GRANT USAGE ON SEQUENCES TO demos_write;
+
+-- Clean up utility function
+DROP FUNCTION revoke_all_on_schema;
+
+-- Utility views
 -- Role assignments
 DROP VIEW IF EXISTS public.vw_role_assignments;
 CREATE VIEW public.vw_role_assignments WITH (security_invoker=true) AS
@@ -167,50 +233,3 @@ GROUP BY
     relation_owner,
     relation_type,
     subject_name;
-
--- Give basic public access to users
--- Start by resetting public access, then grant
-REVOKE ALL ON SCHEMA public FROM PUBLIC;
-REVOKE ALL ON ALL TABLES IN SCHEMA public FROM PUBLIC;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM PUBLIC;
-GRANT USAGE ON SCHEMA public TO PUBLIC;
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO PUBLIC;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO PUBLIC;
-
--- Creating temporary roles for access control
-DROP ROLE IF EXISTS demos_read;
-DROP ROLE IF EXISTS demos_write;
-DROP ROLE IF EXISTS demos_delete;
-CREATE ROLE demos_read;
-CREATE ROLE demos_write;
-CREATE ROLE demos_delete;
-
--- Grant basic usage on schema
-REVOKE ALL ON SCHEMA demos_app FROM demos_read;
-REVOKE ALL ON SCHEMA demos_app FROM demos_write;
-REVOKE ALL ON SCHEMA demos_app FROM demos_delete;
-GRANT USAGE ON SCHEMA demos_app TO demos_read;
-GRANT USAGE ON SCHEMA demos_app TO demos_write;
-GRANT USAGE ON SCHEMA demos_app TO demos_delete;
-
--- Give table access appropriately
-REVOKE ALL ON ALL TABLES IN SCHEMA demos_app FROM demos_read;
-REVOKE ALL ON ALL TABLES IN SCHEMA demos_app FROM demos_write;
-REVOKE ALL ON ALL TABLES IN SCHEMA demos_app FROM demos_delete;
-GRANT SELECT ON ALL TABLES IN SCHEMA demos_app TO demos_read;
-GRANT INSERT, UPDATE ON ALL TABLES IN SCHEMA demos_app TO demos_write;
-GRANT DELETE ON ALL TABLES IN SCHEMA demos_app TO demos_delete;
-
--- Grant sequence usage for writing
-GRANT USAGE ON ALL SEQUENCES IN SCHEMA demos_app TO demos_write;
-
--- Update default privileges for future tables / drops and reloads
--- Eventually, all alter default privileges commands need to be executed by the table owners
-ALTER DEFAULT PRIVILEGES IN SCHEMA demos_app REVOKE ALL ON TABLES FROM demos_read;
-ALTER DEFAULT PRIVILEGES IN SCHEMA demos_app REVOKE ALL ON TABLES FROM demos_write;
-ALTER DEFAULT PRIVILEGES IN SCHEMA demos_app REVOKE ALL ON TABLES FROM demos_delete;
-
-ALTER DEFAULT PRIVILEGES IN SCHEMA demos_app GRANT SELECT ON TABLES TO demos_read;
-ALTER DEFAULT PRIVILEGES IN SCHEMA demos_app GRANT INSERT, UPDATE ON TABLES TO demos_write;
-ALTER DEFAULT PRIVILEGES IN SCHEMA demos_app GRANT DELETE ON TABLES TO demos_delete;
-ALTER DEFAULT PRIVILEGES IN SCHEMA demos_app GRANT USAGE ON SEQUENCES TO demos_write;


### PR DESCRIPTION
Resolves the various collisions between permission and role creation on the database for migrations. This version relies on every database having the three roles of `demos_read`, `demos_write`, and `demos_delete` present already. I modified the `devcontainer` so that when it builds locally, it should make those roles automatically. Note that you will need to tear down and rebuild your stack to get this to work as it only does it on first creation, and we used a persistent data mount for the database. You should be able to use `docker compose -p demos_devcontainer down -v` in the `.devcontainer` folder to do this (note that the `-p` option is due to how devcontainers seem to name their stacks).

This creates a few utility views that are helpful to have from a DBA standpoint. It also revokes everything from the relevant roles and then grants the specific expected items again. The temporary function I wrote to do the revocations just focuses on tables, sequences, and functions; there may be other things in the future to revoke, but for now I think this will be a decent start.