### PR TITLE
Read success field from CreateDemonstrationResult

### DIFF
--- a/client/src/components/dialog/DemonstrationDialog.tsx
+++ b/client/src/components/dialog/DemonstrationDialog.tsx
@@ -306,13 +306,19 @@ export const CreateDemonstrationDialog: React.FC<{
 
   const onSubmit = async (demonstration: DemonstrationDialogFields) => {
     try {
-      await createDemonstrationTrigger({
+      const result = await createDemonstrationTrigger({
         variables: {
           input: getCreateDemonstrationInput(demonstration),
         },
       });
+
+      const success = result.data?.createDemonstration?.success;
       onClose();
-      showSuccess(SUCCESS_MESSAGES.create);
+      if (success) {
+        showSuccess(SUCCESS_MESSAGES.create);
+      } else {
+        showError(result.data?.createDemonstration?.message || ERROR_MESSAGES.create);
+      }
     } catch {
       showError(ERROR_MESSAGES.create);
     }

--- a/client/src/components/dialog/DemonstrationDialog.tsx
+++ b/client/src/components/dialog/DemonstrationDialog.tsx
@@ -312,7 +312,7 @@ export const CreateDemonstrationDialog: React.FC<{
         },
       });
 
-      const success = result.data?.createDemonstration?.success;
+      const success = result.data?.createDemonstration?.success || false;
       onClose();
       if (success) {
         showSuccess(SUCCESS_MESSAGES.create);


### PR DESCRIPTION
In order to better reflect the result from the `CreateDemonstrationResult`, read the message and surface the error in the toast.