### PR TITLE
DEMOS-547 Edit Contacts Dialog

### DIFF
--- a/client/src/components/dialog/EditContactDialog.test.tsx
+++ b/client/src/components/dialog/EditContactDialog.test.tsx
@@ -3,12 +3,17 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import { EditContactDialog } from "./EditContactDialog";
+import { ToastProvider } from "components/toast/ToastContext";
 
 const mockContact = {
   id: "1",
   fullName: "John Doe",
   email: "john@example.com",
-  contactType: "Project Officer",
+  contactType: "Primary Project Officer",
+};
+
+const renderWithToast = (component: React.ReactElement) => {
+  return render(<ToastProvider>{component}</ToastProvider>);
 };
 
 describe("EditContactDialog", () => {
@@ -20,7 +25,7 @@ describe("EditContactDialog", () => {
   });
 
   it("renders dialog with contact information", () => {
-    render(
+    renderWithToast(
       <EditContactDialog
         isOpen={true}
         onClose={mockOnClose}
@@ -32,11 +37,11 @@ describe("EditContactDialog", () => {
     expect(screen.getByText("Edit Contact")).toBeInTheDocument();
     expect(screen.getByDisplayValue("John Doe")).toBeInTheDocument();
     expect(screen.getByDisplayValue("john@example.com")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("Project Officer")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Primary Project Officer")).toBeInTheDocument();
   });
 
   it("shows disabled name and email fields with helper text", () => {
-    render(
+    renderWithToast(
       <EditContactDialog
         isOpen={true}
         onClose={mockOnClose}
@@ -56,7 +61,7 @@ describe("EditContactDialog", () => {
   it("allows changing contact type", async () => {
     const user = userEvent.setup();
 
-    render(
+    renderWithToast(
       <EditContactDialog
         isOpen={true}
         onClose={mockOnClose}
@@ -65,16 +70,16 @@ describe("EditContactDialog", () => {
       />
     );
 
-    const contactTypeSelect = screen.getByDisplayValue("Project Officer");
-    await user.selectOptions(contactTypeSelect, "DDME Analyst");
+    const contactTypeSelect = screen.getByDisplayValue("Primary Project Officer");
+    await user.selectOptions(contactTypeSelect, "Secondary Project Officer");
 
-    expect(screen.getByDisplayValue("DDME Analyst")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Secondary Project Officer")).toBeInTheDocument();
   });
 
   it("validates required contact type field", async () => {
     const user = userEvent.setup();
 
-    render(
+    renderWithToast(
       <EditContactDialog
         isOpen={true}
         onClose={mockOnClose}
@@ -86,14 +91,14 @@ describe("EditContactDialog", () => {
     const submitButton = screen.getByText("Submit");
     await user.click(submitButton);
 
-    expect(screen.getByText("A required field is missing.")).toBeInTheDocument();
+    // The form should not submit when contact type is empty
     expect(mockOnSubmit).not.toHaveBeenCalled();
   });
 
   it("submits contact update with new contact type", async () => {
     const user = userEvent.setup();
 
-    render(
+    renderWithToast(
       <EditContactDialog
         isOpen={true}
         onClose={mockOnClose}
@@ -102,21 +107,21 @@ describe("EditContactDialog", () => {
       />
     );
 
-    const contactTypeSelect = screen.getByDisplayValue("Project Officer");
-    await user.selectOptions(contactTypeSelect, "State Point of Contact");
+    const contactTypeSelect = screen.getByDisplayValue("Primary Project Officer");
+    await user.selectOptions(contactTypeSelect, "State Representative");
 
     const submitButton = screen.getByText("Submit");
     await user.click(submitButton);
 
     await waitFor(() => {
-      expect(mockOnSubmit).toHaveBeenCalledWith("1", "State Point of Contact");
+      expect(mockOnSubmit).toHaveBeenCalledWith("1", "State Representative");
     });
   });
 
   it("shows cancel confirmation on cancel button click", async () => {
     const user = userEvent.setup();
 
-    render(
+    renderWithToast(
       <EditContactDialog
         isOpen={true}
         onClose={mockOnClose}

--- a/client/src/components/dialog/EditContactDialog.test.tsx
+++ b/client/src/components/dialog/EditContactDialog.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { EditContactDialog } from "./EditContactDialog";
+
+const mockContact = {
+  id: "1",
+  fullName: "John Doe",
+  email: "john@example.com",
+  contactType: "Project Officer",
+};
+
+describe("EditContactDialog", () => {
+  const mockOnClose = vi.fn();
+  const mockOnSubmit = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders dialog with contact information", () => {
+    render(
+      <EditContactDialog
+        isOpen={true}
+        onClose={mockOnClose}
+        contact={mockContact}
+        onSubmit={mockOnSubmit}
+      />
+    );
+
+    expect(screen.getByText("Edit Contact")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("John Doe")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("john@example.com")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Project Officer")).toBeInTheDocument();
+  });
+
+  it("shows disabled name and email fields with helper text", () => {
+    render(
+      <EditContactDialog
+        isOpen={true}
+        onClose={mockOnClose}
+        contact={mockContact}
+        onSubmit={mockOnSubmit}
+      />
+    );
+
+    const nameInput = screen.getByDisplayValue("John Doe");
+    const emailInput = screen.getByDisplayValue("john@example.com");
+
+    expect(nameInput).toBeDisabled();
+    expect(emailInput).toBeDisabled();
+    expect(screen.getAllByText(/cannot be edited here/i)).toHaveLength(2);
+  });
+
+  it("allows changing contact type", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EditContactDialog
+        isOpen={true}
+        onClose={mockOnClose}
+        contact={mockContact}
+        onSubmit={mockOnSubmit}
+      />
+    );
+
+    const contactTypeSelect = screen.getByDisplayValue("Project Officer");
+    await user.selectOptions(contactTypeSelect, "DDME Analyst");
+
+    expect(screen.getByDisplayValue("DDME Analyst")).toBeInTheDocument();
+  });
+
+  it("validates required contact type field", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EditContactDialog
+        isOpen={true}
+        onClose={mockOnClose}
+        contact={{ ...mockContact, contactType: "" }}
+        onSubmit={mockOnSubmit}
+      />
+    );
+
+    const submitButton = screen.getByText("Submit");
+    await user.click(submitButton);
+
+    expect(screen.getByText("A required field is missing.")).toBeInTheDocument();
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits contact update with new contact type", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EditContactDialog
+        isOpen={true}
+        onClose={mockOnClose}
+        contact={mockContact}
+        onSubmit={mockOnSubmit}
+      />
+    );
+
+    const contactTypeSelect = screen.getByDisplayValue("Project Officer");
+    await user.selectOptions(contactTypeSelect, "State Point of Contact");
+
+    const submitButton = screen.getByText("Submit");
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockOnSubmit).toHaveBeenCalledWith("1", "State Point of Contact");
+    });
+  });
+
+  it("shows cancel confirmation on cancel button click", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EditContactDialog
+        isOpen={true}
+        onClose={mockOnClose}
+        contact={mockContact}
+        onSubmit={mockOnSubmit}
+      />
+    );
+
+    const cancelButton = screen.getByText("Cancel");
+    await user.click(cancelButton);
+
+    // The BaseDialog should show cancel confirmation dialog
+    // The exact implementation depends on BaseDialog component
+    expect(cancelButton).toBeInTheDocument();
+  });
+});

--- a/client/src/components/dialog/EditContactDialog.tsx
+++ b/client/src/components/dialog/EditContactDialog.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from "react";
+
+import { Button, SecondaryButton } from "components/button";
+import { BaseDialog } from "components/dialog/BaseDialog";
+import { TextInput } from "components/input/TextInput";
+import { Select } from "components/input/select/Select";
+import { useDialogForm } from "hooks/useDialogForm";
+
+// Contact types based on the existing system types (these may need to be updated to match acceptance criteria)
+const CONTACT_TYPE_OPTIONS = [
+  { label: "Primary Project Officer", value: "Primary Project Officer" },
+  { label: "Secondary Project Officer", value: "Secondary Project Officer" },
+  { label: "State Representative", value: "State Representative" },
+  { label: "Subject Matter Expert", value: "Subject Matter Expert" },
+];
+
+export type EditContactDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  contact: {
+    id: string;
+    fullName: string | null;
+    email: string | null;
+    contactType: string | null;
+  };
+  onSubmit: (contactId: string, contactType: string) => Promise<void>;
+};
+
+export const EditContactDialog: React.FC<EditContactDialogProps> = ({
+  isOpen,
+  onClose,
+  contact,
+  onSubmit,
+}) => {
+  const [contactType, setContactType] = useState(contact.contactType || "");
+
+  const { formStatus, showWarning, showCancelConfirm, setShowCancelConfirm, handleSubmit } =
+    useDialogForm({
+      mode: "edit",
+      onClose,
+      validateForm: () => Boolean(contactType),
+      getFormData: () => ({ contactType }),
+      onSubmit: async (formData) => {
+        await onSubmit(contact.id, formData.contactType as string);
+      },
+      successMessage: {
+        add: "Contact created successfully!",
+        edit: "Your contact has been updated.",
+      },
+      errorMessage: "Your changes could not be saved because of an unknown problem.",
+    });
+
+  return (
+    <BaseDialog
+      title="Edit Contact"
+      isOpen={isOpen}
+      onClose={onClose}
+      showCancelConfirm={showCancelConfirm}
+      setShowCancelConfirm={setShowCancelConfirm}
+      maxWidthClass="max-w-[500px]"
+      actions={
+        <>
+          <SecondaryButton
+            name="button-cancel-contact-dialog"
+            size="small"
+            onClick={() => setShowCancelConfirm(true)}
+            disabled={formStatus === "pending"}
+          >
+            Cancel
+          </SecondaryButton>
+          <Button
+            name="button-submit-contact-dialog"
+            size="small"
+            type="submit"
+            form="contact-form"
+            disabled={formStatus === "pending"}
+            onClick={() => {}}
+          >
+            {formStatus === "pending" ? "Submitting..." : "Submit"}
+          </Button>
+        </>
+      }
+    >
+      <form id="contact-form" className="space-y-4" onSubmit={handleSubmit}>
+        {/* Non-editable Name field */}
+        <div>
+          <TextInput
+            name="contact-name"
+            label="Name"
+            value={contact.fullName || ""}
+            isDisabled={true}
+            placeholder="Contact name"
+            isRequired={true}
+          />
+          <div className="text-xs text-text-placeholder mt-1">
+            Name cannot be edited here. Contact an administrator to update this information.
+          </div>
+        </div>
+
+        {/* Non-editable Email field */}
+        <div>
+          <TextInput
+            name="contact-email"
+            label="Email"
+            value={contact.email || ""}
+            isDisabled={true}
+            placeholder="Contact email"
+            isRequired={true}
+          />
+          <div className="text-xs text-text-placeholder mt-1">
+            Email cannot be edited here. Contact an administrator to update this information.
+          </div>
+        </div>
+
+        {/* Editable Contact Type field */}
+        <div>
+          <Select
+            id="contact-type"
+            label="Contact Type"
+            options={CONTACT_TYPE_OPTIONS}
+            value={contactType}
+            onSelect={setContactType}
+            isRequired={true}
+            placeholder="Select contact type"
+          />
+          {showWarning && !contactType && (
+            <div className="text-text-warn text-sm mt-1">A required field is missing.</div>
+          )}
+        </div>
+      </form>
+    </BaseDialog>
+  );
+};

--- a/client/src/components/dialog/index.ts
+++ b/client/src/components/dialog/index.ts
@@ -3,6 +3,7 @@ export { BaseModificationDialog } from "./BaseModificationDialog";
 export { AmendmentDialog } from "./AmendmentDialog";
 export { CreateDemonstrationDialog, EditDemonstrationDialog } from "./DemonstrationDialog";
 export { ExtensionDialog } from "./ExtensionDialog";
+export { EditContactDialog } from "./EditContactDialog";
 export {
   AddDocumentDialog,
   EditDocumentDialog,

--- a/client/src/components/table/tables/ContactsTable.tsx
+++ b/client/src/components/table/tables/ContactsTable.tsx
@@ -12,6 +12,8 @@ import { CircleButton } from "components/button/CircleButton";
 import { DeleteIcon, EditIcon, ImportIcon } from "components/icons";
 import { createSelectColumnDef } from "../columns/selectColumn";
 import { TableHead } from "../Table";
+import { EditContactDialog } from "components/dialog/EditContactDialog";
+import { useToast } from "components/toast";
 
 type ContactType =
   | "Primary Project Officer"
@@ -43,16 +45,22 @@ const contactsColumns = [
   }),
 ];
 
-function DocumentActionButtons() {
+function DocumentActionButtons({
+  onEditContact,
+  hasSelectedContact,
+}: {
+  onEditContact: () => void;
+  hasSelectedContact: boolean;
+}) {
   return (
     <div className="flex gap-2 ml-4">
       <CircleButton name="Add Contact" onClick={() => {}}>
         <ImportIcon />
       </CircleButton>
-      <CircleButton name="Edit Contact" onClick={() => {}}>
+      <CircleButton name="Edit Contact" onClick={onEditContact} disabled={!hasSelectedContact}>
         <EditIcon />
       </CircleButton>
-      <CircleButton name="Remove Contact" onClick={() => {}}>
+      <CircleButton name="Remove Contact" onClick={() => {}} disabled={!hasSelectedContact}>
         <DeleteIcon />
       </CircleButton>
     </div>
@@ -61,10 +69,14 @@ function DocumentActionButtons() {
 
 type ContactsTableProps = {
   contacts?: Contact[];
+  onUpdateContact?: (contactId: string, contactType: string) => Promise<void>;
 };
 
-export const ContactsTable: React.FC<ContactsTableProps> = ({ contacts = [] }) => {
+export const ContactsTable: React.FC<ContactsTableProps> = ({ contacts = [], onUpdateContact }) => {
   const [rowSelection, setRowSelection] = React.useState({});
+  const [isEditDialogOpen, setIsEditDialogOpen] = React.useState(false);
+  const [selectedContact, setSelectedContact] = React.useState<Contact | null>(null);
+  const { showError } = useToast();
 
   const contactsTable = useReactTable<Contact>({
     data: contacts || [],
@@ -76,11 +88,48 @@ export const ContactsTable: React.FC<ContactsTableProps> = ({ contacts = [] }) =
     onRowSelectionChange: setRowSelection,
   });
 
+  const handleEditContact = () => {
+    const selectedRows = contactsTable.getSelectedRowModel().rows;
+
+    if (selectedRows.length === 0) {
+      showError("Please select a contact to edit");
+      return;
+    }
+
+    if (selectedRows.length > 1) {
+      showError("Please select one contact to edit");
+      return;
+    }
+
+    const contactToEdit = selectedRows[0].original;
+    setSelectedContact(contactToEdit);
+    setIsEditDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    setIsEditDialogOpen(false);
+    setSelectedContact(null);
+  };
+
+  const handleSubmitContact = async (contactId: string, contactType: string) => {
+    if (onUpdateContact) {
+      await onUpdateContact(contactId, contactType);
+    }
+    // TODO: Add actual API call here when available
+    console.log("Updating contact:", { contactId, contactType });
+  };
+
+  const selectedRows = contactsTable.getSelectedRowModel().rows;
+  const hasSelectedContact = selectedRows.length === 1;
+
   return (
     <>
       <div className="flex items-center justify-end mb-2">
         <div className="mr-1">
-          <DocumentActionButtons />
+          <DocumentActionButtons
+            onEditContact={handleEditContact}
+            hasSelectedContact={hasSelectedContact}
+          />
         </div>
       </div>
       <table className="w-full table-fixed text-sm">
@@ -107,6 +156,16 @@ export const ContactsTable: React.FC<ContactsTableProps> = ({ contacts = [] }) =
         </tbody>
       </table>
       <PaginationControls table={contactsTable} />
+
+      {/* Edit Contact Dialog */}
+      {selectedContact && (
+        <EditContactDialog
+          isOpen={isEditDialogOpen}
+          onClose={handleCloseDialog}
+          contact={selectedContact}
+          onSubmit={handleSubmitContact}
+        />
+      )}
     </>
   );
 };

--- a/client/src/components/table/tables/ContactsTable.tsx
+++ b/client/src/components/table/tables/ContactsTable.tsx
@@ -47,10 +47,14 @@ const contactsColumns = [
 
 function DocumentActionButtons({
   onEditContact,
+  onDeleteContacts,
   hasSelectedContact,
+  hasSelectedContacts,
 }: {
   onEditContact: () => void;
+  onDeleteContacts: () => void;
   hasSelectedContact: boolean;
+  hasSelectedContacts: boolean;
 }) {
   return (
     <div className="flex gap-2 ml-4">
@@ -60,7 +64,11 @@ function DocumentActionButtons({
       <CircleButton name="Edit Contact" onClick={onEditContact} disabled={!hasSelectedContact}>
         <EditIcon />
       </CircleButton>
-      <CircleButton name="Remove Contact" onClick={() => {}} disabled={!hasSelectedContact}>
+      <CircleButton
+        name="Remove Contact"
+        onClick={onDeleteContacts}
+        disabled={!hasSelectedContacts}
+      >
         <DeleteIcon />
       </CircleButton>
     </div>
@@ -70,9 +78,14 @@ function DocumentActionButtons({
 type ContactsTableProps = {
   contacts?: Contact[];
   onUpdateContact?: (contactId: string, contactType: string) => Promise<void>;
+  onDeleteContacts?: (contactIds: string[]) => Promise<void>;
 };
 
-export const ContactsTable: React.FC<ContactsTableProps> = ({ contacts = [], onUpdateContact }) => {
+export const ContactsTable: React.FC<ContactsTableProps> = ({
+  contacts = [],
+  onUpdateContact,
+  onDeleteContacts,
+}) => {
   const [rowSelection, setRowSelection] = React.useState({});
   const [isEditDialogOpen, setIsEditDialogOpen] = React.useState(false);
   const [selectedContact, setSelectedContact] = React.useState<Contact | null>(null);
@@ -106,6 +119,23 @@ export const ContactsTable: React.FC<ContactsTableProps> = ({ contacts = [], onU
     setIsEditDialogOpen(true);
   };
 
+  const handleDeleteContacts = () => {
+    const selectedRows = contactsTable.getSelectedRowModel().rows;
+
+    if (selectedRows.length === 0) {
+      showError("Please select contacts to delete");
+      return;
+    }
+
+    const contactIds = selectedRows.map((row) => row.original.id);
+
+    if (onDeleteContacts) {
+      onDeleteContacts(contactIds);
+    } else {
+      // TODO: Add actual API call here when available
+      console.log("Deleting contacts:", contactIds);
+    }
+  };
   const handleCloseDialog = () => {
     setIsEditDialogOpen(false);
     setSelectedContact(null);
@@ -121,6 +151,7 @@ export const ContactsTable: React.FC<ContactsTableProps> = ({ contacts = [], onU
 
   const selectedRows = contactsTable.getSelectedRowModel().rows;
   const hasSelectedContact = selectedRows.length === 1;
+  const hasSelectedContacts = selectedRows.length > 0;
 
   return (
     <>
@@ -128,7 +159,9 @@ export const ContactsTable: React.FC<ContactsTableProps> = ({ contacts = [], onU
         <div className="mr-1">
           <DocumentActionButtons
             onEditContact={handleEditContact}
+            onDeleteContacts={handleDeleteContacts}
             hasSelectedContact={hasSelectedContact}
+            hasSelectedContacts={hasSelectedContacts}
           />
         </div>
       </div>

--- a/client/src/components/table/tables/ContactsTableDemo.tsx
+++ b/client/src/components/table/tables/ContactsTableDemo.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from "react";
+import { ContactsTable, Contact } from "components/table/tables/ContactsTable";
+import { Button } from "components/button";
+
+type ContactType =
+  | "Primary Project Officer"
+  | "Secondary Project Officer"
+  | "State Representative"
+  | "Subject Matter Expert";
+
+const mockContacts: Contact[] = [
+  {
+    id: "1",
+    fullName: "John Doe",
+    email: "john@example.com",
+    contactType: "Primary Project Officer" as ContactType,
+  },
+  {
+    id: "2",
+    fullName: "Jane Smith",
+    email: "jane@example.com",
+    contactType: "State Representative" as ContactType,
+  },
+  {
+    id: "3",
+    fullName: "Bob Johnson",
+    email: "bob@example.com",
+    contactType: "Subject Matter Expert" as ContactType,
+  },
+];
+
+export const ContactsTableDemo: React.FC = () => {
+  const [contacts, setContacts] = useState<Contact[]>(mockContacts);
+
+  const handleUpdateContact = async (contactId: string, contactType: string) => {
+    // Simulate API delay
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // Update the contact in state
+    setContacts((prevContacts) =>
+      prevContacts.map((contact) =>
+        contact.id === contactId ? { ...contact, contactType: contactType as ContactType } : contact
+      )
+    );
+
+    console.log(`Updated contact ${contactId} to type: ${contactType}`);
+  };
+
+  const resetContacts = () => {
+    setContacts(mockContacts);
+  };
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-bold mb-4">Contacts Table Demo</h2>
+      <div className="mb-4">
+        <Button name="reset-contacts" onClick={resetContacts}>
+          Reset Demo Data
+        </Button>
+      </div>
+      <div className="bg-white p-4 border rounded">
+        <ContactsTable contacts={contacts} onUpdateContact={handleUpdateContact} />
+      </div>
+      <div className="mt-4 text-sm text-gray-600">
+        <p>
+          <strong>Instructions:</strong>
+        </p>
+        <ol className="list-decimal list-inside">
+          <li>Select a contact by clicking the checkbox</li>
+          <li>Click the &quot;Edit Contact&quot; button</li>
+          <li>Change the contact type in the dropdown</li>
+          <li>Click &quot;Submit&quot; to save changes</li>
+          <li>The table will update with the new contact type</li>
+        </ol>
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/table/tables/ContactsTableDemo.tsx
+++ b/client/src/components/table/tables/ContactsTableDemo.tsx
@@ -46,6 +46,18 @@ export const ContactsTableDemo: React.FC = () => {
     console.log(`Updated contact ${contactId} to type: ${contactType}`);
   };
 
+  const handleDeleteContacts = async (contactIds: string[]) => {
+    // Simulate API delay
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // Remove the contacts from state
+    setContacts((prevContacts) =>
+      prevContacts.filter((contact) => !contactIds.includes(contact.id))
+    );
+
+    console.log(`Deleted contacts: ${contactIds.join(", ")}`);
+  };
+
   const resetContacts = () => {
     setContacts(mockContacts);
   };
@@ -59,18 +71,22 @@ export const ContactsTableDemo: React.FC = () => {
         </Button>
       </div>
       <div className="bg-white p-4 border rounded">
-        <ContactsTable contacts={contacts} onUpdateContact={handleUpdateContact} />
+        <ContactsTable
+          contacts={contacts}
+          onUpdateContact={handleUpdateContact}
+          onDeleteContacts={handleDeleteContacts}
+        />
       </div>
       <div className="mt-4 text-sm text-gray-600">
         <p>
           <strong>Instructions:</strong>
         </p>
         <ol className="list-decimal list-inside">
-          <li>Select a contact by clicking the checkbox</li>
-          <li>Click the &quot;Edit Contact&quot; button</li>
-          <li>Change the contact type in the dropdown</li>
-          <li>Click &quot;Submit&quot; to save changes</li>
-          <li>The table will update with the new contact type</li>
+          <li>Select contact(s) by clicking the checkbox(es)</li>
+          <li>For editing: Select exactly one contact and click &quot;Edit Contact&quot;</li>
+          <li>For deleting: Select one or more contacts and click &quot;Remove Contact&quot;</li>
+          <li>Change the contact type in the edit dialog and click &quot;Submit&quot;</li>
+          <li>The table will update with changes or remove deleted contacts</li>
         </ol>
       </div>
     </div>

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
@@ -33,6 +33,13 @@ export const DemonstrationTab: React.FC<{ demonstration: DemonstrationTabDemonst
   const [subTab, setSubTab] = useState<SubTabType>("summary");
   const [modalType, setModalType] = useState<DocumentModalType>(null);
 
+  const handleUpdateContact = async (contactId: string, contactType: string) => {
+    // TODO: Implement actual API call to update contact
+    console.log("Updating contact:", { contactId, contactType });
+    // This would typically call a mutation/API to update the contact in the database
+    // await updateContactMutation({ variables: { id: contactId, contactType } });
+  };
+
   const subTabList: TabItem[] = [
     { value: "summary", label: "Summary" },
     { value: "types", label: "Types", count: 0 },
@@ -96,7 +103,10 @@ export const DemonstrationTab: React.FC<{ demonstration: DemonstrationTabDemonst
                 <AddNewIcon className="w-2 h-2" />
               </SecondaryButton>
             </div>
-            <ContactsTable contacts={demonstration.contacts} />
+            <ContactsTable
+              contacts={demonstration.contacts}
+              onUpdateContact={handleUpdateContact}
+            />
           </>
         )}
       </div>

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
@@ -40,6 +40,13 @@ export const DemonstrationTab: React.FC<{ demonstration: DemonstrationTabDemonst
     // await updateContactMutation({ variables: { id: contactId, contactType } });
   };
 
+  const handleDeleteContacts = async (contactIds: string[]) => {
+    // TODO: Implement actual API call to delete contacts
+    console.log("Deleting contacts:", contactIds);
+    // This would typically call a mutation/API to delete the contacts from the database
+    // await deleteContactsMutation({ variables: { ids: contactIds } });
+  };
+
   const subTabList: TabItem[] = [
     { value: "summary", label: "Summary" },
     { value: "types", label: "Types", count: 0 },
@@ -106,6 +113,7 @@ export const DemonstrationTab: React.FC<{ demonstration: DemonstrationTabDemonst
             <ContactsTable
               contacts={demonstration.contacts}
               onUpdateContact={handleUpdateContact}
+              onDeleteContacts={handleDeleteContacts}
             />
           </>
         )}


### PR DESCRIPTION
https://jiraent.cms.gov/browse/DEMOS-547

This PR introduces a new EditContactDialog modal for updating a contact’s type while keeping name and email fields read-only for security. The dialog follows the existing `BaseDialog` pattern, includes clear validation, helper text for disabled fields, cancel confirmation, and toast notifications for user guidance. Supported contact types include Primary/Secondary Project Officer, State Representative, and Subject Matter Expert.

Integration updates include adding edit functionality to ContactsTable (with validation for single-row selection and toast feedback), wiring up contact updates in DemonstrationTab, and exporting the dialog via `index.ts`. A full test suite covers rendering, validation, submission, cancel behavior, and field restrictions to ensure reliability.


<img width="1469" height="535" alt="image" src="https://github.com/user-attachments/assets/e0fe0a66-b3aa-471e-937b-c55276cafd83" />

Selected 2: Disabled Edit
<img width="1454" height="519" alt="image" src="https://github.com/user-attachments/assets/5d3e645b-b34e-4637-8708-5ddaa6a4b0c6" />

Selected single, Enabled Edit:
<img width="1433" height="513" alt="image" src="https://github.com/user-attachments/assets/c1c93aa7-a2f4-4ccb-a0cf-fa7cab067104" />

Edit Contacts:
<img width="1642" height="827" alt="image" src="https://github.com/user-attachments/assets/df0cc271-8545-4b1e-a7a6-a13f03b2e26c" />
