### PR TITLE
DEMOS-559 Removes Contacts from contact list

### DIFF
--- a/client/src/components/dialog/RemoveContactDialog.tsx
+++ b/client/src/components/dialog/RemoveContactDialog.tsx
@@ -71,7 +71,7 @@ export const RemoveContactDialog: React.FC<RemoveContactDialogProps> = ({
     >
       <div className="mb-2 text-sm text-text-filled">
         Are you sure you want to remove {contactIds.length > 1 ? "the" : ""} contact
-        {contactIds.length > 1 ? "s" : ""} ? This action cannot be undone!
+        {contactIds.length > 1 ? "s" : ""}?
         <br />
         <span className="text-error flex items-center gap-1 mt-1">
           <ErrorIcon />

--- a/client/src/components/dialog/RemoveContactDialog.tsx
+++ b/client/src/components/dialog/RemoveContactDialog.tsx
@@ -71,7 +71,7 @@ export const RemoveContactDialog: React.FC<RemoveContactDialogProps> = ({
     >
       <div className="mb-2 text-sm text-text-filled">
         Are you sure you want to remove {contactIds.length > 1 ? "the" : ""} contact
-        {contactIds.length > 1 ? "s" : ""}? This action cannot be undone!
+        {contactIds.length > 1 ? "s" : ""} ? This action cannot be undone!
         <br />
         <span className="text-error flex items-center gap-1 mt-1">
           <ErrorIcon />

--- a/client/src/components/dialog/RemoveContactDialog.tsx
+++ b/client/src/components/dialog/RemoveContactDialog.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+
+import { SecondaryButton } from "components/button";
+import { ErrorButton } from "components/button/ErrorButton";
+import { BaseDialog } from "components/dialog/BaseDialog";
+import { ErrorIcon } from "components/icons";
+import { useToast } from "components/toast";
+
+export type RemoveContactDialogProps = {
+  isOpen: boolean;
+  contactIds: string[];
+  onClose: () => void;
+  onConfirm?: (contactIds: string[]) => Promise<void>;
+};
+
+export const RemoveContactDialog: React.FC<RemoveContactDialogProps> = ({
+  isOpen,
+  contactIds,
+  onClose,
+  onConfirm,
+}) => {
+  const { showSuccess, showError } = useToast();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleConfirm = async () => {
+    try {
+      setIsDeleting(true);
+
+      if (onConfirm) {
+        await onConfirm(contactIds);
+      }
+
+      const isMultipleContacts = contactIds.length > 1;
+      showSuccess(`Your contact${isMultipleContacts ? "s have" : " has"} been removed.`);
+      onClose();
+    } catch (error) {
+      console.error("Error in handleConfirm:", error);
+      showError("Your changes could not be saved due to an unknown problem.");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <BaseDialog
+      title={`Remove Contact${contactIds.length > 1 ? "s" : ""}`}
+      isOpen={isOpen}
+      onClose={onClose}
+      actions={
+        <>
+          <SecondaryButton
+            name="button-cancel-delete-contact"
+            size="small"
+            onClick={onClose}
+            disabled={isDeleting}
+          >
+            Cancel
+          </SecondaryButton>
+          <ErrorButton
+            name="button-confirm-delete-contact"
+            size="small"
+            onClick={handleConfirm}
+            aria-label="Confirm Remove Contact"
+            disabled={isDeleting}
+            aria-disabled={isDeleting}
+          >
+            {isDeleting ? "Removing..." : "Remove"}
+          </ErrorButton>
+        </>
+      }
+    >
+      <div className="mb-2 text-sm text-text-filled">
+        Are you sure you want to remove {contactIds.length > 1 ? "the" : ""} contact
+        {contactIds.length > 1 ? "s" : ""}? This action cannot be undone!
+        <br />
+        <span className="text-error flex items-center gap-1 mt-1">
+          <ErrorIcon />
+          This action cannot be undone.
+        </span>
+      </div>
+    </BaseDialog>
+  );
+};

--- a/client/src/components/dialog/RemoveContactDialog.tsx
+++ b/client/src/components/dialog/RemoveContactDialog.tsx
@@ -10,14 +10,12 @@ export type RemoveContactDialogProps = {
   isOpen: boolean;
   contactIds: string[];
   onClose: () => void;
-  onConfirm?: (contactIds: string[]) => Promise<void>;
 };
 
 export const RemoveContactDialog: React.FC<RemoveContactDialogProps> = ({
   isOpen,
   contactIds,
   onClose,
-  onConfirm,
 }) => {
   const { showSuccess, showError } = useToast();
   const [isDeleting, setIsDeleting] = useState(false);
@@ -26,9 +24,8 @@ export const RemoveContactDialog: React.FC<RemoveContactDialogProps> = ({
     try {
       setIsDeleting(true);
 
-      if (onConfirm) {
-        await onConfirm(contactIds);
-      }
+      // TODO: Add actual API call here when available
+      console.log("Deleting contacts:", contactIds);
 
       const isMultipleContacts = contactIds.length > 1;
       showSuccess(`Your contact${isMultipleContacts ? "s have" : " has"} been removed.`);
@@ -43,7 +40,7 @@ export const RemoveContactDialog: React.FC<RemoveContactDialogProps> = ({
 
   return (
     <BaseDialog
-      title={`Remove Contact${contactIds.length > 1 ? "s" : ""}`}
+      title="Remove Contact(s)"
       isOpen={isOpen}
       onClose={onClose}
       actions={
@@ -70,8 +67,7 @@ export const RemoveContactDialog: React.FC<RemoveContactDialogProps> = ({
       }
     >
       <div className="mb-2 text-sm text-text-filled">
-        Are you sure you want to remove {contactIds.length > 1 ? "the" : ""} contact
-        {contactIds.length > 1 ? "s" : ""}?
+        Are you sure you want to remove the contact(s)?
         <br />
         <span className="text-error flex items-center gap-1 mt-1">
           <ErrorIcon />

--- a/client/src/components/dialog/index.ts
+++ b/client/src/components/dialog/index.ts
@@ -4,6 +4,7 @@ export { AmendmentDialog } from "./AmendmentDialog";
 export { CreateDemonstrationDialog, EditDemonstrationDialog } from "./DemonstrationDialog";
 export { ExtensionDialog } from "./ExtensionDialog";
 export { EditContactDialog } from "./EditContactDialog";
+export { RemoveContactDialog } from "./RemoveContactDialog";
 export {
   AddDocumentDialog,
   EditDocumentDialog,

--- a/client/src/components/table/tables/ContactsTable.tsx
+++ b/client/src/components/table/tables/ContactsTable.tsx
@@ -13,6 +13,7 @@ import { DeleteIcon, EditIcon, ImportIcon } from "components/icons";
 import { createSelectColumnDef } from "../columns/selectColumn";
 import { TableHead } from "../Table";
 import { EditContactDialog } from "components/dialog/EditContactDialog";
+import { RemoveContactDialog } from "components/dialog/RemoveContactDialog";
 import { useToast } from "components/toast";
 
 type ContactType =
@@ -88,7 +89,9 @@ export const ContactsTable: React.FC<ContactsTableProps> = ({
 }) => {
   const [rowSelection, setRowSelection] = React.useState({});
   const [isEditDialogOpen, setIsEditDialogOpen] = React.useState(false);
+  const [isRemoveDialogOpen, setIsRemoveDialogOpen] = React.useState(false);
   const [selectedContact, setSelectedContact] = React.useState<Contact | null>(null);
+  const [selectedContactIds, setSelectedContactIds] = React.useState<string[]>([]);
   const { showError } = useToast();
 
   const contactsTable = useReactTable<Contact>({
@@ -128,13 +131,19 @@ export const ContactsTable: React.FC<ContactsTableProps> = ({
     }
 
     const contactIds = selectedRows.map((row) => row.original.id);
+    setSelectedContactIds(contactIds);
+    setIsRemoveDialogOpen(true);
+  };
 
+  const handleConfirmRemoveContacts = async (contactIds: string[]) => {
     if (onDeleteContacts) {
       onDeleteContacts(contactIds);
     } else {
       // TODO: Add actual API call here when available
       console.log("Deleting contacts:", contactIds);
     }
+    setIsRemoveDialogOpen(false);
+    setSelectedContactIds([]);
   };
   const handleCloseDialog = () => {
     setIsEditDialogOpen(false);
@@ -199,6 +208,14 @@ export const ContactsTable: React.FC<ContactsTableProps> = ({
           onSubmit={handleSubmitContact}
         />
       )}
+
+      {/* Remove Contact Dialog */}
+      <RemoveContactDialog
+        isOpen={isRemoveDialogOpen}
+        onClose={() => setIsRemoveDialogOpen(false)}
+        onConfirm={handleConfirmRemoveContacts}
+        contactIds={selectedContactIds}
+      />
     </>
   );
 };

--- a/client/src/components/table/tables/ContactsTableDemo.tsx
+++ b/client/src/components/table/tables/ContactsTableDemo.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from "react";
-import { ContactsTable, Contact } from "components/table/tables/ContactsTable";
+
 import { Button } from "components/button";
+import {
+  Contact,
+  ContactsTable,
+} from "components/table/tables/ContactsTable";
 
 type ContactType =
   | "Primary Project Officer"
@@ -46,18 +50,6 @@ export const ContactsTableDemo: React.FC = () => {
     console.log(`Updated contact ${contactId} to type: ${contactType}`);
   };
 
-  const handleDeleteContacts = async (contactIds: string[]) => {
-    // Simulate API delay
-    await new Promise((resolve) => setTimeout(resolve, 500));
-
-    // Remove the contacts from state
-    setContacts((prevContacts) =>
-      prevContacts.filter((contact) => !contactIds.includes(contact.id))
-    );
-
-    console.log(`Deleted contacts: ${contactIds.join(", ")}`);
-  };
-
   const resetContacts = () => {
     setContacts(mockContacts);
   };
@@ -71,11 +63,7 @@ export const ContactsTableDemo: React.FC = () => {
         </Button>
       </div>
       <div className="bg-white p-4 border rounded">
-        <ContactsTable
-          contacts={contacts}
-          onUpdateContact={handleUpdateContact}
-          onDeleteContacts={handleDeleteContacts}
-        />
+        <ContactsTable contacts={contacts} onUpdateContact={handleUpdateContact} />
       </div>
       <div className="mt-4 text-sm text-gray-600">
         <p>
@@ -86,7 +74,10 @@ export const ContactsTableDemo: React.FC = () => {
           <li>For editing: Select exactly one contact and click &quot;Edit Contact&quot;</li>
           <li>For deleting: Select one or more contacts and click &quot;Remove Contact&quot;</li>
           <li>Change the contact type in the edit dialog and click &quot;Submit&quot;</li>
-          <li>The table will update with changes or remove deleted contacts</li>
+          <li>
+            The table will update with contact type changes. Deletion shows confirmation toast but
+            contacts remain in demo for testing purposes.
+          </li>
         </ol>
       </div>
     </div>

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
@@ -7,8 +7,18 @@ import { AddNewIcon } from "components/icons";
 import { ContactsTable } from "components/table/tables/ContactsTable";
 import { DocumentTable } from "components/table/tables/DocumentTable";
 import { SummaryDetailsTable } from "components/table/tables/SummaryDetailsTable";
-import { TabItem, Tabs } from "layout/Tabs";
-import { Demonstration, DemonstrationStatus, Document, State, User } from "demos-server";
+import {
+  Demonstration,
+  DemonstrationStatus,
+  Document,
+  State,
+  User,
+} from "demos-server";
+import {
+  TabItem,
+  Tabs,
+} from "layout/Tabs";
+
 import { Contact } from "./DemonstrationDetail";
 
 type SubTabType = "summary" | "types" | "documents" | "contacts";
@@ -38,13 +48,6 @@ export const DemonstrationTab: React.FC<{ demonstration: DemonstrationTabDemonst
     console.log("Updating contact:", { contactId, contactType });
     // This would typically call a mutation/API to update the contact in the database
     // await updateContactMutation({ variables: { id: contactId, contactType } });
-  };
-
-  const handleDeleteContacts = async (contactIds: string[]) => {
-    // TODO: Implement actual API call to delete contacts
-    console.log("Deleting contacts:", contactIds);
-    // This would typically call a mutation/API to delete the contacts from the database
-    // await deleteContactsMutation({ variables: { ids: contactIds } });
   };
 
   const subTabList: TabItem[] = [
@@ -113,7 +116,6 @@ export const DemonstrationTab: React.FC<{ demonstration: DemonstrationTabDemonst
             <ContactsTable
               contacts={demonstration.contacts}
               onUpdateContact={handleUpdateContact}
-              onDeleteContacts={handleDeleteContacts}
             />
           </>
         )}

--- a/client/vitest.setup.ts
+++ b/client/vitest.setup.ts
@@ -1,9 +1,12 @@
 // Import DOM testing library for Jest, to be used by all test files
 import "@testing-library/jest-dom";
+
 import React from "react";
+
 import { vi } from "vitest";
 
 // Mock HTML dialog element for tests
+// HTMLDialogElement API is not fully supported in jsdom yet, so we need these mocks
 Object.defineProperty(HTMLDialogElement.prototype, "showModal", {
   value: vi.fn(function (this: HTMLDialogElement) {
     this.open = true;

--- a/client/vitest.setup.ts
+++ b/client/vitest.setup.ts
@@ -5,17 +5,23 @@ import { vi } from "vitest";
 
 // Mock HTML dialog element for tests
 Object.defineProperty(HTMLDialogElement.prototype, "showModal", {
-  value: vi.fn(),
+  value: vi.fn(function (this: HTMLDialogElement) {
+    this.open = true;
+  }),
   writable: true,
 });
 
 Object.defineProperty(HTMLDialogElement.prototype, "show", {
-  value: vi.fn(),
+  value: vi.fn(function (this: HTMLDialogElement) {
+    this.open = true;
+  }),
   writable: true,
 });
 
 Object.defineProperty(HTMLDialogElement.prototype, "close", {
-  value: vi.fn(),
+  value: vi.fn(function (this: HTMLDialogElement) {
+    this.open = false;
+  }),
   writable: true,
 });
 


### PR DESCRIPTION
https://jiraent.cms.gov/browse/DEMOS-559

# Add Contact Removal Confirmation Dialog

This PR implements a confirmation dialog for removing contacts from the contacts table to prevent accidental deletions. The changes include creating a new `RemoveContactDialog` component that appears when users click the "Remove Contact" button, requiring explicit confirmation before deletion occurs.

The implementation also fixes a test environment issue where HTML dialog elements weren't properly mocked in Vitest. The dialog mocks now correctly set the `open` property when `showModal()` is called, ensuring that dialog-based components can be properly tested. All existing tests continue to pass with the new confirmation workflow.

<img width="1413" height="457" alt="image" src="https://github.com/user-attachments/assets/e55e106b-a93d-4701-bcb3-4818669304b4" />

<img width="1470" height="691" alt="image" src="https://github.com/user-attachments/assets/cdac52e0-cb0e-43b4-9714-3ddb1a9713b1" />
