### PR TITLE
DEMOS-811: exit cli with non-zero when scripts error

### DIFF
--- a/deployment/demosctl/commands/addCloudfrontRedirect.test.ts
+++ b/deployment/demosctl/commands/addCloudfrontRedirect.test.ts
@@ -11,15 +11,11 @@ jest.mock("../lib/readOutputs");
 
 describe("addCloudfrontRedirect", () => {
   beforeEach(() => {
-    //@ts-expect-error ignore invalid mock
-    jest.spyOn(process, "exit").mockImplementation(() => "exit");
     jest.spyOn(console, "log").mockImplementation(() => true);
     jest.spyOn(console, "error").mockImplementation(() => true);
   });
 
   afterEach(() => {
-    // @ts-expect-error ignore invalid mock
-    (process.exit as jest.Mock).mockRestore();
     (console.log as jest.Mock).mockRestore();
     (console.error as jest.Mock).mockRestore();
   });
@@ -59,11 +55,12 @@ describe("addCloudfrontRedirect", () => {
     const rc = runCommand as jest.Mock;
     rc.mockResolvedValue(1);
     const mockStageName = "unit-test";
+    let exitCode;
     try {
-      await addCloudfrontRedirect(mockStageName);
+      exitCode = await addCloudfrontRedirect(mockStageName);
     } finally {
       expect(console.error).toHaveBeenCalledTimes(1);
-      expect(process.exit).toHaveBeenCalledWith(1);
+      expect(exitCode).toBe(1);
     }
   });
 });

--- a/deployment/demosctl/commands/addCloudfrontRedirect.ts
+++ b/deployment/demosctl/commands/addCloudfrontRedirect.ts
@@ -18,7 +18,7 @@ export async function addCloudfrontRedirect(environment: string) {
 
   if (cmd != 0) {
     console.error(`deploy-no-execute command failed with code ${cmd}`);
-    return process.exit(cmd);
+    return cmd;
   }
 
   const outputData = readOutputs("all-outputs.json");
@@ -30,4 +30,5 @@ export async function addCloudfrontRedirect(environment: string) {
   );
 
   console.log(`\n======\ncloudfront url added as a valid redirect\n======\n`);
+  return 0;
 }

--- a/deployment/demosctl/commands/buildClient.test.ts
+++ b/deployment/demosctl/commands/buildClient.test.ts
@@ -87,10 +87,7 @@ describe("buildClient", () => {
     const rc = runCommand as jest.Mock;
     rc.mockResolvedValue(1);
 
-    //@ts-expect-error ignore invalid mock
-    jest.spyOn(process, "exit").mockImplementation(() => "exit");
-
-    await buildClient(mockStageName, true);
+    const exitCode = await buildClient(mockStageName, true);
     expect(rc).toHaveBeenCalled();
     expect(rc).toHaveBeenCalledWith(
       "deploy-core-no-execute",
@@ -98,6 +95,6 @@ describe("buildClient", () => {
       expect.arrayContaining([`stage=${mockStageName}`, `demos-${mockStageName}-core`])
     );
 
-    expect(process.exit).toHaveBeenCalled();
+    expect(exitCode).toBe(1);
   });
 });

--- a/deployment/demosctl/commands/buildClient.ts
+++ b/deployment/demosctl/commands/buildClient.ts
@@ -22,13 +22,13 @@ export async function buildClient(environment: string, refreshOutputs: boolean =
 
     if (cmd != 0) {
       console.error(`deploy-no-execute command failed with code ${cmd}`);
-      return process.exit(cmd);
+      return cmd;
     }
   }
 
   const coreOutputData = readOutputs("core-outputs.json");
 
-  await runShell("client-build", "npm ci && npm run build", {
+  return await runShell("client-build", "npm ci && npm run build", {
     cwd: clientPath,
     env: {
       ...process.env,

--- a/deployment/demosctl/commands/buildServer.ts
+++ b/deployment/demosctl/commands/buildServer.ts
@@ -4,7 +4,7 @@ import { runShell } from "../lib/runCommand";
 
 export async function buildServer() {
   const serverPath = path.join("..", "server");
-  await runShell("server-build", "npm ci && npm run build:ci", {
+  return await runShell("server-build", "npm ci && npm run build:ci", {
     cwd: serverPath,
   });
 }

--- a/deployment/demosctl/commands/down.ts
+++ b/deployment/demosctl/commands/down.ts
@@ -4,7 +4,7 @@ import { runCommand } from "../lib/runCommand";
 export async function down(environment: string) {
   if (["prod", "impl", "test", "dev"].includes(environment)) {
     console.log("'down' can only be used for ephemeral environments");
-    return process.exit(1);
+    return 1;
   }
 
   const confirmed = await confirm(
@@ -14,11 +14,13 @@ export async function down(environment: string) {
   );
   if (!confirmed) {
     console.log("Only 'yes' (case-sensitive) is accepted as a confirmation. Cancelling...");
-    return process.exit(1);
+    return 1;
   }
 
+  let exitCode: number = 0;
+
   try {
-    await runCommand("down", "npx", [
+    exitCode = await runCommand("down", "npx", [
       "cdk",
       "destroy",
       "--context",
@@ -30,6 +32,8 @@ export async function down(environment: string) {
     ]);
   } catch (err) {
     console.error(`deployment failed: ${err}`);
-    return process.exit(1);
+    return 1;
   }
+
+  return exitCode;
 }

--- a/deployment/demosctl/commands/fullDeploy.test.ts
+++ b/deployment/demosctl/commands/fullDeploy.test.ts
@@ -44,10 +44,8 @@ describe("fullDeploy", () => {
     rc.mockResolvedValue(1);
 
     jest.spyOn(console, "error");
-    // @ts-expect-error ignore invalid mock
-    jest.spyOn(process, "exit").mockImplementation(() => "exit");
 
-    await fullDeploy(mockStageName);
+    const exitCode = await fullDeploy(mockStageName);
 
     expect(rc).toHaveBeenCalledWith(
       "deploy-all",
@@ -56,6 +54,6 @@ describe("fullDeploy", () => {
     );
 
     expect(console.error).toHaveBeenCalledWith("complete deploy command failed with code 1");
-    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(exitCode).toBe(1);
   });
 });

--- a/deployment/demosctl/commands/fullDeploy.ts
+++ b/deployment/demosctl/commands/fullDeploy.ts
@@ -17,16 +17,17 @@ export async function fullDeploy(environment: string) {
 
   if (completeDeployCmd != 0) {
     console.error(`complete deploy command failed with code ${completeDeployCmd}`);
-    return process.exit(completeDeployCmd);
+    return completeDeployCmd;
   }
 
   // Add cloudfront url to list of redirect urls
   const outputData = readOutputs("all-outputs.json");
-  addCognitoRedirect(
+  await addCognitoRedirect(
     getOutputValue(outputData, `demos-${environment}-core`, "cognitoAuthority").split("/").pop()!,
     getOutputValue(outputData, `demos-${environment}-core`, "cognitoClientId"),
     getOutputValue(outputData, `demos-${environment}-ui`, "CloudfrontURL")
   );
 
   console.log(`\n======\ncomplete deploy command succeeded\n======\n`);
+  return 0;
 }

--- a/deployment/demosctl/commands/getCoreOutputs.test.ts
+++ b/deployment/demosctl/commands/getCoreOutputs.test.ts
@@ -1,10 +1,8 @@
 import { getCoreOutputs } from "./getCoreOutputs";
 
 import { runCommand } from "../lib/runCommand";
-import { readOutputs } from "../lib/readOutputs";
 
 jest.mock("../lib/runCommand");
-jest.mock("../lib/readOutputs");
 jest.mock("../lib/addCognitoRedirect");
 
 describe("getCoreOutputs", () => {
@@ -16,7 +14,7 @@ describe("getCoreOutputs", () => {
 
     jest.spyOn(console, "log");
 
-    await getCoreOutputs(mockStageName);
+    const exitCode = await getCoreOutputs(mockStageName);
 
     expect(rc).toHaveBeenCalledWith(
       "core-deploy",
@@ -24,7 +22,7 @@ describe("getCoreOutputs", () => {
       expect.arrayContaining(["deploy", `demos-${mockStageName}-core`, `stage=${mockStageName}`])
     );
 
-    expect(readOutputs).toHaveBeenCalled();
+    expect(exitCode).toBe(0);
   });
   test("should exit on error", async () => {
     const mockStageName = "unit-test";
@@ -33,10 +31,8 @@ describe("getCoreOutputs", () => {
     rc.mockResolvedValue(1);
 
     jest.spyOn(console, "error");
-    // @ts-expect-error ignore invalid mock
-    jest.spyOn(process, "exit").mockImplementation(() => "exit");
 
-    await getCoreOutputs(mockStageName);
+    const exitCode = await getCoreOutputs(mockStageName);
 
     expect(rc).toHaveBeenCalledWith(
       "core-deploy",
@@ -45,6 +41,6 @@ describe("getCoreOutputs", () => {
     );
 
     expect(console.error).toHaveBeenCalledWith("core output command failed with code 1");
-    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(exitCode).toBe(1);
   });
 });

--- a/deployment/demosctl/commands/getCoreOutputs.ts
+++ b/deployment/demosctl/commands/getCoreOutputs.ts
@@ -1,4 +1,3 @@
-import { readOutputs } from "../lib/readOutputs";
 import { runCommand } from "../lib/runCommand";
 
 export async function getCoreOutputs(environment: string) {
@@ -14,7 +13,7 @@ export async function getCoreOutputs(environment: string) {
 
   if (coreOutputCmd != 0) {
     console.error(`core output command failed with code ${coreOutputCmd}`);
-    return process.exit(coreOutputCmd);
+    return coreOutputCmd;
   }
-  return readOutputs("core-outputs.json");
+  return 0;
 }

--- a/deployment/demosctl/commands/runMigration.test.ts
+++ b/deployment/demosctl/commands/runMigration.test.ts
@@ -22,7 +22,7 @@ describe("runMigration", () => {
     await runMigration(mockStageName, targetDB, mockDBData);
 
     expect(runShell).toHaveBeenCalledWith(
-      "server-build",
+      "migrate-deploy",
       "npm run migrate:deploy",
       expect.objectContaining({
         cwd: "../server",
@@ -45,7 +45,7 @@ describe("runMigration", () => {
     await runMigration(mockStageName, targetDB);
 
     expect(runShell).toHaveBeenCalledWith(
-      "server-build",
+      "migrate-deploy",
       "npm run migrate:deploy",
       expect.objectContaining({
         cwd: "../server",

--- a/deployment/demosctl/commands/runMigration.ts
+++ b/deployment/demosctl/commands/runMigration.ts
@@ -29,7 +29,7 @@ export async function runMigration(environment: string, dbname: string = "demos"
 
   const dbUrl = `postgresql://${secretData.username}:${secretData.password}@${secretData.host}:${secretData.port}/${dbname}?schema=demos_app`;
   const serverPath = path.join("..", "server");
-  return await runShell("server-build", "npm run migrate:deploy", {
+  return await runShell("migrate-deploy", "npm run migrate:deploy", {
     cwd: serverPath,
     env: {
       ...process.env,

--- a/deployment/demosctl/commands/testMigration.test.ts
+++ b/deployment/demosctl/commands/testMigration.test.ts
@@ -85,18 +85,18 @@ describe("testMigration", () => {
   test("should exit if no db name is specified", async () => {
     const mockStageName = "unit-test";
 
-    await testMigration(mockStageName);
+    const exitCode = await testMigration(mockStageName);
     expect(console.error).toHaveBeenCalledWith("you must specify a database name");
-    expect(process.exit).toHaveBeenCalled();
+    expect(exitCode).toBe(1);
   });
 
   test("should exit if db is set to 'demos'", async () => {
     const mockStageName = "unit-test";
     const targetDB = "demos";
 
-    await testMigration(mockStageName, targetDB);
+    const exitCode = await testMigration(mockStageName, targetDB);
     expect(console.error).toHaveBeenCalledWith("testMigration cannot be run against 'demos' db");
-    expect(process.exit).toHaveBeenCalled();
+    expect(exitCode).toBe(1);
   });
 
   test("should fail when secret data can't be retrieved", async () => {
@@ -117,10 +117,10 @@ describe("testMigration", () => {
 
     (getSecret as jest.Mock).mockResolvedValue(null);
 
-    await testMigration(mockStageName, targetDB);
+    const exitCode = await testMigration(mockStageName, targetDB);
 
     expect(console.error).toHaveBeenCalledWith(`unable to retrieve secret data for demos-${mockStageName}-rds-admin`);
-    expect(process.exit).toHaveBeenCalled();
+    expect(exitCode).toBe(1);
   });
 
   test("should print error if migration fails", async () => {
@@ -142,10 +142,10 @@ describe("testMigration", () => {
     (getSecret as jest.Mock).mockResolvedValue(JSON.stringify(mockDBData));
     (runMigration as jest.Mock).mockRejectedValue("something went wrong");
 
-    await testMigration(mockStageName, targetDB);
+    const exitCode = await testMigration(mockStageName, targetDB);
 
     expect(console.error).toHaveBeenCalledWith("migrationStatus error", "something went wrong");
-    expect(process.exit).toHaveBeenCalled();
+    expect(exitCode).toBe(1);
   });
 
   test("should handle error when failing to drop database", async () => {
@@ -170,7 +170,7 @@ describe("testMigration", () => {
     // @ts-expect-error ignore invalid mock
     mockQuery.mockRejectedValueOnce(1);
 
-    await testMigration(mockStageName, targetDB);
+    const exitCode = await testMigration(mockStageName, targetDB);
 
     expect(console.error).toHaveBeenCalledTimes(2);
     expect(console.error).toHaveBeenCalledWith("failed to drop database:", 1);
@@ -178,6 +178,6 @@ describe("testMigration", () => {
       expect.stringContaining("`prisma migration deploy` exited with a non-zero exit code")
     );
 
-    expect(process.exit).toHaveBeenCalled();
+    expect(exitCode).toBe(1);
   });
 });

--- a/deployment/demosctl/commands/testMigration.ts
+++ b/deployment/demosctl/commands/testMigration.ts
@@ -24,12 +24,12 @@ export function fetchCACert(url: string): Promise<string> {
 export async function testMigration(environment: string, dbname?: string) {
   if (!dbname) {
     console.error("you must specify a database name");
-    return process.exit(1);
+    return 1;
   }
 
   if (dbname == "demos") {
     console.error("testMigration cannot be run against 'demos' db");
-    return process.exit(1);
+    return 1;
   }
 
   console.log("test-migration:", environment);
@@ -37,7 +37,7 @@ export async function testMigration(environment: string, dbname?: string) {
   const secretDataRaw = await getSecret(`demos-${environment}-rds-admin`);
   if (!secretDataRaw) {
     console.error(`unable to retrieve secret data for demos-${environment}-rds-admin`);
-    return process.exit(1);
+    return 1;
   }
 
   console.log("secret retrieved successfully");
@@ -51,7 +51,7 @@ export async function testMigration(environment: string, dbname?: string) {
     migrationStatus = await runMigration(environment, dbname, secretData);
   } catch (err) {
     console.error("migrationStatus error", err);
-    return process.exit(1);
+    return 1;
   }
 
   // clean up
@@ -76,6 +76,8 @@ export async function testMigration(environment: string, dbname?: string) {
   }
   if (migrationStatus != 0) {
     console.error("\n\n`prisma migration deploy` exited with a non-zero exit code");
-    return process.exit(1);
+    return migrationStatus;
   }
+
+  return 0;
 }

--- a/deployment/demosctl/commands/up.ts
+++ b/deployment/demosctl/commands/up.ts
@@ -6,7 +6,7 @@ import { getCoreOutputs } from "./getCoreOutputs";
 export async function up(environment: string) {
   if (["prod", "impl", "test", "dev"].includes(environment)) {
     console.error("'up' can only be used for ephemeral environments");
-    return process.exit(1);
+    return 1;
   }
   try {
     await getCoreOutputs(environment);
@@ -14,6 +14,8 @@ export async function up(environment: string) {
     await fullDeploy(environment);
   } catch (err) {
     console.error(`deployment failed: ${err}`);
-    return process.exit(1);
+    return 1;
   }
+
+  return 0;
 }

--- a/deployment/demosctl/demosctl.ts
+++ b/deployment/demosctl/demosctl.ts
@@ -19,34 +19,25 @@ export async function main() {
   const environment = args[1];
   switch (command) {
     case "build:client":
-      await buildClient(environment, args[2] == "true");
-      break;
+      return await buildClient(environment, args[2] == "true");
     case "build:server":
-      await buildServer();
-      break;
+      return await buildServer();
     case "deploy:core":
-      await getCoreOutputs(environment);
-      break;
+      return await getCoreOutputs(environment);
     case "deploy:all":
-      await fullDeploy(environment);
-      break;
+      return await fullDeploy(environment);
     case "deploy:add-cloudfront-redirect":
-      await addCloudfrontRedirect(environment);
-      break;
+      return await addCloudfrontRedirect(environment);
     case "up":
-      await up(environment);
-      break;
+      return await up(environment);
     case "down":
-      down(environment);
-      break;
+      return await down(environment);
     case "migrate":
-      runMigration(environment, args[2]);
-      break;
+      return await runMigration(environment, args[2]);
     case "test-migration":
-      testMigration(environment, args[2]);
-      break;
+      return await testMigration(environment, args[2]);
     default:
       console.error(`Unknown command: ${command}`);
-      process.exit(1);
+      return 1;
   }
 }

--- a/deployment/demosctl/demosctl.ts
+++ b/deployment/demosctl/demosctl.ts
@@ -8,7 +8,7 @@ import { down } from "./commands/down";
 import { runMigration } from "./commands/runMigration";
 import { testMigration } from "./commands/testMigration";
 
-export async function main() {
+export async function main(): Promise<number | null> {
   const args = process.argv.slice(2);
   if (args.length < 2) {
     console.log("command and environment must be specified");

--- a/deployment/demosctl/index.ts
+++ b/deployment/demosctl/index.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env tsx
 import { main } from "./demosctl";
 
-main();
+(async () => {
+  process.exit(await main());
+})();


### PR DESCRIPTION
Updates the demosctl utility (which is used in the jenkins pipelines) so that the exit codes match the processes the commands run. Previously at the root level, commands were being called, but some exit codes were being ignored. As part of this change, I modified the code to return the exit code and only call process.exit at the top level rather than individually within the functions.