### PR TITLE
DEMOS-764: Add systems manager VPC endpoint

### DIFF
--- a/deployment/stacks/core.test.ts
+++ b/deployment/stacks/core.test.ts
@@ -29,7 +29,7 @@ describe("Core Stack", () => {
 
     template.resourceCountIs("AWS::Cognito::UserPool", 1);
     template.resourceCountIs("AWS::Cognito::UserPoolClient", 1);
-    template.resourceCountIs("AWS::EC2::VPCEndpoint", 2);
+    template.resourceCountIs("AWS::EC2::VPCEndpoint", 3);
   });
 
   test("should create proper resources when ephemeral", () => {

--- a/deployment/stacks/core.ts
+++ b/deployment/stacks/core.ts
@@ -97,6 +97,22 @@ export class CoreStack extends Stack {
       vpc.addGatewayEndpoint("s3GatewayEndpoint", {
         service: aws_ec2.GatewayVpcEndpointAwsService.S3,
       });
+
+      const ssmEndpointSecurityGroupName = `${commonProps.project}-${commonProps.hostEnvironment}-ssm-vpce`;
+      const ssmEndpoint = securityGroup.create({
+        ...commonProps,
+        vpc,
+        scope: this,
+        name: ssmEndpointSecurityGroupName,
+      }).securityGroup;
+
+      vpc.addInterfaceEndpoint("ssmEndpoint", {
+        service: aws_ec2.InterfaceVpcEndpointAwsService.SSM,
+        subnets: {
+          subnets: vpc.privateSubnets,
+        },
+        securityGroups: [ssmEndpoint],
+      });
     } else {
       // Ephemeral Environments
       secretsManagerEndpointSG = aws_ec2.SecurityGroup.fromLookupByName(


### PR DESCRIPTION
This change adds a new VPC Endpoint to that will be used for access to the parameter store. The current use case is for storing info related to DB users, but may be used for other items in the future