### PR TITLE
DEMOS-839: remove interactive command from jenkins pipeline

### DIFF
--- a/deployment/demosctl/commands/getCoreOutputs.ts
+++ b/deployment/demosctl/commands/getCoreOutputs.ts
@@ -7,6 +7,7 @@ export async function getCoreOutputs(environment: string) {
     "--context",
     `stage=${environment}`,
     `demos-${environment}-core`,
+    "--require-approval=never",
     "--outputs-file",
     "core-outputs.json",
   ]);


### PR DESCRIPTION
The core-outputs command has to deploy. Some changes require a manual approval on the cli, but that doesn't work on Jenkins since there is no interactive CLI. The require-approval=never flag is used to avoid this.

This is already being used for the full deployment. The approval itself is assumed from the approval/merge of the PR