### PR TITLE
DEMOS-831-refactor-connect-usage

### DIFF
--- a/server/src/errors/handlePrismaError.ts
+++ b/server/src/errors/handlePrismaError.ts
@@ -1,6 +1,6 @@
 import { Prisma } from "@prisma/client";
 
-export function handlePrismaError(error: unknown) {
+export function handlePrismaError(error: unknown): never {
   if (error instanceof Prisma.PrismaClientKnownRequestError) {
     switch (error.code) {
       case "P2003":
@@ -8,6 +8,8 @@ export function handlePrismaError(error: unknown) {
           "Foreign key constraint failed, please validate your input parameters. Constraint violated: " +
             error.meta!.constraint
         );
+      default:
+        throw new Error("A Prisma error was encountered: " + error);
     }
   } else {
     throw error;

--- a/server/src/model/bundle/bundleResolvers.ts
+++ b/server/src/model/bundle/bundleResolvers.ts
@@ -1,7 +1,12 @@
 import { prisma } from "../../prismaClient";
 import { getDemonstration } from "../demonstration/demonstrationResolvers.js";
 import { getAmendment, getExtension } from "../modification/modificationResolvers.js";
+import { Bundle } from "@prisma/client";
 import { BundleType } from "../../types.js";
+
+const demonstrationBundleTypeId: BundleType = "DEMONSTRATION";
+const amendmentBundleTypeId: BundleType = "AMENDMENT";
+const extensionBundleTypeId: BundleType = "EXTENSION";
 
 export async function getBundle(bundleId: string) {
   const bundle = await prisma().bundle.findUnique({
@@ -22,3 +27,17 @@ export async function getBundle(bundleId: string) {
     return getExtension(undefined, { id: bundleId });
   }
 }
+
+export const bundleResolvers = {
+  Bundle: {
+    __resolveType(obj: Bundle) {
+      if (obj.bundleTypeId === demonstrationBundleTypeId) {
+        return "Demonstration";
+      } else if (obj.bundleTypeId === amendmentBundleTypeId) {
+        return "Amendment";
+      } else if (obj.bundleTypeId === extensionBundleTypeId) {
+        return "Extension";
+      }
+    },
+  },
+};

--- a/server/src/model/document/documentResolvers.ts
+++ b/server/src/model/document/documentResolvers.ts
@@ -1,7 +1,6 @@
 import { GraphQLError } from "graphql";
 
-import { Bundle, Document, DocumentPendingUpload } from "@prisma/client";
-
+import { Document, DocumentPendingUpload } from "@prisma/client";
 import { BUNDLE_TYPE } from "../../constants.js";
 import { prisma } from "../../prismaClient.js";
 import { BundleType } from "../../types.js";
@@ -9,12 +8,11 @@ import { UploadDocumentInput, UpdateDocumentInput } from "./documentSchema.js";
 import { S3Client, PutObjectCommand, GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { GraphQLContext } from "../../auth/auth.util.js";
+import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields.js";
+import { getBundle } from "../bundle/bundleResolvers.js";
+import { handlePrismaError } from "../../errors/handlePrismaError.js";
 
-const demonstrationBundleTypeId: BundleType = BUNDLE_TYPE.DEMONSTRATION;
-const amendmentBundleTypeId: BundleType = BUNDLE_TYPE.AMENDMENT;
-const extensionBundleTypeId: BundleType = BUNDLE_TYPE.EXTENSION;
-
-// TODO: We should look into caching this
+// We should look into caching this
 // Otherwise, there are duplicative DB calls if requesting bundle and bundleType
 async function getBundleTypeId(bundleId: string) {
   const result = await prisma().bundle.findUnique({
@@ -35,14 +33,14 @@ async function getPresignedUploadUrl(
 ): Promise<string> {
   const s3ClientConfig = process.env.S3_ENDPOINT_LOCAL
     ? {
-      region: "us-east-1",
-      endpoint: process.env.S3_ENDPOINT_LOCAL,
-      forcePathStyle: true,
-      credentials: {
-        accessKeyId: "",
-        secretAccessKey: "",
-      },
-    }
+        region: "us-east-1",
+        endpoint: process.env.S3_ENDPOINT_LOCAL,
+        forcePathStyle: true,
+        credentials: {
+          accessKeyId: "",
+          secretAccessKey: "",
+        },
+      }
     : {};
   const s3 = new S3Client(s3ClientConfig);
   const uploadBucket = process.env.UPLOAD_BUCKET;
@@ -59,14 +57,14 @@ async function getPresignedUploadUrl(
 async function getPresignedDownloadUrl(document: Document): Promise<string> {
   const s3ClientConfig = process.env.S3_ENDPOINT_LOCAL
     ? {
-      region: "us-east-1",
-      endpoint: process.env.S3_ENDPOINT_LOCAL,
-      forcePathStyle: true,
-      credentials: {
-        accessKeyId: "",
-        secretAccessKey: "",
-      },
-    }
+        region: "us-east-1",
+        endpoint: process.env.S3_ENDPOINT_LOCAL,
+        forcePathStyle: true,
+        credentials: {
+          accessKeyId: "",
+          secretAccessKey: "",
+        },
+      }
     : {};
   const s3 = new S3Client(s3ClientConfig);
   const cleanBucket = process.env.CLEAN_BUCKET;
@@ -80,7 +78,6 @@ async function getPresignedDownloadUrl(document: Document): Promise<string> {
   });
   return s3Url;
 }
-
 
 export const documentResolvers = {
   Query: {
@@ -114,15 +111,23 @@ export const documentResolvers = {
   },
 
   Mutation: {
-    uploadDocument: async (context: GraphQLContext, { input }: { input: UploadDocumentInput }) => {
-      const { documentType, bundleId, ...rest } = input;
-
+    uploadDocument: async (
+      parent: undefined,
+      { input }: { input: UploadDocumentInput },
+      context: GraphQLContext
+    ) => {
+      if (context.user === null) {
+        throw new Error(
+          "The GraphQL context does not have user information. Are you properly authenticated?"
+        );
+      }
       const documentPendingUpload = await prisma().documentPendingUpload.create({
         data: {
-          ...rest,
-          owner: { connect: { id: context.user?.id } },
-          documentType: { connect: { id: documentType } },
-          bundle: { connect: { id: bundleId } },
+          title: input.title,
+          description: input.description,
+          ownerUserId: context.user.id,
+          documentTypeId: input.documentType,
+          bundleId: input.bundleId,
         },
       });
 
@@ -130,10 +135,7 @@ export const documentResolvers = {
       return { presignedURL };
     },
 
-    downloadDocument: async (
-      _: undefined,
-      { id }: { id: string }
-    ) => {
+    downloadDocument: async (_: undefined, { id }: { id: string }) => {
       const document = await prisma().document.findUnique({
         where: { id: id },
       });
@@ -152,23 +154,20 @@ export const documentResolvers = {
       _: undefined,
       { id, input }: { id: string; input: UpdateDocumentInput }
     ): Promise<Document> => {
-      const { documentType, bundleId, ...rest } = input;
-      return await prisma().document.update({
-        where: { id: id },
-        data: {
-          ...rest,
-          ...(documentType && {
-            documentType: {
-              connect: { id: documentType },
-            },
-          }),
-          ...(bundleId && {
-            bundle: {
-              connect: { id: bundleId },
-            },
-          }),
-        },
-      });
+      checkOptionalNotNullFields(["title", "description", "documentType", "bundleId"], input);
+      try {
+        return await prisma().document.update({
+          where: { id: id },
+          data: {
+            title: input.title,
+            description: input.description,
+            documentTypeId: input.documentType,
+            bundleId: input.bundleId,
+          },
+        });
+      } catch (error) {
+        handlePrismaError(error);
+      }
     },
 
     deleteDocuments: async (_: undefined, { ids }: { ids: string[] }) => {
@@ -194,49 +193,13 @@ export const documentResolvers = {
       });
     },
 
-    // NOTE: Not checking for the bundle type being implemented here
-    // This means if we add a bundle type to the DB and leave this untouched
-    // It will fail silently
     bundle: async (parent: Document) => {
-      const bundleTypeId = await getBundleTypeId(parent.bundleId);
-      if (bundleTypeId === demonstrationBundleTypeId) {
-        return await prisma().demonstration.findUnique({
-          where: { id: parent.bundleId },
-        });
-      } else if (bundleTypeId === amendmentBundleTypeId) {
-        return await prisma().modification.findUnique({
-          where: {
-            id: parent.bundleId,
-            bundleTypeId: amendmentBundleTypeId,
-          },
-        });
-      } else if (bundleTypeId === extensionBundleTypeId) {
-        return await prisma().modification.findUnique({
-          where: {
-            id: parent.bundleId,
-            bundleTypeId: extensionBundleTypeId,
-          },
-        });
-      } else {
-        return null;
-      }
+      return await getBundle(parent.bundleId);
     },
 
     bundleType: async (parent: Document) => {
       const bundleTypeId = await getBundleTypeId(parent.bundleId);
       return bundleTypeId;
-    },
-  },
-
-  Bundle: {
-    __resolveType(obj: Bundle) {
-      if (obj.bundleTypeId === demonstrationBundleTypeId) {
-        return "Demonstration";
-      } else if (obj.bundleTypeId === amendmentBundleTypeId) {
-        return "Amendment";
-      } else if (obj.bundleTypeId === extensionBundleTypeId) {
-        return "Extension";
-      }
     },
   },
 };

--- a/server/src/model/graphql.ts
+++ b/server/src/model/graphql.ts
@@ -1,6 +1,7 @@
 import { gql } from "graphql-tag";
 
 import { bundleSchema } from "./bundle/bundleSchema.js";
+import { bundleResolvers } from "./bundle/bundleResolvers.js";
 
 import { bundleStatusSchema } from "./bundleStatus/bundleStatusSchema.js";
 
@@ -92,6 +93,7 @@ export const typeDefs = [
 ];
 
 export const resolvers = [
+  bundleResolvers,
   bundlePhaseResolvers,
   bundlePhaseDateResolvers,
   demonstrationResolvers,

--- a/server/src/seeder.ts
+++ b/server/src/seeder.ts
@@ -122,9 +122,7 @@ async function seedDatabase() {
   for (let i = 0; i < userCount; i++) {
     const person = await prisma().person.create({
       data: {
-        personType: {
-          connect: { id: PERSON_TYPES[i % (PERSON_TYPES.length - 1)] },
-        },
+        personTypeId: PERSON_TYPES[i % (PERSON_TYPES.length - 1)],
         email: faker.internet.email(),
         fullName: faker.person.fullName(),
         displayName: faker.internet.username(),


### PR DESCRIPTION
This is a small PR which refactors the `document` resolvers to streamline them and remove usage of `connect` in favor of direct assignment. It also slightly improves error handling for the update method and catches the extremely unlikely chance that the context variable doesn't have a user.

I verified the functionality by exercising the API locally and also checking that the seeder continues to work correctly. No issues observed.