### PR TITLE
DEMOS-776 Add pg_cron to devcontainer

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,11 +15,13 @@ services:
       - "4000:4000"
 
   db:
-    image: postgres:latest
+    build:
+      context: ./postgres
+      dockerfile: Dockerfile
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
-      - ./postgres-init:/docker-entrypoint-initdb.d
+      - ./postgres/postgres-data:/var/lib/postgresql/data
+      - ./postgres/postgres-init:/docker-entrypoint-initdb.d
     environment:
       POSTGRES_PASSWORD: postgres # pragma: allowlist secret
       POSTGRES_USER: postgres

--- a/.devcontainer/postgres/Dockerfile
+++ b/.devcontainer/postgres/Dockerfile
@@ -1,0 +1,7 @@
+FROM postgres:17-bookworm
+
+RUN apt-get update && apt-get install -y postgresql-17-cron
+
+RUN echo "shared_preload_libraries='pg_cron'" >> /usr/share/postgresql/postgresql.conf.sample
+RUN echo "cron.database_name='demos'" >> /usr/share/postgresql/postgresql.conf.sample
+

--- a/.devcontainer/postgres/postgres-init/create_base_roles.sql
+++ b/.devcontainer/postgres/postgres-init/create_base_roles.sql
@@ -1,3 +1,5 @@
 CREATE ROLE demos_read;
 CREATE ROLE demos_write;
 CREATE ROLE demos_delete;
+
+CREATE EXTENSION pg_cron;

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ server/localstack/demos-server.zip
 
 core-outputs.json
 all-outputs.json
+
+.devcontainer/postgres/postgres-data
+.env


### PR DESCRIPTION
Adds pg_cron ( https://github.com/citusdata/pg_cron ) to the postgres devcontainer.  Also fixed a bug where the pg data folder wasn't set properly and added a root .env to the .gitignore just in case. 