### PR TITLE
DEMOS-766 add stackTrace and appVersion to logEvent

### DIFF
--- a/client/src/hooks/event/useEvent.test.ts
+++ b/client/src/hooks/event/useEvent.test.ts
@@ -28,7 +28,7 @@ vi.mock("react-router-dom", () => ({
  */
 describe("useEvent", () => {
   beforeEach(() => {
-    mockLogEvent.mockClear(); // ✅ Added: Clear the mock before each test
+    mockLogEvent.mockClear();
   });
 
   it("should provide logEvent function", () => {

--- a/client/src/hooks/event/useEvent.test.ts
+++ b/client/src/hooks/event/useEvent.test.ts
@@ -6,9 +6,10 @@ import { formatDateTime } from "util/formatDate";
 /**
  * MOCKS
  */
+const mockLogEvent = vi.fn();
 vi.mock("@apollo/client", () => ({
   useLazyQuery: vi.fn(() => [vi.fn(), { data: undefined, loading: false, error: undefined }]),
-  useMutation: vi.fn(() => [vi.fn(), { data: undefined, loading: false, error: undefined }]),
+  useMutation: vi.fn(() => [mockLogEvent, { data: undefined, loading: false, error: undefined }]),
 }));
 
 vi.mock("queries/eventQueries", () => ({
@@ -26,6 +27,10 @@ vi.mock("react-router-dom", () => ({
  * TESTS
  */
 describe("useEvent", () => {
+  beforeEach(() => {
+    mockLogEvent.mockClear(); // ✅ Added: Clear the mock before each test
+  });
+
   it("should provide logEvent function", () => {
     const { result } = renderHook(() => useEvent());
 
@@ -37,21 +42,29 @@ describe("useEvent", () => {
     const { result } = renderHook(() => useEvent());
 
     expect(result.current.getEvents).toBeDefined();
-    expect(result.current.getEvents).toBeDefined();
     expect(typeof result.current.getEvents).toBe("function");
   });
 
-  it("should support LogEventArguments without eventData or route", () => {
+  it("should support LogEventArguments without eventData or route", async () => {
     const { result } = renderHook(() => useEvent());
 
     const eventInput: LogEventArguments = {
       eventType: "LOGIN_SUCCEEDED",
     };
 
-    result.current.logEvent(eventInput);
+    await result.current.logEvent(eventInput);
+
+    const calledWith = mockLogEvent.mock.calls[0][0]; // The first call's first argument
+    const { variables } = calledWith;
+    const { input: loggedInput } = variables;
+
+    expect(loggedInput.eventData).toHaveProperty("appVersion");
+    expect(loggedInput.eventData).toHaveProperty("stackTrace");
+    expect(typeof loggedInput.eventData.stackTrace).toBe("string");
+    expect(loggedInput.route).toBe("/mock-path");
   });
 
-  it("should handle event data properly", () => {
+  it("should handle event data properly", async () => {
     const { result } = renderHook(() => useEvent());
 
     const eventInput: LogEventArguments = {
@@ -63,6 +76,16 @@ describe("useEvent", () => {
       },
     };
 
-    result.current.logEvent(eventInput);
+    await result.current.logEvent(eventInput);
+
+    const calledWith = mockLogEvent.mock.calls[0][0];
+    const { variables } = calledWith;
+    const { input: loggedInput } = variables;
+
+    expect(loggedInput.eventData.userId).toBe("123");
+    expect(loggedInput.eventData).toHaveProperty("appVersion");
+    expect(loggedInput.eventData).toHaveProperty("stackTrace");
+    expect(typeof loggedInput.eventData.stackTrace).toBe("string");
+    expect(loggedInput.route).toBe("/mock-path");
   });
 });

--- a/client/src/hooks/event/useEvent.ts
+++ b/client/src/hooks/event/useEvent.ts
@@ -3,6 +3,7 @@ import { useLocation } from "react-router-dom";
 import { LOG_EVENT_MUTATION, GET_EVENTS_QUERY } from "queries/eventQueries";
 import { Event, EventLoggedStatus, LogEventInput } from "demos-server";
 import { getLogLevelForEventType, EventType } from "./eventTypes";
+import { version } from "../../../package.json";
 
 export type LogEventArguments = {
   eventType: EventType;
@@ -28,9 +29,19 @@ export const useEvent = (): EventOperations => {
 
   return {
     logEvent: async (input: LogEventArguments) => {
+      const rawStack = new Error().stack || "";
+      const stackTrace = rawStack
+        .split("\n")
+        .filter((line, idx) => idx !== 0) // Remove the "Error" line
+        .join("\n");
+      const eventData = {
+        ...(input.eventData ?? {}),
+        appVersion: version,
+        stackTrace,
+      };
       const logEventInput: LogEventInput = {
         ...input,
-        eventData: input.eventData ?? {},
+        eventData,
         route: location.pathname,
         logLevel: getLogLevelForEventType(input.eventType),
       };


### PR DESCRIPTION
Adds two new fields to the logEvent eventData
- stackTrace: available by generating an error (not throwing) - originally thought I could use console.trace but there's no (reasonable) way to capture this as a string
- appVersion: pulled from package.json

Updated test to check for these fields


Also fixes a bug that prevents logEvent from being called.