### PR TITLE
task/update-procedure-add-cms-admin-persons-to-all-states

### DIFF
--- a/server/src/model/migrations/20250923170946_all_cms_admins_and_users_to_all_states/migration.sql
+++ b/server/src/model/migrations/20250923170946_all_cms_admins_and_users_to_all_states/migration.sql
@@ -2,7 +2,7 @@
 CREATE OR REPLACE FUNCTION assign_cms_user_to_all_states()
 RETURNS TRIGGER AS $$
 BEGIN
-    -- Check if the inserted person is a demos-cms-user
+    -- Check if the inserted person is a demos-cms-user or a demos-admin
     IF NEW.person_type_id IN ('demos-admin', 'demos-cms-user') THEN
         -- Insert a record into person_state for each state
         INSERT INTO person_state (person_id, state_id)


### PR DESCRIPTION
Update the trigger to add `demos-admin` as well as `demos-cms-user` to all states. We should have done this at the start because it's the equivalent of bypassing any state restrictions for admin users.