### PR TITLE
DEMOS-862: Sign out of IDM without redirect

### DIFF
--- a/client/src/components/auth/AuthActions.tsx
+++ b/client/src/components/auth/AuthActions.tsx
@@ -8,7 +8,7 @@ export function useAuthActions() {
 
   const signOut = async () => {
     try {
-      auth.signinSilent?.();
+      auth.signoutSilent();
       auth.removeUser();
     } catch (error) {
       console.warn("[Logout] logout failed", error);

--- a/client/src/router/cognitoConfig.ts
+++ b/client/src/router/cognitoConfig.ts
@@ -57,7 +57,7 @@ const PRODUCTION_COGNITO_CONFIG: CognitoConfig = {
   client_id: import.meta.env.VITE_COGNITO_CLIENT_ID!,
   redirect_uri:
     import.meta.env.BASE_URL === "/" ? `${window.location.origin}/` : import.meta.env.BASE_URL,
-  post_logout_redirect_uri: import.meta.env.VITE_IDM_LOGOUT_URI ?? `${window.location.origin}/`,
+  post_logout_redirect_uri: `${window.location.origin}/`,
 };
 
 /** Only pass the OIDC fields to <AuthProvider/>. */

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -25,7 +25,6 @@ interface ImportMetaEnv {
   readonly VITE_APPLICATION_HOSTNAME: EnvironmentVariable;
   readonly VITE_API_URL_PREFIX: EnvironmentVariable;
   readonly VITE_IDLE_TIMEOUT: EnvironmentVariable;
-  readonly VITE_IDM_LOGOUT_URI: EnvironmentVariable;
 }
 
 interface ImportMeta {

--- a/deployment/demosctl/commands/buildClient.test.ts
+++ b/deployment/demosctl/commands/buildClient.test.ts
@@ -56,10 +56,7 @@ describe("buildClient", () => {
     expect(rc).toHaveBeenCalledWith(
       "deploy-core-no-execute",
       "npx",
-      expect.arrayContaining([
-        `stage=${mockStageName}`,
-        `demos-${mockStageName}-core`,
-      ])
+      expect.arrayContaining([`stage=${mockStageName}`, `demos-${mockStageName}-core`])
     );
 
     expect(rs).toHaveBeenCalledWith(
@@ -71,7 +68,6 @@ describe("buildClient", () => {
           VITE_COGNITO_DOMAIN: "cognitoDomain",
           VITE_COGNITO_CLIENT_ID: "cognitoClientId",
           VITE_API_URL_PREFIX: "/api/graphql",
-          VITE_IDM_LOGOUT_URI: "",
         }),
       })
     );
@@ -95,10 +91,7 @@ describe("buildClient", () => {
     expect(rc).toHaveBeenCalledWith(
       "deploy-core-no-execute",
       "npx",
-      expect.arrayContaining([
-        `stage=${mockStageName}`,
-        `demos-${mockStageName}-core`,
-      ])
+      expect.arrayContaining([`stage=${mockStageName}`, `demos-${mockStageName}-core`])
     );
 
     expect(exitCode).toBe(1);

--- a/deployment/demosctl/commands/buildClient.ts
+++ b/deployment/demosctl/commands/buildClient.ts
@@ -36,9 +36,6 @@ export async function buildClient(environment: string, refreshOutputs: boolean =
       VITE_COGNITO_DOMAIN: getOutputValue(coreOutputData, `demos-${environment}-core`, `cognitoDomain`),
       VITE_COGNITO_CLIENT_ID: getOutputValue(coreOutputData, `demos-${environment}-core`, `cognitoClientId`),
       VITE_API_URL_PREFIX: "/api/graphql",
-      VITE_IDM_LOGOUT_URI: ["dev", "test"].includes(environment)
-      ? "https://test.idp.idm.cms.gov/login/signout"
-      : "",
     },
   });
 }

--- a/deployment/lib/cognito.ts
+++ b/deployment/lib/cognito.ts
@@ -133,6 +133,7 @@ function createIdmIdp(scope: Construct, stage: string, userPool: aws_cognito.IUs
     userPool,
     name: `demos-${stage}-idm`,
     metadata: UserPoolIdentityProviderSamlMetadata.url(metadataEndpoint),
+    idpSignout: true,
     attributeMapping: {
       email: ProviderAttribute.other("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"),
       familyName: ProviderAttribute.other("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"),

--- a/deployment/stacks/fileupload.ts
+++ b/deployment/stacks/fileupload.ts
@@ -52,9 +52,9 @@ export class FileUploadStack extends Stack {
 
     const accessLogs = new Bucket(this, "fileUploadAccessLogBucket", {
       encryption: aws_s3.BucketEncryption.S3_MANAGED,
-      removalPolicy: props.isDev ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN,
+      removalPolicy: props.isDev || props.isEphemeral ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN,
       blockPublicAccess: aws_s3.BlockPublicAccess.BLOCK_ALL,
-      autoDeleteObjects: props.isDev,
+      autoDeleteObjects: props.isDev || props.isEphemeral,
       enforceSSL: true,
     });
 

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -52,8 +52,8 @@ export class UiStack extends Stack {
       publicReadAccess: false,
       blockPublicAccess: aws_s3.BlockPublicAccess.BLOCK_ALL,
       objectOwnership: aws_s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
-      removalPolicy: commonProps.isDev ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN,
-      autoDeleteObjects: commonProps.isDev,
+      removalPolicy: commonProps.isDev || commonProps.isEphemeral ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN,
+      autoDeleteObjects: commonProps.isDev || commonProps.isEphemeral,
       enforceSSL: true,
       bucketName: `demos-${commonProps.stage}-ui-server-access`,
     });


### PR DESCRIPTION
This change removes the redirect to the IDM signout url. This was previously used to force an IDM logout, but also caused confusion because it would redirect you to the IDM page, so if you sign in to demos, sign out, and then sign right back in, you would be signing back in to the IDM dashboard rather than demos.

With this change, Cognito will now make a call to IDM to sign users out of both the user pool and IDM simultaneously.

`idpSignout: true,` is the main change to the cognito config, however, this option does not work without additional configuration by the IDM team, which needed to be taken care of first.