### PR TITLE
DEMOS-894-fix-naming-of-phase

### DIFF
--- a/client/src/components/application/ApplicationWorkflow.test.tsx
+++ b/client/src/components/application/ApplicationWorkflow.test.tsx
@@ -47,7 +47,7 @@ describe("ApplicationWorkflow", () => {
           contactType: "Project Officer",
         },
       ],
-      currentPhase: "Federal Comment" as const,
+      currentPhaseName: "Federal Comment" as const,
     };
     render(
       <TestProvider>

--- a/client/src/components/application/ApplicationWorkflow.tsx
+++ b/client/src/components/application/ApplicationWorkflow.tsx
@@ -5,8 +5,8 @@ import type { Demonstration } from "demos-server";
 
 export type ApplicationWorkflowDemonstration = Pick<
   Demonstration,
-  "id" | "status" | "currentPhase"
->
+  "id" | "status" | "currentPhaseName"
+>;
 
 export const ApplicationWorkflow = ({
   demonstration,
@@ -20,7 +20,7 @@ export const ApplicationWorkflow = ({
         <DemonstrationStatusBadge demonstrationStatus={demonstration.status} />
       </div>
       <hr className="text-border-rules" />
-      <PhaseSelector demonstration={demonstration}/>
+      <PhaseSelector demonstration={demonstration} />
     </div>
   );
 };

--- a/client/src/components/application/dates/PhaseDateSimulation.tsx
+++ b/client/src/components/application/dates/PhaseDateSimulation.tsx
@@ -14,9 +14,9 @@ import { formatDateTime } from "util/formatDate";
 type SimulationState = SimplePhase[];
 
 const DEFAULT_SIMULATION_STATE: SimulationState = [
-  { phase: "Concept", phaseStatus: "Not Started", phaseDates: [] },
-  { phase: "State Application", phaseStatus: "Not Started", phaseDates: [] },
-  { phase: "Completeness", phaseStatus: "Not Started", phaseDates: [] },
+  { phaseName: "Concept", phaseStatus: "Not Started", phaseDates: [] },
+  { phaseName: "State Application", phaseStatus: "Not Started", phaseDates: [] },
+  { phaseName: "Completeness", phaseStatus: "Not Started", phaseDates: [] },
 ];
 const STYLES = {
   phaseBox: tw`p-4 border-2 rounded-lg bg-white min-h-[120px] flex flex-col justify-between`,
@@ -106,7 +106,7 @@ export const PhaseDatesSimulation: React.FC = () => {
     dateValue: Date
   ): SimulationState => {
     return phases.map((phase) => {
-      if (phase.phase === phaseName) {
+      if (phase.phaseName === phaseName) {
         const updatedDates = setDateInPhaseDates(phase.phaseDates, dateType, dateValue);
 
         // If the date doesn't exist, add it
@@ -257,7 +257,7 @@ export const PhaseDatesSimulation: React.FC = () => {
   };
 
   const isStateApplicationSubmittedDateSet = () => {
-    const stateApplicationPhase = simulationState.find((p) => p.phase === "State Application");
+    const stateApplicationPhase = simulationState.find((p) => p.phaseName === "State Application");
     if (!stateApplicationPhase) return false;
 
     const submittedDate = getDateFromPhaseDates(
@@ -307,14 +307,14 @@ export const PhaseDatesSimulation: React.FC = () => {
                 <div className={STYLES.dateDisplay}>
                   Start Date:{" "}
                   {getDateDisplay(
-                    simulationState.find((p) => p.phase === "Concept")!,
+                    simulationState.find((p) => p.phaseName === "Concept")!,
                     "Start Date"
                   )}
                 </div>
                 <div className={STYLES.dateDisplay}>
                   Completion Date:{" "}
                   {getDateDisplay(
-                    simulationState.find((p) => p.phase === "Concept")!,
+                    simulationState.find((p) => p.phaseName === "Concept")!,
                     "Completion Date"
                   )}
                 </div>
@@ -350,21 +350,21 @@ export const PhaseDatesSimulation: React.FC = () => {
                 <div className={STYLES.dateDisplay}>
                   Start Date:{" "}
                   {getDateDisplay(
-                    simulationState.find((p) => p.phase === "State Application")!,
+                    simulationState.find((p) => p.phaseName === "State Application")!,
                     "Start Date"
                   )}
                 </div>
                 <div className={STYLES.dateDisplay}>
                   Submitted Date:{" "}
                   {getDateDisplay(
-                    simulationState.find((p) => p.phase === "State Application")!,
+                    simulationState.find((p) => p.phaseName === "State Application")!,
                     "State Application Submitted Date"
                   )}
                 </div>
                 <div className={STYLES.dateDisplay}>
                   Completion Date:{" "}
                   {getDateDisplay(
-                    simulationState.find((p) => p.phase === "State Application")!,
+                    simulationState.find((p) => p.phaseName === "State Application")!,
                     "Completion Date"
                   )}
                 </div>
@@ -412,14 +412,14 @@ export const PhaseDatesSimulation: React.FC = () => {
                 <div className={STYLES.dateDisplay}>
                   Start Date:{" "}
                   {getDateDisplay(
-                    simulationState.find((p) => p.phase === "Completeness")!,
+                    simulationState.find((p) => p.phaseName === "Completeness")!,
                     "Start Date"
                   )}
                 </div>
                 <div className={STYLES.dateDisplay}>
                   Completion Date:{" "}
                   {getDateDisplay(
-                    simulationState.find((p) => p.phase === "Completeness")!,
+                    simulationState.find((p) => p.phaseName === "Completeness")!,
                     "Completion Date"
                   )}
                 </div>

--- a/client/src/components/application/dates/phaseDateQueries.test.ts
+++ b/client/src/components/application/dates/phaseDateQueries.test.ts
@@ -4,7 +4,7 @@ import { SetPhaseDateInput } from "demos-server";
 
 const TEST_SET_PHASE_DATE_INPUT: SetPhaseDateInput = {
   bundleId: "test-bundle-123",
-  phase: "Concept",
+  phaseName: "Concept",
   dateType: "Start Date",
   dateValue: new Date(Date.parse("2025-01-15T10:30:00.000Z")),
 };
@@ -16,7 +16,7 @@ describe("phaseDateQueries", () => {
 
       expect(result).toContain("mutation SetPhaseDate");
       expect(result).toContain('bundleId: "test-bundle-123"');
-      expect(result).toContain("phase: Concept");
+      expect(result).toContain("phaseName: Concept");
       expect(result).toContain("dateType: Start Date");
       expect(result).toContain('dateValue: "2025-01-15T10:30:00.000Z"');
     });
@@ -38,11 +38,11 @@ describe("phaseDateQueries", () => {
       phases.forEach((phase) => {
         const input: SetPhaseDateInput = {
           ...TEST_SET_PHASE_DATE_INPUT,
-          phase: phase,
+          phaseName: phase,
         };
 
         const result = getQueryForSetPhaseDate(input);
-        expect(result).toContain(`phase: ${phase}`);
+        expect(result).toContain(`phaseName: ${phase}`);
       });
     });
 
@@ -85,7 +85,7 @@ describe("phaseDateQueries", () => {
       expect(result).toMatch(/mutation SetPhaseDate\s*{/);
       expect(result).toMatch(/setPhaseDate\s*\(\s*input:\s*{/);
       expect(result).toContain("bundleId:");
-      expect(result).toContain("phase:");
+      expect(result).toContain("phaseName:");
       expect(result).toContain("dateType:");
       expect(result).toContain("dateValue:");
       expect(result).toMatch(/}\s*\)\s*}/);

--- a/client/src/components/application/dates/phaseDateQueries.ts
+++ b/client/src/components/application/dates/phaseDateQueries.ts
@@ -7,7 +7,7 @@ export const getQueryForSetPhaseDate = (setPhaseDateInput: SetPhaseDateInput): s
     mutation SetPhaseDate {
       setPhaseDate(input: {
         bundleId: "${setPhaseDateInput.bundleId}",
-        phase: ${setPhaseDateInput.phase},
+        phaseName: ${setPhaseDateInput.phaseName},
         dateType: ${setPhaseDateInput.dateType},
         dateValue: "${isoDateString}"
       })

--- a/client/src/components/application/dates/phaseDates.test.ts
+++ b/client/src/components/application/dates/phaseDates.test.ts
@@ -30,7 +30,7 @@ const mockPhaseDates: SimplePhaseDate[] = [
 
 const mockBundlePhases: SimplePhase[] = [
   {
-    phase: "Concept",
+    phaseName: "Concept",
     phaseStatus: "Started",
     phaseDates: [
       {
@@ -40,7 +40,7 @@ const mockBundlePhases: SimplePhase[] = [
     ],
   },
   {
-    phase: "State Application",
+    phaseName: "State Application",
     phaseStatus: "Not Started",
     phaseDates: [
       {
@@ -50,7 +50,7 @@ const mockBundlePhases: SimplePhase[] = [
     ],
   },
   {
-    phase: "Completeness",
+    phaseName: "Completeness",
     phaseStatus: "Not Started",
     phaseDates: [],
   },
@@ -231,12 +231,12 @@ describe("phaseDates", () => {
     it("should handle multiple phases with same date types", () => {
       const phases: SimplePhase[] = [
         {
-          phase: "Concept",
+          phaseName: "Concept",
           phaseStatus: "Started",
           phaseDates: [{ dateType: "Start Date", dateValue: new Date("2025-01-01") }],
         },
         {
-          phase: "State Application",
+          phaseName: "State Application",
           phaseStatus: "Not Started",
           phaseDates: [{ dateType: "Start Date", dateValue: new Date("2025-02-01") }],
         },

--- a/client/src/components/application/dates/phaseDates.ts
+++ b/client/src/components/application/dates/phaseDates.ts
@@ -1,6 +1,6 @@
 import { TZDate } from "@date-fns/tz";
 import { UTCDate } from "@date-fns/utc";
-import { BundlePhase, Phase, PhaseStatus, BundlePhaseDate, DateType } from "demos-server";
+import { BundlePhase, PhaseName, PhaseStatus, BundlePhaseDate, DateType } from "demos-server";
 
 export type SimplePhaseDate = Omit<BundlePhaseDate, "createdAt" | "updatedAt">;
 export type SimplePhase = Omit<BundlePhase, "createdAt" | "updatedAt" | "phaseDates"> & {
@@ -51,19 +51,19 @@ export const getEndOfDayEST = (year: number, month: number, day: number): EndOfD
  */
 export const getStatusForPhase = (
   bundlePhases: SimplePhase[],
-  phaseName: Phase
+  phaseName: PhaseName
 ): PhaseStatus | null => {
-  const phase = bundlePhases.find((p) => p.phase === phaseName);
+  const phase = bundlePhases.find((p) => p.phaseName === phaseName);
   return phase ? phase.phaseStatus : null;
 };
 
 export const setStatusForPhase = (
   bundlePhases: SimplePhase[],
-  phaseName: Phase,
+  phaseName: PhaseName,
   phaseStatus: PhaseStatus
 ): SimplePhase[] => {
   return bundlePhases.map((phase) => {
-    if (phase.phase === phaseName) {
+    if (phase.phaseName === phaseName) {
       return { ...phase, phaseStatus };
     }
     return phase;
@@ -96,9 +96,9 @@ export const setDateInPhaseDates = (
 
 export const getAllDatesForPhase = (
   bundlePhases: SimplePhase[],
-  phaseName: Phase
+  phaseName: PhaseName
 ): SimplePhaseDate[] | null => {
-  const phase = bundlePhases.find((p) => p.phase === phaseName);
+  const phase = bundlePhases.find((p) => p.phaseName === phaseName);
   return phase ? phase.phaseDates : null;
 };
 

--- a/client/src/components/application/phase-selector/PhaseSelector.test.tsx
+++ b/client/src/components/application/phase-selector/PhaseSelector.test.tsx
@@ -47,12 +47,12 @@ describe("PhaseSelector", () => {
           contactType: "Project Officer",
         },
       ],
-      currentPhase: "Federal Comment" as const,
+      currentPhaseName: "Federal Comment" as const,
     };
 
     render(
       <TestProvider>
-        <PhaseSelector demonstration={demonstration}/>
+        <PhaseSelector demonstration={demonstration} />
       </TestProvider>
     );
     [

--- a/client/src/components/application/phase-selector/PhaseSelector.tsx
+++ b/client/src/components/application/phase-selector/PhaseSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import type { Phase as ServerPhase, PhaseStatus as ServerPhaseStatus } from "demos-server";
+import type { PhaseName as ServerPhase, PhaseStatus as ServerPhaseStatus } from "demos-server";
 
 import { ApplicationWorkflowDemonstration } from "../ApplicationWorkflow";
 import {
@@ -13,13 +13,13 @@ import {
   SmeFrtPhase,
   StateApplicationPhase,
 } from "../phases";
-import { PHASE } from "demos-server-constants";
+import { PHASE_NAME } from "demos-server-constants";
 import { PhaseBox } from "./PhaseBox";
 
 // TODO: get past-due added to the shared enum
 export type PhaseStatus = ServerPhaseStatus | "past-due";
 export type PhaseName = Exclude<ServerPhase, "None">;
-const PHASE_NAMES: PhaseName[] = PHASE.filter((phase): phase is PhaseName => phase !== "None");
+const PHASE_NAMES: PhaseName[] = PHASE_NAME.filter((phase): phase is PhaseName => phase !== "None");
 
 const MOCK_PHASE_DATE_LOOKUP: Partial<Record<PhaseName, Date>> = {
   Concept: new Date(2024, 4, 20),
@@ -65,8 +65,8 @@ export const PhaseSelector = ({
 }: PhaseSelectorProps) => {
   const fallbackPhase: PhaseName = "Concept";
   const initialPhase: PhaseName =
-    demonstration.currentPhase && demonstration.currentPhase !== "None"
-      ? (demonstration.currentPhase as PhaseName)
+    demonstration.currentPhaseName && demonstration.currentPhaseName !== "None"
+      ? (demonstration.currentPhaseName as PhaseName)
       : fallbackPhase;
   const [selectedPhase, setSelectedPhase] = useState<PhaseName>(initialPhase);
 

--- a/client/src/components/dialog/document/DocumentDialog.tsx
+++ b/client/src/components/dialog/document/DocumentDialog.tsx
@@ -458,7 +458,7 @@ export const AddDocumentDialog: React.FC<{
       title: dialogFields.title,
       description: dialogFields.description,
       documentType: dialogFields.documentType,
-      phase: "None",
+      phaseName: "None",
     };
 
     const uploadDocumentResponse = await uploadDocumentTrigger({

--- a/client/src/pages/DemonstrationDetail/DemonstrationDetail.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetail.tsx
@@ -64,7 +64,7 @@ export const DEMONSTRATION_DETAIL_QUERY = gql`
           email
         }
       }
-      currentPhase
+      currentPhaseName
     }
   }
 `;

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
@@ -13,7 +13,7 @@ import {
   DemonstrationRoleAssignment,
   Demonstration,
   Document,
-  Phase,
+  PhaseName,
   Person,
   State,
   User,
@@ -38,7 +38,7 @@ export type DemonstrationTabDemonstration = Pick<
   roles: Role[];
   projectOfficer: Pick<User, "id">;
   status: BundleStatus;
-  currentPhase: Phase;
+  currentPhaseName: PhaseName;
 };
 
 export const DemonstrationTab: React.FC<{ demonstration: DemonstrationTabDemonstration }> = ({

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -52,7 +52,7 @@ export const DOCUMENT_TYPES = [
   "State Application",
 ] as const;
 
-export const PHASE = [
+export const PHASE_NAME = [
   "None",
   "Concept",
   "State Application",

--- a/server/src/model/bundlePhase/bundlePhaseResolvers.ts
+++ b/server/src/model/bundlePhase/bundlePhaseResolvers.ts
@@ -3,7 +3,7 @@ import { prisma } from "../../prismaClient.js";
 
 export const bundlePhaseResolvers = {
   BundlePhase: {
-    phase: async (parent: BundlePhase) => {
+    phaseName: async (parent: BundlePhase) => {
       return parent.phaseId;
     },
     phaseStatus: async (parent: BundlePhase) => {

--- a/server/src/model/bundlePhase/bundlePhaseSchema.ts
+++ b/server/src/model/bundlePhase/bundlePhaseSchema.ts
@@ -1,9 +1,9 @@
-import { Phase, PhaseStatus, BundlePhaseDate } from "../../types.js";
+import { PhaseName, PhaseStatus, BundlePhaseDate } from "../../types.js";
 import { gql } from "graphql-tag";
 
 export const bundlePhaseSchema = gql`
   type BundlePhase {
-    phase: Phase!
+    phaseName: PhaseName!
     phaseStatus: PhaseStatus!
     phaseDates: [BundlePhaseDate!]!
     createdAt: DateTime!
@@ -12,7 +12,7 @@ export const bundlePhaseSchema = gql`
 `;
 
 export interface BundlePhase {
-  phase: Phase;
+  phaseName: PhaseName;
   phaseStatus: PhaseStatus;
   phaseDates: BundlePhaseDate[];
   createdAt: Date;

--- a/server/src/model/bundlePhaseDate/bundlePhaseDateResolvers.ts
+++ b/server/src/model/bundlePhaseDate/bundlePhaseDateResolvers.ts
@@ -10,7 +10,7 @@ async function setPhaseDate(_: undefined, { input }: { input: SetPhaseDateInput 
       where: {
         bundleId_phaseId_dateTypeId: {
           bundleId: input.bundleId,
-          phaseId: input.phase,
+          phaseId: input.phaseName,
           dateTypeId: input.dateType,
         },
       },
@@ -19,7 +19,7 @@ async function setPhaseDate(_: undefined, { input }: { input: SetPhaseDateInput 
       },
       create: {
         bundleId: input.bundleId,
-        phaseId: input.phase,
+        phaseId: input.phaseName,
         dateTypeId: input.dateType,
         dateValue: input.dateValue,
       },

--- a/server/src/model/bundlePhaseDate/bundlePhaseDateSchema.ts
+++ b/server/src/model/bundlePhaseDate/bundlePhaseDateSchema.ts
@@ -1,5 +1,5 @@
 import { gql } from "graphql-tag";
-import { DateType, Phase } from "../../types.js";
+import { DateType, PhaseName } from "../../types.js";
 
 export const bundlePhaseDateSchema = gql`
   type BundlePhaseDate {
@@ -11,7 +11,7 @@ export const bundlePhaseDateSchema = gql`
 
   input SetPhaseDateInput {
     bundleId: ID!
-    phase: Phase!
+    phaseName: PhaseName!
     dateType: DateType!
     dateValue: DateTime!
   }
@@ -23,7 +23,7 @@ export const bundlePhaseDateSchema = gql`
 
 export interface SetPhaseDateInput {
   bundleId: string;
-  phase: Phase;
+  phaseName: PhaseName;
   dateType: DateType;
   dateValue: Date;
 }

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -2,7 +2,7 @@ import { Demonstration } from "@prisma/client";
 
 import { BUNDLE_TYPE } from "../../constants.js";
 import { prisma } from "../../prismaClient.js";
-import { BundleType, Phase, BundleStatus, GrantLevel, Role } from "../../types.js";
+import { BundleType, PhaseName, BundleStatus, GrantLevel, Role } from "../../types.js";
 import { CreateDemonstrationInput, UpdateDemonstrationInput } from "./demonstrationSchema.js";
 import { resolveBundleStatus } from "../bundleStatus/bundleStatusResolvers.js";
 import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields.js";
@@ -12,7 +12,7 @@ const roleProjectOfficer: Role = "Project Officer";
 const demonstrationBundleTypeId: BundleType = BUNDLE_TYPE.DEMONSTRATION;
 const amendmentBundleTypeId: BundleType = BUNDLE_TYPE.AMENDMENT;
 const extensionBundleTypeId: BundleType = BUNDLE_TYPE.EXTENSION;
-const conceptPhaseId: Phase = "Concept";
+const conceptPhaseName: PhaseName = "Concept";
 const newBundleStatusId: BundleStatus = "Pre-Submission";
 
 export async function getDemonstration(parent: undefined, { id }: { id: string }) {
@@ -47,7 +47,7 @@ export async function createDemonstration(
           signatureLevelId: input.signatureLevel,
           statusId: newBundleStatusId,
           stateId: input.stateId,
-          currentPhaseId: conceptPhaseId,
+          currentPhaseId: conceptPhaseName,
         },
       });
 
@@ -97,7 +97,7 @@ export async function updateDemonstration(
   parent: undefined,
   { id, input }: { id: string; input: UpdateDemonstrationInput }
 ) {
-  checkOptionalNotNullFields(["name", "status", "currentPhase", "stateId"], input);
+  checkOptionalNotNullFields(["name", "status", "currentPhaseName", "stateId"], input);
   return await prisma().demonstration.update({
     where: { id },
     data: {
@@ -108,7 +108,7 @@ export async function updateDemonstration(
       cmcsDivisionId: input.cmcsDivision,
       signatureLevelId: input.signatureLevel,
       statusId: input.status,
-      currentPhaseId: input.currentPhase,
+      currentPhaseId: input.currentPhaseName,
       stateId: input.stateId,
     },
   });
@@ -171,7 +171,7 @@ export const demonstrationResolvers = {
       return parent.signatureLevelId;
     },
 
-    currentPhase: async (parent: Demonstration) => {
+    currentPhaseName: async (parent: Demonstration) => {
       return parent.currentPhaseId;
     },
 

--- a/server/src/model/demonstration/demonstrationSchema.ts
+++ b/server/src/model/demonstration/demonstrationSchema.ts
@@ -5,7 +5,7 @@ import { State } from "../state/stateSchema.js";
 import {
   CmcsDivision,
   SignatureLevel,
-  Phase,
+  PhaseName,
   BundlePhase,
   BundleStatus,
   DemonstrationRoleAssignment,
@@ -22,7 +22,7 @@ export const demonstrationSchema = gql`
     signatureLevel: SignatureLevel
     status: BundleStatus!
     state: State!
-    currentPhase: Phase!
+    currentPhaseName: PhaseName!
     phases: [BundlePhase!]!
     documents: [Document!]!
     amendments: [Amendment!]!
@@ -49,7 +49,7 @@ export const demonstrationSchema = gql`
     cmcsDivision: CmcsDivision
     signatureLevel: SignatureLevel
     status: BundleStatus
-    currentPhase: Phase
+    currentPhaseName: PhaseName
     stateId: ID
   }
 
@@ -80,7 +80,7 @@ export interface Demonstration {
   signatureLevel?: SignatureLevel;
   status: BundleStatus;
   state: State;
-  currentPhase: Phase;
+  currentPhaseName: PhaseName;
   phases: BundlePhase[];
   documents: Document[];
   amendments: Amendment[];
@@ -109,6 +109,6 @@ export interface UpdateDemonstrationInput {
   cmcsDivision?: CmcsDivision;
   signatureLevel?: SignatureLevel;
   status?: BundleStatus;
-  currentPhase?: Phase;
+  currentPhaseName?: PhaseName;
   stateId?: string;
 }

--- a/server/src/model/document/documentResolvers.ts
+++ b/server/src/model/document/documentResolvers.ts
@@ -128,7 +128,7 @@ export const documentResolvers = {
           ownerUserId: context.user.id,
           documentTypeId: input.documentType,
           bundleId: input.bundleId,
-          phaseId: input.phase,
+          phaseId: input.phaseName,
         },
       });
 
@@ -156,7 +156,7 @@ export const documentResolvers = {
       { id, input }: { id: string; input: UpdateDocumentInput }
     ): Promise<Document> => {
       checkOptionalNotNullFields(
-        ["title", "description", "documentType", "bundleId", "phase"],
+        ["title", "description", "documentType", "bundleId", "phaseName"],
         input
       );
       try {
@@ -167,7 +167,7 @@ export const documentResolvers = {
             description: input.description,
             documentTypeId: input.documentType,
             bundleId: input.bundleId,
-            phaseId: input.phase,
+            phaseId: input.phaseName,
           },
         });
       } catch (error) {
@@ -205,7 +205,7 @@ export const documentResolvers = {
       return bundleTypeId;
     },
 
-    phase: async (parent: Document) => {
+    phaseName: async (parent: Document) => {
       return parent.phaseId;
     },
   },

--- a/server/src/model/document/documentSchema.ts
+++ b/server/src/model/document/documentSchema.ts
@@ -1,7 +1,7 @@
 import { gql } from "graphql-tag";
 
 import { User } from "../user/userSchema.js";
-import { DocumentType, Bundle, Phase } from "../../types.js";
+import { DocumentType, Bundle, PhaseName } from "../../types.js";
 
 export const documentSchema = gql`
   type Document {
@@ -13,7 +13,7 @@ export const documentSchema = gql`
     documentType: DocumentType!
     bundle: Bundle!
     bundleType: String!
-    phase: Phase!
+    phaseName: PhaseName!
     createdAt: DateTime!
     updatedAt: DateTime!
   }
@@ -23,7 +23,7 @@ export const documentSchema = gql`
     description: String!
     documentType: DocumentType!
     bundleId: ID!
-    phase: Phase!
+    phaseName: PhaseName!
   }
 
   input UpdateDocumentInput {
@@ -31,7 +31,7 @@ export const documentSchema = gql`
     description: String
     documentType: DocumentType
     bundleId: ID
-    phase: Phase
+    phaseName: PhaseName
   }
 
   type UploadDocumentResponse {
@@ -60,7 +60,7 @@ export interface Document {
   documentType: DocumentType;
   bundle: Bundle;
   bundleType: string;
-  phase: Phase;
+  phaseName: PhaseName;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -70,7 +70,7 @@ export interface UploadDocumentInput {
   description: string;
   documentType: DocumentType;
   bundleId: string;
-  phase: Phase;
+  phaseName: PhaseName;
 }
 
 export interface UpdateDocumentInput {
@@ -78,5 +78,5 @@ export interface UpdateDocumentInput {
   description?: string;
   documentType?: DocumentType;
   bundleId?: string;
-  phase?: Phase;
+  phaseName?: PhaseName;
 }

--- a/server/src/model/modification/modificationResolvers.ts
+++ b/server/src/model/modification/modificationResolvers.ts
@@ -2,7 +2,7 @@ import { Modification } from "@prisma/client";
 
 import { BUNDLE_TYPE } from "../../constants.js";
 import { prisma } from "../../prismaClient.js";
-import { BundleStatus, BundleType, Phase } from "../../types.js";
+import { BundleStatus, BundleType, PhaseName } from "../../types.js";
 import {
   CreateAmendmentInput,
   CreateExtensionInput,
@@ -14,7 +14,7 @@ import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFie
 
 const amendmentBundleTypeId: BundleType = BUNDLE_TYPE.AMENDMENT;
 const extensionBundleTypeId: BundleType = BUNDLE_TYPE.EXTENSION;
-const conceptPhaseId: Phase = "Concept";
+const conceptPhaseName: PhaseName = "Concept";
 const newBundleStatusId: BundleStatus = "Pre-Submission";
 
 async function getModification(
@@ -90,7 +90,7 @@ async function createModification(
         name: input.name,
         description: input.description,
         statusId: newBundleStatusId,
-        currentPhaseId: conceptPhaseId,
+        currentPhaseId: conceptPhaseName,
       },
     });
   });
@@ -119,7 +119,7 @@ async function updateModification(
   info: undefined,
   bundleTypeId: typeof amendmentBundleTypeId | typeof extensionBundleTypeId
 ) {
-  checkOptionalNotNullFields(["demonstrationId", "name", "status", "currentPhase"], input);
+  checkOptionalNotNullFields(["demonstrationId", "name", "status", "currentPhaseName"], input);
   return await prisma().modification.update({
     where: {
       id: id,
@@ -132,7 +132,7 @@ async function updateModification(
       effectiveDate: input.effectiveDate,
       expirationDate: input.expirationDate,
       statusId: input.status,
-      currentPhaseId: input.currentPhase,
+      currentPhaseId: input.currentPhaseName,
     },
   });
 }
@@ -214,7 +214,7 @@ export const modificationResolvers = {
   Amendment: {
     demonstration: getParentDemonstration,
     documents: getDocuments,
-    currentPhase: getCurrentPhase,
+    currentPhaseName: getCurrentPhase,
     status: resolveBundleStatus,
     phases: getPhases,
   },
@@ -222,7 +222,7 @@ export const modificationResolvers = {
   Extension: {
     demonstration: getParentDemonstration,
     documents: getDocuments,
-    currentPhase: getCurrentPhase,
+    currentPhaseName: getCurrentPhase,
     status: resolveBundleStatus,
     phases: getPhases,
   },

--- a/server/src/model/modification/modificationSchema.ts
+++ b/server/src/model/modification/modificationSchema.ts
@@ -1,6 +1,6 @@
 import { gql } from "graphql-tag";
 
-import { Phase, BundleStatus, BundlePhase, Demonstration, Document } from "../../types.js";
+import { PhaseName, BundleStatus, BundlePhase, Demonstration, Document } from "../../types.js";
 
 export const modificationSchema = gql`
   type Amendment {
@@ -11,7 +11,7 @@ export const modificationSchema = gql`
     effectiveDate: Date
     expirationDate: Date
     status: BundleStatus!
-    currentPhase: Phase!
+    currentPhaseName: PhaseName!
     phases: [BundlePhase!]!
     documents: [Document!]!
     createdAt: DateTime!
@@ -31,7 +31,7 @@ export const modificationSchema = gql`
     effectiveDate: Date
     expirationDate: Date
     status: BundleStatus
-    currentPhase: Phase
+    currentPhaseName: PhaseName
   }
 
   type Extension {
@@ -42,7 +42,7 @@ export const modificationSchema = gql`
     effectiveDate: Date
     expirationDate: Date
     status: BundleStatus!
-    currentPhase: Phase!
+    currentPhaseName: PhaseName!
     phases: [BundlePhase!]!
     documents: [Document!]!
     createdAt: DateTime!
@@ -62,7 +62,7 @@ export const modificationSchema = gql`
     effectiveDate: Date
     expirationDate: Date
     status: BundleStatus
-    currentPhase: Phase
+    currentPhaseName: PhaseName
   }
 
   type Mutation {
@@ -90,7 +90,7 @@ export interface Amendment {
   effectiveDate: Date | null;
   expirationDate: Date | null;
   status: BundleStatus;
-  currentPhase: Phase;
+  currentPhaseName: PhaseName;
   phases: BundlePhase[];
   documents: Document[];
   createdAt: Date;
@@ -110,7 +110,7 @@ export interface UpdateAmendmentInput {
   effectiveDate?: Date;
   expirationDate?: Date;
   status?: BundleStatus;
-  currentPhase?: Phase;
+  currentPhaseName?: PhaseName;
 }
 
 export interface Extension {
@@ -121,7 +121,7 @@ export interface Extension {
   effectiveDate: Date | null;
   expirationDate: Date | null;
   status: BundleStatus;
-  currentPhase: Phase;
+  currentPhaseName: PhaseName;
   phases: BundlePhase[];
   documents: Document[];
   createdAt: Date;
@@ -141,5 +141,5 @@ export interface UpdateExtensionInput {
   effectiveDate?: Date;
   expirationDate?: Date;
   status?: BundleStatus;
-  currentPhase?: Phase;
+  currentPhaseName?: PhaseName;
 }

--- a/server/src/model/phase/phaseResolvers.ts
+++ b/server/src/model/phase/phaseResolvers.ts
@@ -1,10 +1,11 @@
 import { generateCustomSetScalar } from "../../resolverFunctions.js";
-import { PHASE } from "../../constants.js";
+import { PHASE_NAME } from "../../constants.js";
 
+// Note: this is being called PhaseName to avoid confusion with phase-related objects
 export const phaseResolvers = {
-  Phase: generateCustomSetScalar(
-    PHASE,
-    "Phase",
+  PhaseName: generateCustomSetScalar(
+    PHASE_NAME,
+    "PhaseName",
     "A string representing a phase of an application."
   ),
 };

--- a/server/src/model/phase/phaseSchema.ts
+++ b/server/src/model/phase/phaseSchema.ts
@@ -1,5 +1,5 @@
 import gql from "graphql-tag";
 
 export const phaseSchema = gql`
-  scalar Phase
+  scalar PhaseName
 `;

--- a/server/src/seeder.ts
+++ b/server/src/seeder.ts
@@ -9,7 +9,7 @@ import {
   UpdateExtensionInput,
 } from "./types.js";
 import { prisma } from "./prismaClient.js";
-import { DocumentType, Phase } from "./types.js";
+import { DocumentType, PhaseName } from "./types.js";
 import {
   getManyDemonstrations,
   createDemonstration,
@@ -209,7 +209,7 @@ async function seedDatabase() {
       description: faker.lorem.sentence(),
       cmcsDivision: sampleFromArray([...CMCS_DIVISION, undefined], 1)[0],
       signatureLevel: sampleFromArray([...SIGNATURE_LEVEL, undefined], 1)[0],
-      stateId: person.personStates[0].stateId,
+      stateId: sampleFromArray(person.personStates, 1)[0].stateId,
       projectOfficerUserId: person.id,
     };
     await createDemonstration(undefined, { input: createInput });
@@ -228,7 +228,7 @@ async function seedDatabase() {
        * And correctly seed valid dates, phase statuses, etc...
        */
       if (index === 0) {
-        updatePayload.currentPhase = "Federal Comment";
+        updatePayload.currentPhaseName = "Federal Comment";
         updatePayload.status = "Under Review";
       }
 
@@ -288,8 +288,8 @@ async function seedDatabase() {
   console.log("🌱 Seeding documents...");
   // Get the application document type
   const stateApplicationDocumentType: DocumentType = "State Application";
-  const stateApplicationPhase: Phase = "State Application";
-  const nonePhase: Phase = "None";
+  const stateApplicationPhaseName: PhaseName = "State Application";
+  const nonePhaseName: PhaseName = "None";
   for (const demonstration of demonstrations) {
     const fakeTitle = faker.lorem.sentence(2);
     await prisma().document.create({
@@ -300,7 +300,7 @@ async function seedDatabase() {
         ownerUserId: (await prisma().user.findRandom())!.id,
         documentTypeId: stateApplicationDocumentType,
         bundleId: demonstration.id,
-        phaseId: stateApplicationPhase,
+        phaseId: stateApplicationPhaseName,
       },
     });
   }
@@ -319,7 +319,7 @@ async function seedDatabase() {
         ownerUserId: (await prisma().user.findRandom())!.id,
         documentTypeId: stateApplicationDocumentType,
         bundleId: amendmentId.id,
-        phaseId: stateApplicationPhase,
+        phaseId: stateApplicationPhaseName,
       },
     });
   }
@@ -337,7 +337,7 @@ async function seedDatabase() {
         ownerUserId: (await prisma().user.findRandom())!.id,
         documentTypeId: stateApplicationDocumentType,
         bundleId: extensionId.id,
-        phaseId: stateApplicationPhase,
+        phaseId: stateApplicationPhaseName,
       },
     });
   }
@@ -348,7 +348,7 @@ async function seedDatabase() {
     const allowedPhaseDocumentTypes = await prisma().phaseDocumentType.findRandom({
       where: {
         NOT: {
-          OR: [{ documentTypeId: stateApplicationDocumentType }, { phaseId: nonePhase }],
+          OR: [{ documentTypeId: stateApplicationDocumentType }, { phaseId: nonePhaseName }],
         },
       },
     });

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -4,7 +4,7 @@ import {
   CMCS_DIVISION,
   SIGNATURE_LEVEL,
   DOCUMENT_TYPES,
-  PHASE,
+  PHASE_NAME,
   PHASE_STATUS,
   PERSON_TYPES,
   GRANT_LEVELS,
@@ -59,7 +59,7 @@ export type BundleType = (typeof BUNDLE_TYPE)[keyof typeof BUNDLE_TYPE];
 export type CmcsDivision = (typeof CMCS_DIVISION)[number];
 export type SignatureLevel = (typeof SIGNATURE_LEVEL)[number];
 export type DocumentType = (typeof DOCUMENT_TYPES)[number];
-export type Phase = (typeof PHASE)[number];
+export type PhaseName = (typeof PHASE_NAME)[number];
 export type PhaseStatus = (typeof PHASE_STATUS)[number];
 export type PersonType = (typeof PERSON_TYPES)[number];
 export type GrantLevel = (typeof GRANT_LEVELS)[number];


### PR DESCRIPTION
This PR replaces Phase with PhaseName throughout the application to distinguish between the scalar name of a phase, and a full phase object (currently called a BundlePhase, but possibly renamed in the future). This is based on some conversations with @tresdonicf and @connor-parke-icf on naming. I didn't include a rename of `BundlePhase` as that touches on some other things and I wanted to keep the size of this fix tractable. All tests pass, builds look fine, I tried the site locally and exercised the API via the Apollo web client.