### PR TITLE
DEMOS-919: Send slack notification with mentions if migrations fail

### DIFF
--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -86,6 +86,13 @@ pipeline {
           }
         }
       }
+      post {
+        failure {
+          script {
+            notifyMigrationError(env.STAGE)
+          }
+        }
+      }
     }
 
     stage('Deploy') {

--- a/pipelines/lib/vars/notifyMigrationError.groovy
+++ b/pipelines/lib/vars/notifyMigrationError.groovy
@@ -1,0 +1,15 @@
+def call(stage: String) {
+  def username = sh(script: '''
+  curl https://api.github.com/repos/Enterprise-CMCS/demos/commits/$(git log -1 --pretty=format:"%H") | grep '"login":' | head -n1 | sed -E 's/.*"login": *"(.*)".*/\\1/'
+  ''', returnStdout: true).trim()
+  def slackId = slackIdFromGithubUser(username)
+  def arr = env.SLACK_DB_NOTIFICATION_USERS.toString().split(",").collect { "${it.trim()}".toString() }
+  
+  
+  if (slackId && !arr.contains(slackId.trim())) {
+    arr << slackId
+  }
+
+  def mentions =  arr.collect { "<@$it>" }.join(" ")
+  slackSend(color: "danger", message: "${mentions} There was an issue applying migrations in ${stage}")
+}


### PR DESCRIPTION
This change adds a notification within the deployment pipeline if the migrations fail

Since this pipeline is only run after code is merged, there are no Jenkins ENVs to get the github username, which is what has been set up to correlate everyone with their slack ID. So this change just gets the commit hash from the latest commit, then queries github to get the username. It will mention that person, plus any slack IDs listed in SLACK_DB_NOTIFICATION_USERS, which is a comma-separated list of ids managed on the Jenkins instance (and currently contains only Tom's ID). 