### PR TITLE
DEMOS-792 Amendment/Extension Dialog Changes

### DIFF
--- a/client/src/hooks/useDemonstration.test.tsx
+++ b/client/src/hooks/useDemonstration.test.tsx
@@ -1,0 +1,210 @@
+import React, { ReactNode } from "react";
+
+import { MockedProvider } from "@apollo/client/testing";
+import { renderHook, waitFor } from "@testing-library/react";
+
+import { GET_DEMONSTRATION_BY_ID_QUERY, useDemonstration } from "./useDemonstration";
+
+// Mock data
+const mockDemonstrationData = {
+  id: "demo-123",
+  name: "Test Demonstration",
+  description: "Test demonstration description",
+  state: {
+    id: "CA",
+    name: "California",
+  },
+  roles: [
+    {
+      isPrimary: true,
+      role: "Project Officer",
+      person: {
+        id: "user-456",
+        fullName: "John Doe",
+      },
+    },
+    {
+      isPrimary: false,
+      role: "State Lead",
+      person: {
+        id: "user-789",
+        fullName: "Jane Smith",
+      },
+    },
+  ],
+};
+
+const mockDemonstrationWithoutProjectOfficer = {
+  ...mockDemonstrationData,
+  roles: [
+    {
+      isPrimary: false,
+      role: "State Lead",
+      person: {
+        id: "user-789",
+        fullName: "Jane Smith",
+      },
+    },
+  ],
+};
+
+const mocks = [
+  {
+    request: {
+      query: GET_DEMONSTRATION_BY_ID_QUERY,
+      variables: { id: "demo-123" },
+    },
+    result: {
+      data: {
+        demonstration: mockDemonstrationData,
+      },
+    },
+  },
+  {
+    request: {
+      query: GET_DEMONSTRATION_BY_ID_QUERY,
+      variables: { id: "demo-456" },
+    },
+    result: {
+      data: {
+        demonstration: mockDemonstrationWithoutProjectOfficer,
+      },
+    },
+  },
+  {
+    request: {
+      query: GET_DEMONSTRATION_BY_ID_QUERY,
+      variables: { id: "error-demo" },
+    },
+    error: new Error("Failed to fetch demonstration"),
+  },
+];
+
+const createWrapper = () => {
+  const TestWrapper = ({ children }: { children: ReactNode }) => (
+    <MockedProvider mocks={mocks} addTypename={false}>
+      {children}
+    </MockedProvider>
+  );
+  TestWrapper.displayName = "TestWrapper";
+  return TestWrapper;
+};
+
+describe("useDemonstration", () => {
+  it("should return initial state when no id is provided", () => {
+    const { result } = renderHook(() => useDemonstration(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.demonstration).toBeUndefined();
+    expect(result.current.projectOfficer).toBeUndefined();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("should fetch demonstration data when id is provided", async () => {
+    const { result } = renderHook(() => useDemonstration("demo-123"), {
+      wrapper: createWrapper(),
+    });
+
+    // Initially loading
+    expect(result.current.loading).toBe(true);
+    expect(result.current.demonstration).toBeUndefined();
+
+    // Wait for data to load
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.demonstration).toEqual(mockDemonstrationData);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("should extract project officer from roles", async () => {
+    const { result } = renderHook(() => useDemonstration("demo-123"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.projectOfficer).toEqual({
+      isPrimary: true,
+      role: "Project Officer",
+      person: {
+        id: "user-456",
+        fullName: "John Doe",
+      },
+    });
+  });
+
+  it("should return undefined project officer when no primary project officer exists", async () => {
+    const { result } = renderHook(() => useDemonstration("demo-456"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.demonstration).toEqual(mockDemonstrationWithoutProjectOfficer);
+    expect(result.current.projectOfficer).toBeUndefined();
+  });
+
+  it("should handle query errors", async () => {
+    const { result } = renderHook(() => useDemonstration("error-demo"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.demonstration).toBeUndefined();
+    expect(result.current.projectOfficer).toBeUndefined();
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.message).toBe("Failed to fetch demonstration");
+  });
+
+  it("should skip query when id changes to undefined", () => {
+    let demonstrationId: string | undefined = "demo-123";
+
+    const { result, rerender } = renderHook(() => useDemonstration(demonstrationId), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.loading).toBe(true);
+
+    // Change id to undefined
+    demonstrationId = undefined;
+    rerender();
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.demonstration).toBeUndefined();
+  });
+
+  it("should use cache-first fetch policy", async () => {
+    const { result } = renderHook(() => useDemonstration("demo-123"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // First hook should have loaded data
+    expect(result.current.demonstration).toEqual(mockDemonstrationData);
+
+    // Second render with same wrapper should eventually use cached data
+    const { result: result2 } = renderHook(() => useDemonstration("demo-123"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result2.current.loading).toBe(false);
+    });
+
+    expect(result2.current.demonstration).toEqual(mockDemonstrationData);
+  });
+});

--- a/client/src/hooks/useDemonstration.ts
+++ b/client/src/hooks/useDemonstration.ts
@@ -1,0 +1,75 @@
+import { useQuery } from "@apollo/client";
+import { gql } from "@apollo/client";
+
+export const GET_DEMONSTRATION_BY_ID_QUERY = gql`
+  query GetDemonstrationById($id: ID!) {
+    demonstration(id: $id) {
+      id
+      name
+      description
+      state {
+        id
+        name
+      }
+      roles {
+        isPrimary
+        role
+        person {
+          id
+          fullName
+        }
+      }
+    }
+  }
+`;
+
+interface DemonstrationState {
+  id: string;
+  name: string;
+}
+
+interface DemonstrationRole {
+  isPrimary: boolean;
+  role: string;
+  person: {
+    id: string;
+    fullName: string;
+  };
+}
+
+interface DemonstrationDetails {
+  id: string;
+  name: string;
+  description: string;
+  state: DemonstrationState;
+  roles: DemonstrationRole[];
+}
+
+interface DemonstrationQueryResult {
+  demonstration: DemonstrationDetails;
+}
+
+export const useDemonstration = (id?: string) => {
+  const { data, loading, error } = useQuery<DemonstrationQueryResult>(
+    GET_DEMONSTRATION_BY_ID_QUERY,
+    {
+      variables: { id: id! },
+      skip: !id,
+      fetchPolicy: "cache-first",
+    }
+  );
+
+  const demonstration = data?.demonstration;
+
+  // Extract project officer information
+  const projectOfficer = demonstration?.roles.find(
+    (role) => role.role === "Project Officer" && role.isPrimary === true
+  );
+
+  return {
+    demonstration,
+    projectOfficer,
+    loading,
+    error,
+  };
+};


### PR DESCRIPTION
# Amendment/Extension Dialog Changes

## Summary

Implemented context-aware behavior for Amendment and Extension creation dialogs based on user requirements.

## Requirements Implemented

### 1. State/Territory Field Behavior

- **When creating from landing page**: State field is enabled and user can select any state
- **When creating from within demonstration**: State field is disabled and pre-populated with the demonstration's state value

### 2. Project Officer Field Behavior

- **When creating from landing page**: Project Officer field is visible and required
- **When creating from within demonstration**: Project Officer field is hidden (not shown in UI)

## Files Modified

### Core Components

- `BaseModificationDialog.tsx` - Added conditional field rendering and state pre-population logic
- `BaseModificationDialog.test.tsx` - Enhanced with comprehensive test coverage for both scenarios

### New Hook

- `useDemonstration.ts` - New hook to fetch detailed demonstration data for form pre-population

## Technical Details

### Context Detection

The dialog detects context based on the presence of `demonstrationId` prop:

- `demonstrationId` present = user is within demonstration context
- `demonstrationId` absent = user is creating from landing page

### Form Validation

- Landing page scenario: Requires demonstration, title, state, and project officer
- Demonstration context: Requires only title (demonstration and state are pre-populated, project officer not needed)

## Testing

- 19 total tests passing
- Covers both creation scenarios (landing page vs demonstration context)
- Validates field visibility, state pre-population, and form validation logic

Within a demonstration:
<img width="655" height="581" alt="image" src="https://github.com/user-attachments/assets/3baa7e48-d002-4cc2-8681-1ba247489637" />

From Create New outside demonstration details:
<img width="650" height="650" alt="image" src="https://github.com/user-attachments/assets/85a6d81c-cc5d-43a2-8a84-1701eeaf316d" />

