### PR TITLE
DEMOS-866: prevented autocomplete on search field

### DIFF
--- a/client/src/components/input/select/AutoCompleteSelect.tsx
+++ b/client/src/components/input/select/AutoCompleteSelect.tsx
@@ -113,6 +113,7 @@ export const AutoCompleteSelect: React.FC<AutoCompleteSelectProps> = ({
           disabled={isDisabled}
           className={`${INPUT_BASE_CLASSES} ${getInputColors("")} w-full`}
           data-form-type="other"
+          autoComplete="off"
         />
         <div className="pointer-events-none absolute inset-y-0 end-0 flex items-center">
           <ChevronDownIcon className={ICON_CLASSES} />


### PR DESCRIPTION
So this feels more like addressing a symptom of a problem rather than the core issue; i have suspicions we might need some adjustments to this component for 508 testing, as we are using this as a select, but it actually is a text input. Issue is that chrome sees this text input and attempts to autofill it, or provide options based on previously submitted values. Since this search bar is intended to be more of a helper for finding the correct value, ive gone ahead and simply disabled autocomplete. 

The other solutions ive seen proposed for this is to make the select actually contain a hidden select field, which is actually whats used in the form. This seems at the time a bigger refactor than the scope of this ticket, but not entirely sure whats the best way to go with this. 

Nonetheless, this does resolve the current bug, where the autofill options make the component difficult to use. If this does come up in 508 compliance, i think that would be a good time for deeper investigation. 