### PR TITLE
 DEMOS-956: Add jenkins library function hasChange 

### DIFF
--- a/pipelines/lib/vars/hasChange.groovy
+++ b/pipelines/lib/vars/hasChange.groovy
@@ -1,0 +1,33 @@
+import groovy.transform.Field
+
+@Field Map<String, Boolean> changes = [:]
+
+def call(String path, String target = "") {
+
+  if (!env.CHANGE_ID) {
+    echo "Always trigger if pipeline run is not a pull request"
+    return true
+  }
+
+  if (changes.containsKey(path)) {
+    return changes[path]
+  }
+
+  if (target == "") {
+    target = env.CHANGE_TARGET
+  }
+  
+  def diffStatus = sh(script: "git diff --name-only --merge-base origin/${target} -- ${path}", returnStdout: true).trim()
+  echo "Diff status for path '${path}': ${diffStatus}"
+  changes[path] = diffStatus != ""
+  return changes[path]
+}
+
+def call(List<String> paths, String target = "") {
+  for (String path : paths) {
+    if (call(path, target)) {
+      return true
+    }
+  }
+  return false
+}

--- a/pipelines/lib/vars/notifyMigrationError.groovy
+++ b/pipelines/lib/vars/notifyMigrationError.groovy
@@ -1,4 +1,4 @@
-def call(stage: String) {
+def call(String stage) {
   def username = sh(script: '''
   curl https://api.github.com/repos/Enterprise-CMCS/demos/commits/$(git log -1 --pretty=format:"%H") | grep '"login":' | head -n1 | sed -E 's/.*"login": *"(.*)".*/\\1/'
   ''', returnStdout: true).trim()


### PR DESCRIPTION
This is the first part of a 2-part PR for skipping unnecessary pipeline stages when a PR is made. This PR has to be split up because the library is always pulled from `main`, so the pipeline changes will throw errors if the library function isn't merged first.

The library function hasChange takes a path and an optional target branch to compare with. If paths are passed as a list, each given path will be checked. The function returns "true" if the git diff contains a matching path. This will be used in the pipelines to conditionally run the stages.

If hasChange is called and the pipeline is not being run as part of a PR, this function will always return true so that no stages are skipped. This is important for the main branches (`main` and `test`)

---
A second commit was also made to correct a parameter definition in another library function.