### PR TITLE
DEMOS-1625: added state user view for deliverables

### DIFF
--- a/client/src/components/table/Table.tsx
+++ b/client/src/components/table/Table.tsx
@@ -20,7 +20,7 @@ import { arrIncludesAllInsensitive } from "./KeywordSearch";
 import { ChevronDownIcon, ChevronUpIcon, SortIcon } from "components/icons";
 
 const STYLES = {
-  table: "w-full table-auto",
+  table: "w-full min-w-max table-auto",
   th: "bg-gray-primary-layout p-1 font-semibold text-left border-b cursor-pointer select-none",
   tr: "h-[56px] border-b p-1",
   td: "p-1 text-[14px] break-words overflow-wrap",
@@ -123,7 +123,7 @@ function TableSearch<T>({
   columnFilter?: (table: TanstackTable<T>) => React.ReactNode;
 }) {
   return (
-    <div className="grid w-full grid-cols-1 items-end gap-[24px] md:grid-cols-4 sm:grid-cols-1">
+    <div className="grid w-full min-w-0 grid-cols-1 items-end gap-[24px] md:grid-cols-4 sm:grid-cols-1">
       <div className="col-span-1">{keywordSearch && keywordSearch(table)}</div>
       <div className="col-span-2">{columnFilter && columnFilter(table)}</div>
     </div>
@@ -224,23 +224,27 @@ export function Table<T extends { id: string }>({
   return (
     <>
       {!hideSearchAndActions && (
-        <div className="flex flex-col gap-4 items-start sm:flex-row sm:items-center justify-between mb-[24px]">
-          <TableSearch table={table} keywordSearch={keywordSearch} columnFilter={columnFilter} />
-          <div className="mr-1">{actionButtons?.(table)}</div>
+        <div className="mb-[24px] flex flex-col items-start gap-4 justify-between xl:flex-row xl:items-center">
+          <div className="w-full min-w-0 xl:flex-1">
+            <TableSearch table={table} keywordSearch={keywordSearch} columnFilter={columnFilter} />
+          </div>
+          <div className="mr-1 shrink-0">{actionButtons?.(table)}</div>
         </div>
       )}
 
       {actionModals && actionModals(table)}
 
-      <table className={STYLES.table}>
-        <TableHead headerGroups={table.getHeaderGroups()} />
-        <TableBody
-          data={data}
-          table={table}
-          emptyRowsMessage={emptyRowsMessage}
-          noResultsFoundMessage={noResultsFoundMessage}
-        />
-      </table>
+      <div className="w-full overflow-x-auto">
+        <table className={STYLES.table}>
+          <TableHead headerGroups={table.getHeaderGroups()} />
+          <TableBody
+            data={data}
+            table={table}
+            emptyRowsMessage={emptyRowsMessage}
+            noResultsFoundMessage={noResultsFoundMessage}
+          />
+        </table>
+      </div>
       {pagination && pagination(table)}
     </>
   );

--- a/client/src/components/table/columns/DeliverableColumns.tsx
+++ b/client/src/components/table/columns/DeliverableColumns.tsx
@@ -8,10 +8,47 @@ import { STATES_AND_TERRITORIES } from "demos-server-constants";
 
 import { SecondaryButton } from "../../button/SecondaryButton";
 import { highlightCell } from "../KeywordSearch";
-import { DeliverableTableRow } from "../tables/DeliverableTable";
+import type { DeliverableTableRow, DeliverableTableViewMode } from "../tables/DeliverableTable";
 
-export function DeliverableColumns() {
+type DeliverableColumnsProps = {
+  viewMode?: DeliverableTableViewMode;
+};
+
+export function DeliverableColumns({ viewMode = "default" }: DeliverableColumnsProps = {}) {
   const columnHelper = createColumnHelper<DeliverableTableRow>();
+
+  const demonstrationNameColumn = columnHelper.accessor("demonstrationName", {
+    header: "Demonstration Name",
+    cell: highlightCell,
+  });
+
+  const deliverableTypeColumn = columnHelper.accessor("deliverableType", {
+    header: "Deliverable Type",
+    cell: highlightCell,
+  });
+
+  const deliverableNameColumn = columnHelper.accessor("deliverableName", {
+    header: "Deliverable Name",
+    cell: highlightCell,
+  });
+
+  const dueDateColumn = createDateColumnDef(columnHelper, "dueDate", "Due Date");
+  const submissionDateColumn = createDateColumnDef(columnHelper, "submissionDate", "Submission Date");
+  const statusColumn = columnHelper.accessor("status", {
+    header: "Status",
+    cell: highlightCell,
+  });
+
+  if (viewMode === "stateUser") {
+    return [
+      demonstrationNameColumn,
+      deliverableTypeColumn,
+      deliverableNameColumn,
+      dueDateColumn,
+      submissionDateColumn,
+      statusColumn,
+    ];
+  }
 
   return [
     createSelectColumnDef(columnHelper),
@@ -31,28 +68,16 @@ export function DeliverableColumns() {
         },
       },
     }),
-    columnHelper.accessor("demonstrationName", {
-      header: "Demonstration Name",
-      cell: highlightCell,
-    }),
-    columnHelper.accessor("deliverableType", {
-      header: "Deliverable Type",
-      cell: highlightCell,
-    }),
-    columnHelper.accessor("deliverableName", {
-      header: "Deliverable Name",
-      cell: highlightCell,
-    }),
+    demonstrationNameColumn,
+    deliverableTypeColumn,
+    deliverableNameColumn,
     columnHelper.accessor("cmsOwner", {
       header: "CMS Owner",
       cell: highlightCell,
     }),
-    createDateColumnDef(columnHelper, "dueDate", "Due Date"),
-    createDateColumnDef(columnHelper, "submissionDate", "Submission Date"),
-    columnHelper.accessor("status", {
-      header: "Status",
-      cell: highlightCell,
-    }),
+    dueDateColumn,
+    submissionDateColumn,
+    statusColumn,
     columnHelper.display({
       id: "view",
       cell: ({ row }) => {

--- a/client/src/components/table/columns/DeliverableColumns.tsx
+++ b/client/src/components/table/columns/DeliverableColumns.tsx
@@ -39,7 +39,7 @@ export function DeliverableColumns({ viewMode }: DeliverableColumnsProps) {
     cell: highlightCell,
   });
 
-  if (viewMode === "stateUser") {
+  if (viewMode === "demos-state-user") {
     return [
       demonstrationNameColumn,
       deliverableTypeColumn,

--- a/client/src/components/table/columns/DeliverableColumns.tsx
+++ b/client/src/components/table/columns/DeliverableColumns.tsx
@@ -11,10 +11,10 @@ import { highlightCell } from "../KeywordSearch";
 import type { DeliverableTableRow, DeliverableTableViewMode } from "../tables/DeliverableTable";
 
 type DeliverableColumnsProps = {
-  viewMode?: DeliverableTableViewMode;
+  viewMode: DeliverableTableViewMode;
 };
 
-export function DeliverableColumns({ viewMode = "default" }: DeliverableColumnsProps = {}) {
+export function DeliverableColumns({ viewMode }: DeliverableColumnsProps) {
   const columnHelper = createColumnHelper<DeliverableTableRow>();
 
   const demonstrationNameColumn = columnHelper.accessor("demonstrationName", {

--- a/client/src/components/table/tables/DeliverableTable.test.tsx
+++ b/client/src/components/table/tables/DeliverableTable.test.tsx
@@ -170,3 +170,31 @@ describe("DeliverableTable", () => {
     expect(screen.getByText(/Items per page/i)).toBeInTheDocument();
   });
 });
+
+describe("DeliverableTable stateUser view mode", () => {
+  it("renders the state-user column set and hides state/CMS owner", async () => {
+    render(<DeliverableTable deliverables={MOCK_DELIVERABLES} viewMode="stateUser" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("table")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("columnheader", { name: /Demonstration Name/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /Deliverable Type/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /Deliverable Name/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /Due Date/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /Submission Date/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /Status/i })).toBeInTheDocument();
+
+    expect(screen.queryByRole("columnheader", { name: /State\/Territory/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: /CMS Owner/i })).not.toBeInTheDocument();
+  });
+
+  it("hides row action buttons in state-user mode", () => {
+    render(<DeliverableTable deliverables={MOCK_DELIVERABLES} viewMode="stateUser" />);
+
+    expect(screen.queryByLabelText(/Add Deliverable/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Edit Deliverable/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Remove Deliverable/i)).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/table/tables/DeliverableTable.test.tsx
+++ b/client/src/components/table/tables/DeliverableTable.test.tsx
@@ -8,7 +8,7 @@ import { MOCK_DELIVERABLES } from "mock-data/deliverableMocks";
 
 describe("DeliverableTable", () => {
   beforeEach(async () => {
-    render(<DeliverableTable deliverables={MOCK_DELIVERABLES} viewMode="cmsUser" />);
+    render(<DeliverableTable deliverables={MOCK_DELIVERABLES} viewMode="demos-cms-user" />);
     await waitFor(() => {
       expect(screen.getByRole("table")).toBeInTheDocument();
     });
@@ -23,7 +23,7 @@ describe("DeliverableTable", () => {
   });
 
   it("shows empty state when no deliverables provided", async () => {
-    render(<DeliverableTable deliverables={[]} viewMode="cmsUser" />);
+    render(<DeliverableTable deliverables={[]} viewMode="demos-cms-user" />);
 
     await waitFor(() => {
       expect(
@@ -37,7 +37,7 @@ describe("DeliverableTable", () => {
       <DeliverableTable
         deliverables={[]}
         emptyRowsMessage="You have no assigned Deliverables at this time"
-        viewMode="cmsUser"
+        viewMode="demos-cms-user"
       />
     );
 
@@ -172,9 +172,9 @@ describe("DeliverableTable", () => {
   });
 });
 
-describe("DeliverableTable stateUser view mode", () => {
+describe("DeliverableTable demos-state-user view mode", () => {
   it("renders the state-user column set and hides state/CMS owner", async () => {
-    render(<DeliverableTable deliverables={MOCK_DELIVERABLES} viewMode="stateUser" />);
+    render(<DeliverableTable deliverables={MOCK_DELIVERABLES} viewMode="demos-state-user" />);
 
     await waitFor(() => {
       expect(screen.getByRole("table")).toBeInTheDocument();
@@ -192,7 +192,7 @@ describe("DeliverableTable stateUser view mode", () => {
   });
 
   it("hides row action buttons in state-user mode", () => {
-    render(<DeliverableTable deliverables={MOCK_DELIVERABLES} viewMode="stateUser" />);
+    render(<DeliverableTable deliverables={MOCK_DELIVERABLES} viewMode="demos-state-user" />);
 
     expect(screen.queryByLabelText(/Add Deliverable/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/Edit Deliverable/i)).not.toBeInTheDocument();

--- a/client/src/components/table/tables/DeliverableTable.test.tsx
+++ b/client/src/components/table/tables/DeliverableTable.test.tsx
@@ -8,7 +8,7 @@ import { MOCK_DELIVERABLES } from "mock-data/deliverableMocks";
 
 describe("DeliverableTable", () => {
   beforeEach(async () => {
-    render(<DeliverableTable deliverables={MOCK_DELIVERABLES} />);
+    render(<DeliverableTable deliverables={MOCK_DELIVERABLES} viewMode="cmsUser" />);
     await waitFor(() => {
       expect(screen.getByRole("table")).toBeInTheDocument();
     });
@@ -23,7 +23,7 @@ describe("DeliverableTable", () => {
   });
 
   it("shows empty state when no deliverables provided", async () => {
-    render(<DeliverableTable deliverables={[]} />);
+    render(<DeliverableTable deliverables={[]} viewMode="cmsUser" />);
 
     await waitFor(() => {
       expect(
@@ -37,6 +37,7 @@ describe("DeliverableTable", () => {
       <DeliverableTable
         deliverables={[]}
         emptyRowsMessage="You have no assigned Deliverables at this time"
+        viewMode="cmsUser"
       />
     );
 

--- a/client/src/components/table/tables/DeliverableTable.tsx
+++ b/client/src/components/table/tables/DeliverableTable.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Deliverable } from "pages/DeliverablesPage";
 import { DeliverableColumns } from "../columns/DeliverableColumns";
-import { Table } from "../Table";
+import { Table, type TableProps } from "../Table";
 import { ColumnFilter } from "../ColumnFilter";
 import { PaginationControls } from "../PaginationControls";
 import { KeywordSearch } from "../KeywordSearch";
@@ -68,10 +68,66 @@ export const DeliverableTable: React.FC<{
     status: formatDeliverableStatus(deliverable),
   }));
 
-  /* const { showAddDeliverableDialog, showEditDeliverableDialog, showRemoveDeliverableDialog } = useDialog(); */
   const showAddDeliverableDialog = () => { };
   const showEditDeliverableDialog = () => { };
   const showRemoveDeliverableDialog = () => { };
+  type DeliverableActionButtons = NonNullable<TableProps<DeliverableTableRow>["actionButtons"]>;
+
+  const renderActionButtons: DeliverableActionButtons = (table) => {
+    const selectedCount = table.getSelectedRowModel().rows.length;
+
+    const editEnabled = selectedCount === 1;
+    const deleteEnabled = selectedCount >= 1;
+
+    const editTooltip = selectionTooltip({
+      action: "Edit",
+      nounSingular: "Deliverable",
+      selectedCount,
+      rule: { kind: "exactly", count: 1 },
+    });
+
+    const deleteTooltip = selectionTooltip({
+      action: "Delete",
+      nounSingular: "Deliverable",
+      selectedCount,
+      rule: { kind: "atLeast", count: 1 },
+    });
+
+    return (
+      <div className="flex gap-1 ml-4">
+        <CircleButton
+          name="add-deliverable"
+          ariaLabel="Add Deliverable"
+          tooltip="Add Deliverable"
+          onClick={() => showAddDeliverableDialog()}
+        >
+          <ImportIcon />
+        </CircleButton>
+
+        <CircleButton
+          name="edit-deliverable"
+          ariaLabel="Edit Deliverable"
+          tooltip={editTooltip}
+          disabled={!editEnabled}
+          onClick={() => showEditDeliverableDialog()}
+        >
+          <EditIcon />
+        </CircleButton>
+
+        <CircleButton
+          name="remove-deliverable"
+          ariaLabel="Remove Deliverable"
+          tooltip={deleteTooltip}
+          disabled={!deleteEnabled}
+          onClick={() => showRemoveDeliverableDialog()}
+        >
+          <DeleteIcon />
+        </CircleButton>
+      </div>
+    );
+  };
+
+  const actionButtons = viewMode === "stateUser" ? undefined : renderActionButtons;
 
   return (
     <div className="flex flex-col gap-[24px]" data-view-mode={viewMode}>
@@ -84,64 +140,7 @@ export const DeliverableTable: React.FC<{
           pagination={(table) => <PaginationControls table={table} />}
           emptyRowsMessage={emptyRowsMessage}
           noResultsFoundMessage={DEFAULT_NO_SEARCH_RESULTS_MESSAGE}
-          actionButtons={
-            viewMode === "stateUser"
-              ? undefined
-              : (table) => {
-                const selectedDeliverables = table.getSelectedRowModel().rows.map((row) => row.original);
-                const selectedCount = selectedDeliverables.length;
-
-                const editEnabled = selectedCount === 1;
-                const deleteEnabled = selectedCount >= 1;
-
-                const editTooltip = selectionTooltip({
-                  action: "Edit",
-                  nounSingular: "Deliverable",
-                  selectedCount,
-                  rule: { kind: "exactly", count: 1 },
-                });
-
-                const deleteTooltip = selectionTooltip({
-                  action: "Delete",
-                  nounSingular: "Deliverable",
-                  selectedCount,
-                  rule: { kind: "atLeast", count: 1 },
-                });
-
-                return (
-                  <div className="flex gap-1 ml-4">
-                    <CircleButton
-                      name="add-deliverable"
-                      ariaLabel="Add Deliverable"
-                      tooltip="Add Deliverable"
-                      onClick={() => showAddDeliverableDialog()}
-                    >
-                      <ImportIcon />
-                    </CircleButton>
-
-                    <CircleButton
-                      name="edit-deliverable"
-                      ariaLabel="Edit Deliverable"
-                      tooltip={editTooltip}
-                      disabled={!editEnabled}
-                      onClick={() => showEditDeliverableDialog()}
-                    >
-                      <EditIcon />
-                    </CircleButton>
-
-                    <CircleButton
-                      name="remove-deliverable"
-                      ariaLabel="Remove Deliverable"
-                      tooltip={deleteTooltip}
-                      disabled={!deleteEnabled}
-                      onClick={() => showRemoveDeliverableDialog()}
-                    >
-                      <DeleteIcon />
-                    </CircleButton>
-                  </div>
-                );
-              }
-          }
+          actionButtons={actionButtons}
         />
       )}
     </div>

--- a/client/src/components/table/tables/DeliverableTable.tsx
+++ b/client/src/components/table/tables/DeliverableTable.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { PersonType } from "demos-server";
 
 import { Deliverable } from "pages/DeliverablesPage";
 import { DeliverableColumns } from "../columns/DeliverableColumns";
@@ -24,11 +25,10 @@ export type DeliverableTableRow = {
   state: { id: string };
 };
 
-export type DeliverableTableViewMode = "cmsUser" | "stateUser";
+export type DeliverableTableViewMode = Exclude<PersonType, "non-user-contact">;
 
-const DEFAULT_EMPTY_ROWS_MESSAGE = "There are no assigned Deliverables at this time";
-const DEFAULT_NO_SEARCH_RESULTS_MESSAGE =
-  "No results were returned. Adjust your search and filter criteria.";
+const EMPTY_ROWS_MESSAGE = "There are no assigned Deliverables at this time";
+const NO_RESULTS_FOUND = "No results were returned. Adjust your search and filter criteria.";
 
 export const formatDeliverableStatus = ({
   status,
@@ -59,7 +59,7 @@ export const DeliverableTable: React.FC<{
   viewMode: DeliverableTableViewMode;
 }> = ({
   deliverables,
-  emptyRowsMessage = DEFAULT_EMPTY_ROWS_MESSAGE,
+  emptyRowsMessage = EMPTY_ROWS_MESSAGE,
   viewMode,
 }) => {
   const deliverableColumns = DeliverableColumns({ viewMode });
@@ -127,7 +127,7 @@ export const DeliverableTable: React.FC<{
     );
   };
 
-  const actionButtons = viewMode === "stateUser" ? undefined : renderActionButtons;
+  const actionButtons = viewMode === "demos-state-user" ? undefined : renderActionButtons;
 
   return (
     <div className="flex flex-col gap-[24px]" data-view-mode={viewMode}>
@@ -139,7 +139,7 @@ export const DeliverableTable: React.FC<{
           columnFilter={(table) => <ColumnFilter table={table} />}
           pagination={(table) => <PaginationControls table={table} />}
           emptyRowsMessage={emptyRowsMessage}
-          noResultsFoundMessage={DEFAULT_NO_SEARCH_RESULTS_MESSAGE}
+          noResultsFoundMessage={NO_RESULTS_FOUND}
           actionButtons={actionButtons}
         />
       )}

--- a/client/src/components/table/tables/DeliverableTable.tsx
+++ b/client/src/components/table/tables/DeliverableTable.tsx
@@ -24,6 +24,8 @@ export type DeliverableTableRow = {
   state: { id: string };
 };
 
+export type DeliverableTableViewMode = "default" | "stateUser";
+
 const DEFAULT_EMPTY_ROWS_MESSAGE = "There are no assigned Deliverables at this time";
 const DEFAULT_NO_SEARCH_RESULTS_MESSAGE =
   "No results were returned. Adjust your search and filter criteria.";
@@ -54,11 +56,13 @@ export const formatDeliverableStatus = ({
 export const DeliverableTable: React.FC<{
   deliverables: Deliverable[];
   emptyRowsMessage?: string;
+  viewMode?: DeliverableTableViewMode;
 }> = ({
   deliverables,
   emptyRowsMessage = DEFAULT_EMPTY_ROWS_MESSAGE,
+  viewMode = "default",
 }) => {
-  const deliverableColumns = DeliverableColumns();
+  const deliverableColumns = DeliverableColumns({ viewMode });
   const formattedDeliverables = deliverables.map((deliverable) => ({
     ...deliverable,
     status: formatDeliverableStatus(deliverable),
@@ -70,7 +74,7 @@ export const DeliverableTable: React.FC<{
   const showRemoveDeliverableDialog = () => { };
 
   return (
-    <div className="flex flex-col gap-[24px]">
+    <div className="flex flex-col gap-[24px]" data-view-mode={viewMode}>
       {deliverableColumns && (
         <Table<DeliverableTableRow>
           data={formattedDeliverables}
@@ -80,60 +84,64 @@ export const DeliverableTable: React.FC<{
           pagination={(table) => <PaginationControls table={table} />}
           emptyRowsMessage={emptyRowsMessage}
           noResultsFoundMessage={DEFAULT_NO_SEARCH_RESULTS_MESSAGE}
-          actionButtons={(table) => {
-            const selectedDeliverables = table.getSelectedRowModel().rows.map((row) => row.original);
-            const selectedCount = selectedDeliverables.length;
+          actionButtons={
+            viewMode === "stateUser"
+              ? undefined
+              : (table) => {
+                const selectedDeliverables = table.getSelectedRowModel().rows.map((row) => row.original);
+                const selectedCount = selectedDeliverables.length;
 
-            const editEnabled = selectedCount === 1;
-            const deleteEnabled = selectedCount >= 1;
+                const editEnabled = selectedCount === 1;
+                const deleteEnabled = selectedCount >= 1;
 
-            const editTooltip = selectionTooltip({
-              action: "Edit",
-              nounSingular: "Deliverable",
-              selectedCount,
-              rule: { kind: "exactly", count: 1 },
-            });
+                const editTooltip = selectionTooltip({
+                  action: "Edit",
+                  nounSingular: "Deliverable",
+                  selectedCount,
+                  rule: { kind: "exactly", count: 1 },
+                });
 
-            const deleteTooltip = selectionTooltip({
-              action: "Delete",
-              nounSingular: "Deliverable",
-              selectedCount,
-              rule: { kind: "atLeast", count: 1 },
-            });
+                const deleteTooltip = selectionTooltip({
+                  action: "Delete",
+                  nounSingular: "Deliverable",
+                  selectedCount,
+                  rule: { kind: "atLeast", count: 1 },
+                });
 
-            return (
-              <div className="flex gap-1 ml-4">
-                <CircleButton
-                  name="add-deliverable"
-                  ariaLabel="Add Deliverable"
-                  tooltip="Add Deliverable"
-                  onClick={() => showAddDeliverableDialog()}
-                >
-                  <ImportIcon />
-                </CircleButton>
+                return (
+                  <div className="flex gap-1 ml-4">
+                    <CircleButton
+                      name="add-deliverable"
+                      ariaLabel="Add Deliverable"
+                      tooltip="Add Deliverable"
+                      onClick={() => showAddDeliverableDialog()}
+                    >
+                      <ImportIcon />
+                    </CircleButton>
 
-                <CircleButton
-                  name="edit-deliverable"
-                  ariaLabel="Edit Deliverable"
-                  tooltip={editTooltip}
-                  disabled={!editEnabled}
-                  onClick={() => showEditDeliverableDialog()}
-                >
-                  <EditIcon />
-                </CircleButton>
+                    <CircleButton
+                      name="edit-deliverable"
+                      ariaLabel="Edit Deliverable"
+                      tooltip={editTooltip}
+                      disabled={!editEnabled}
+                      onClick={() => showEditDeliverableDialog()}
+                    >
+                      <EditIcon />
+                    </CircleButton>
 
-                <CircleButton
-                  name="remove-deliverable"
-                  ariaLabel="Remove Deliverable"
-                  tooltip={deleteTooltip}
-                  disabled={!deleteEnabled}
-                  onClick={() => showRemoveDeliverableDialog()}
-                >
-                  <DeleteIcon />
-                </CircleButton>
-              </div>
-            );
-          }}
+                    <CircleButton
+                      name="remove-deliverable"
+                      ariaLabel="Remove Deliverable"
+                      tooltip={deleteTooltip}
+                      disabled={!deleteEnabled}
+                      onClick={() => showRemoveDeliverableDialog()}
+                    >
+                      <DeleteIcon />
+                    </CircleButton>
+                  </div>
+                );
+              }
+          }
         />
       )}
     </div>

--- a/client/src/components/table/tables/DeliverableTable.tsx
+++ b/client/src/components/table/tables/DeliverableTable.tsx
@@ -24,7 +24,7 @@ export type DeliverableTableRow = {
   state: { id: string };
 };
 
-export type DeliverableTableViewMode = "default" | "stateUser";
+export type DeliverableTableViewMode = "cmsUser" | "stateUser";
 
 const DEFAULT_EMPTY_ROWS_MESSAGE = "There are no assigned Deliverables at this time";
 const DEFAULT_NO_SEARCH_RESULTS_MESSAGE =
@@ -56,11 +56,11 @@ export const formatDeliverableStatus = ({
 export const DeliverableTable: React.FC<{
   deliverables: Deliverable[];
   emptyRowsMessage?: string;
-  viewMode?: DeliverableTableViewMode;
+  viewMode: DeliverableTableViewMode;
 }> = ({
   deliverables,
   emptyRowsMessage = DEFAULT_EMPTY_ROWS_MESSAGE,
-  viewMode = "default",
+  viewMode,
 }) => {
   const deliverableColumns = DeliverableColumns({ viewMode });
   const formattedDeliverables = deliverables.map((deliverable) => ({

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useDebounced } from "./useDebounced";
+export { useSessionTab } from "./useSessionTab";

--- a/client/src/hooks/useSessionTab.test.ts
+++ b/client/src/hooks/useSessionTab.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useSessionTab } from "./useSessionTab";
+
+describe("useSessionTab", () => {
+  const key = "selected-tab";
+  const defaultValue = "my-deliverables";
+  const allowedValues = ["my-deliverables", "deliverables"] as const;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("uses the default value and stores it when nothing is in session storage", () => {
+    const { result } = renderHook(() =>
+      useSessionTab({ key, defaultValue, allowedValues })
+    );
+
+    expect(result.current[0]).toBe("my-deliverables");
+    expect(sessionStorage.getItem(key)).toBe("my-deliverables");
+  });
+
+  it("uses stored value when it is allowed", () => {
+    sessionStorage.setItem(key, "deliverables");
+
+    const { result } = renderHook(() =>
+      useSessionTab({ key, defaultValue, allowedValues })
+    );
+
+    expect(result.current[0]).toBe("deliverables");
+    expect(sessionStorage.getItem(key)).toBe("deliverables");
+  });
+
+  it("falls back to default when stored value is not allowed", () => {
+    sessionStorage.setItem(key, "bad-tab-value");
+
+    const { result } = renderHook(() =>
+      useSessionTab({ key, defaultValue, allowedValues })
+    );
+
+    expect(result.current[0]).toBe("my-deliverables");
+    expect(sessionStorage.getItem(key)).toBe("my-deliverables");
+  });
+
+  it("updates state and session storage when selecting an allowed tab", () => {
+    const { result } = renderHook(() =>
+      useSessionTab({ key, defaultValue, allowedValues })
+    );
+
+    act(() => {
+      result.current[1]("deliverables");
+    });
+
+    expect(result.current[0]).toBe("deliverables");
+    expect(sessionStorage.getItem(key)).toBe("deliverables");
+  });
+
+  it("resets to default when selecting a tab that is not allowed", () => {
+    const { result } = renderHook(() =>
+      useSessionTab({ key, defaultValue, allowedValues })
+    );
+
+    act(() => {
+      result.current[1]("not-allowed");
+    });
+
+    expect(result.current[0]).toBe("my-deliverables");
+    expect(sessionStorage.getItem(key)).toBe("my-deliverables");
+  });
+});

--- a/client/src/hooks/useSessionTab.ts
+++ b/client/src/hooks/useSessionTab.ts
@@ -1,0 +1,47 @@
+import { useCallback, useState } from "react";
+
+type UseSessionTabOptions<T extends string> = {
+  key: string;
+  defaultValue: T;
+  allowedValues: readonly T[];
+};
+
+function getInitialTabValue<T extends string>({
+  key,
+  defaultValue,
+  allowedValues,
+}: UseSessionTabOptions<T>): T {
+  if (typeof window === "undefined") {
+    return defaultValue;
+  }
+
+  const stored = sessionStorage.getItem(key);
+  const tabValue = allowedValues.includes(stored as T) ? (stored as T) : defaultValue;
+  sessionStorage.setItem(key, tabValue);
+
+  return tabValue;
+}
+
+export function useSessionTab<T extends string>({
+  key,
+  defaultValue,
+  allowedValues,
+}: UseSessionTabOptions<T>): readonly [T, (value: string) => void] {
+  const [tabValue, setTabValue] = useState<T>(() =>
+    getInitialTabValue({ key, defaultValue, allowedValues })
+  );
+
+  const onTabSelect = useCallback(
+    (value: string) => {
+      const nextValue = allowedValues.includes(value as T) ? (value as T) : defaultValue;
+      setTabValue(nextValue);
+
+      if (typeof window !== "undefined") {
+        sessionStorage.setItem(key, nextValue);
+      }
+    },
+    [allowedValues, defaultValue, key]
+  );
+
+  return [tabValue, onTabSelect] as const;
+}

--- a/client/src/mock-data/deliverableMocks.ts
+++ b/client/src/mock-data/deliverableMocks.ts
@@ -42,7 +42,7 @@ export const MOCK_DELIVERABLES: MockDeliverable[] = [
   {
     id: "8f3a0c8a-2f9f-4bf0-9a3a-6b7eac31f201",
     deliverableName: "Budget Neutrality Report",
-    demonstrationName: "Dusty Demo",
+    demonstrationName: "Demonstration A",
     deliverableType: "Annual Budget Neutrality Report",
     cmsOwner: "Ashoka Tano",
     dueDate: "2024-07-01",
@@ -61,7 +61,7 @@ export const MOCK_DELIVERABLES: MockDeliverable[] = [
   {
     id: "1b6d2e71-4c98-4a26-a8ff-2cbf4af7d2a4",
     deliverableName: "Quarterly Report For NYC Demonstration",
-    demonstrationName: "Dusty Demo",
+    demonstrationName: "NYC Demonstration",
     deliverableType: "Demonstration-Specific Deliverable",
     cmsOwner: "Dusty Rhodes",
     dueDate: "2024-08-15",
@@ -80,7 +80,7 @@ export const MOCK_DELIVERABLES: MockDeliverable[] = [
   {
     id: "1b6d2e71-4c98-4a26-a8ff-2csf4af7d2a4",
     deliverableName: "Annual Report For AL Demonstration",
-    demonstrationName: "Dusty Demo",
+    demonstrationName: "Alabama Health and wellness",
     deliverableType: "Evaluation Design",
     cmsOwner: "Ackbar",
     dueDate: "2026-04-15",
@@ -99,7 +99,7 @@ export const MOCK_DELIVERABLES: MockDeliverable[] = [
   {
     id: "1b7d2e71-4c98-4a26-a8ff-2cbf4af7d2a4",
     deliverableName: "Budget Neutrality Worksheet",
-    demonstrationName: "Dusty Demo",
+    demonstrationName: "ALADEMO",
     deliverableType: "HCBS Actual and Estimated Enrollment Number Report (1915(i)-like)",
     cmsOwner: "Dusty Rhodes",
     dueDate: "2024-08-15",

--- a/client/src/mock-data/deliverableMocks.ts
+++ b/client/src/mock-data/deliverableMocks.ts
@@ -42,7 +42,7 @@ export const MOCK_DELIVERABLES: MockDeliverable[] = [
   {
     id: "8f3a0c8a-2f9f-4bf0-9a3a-6b7eac31f201",
     deliverableName: "Budget Neutrality Report",
-    demonstrationName: "Demonstration A",
+    demonstrationName: "Dusty Demo",
     deliverableType: "Annual Budget Neutrality Report",
     cmsOwner: "Ashoka Tano",
     dueDate: "2024-07-01",
@@ -61,7 +61,7 @@ export const MOCK_DELIVERABLES: MockDeliverable[] = [
   {
     id: "1b6d2e71-4c98-4a26-a8ff-2cbf4af7d2a4",
     deliverableName: "Quarterly Report For NYC Demonstration",
-    demonstrationName: "NYC Demonstration",
+    demonstrationName: "Dusty Demo",
     deliverableType: "Demonstration-Specific Deliverable",
     cmsOwner: "Dusty Rhodes",
     dueDate: "2024-08-15",
@@ -80,7 +80,7 @@ export const MOCK_DELIVERABLES: MockDeliverable[] = [
   {
     id: "1b6d2e71-4c98-4a26-a8ff-2csf4af7d2a4",
     deliverableName: "Annual Report For AL Demonstration",
-    demonstrationName: "Alabama Health and wellness",
+    demonstrationName: "Dusty Demo",
     deliverableType: "Evaluation Design",
     cmsOwner: "Ackbar",
     dueDate: "2026-04-15",
@@ -99,7 +99,7 @@ export const MOCK_DELIVERABLES: MockDeliverable[] = [
   {
     id: "1b7d2e71-4c98-4a26-a8ff-2cbf4af7d2a4",
     deliverableName: "Budget Neutrality Worksheet",
-    demonstrationName: "ALADEMO",
+    demonstrationName: "Dusty Demo",
     deliverableType: "HCBS Actual and Estimated Enrollment Number Report (1915(i)-like)",
     cmsOwner: "Dusty Rhodes",
     dueDate: "2024-08-15",

--- a/client/src/pages/DeliverablesPage.test.tsx
+++ b/client/src/pages/DeliverablesPage.test.tsx
@@ -1,16 +1,30 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as UserContext from "components/user/UserContext";
 
 import { DeliverablesPage } from "./DeliverablesPage";
 import { MOCK_DELIVERABLES } from "mock-data/deliverableMocks";
+import { mockUsers } from "mock-data/userMocks";
+
+vi.mock("components/user/UserContext", async (importOriginal) => {
+  const actual = await importOriginal<typeof UserContext>();
+  return {
+    ...actual,
+    getCurrentUser: vi.fn(),
+  };
+});
 
 describe("DeliverablesPage tab persistence", () => {
   const TAB_KEY = "selectedDeliverableTab";
   const CURRENT_USER_ID = "dustyrhodes";
+  const mockGetCurrentUser = vi.mocked(UserContext.getCurrentUser);
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetCurrentUser.mockReturnValue({
+      currentUser: mockUsers[0],
+    });
     sessionStorage.clear();
   });
 
@@ -80,5 +94,23 @@ describe("DeliverablesPage tab persistence", () => {
     expect(screen.getByText("Budget Neutrality Report")).toBeInTheDocument();
     expect(screen.getByText("Quarterly Report For NYC Demonstration")).toBeInTheDocument();
     expect(screen.getByText("Deliverable 8")).toBeInTheDocument();
+  });
+
+  it("uses state-user table columns when current user is demos-state-user", () => {
+    mockGetCurrentUser.mockReturnValue({
+      currentUser: {
+        ...mockUsers[0],
+        person: {
+          ...mockUsers[0].person,
+          personType: "demos-state-user",
+        },
+      },
+    });
+
+    render(<DeliverablesPage />);
+
+    expect(screen.queryByRole("columnheader", { name: /State\/Territory/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: /CMS Owner/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /Demonstration Name/i })).toBeInTheDocument();
   });
 });

--- a/client/src/pages/DeliverablesPage.test.tsx
+++ b/client/src/pages/DeliverablesPage.test.tsx
@@ -113,4 +113,39 @@ describe("DeliverablesPage tab persistence", () => {
     expect(screen.queryByRole("columnheader", { name: /CMS Owner/i })).not.toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: /Demonstration Name/i })).toBeInTheDocument();
   });
+
+  it("shows All Deliverables tab for demos-state-user", () => {
+    mockGetCurrentUser.mockReturnValue({
+      currentUser: {
+        ...mockUsers[0],
+        person: {
+          ...mockUsers[0].person,
+          personType: "demos-state-user",
+        },
+      },
+    });
+
+    render(<DeliverablesPage />);
+
+    expect(screen.getByTestId("button-deliverables")).toBeInTheDocument();
+    expect(screen.getByTestId("button-my-deliverables")).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("uses stored deliverables tab for demos-state-user", () => {
+    mockGetCurrentUser.mockReturnValue({
+      currentUser: {
+        ...mockUsers[0],
+        person: {
+          ...mockUsers[0].person,
+          personType: "demos-state-user",
+        },
+      },
+    });
+    sessionStorage.setItem(TAB_KEY, "deliverables");
+
+    render(<DeliverablesPage />);
+
+    expect(sessionStorage.getItem(TAB_KEY)).toBe("deliverables");
+    expect(screen.getByTestId("button-deliverables")).toHaveAttribute("aria-selected", "true");
+  });
 });

--- a/client/src/pages/DeliverablesPage.tsx
+++ b/client/src/pages/DeliverablesPage.tsx
@@ -1,12 +1,13 @@
 import { DeliverableTable } from "components/table/tables/DeliverableTable";
-import type { DeliverableTableViewMode } from "components/table/tables/DeliverableTable";
 import { getCurrentUser } from "components/user/UserContext";
 import { HorizontalSectionTabs, Tab } from "layout/Tabs";
 import React from "react";
+import { PersonType } from "demos-server";
+import { useSessionTab } from "hooks/useSessionTab";
 
 import { MOCK_DELIVERABLES } from "mock-data/deliverableMocks";
 
-/* TODO: Probably replace with like Pick<Deliverable, "id" | ... > when schema is defined */
+/* TODO: Probably replace with Pick<Deliverable, "id" | ... > when schema is defined */
 export type Deliverable = {
   id: string;
   deliverableName: string;
@@ -31,12 +32,13 @@ type DeliverablesPageQueryResult = {
   deliverables: Deliverable[];
   currentUserId: string;
 };
+type DeliverableTableViewMode = Exclude<PersonType, "non-user-contact">;
 
 export const DeliverablesPage: React.FC = () => {
   const { currentUser } = getCurrentUser();
-  const viewMode: DeliverableTableViewMode =
-    currentUser?.person.personType === "demos-state-user" ? "stateUser" : "cmsUser";
-
+  const rawPersonType = currentUser?.person.personType;
+  // Note. currentUser type by default cannot be non-user-contact.
+  const viewMode = rawPersonType as DeliverableTableViewMode;
   // Placeholder query-state shape until this page is wired to real API data.
   const [loading] = React.useState(false);
   const [error] = React.useState<Error | undefined>(undefined);
@@ -50,35 +52,35 @@ export const DeliverablesPage: React.FC = () => {
   //   DELIVERABLES_PAGE_QUERY
   // );
 
-  const deliverables = data?.deliverables || [];
-  const myDeliverables = deliverables.filter((d) => d.primaryContact?.id === data?.currentUserId);
+  const deliverables = data?.deliverables ?? [];
+  const myDeliverables = deliverables.filter(
+    (deliverable) => deliverable.primaryContact?.id === data?.currentUserId
+  );
 
-  const tabDeliKey = "selectedDeliverableTab";
-  let tabValue = "my-deliverables";
-
-  // Go back to the tab you came from.
-  if (typeof window !== "undefined") {
-    const stored = sessionStorage.getItem(tabDeliKey);
-    tabValue = ["my-deliverables", "deliverables"].includes(stored ?? "") ? stored! : tabValue;
-    sessionStorage.setItem(tabDeliKey, tabValue);
-  }
+  const [tabValue, onTabSelect] = useSessionTab({
+    key: "selectedDeliverableTab",
+    defaultValue: "my-deliverables",
+    allowedValues: ["my-deliverables", "deliverables"],
+  });
 
   return (
     <div className="shadow-md bg-white p-[16px]">
       <h1 className="text-[20px] font-bold mb-[24px] text-brand uppercase border-b-1 pb-[8px]">
         Deliverables
       </h1>
+
       {loading && <div className="p-4">Loading deliverables...</div>}
       {error && <div className="p-4 text-red-500">Error loading deliverables.</div>}
+
       {data && (
         <HorizontalSectionTabs
           defaultValue={tabValue}
-          onSelect={(value) => sessionStorage.setItem(tabDeliKey, value)}
+          onSelect={onTabSelect}
         >
           <Tab label={`My Deliverables (${myDeliverables.length})`} value="my-deliverables">
             <DeliverableTable
               deliverables={myDeliverables}
-              emptyRowsMessage={"You have no assigned Deliverables at this time"}
+              emptyRowsMessage="You have no assigned Deliverables at this time"
               viewMode={viewMode}
             />
           </Tab>

--- a/client/src/pages/DeliverablesPage.tsx
+++ b/client/src/pages/DeliverablesPage.tsx
@@ -1,4 +1,5 @@
 import { DeliverableTable } from "components/table/tables/DeliverableTable";
+import type { DeliverableTableViewMode } from "components/table/tables/DeliverableTable";
 import { getCurrentUser } from "components/user/UserContext";
 import { HorizontalSectionTabs, Tab } from "layout/Tabs";
 import React from "react";
@@ -33,7 +34,8 @@ type DeliverablesPageQueryResult = {
 
 export const DeliverablesPage: React.FC = () => {
   const { currentUser } = getCurrentUser();
-  const isStateUser = currentUser?.person.personType === "demos-state-user";
+  const viewMode: DeliverableTableViewMode =
+    currentUser?.person.personType === "demos-state-user" ? "stateUser" : "cmsUser";
 
   // Placeholder query-state shape until this page is wired to real API data.
   const [loading] = React.useState(false);
@@ -77,13 +79,13 @@ export const DeliverablesPage: React.FC = () => {
             <DeliverableTable
               deliverables={myDeliverables}
               emptyRowsMessage={"You have no assigned Deliverables at this time"}
-              viewMode={isStateUser ? "stateUser" : "default"}
+              viewMode={viewMode}
             />
           </Tab>
           <Tab label={`All Deliverables (${deliverables.length})`} value="deliverables">
             <DeliverableTable
               deliverables={deliverables}
-              viewMode={isStateUser ? "stateUser" : "default"}
+              viewMode={viewMode}
             />
           </Tab>
         </HorizontalSectionTabs>

--- a/client/src/pages/DeliverablesPage.tsx
+++ b/client/src/pages/DeliverablesPage.tsx
@@ -1,4 +1,5 @@
 import { DeliverableTable } from "components/table/tables/DeliverableTable";
+import { getCurrentUser } from "components/user/UserContext";
 import { HorizontalSectionTabs, Tab } from "layout/Tabs";
 import React from "react";
 
@@ -31,6 +32,9 @@ type DeliverablesPageQueryResult = {
 };
 
 export const DeliverablesPage: React.FC = () => {
+  const { currentUser } = getCurrentUser();
+  const isStateUser = currentUser?.person.personType === "demos-state-user";
+
   // Placeholder query-state shape until this page is wired to real API data.
   const [loading] = React.useState(false);
   const [error] = React.useState<Error | undefined>(undefined);
@@ -73,10 +77,14 @@ export const DeliverablesPage: React.FC = () => {
             <DeliverableTable
               deliverables={myDeliverables}
               emptyRowsMessage={"You have no assigned Deliverables at this time"}
+              viewMode={isStateUser ? "stateUser" : "default"}
             />
           </Tab>
           <Tab label={`All Deliverables (${deliverables.length})`} value="deliverables">
-            <DeliverableTable deliverables={deliverables} />
+            <DeliverableTable
+              deliverables={deliverables}
+              viewMode={isStateUser ? "stateUser" : "default"}
+            />
           </Tab>
         </HorizontalSectionTabs>
       )}

--- a/client/src/pages/DemonstrationsPage.tsx
+++ b/client/src/pages/DemonstrationsPage.tsx
@@ -10,6 +10,7 @@ import {
   User,
 } from "demos-server";
 import { Tab, HorizontalSectionTabs } from "layout/Tabs";
+import { useSessionTab } from "hooks/useSessionTab";
 
 export const DEMONSTRATIONS_PAGE_QUERY = gql`
   query GetDemonstrationsPage {
@@ -72,15 +73,12 @@ export const DemonstrationsPage: React.FC = () => {
   const myDemonstrations = demonstrations.filter(
     (d) => d.primaryProjectOfficer.id === data?.currentUser.id
   );
-
-  const tabDemoKey = "selectedDemonstrationTab";
-  let tabValue = "my-demonstrations";
-
-  if (typeof window !== "undefined") {
-    const stored = sessionStorage.getItem(tabDemoKey);
-    tabValue = ["my-demonstrations", "demonstrations"].includes(stored ?? "") ? stored! : tabValue;
-    sessionStorage.setItem(tabDemoKey, tabValue);
-  }
+  // Sets session to remember which tab you were on.
+  const [tabValue, onTabSelect] = useSessionTab({
+    key: "selectedDemonstrationTab",
+    defaultValue: "my-demonstrations",
+    allowedValues: ["my-demonstrations", "demonstrations"],
+  });
 
   return (
     <div className="shadow-md bg-white p-[16px]">
@@ -92,7 +90,7 @@ export const DemonstrationsPage: React.FC = () => {
       {data && (
         <HorizontalSectionTabs
           defaultValue={tabValue}
-          onSelect={(value) => sessionStorage.setItem(tabDemoKey, value)}
+          onSelect={onTabSelect}
         >
           <Tab label={`My Demonstrations (${myDemonstrations.length})`} value="my-demonstrations">
             <DemonstrationTable


### PR DESCRIPTION
Added state user view, refactored some stuff, Including centralizing the session remember of which tab you were on, and fixed issue with table. (see SS)

Added some test coverage. 
Made the viewMode PERSON_TYPE_ID since this is natural and made sense to me instead of adding new strings for it. 

<img width="1500" height="auto" alt="Screenshot 2026-04-08 at 14 59 02" src="https://github.com/user-attachments/assets/978551a9-b99e-41d7-ae7d-9ff0422afb69" />


<img width="700" height="auto" alt="Screenshot 2026-04-09 at 13 26 28" src="https://github.com/user-attachments/assets/fc777830-b8c5-4916-a3d1-d43ee5a7fa5e" />

Fix: 
<img width="700" height="auto" alt="Screenshot 2026-04-09 at 14 02 25" src="https://github.com/user-attachments/assets/a3b1e32a-35a2-43a1-b5df-abecb32d8b9c" />
