### PR TITLE
DEMOS-1795 Phase 3 Declare Incomplete clears dates

### DIFF
--- a/client/src/components/application/phases/CompletenessPhase.test.tsx
+++ b/client/src/components/application/phases/CompletenessPhase.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { TestProvider } from "test-utils/TestProvider";
@@ -89,6 +89,7 @@ describe("CompletenessPhase", () => {
     applicationId: "app-123",
     applicationIntakeComplete: true,
     completenessComplete: false,
+    completenessIncomplete: false,
     completenessReviewDate: "2026-02-28",
     stateDeemedCompleteDate: "",
     completenessDocuments: [],
@@ -233,6 +234,47 @@ describe("CompletenessPhase", () => {
       expect(mockDeclareCompletenessPhaseIncomplete).toHaveBeenCalledWith("app-123");
     });
 
+    it("clears all date pickers when phase is Incomplete even if a Completeness Letter document exists", () => {
+      setup({
+        completenessIncomplete: true,
+        completenessDocuments: [mockCompletenessDoc, mockInternalDoc],
+        stateDeemedCompleteDate: "",
+      });
+
+      expect(screen.getByTestId(STATE_DEEMED_COMPLETE_DATEPICKER_NAME)).toHaveValue("");
+      expect(screen.getByTestId(FEDERAL_COMMENT_START_DATEPICKER_NAME)).toHaveValue("");
+      expect(screen.getByTestId(FEDERAL_COMMENT_END_DATEPICKER_NAME)).toHaveValue("");
+    });
+
+    it("clears a user-selected date when phase transitions to Incomplete", () => {
+      const { rerender } = render(
+        <TestProvider>
+          <CompletenessPhase
+            {...defaultProps}
+            completenessDocuments={[mockCompletenessDoc, mockInternalDoc]}
+          />
+        </TestProvider>
+      );
+
+      const dateInput = screen.getByTestId(STATE_DEEMED_COMPLETE_DATEPICKER_NAME);
+      fireEvent.change(dateInput, { target: { value: "2026-03-15" } });
+      expect(dateInput).toHaveValue("2026-03-15");
+
+      rerender(
+        <TestProvider>
+          <CompletenessPhase
+            {...defaultProps}
+            completenessIncomplete={true}
+            completenessDocuments={[mockCompletenessDoc, mockInternalDoc]}
+          />
+        </TestProvider>
+      );
+
+      expect(screen.getByTestId(STATE_DEEMED_COMPLETE_DATEPICKER_NAME)).toHaveValue("");
+      expect(screen.getByTestId(FEDERAL_COMMENT_START_DATEPICKER_NAME)).toHaveValue("");
+      expect(screen.getByTestId(FEDERAL_COMMENT_END_DATEPICKER_NAME)).toHaveValue("");
+    });
+
     it("disables Declare Incomplete button when completeness is complete", () => {
       setup({
         completenessComplete: true,
@@ -343,6 +385,7 @@ describe("CompletenessPhase", () => {
             applicationIntakeComplete={true}
             completenessReviewDate={reviewDate}
             completenessComplete={false}
+            completenessIncomplete={false}
             stateDeemedCompleteDate=""
             completenessDocuments={[]}
             setSelectedPhase={mockSetSelectedPhase}
@@ -371,6 +414,7 @@ describe("CompletenessPhase", () => {
             applicationIntakeComplete={true}
             completenessReviewDate={undefined}
             completenessComplete={true}
+            completenessIncomplete={false}
             stateDeemedCompleteDate=""
             completenessDocuments={[]}
             setSelectedPhase={mockSetSelectedPhase}
@@ -441,5 +485,28 @@ describe("getApplicationCompletenessFromApplication", () => {
     });
     expect(screen.getByText("Completeness Letter")).toBeInTheDocument();
     expect(screen.queryByText("Internal Form")).not.toBeInTheDocument();
+  });
+
+  it("does not auto-fill dates from a Completeness Letter document when phase is Incomplete", () => {
+    setup({
+      phases: [
+        {
+          phaseName: "Application Intake",
+          phaseStatus: "Started",
+          phaseDates: [],
+          phaseNotes: [],
+        },
+        {
+          phaseName: "Completeness",
+          phaseStatus: "Incomplete",
+          phaseDates: [],
+          phaseNotes: [],
+        },
+      ],
+      documents: [mockCompletenessDoc, mockInternalDoc],
+    });
+    expect(screen.getByTestId(STATE_DEEMED_COMPLETE_DATEPICKER_NAME)).toHaveValue("");
+    expect(screen.getByTestId(FEDERAL_COMMENT_START_DATEPICKER_NAME)).toHaveValue("");
+    expect(screen.getByTestId(FEDERAL_COMMENT_END_DATEPICKER_NAME)).toHaveValue("");
   });
 });

--- a/client/src/components/application/phases/CompletenessPhase.test.tsx
+++ b/client/src/components/application/phases/CompletenessPhase.test.tsx
@@ -88,8 +88,7 @@ describe("CompletenessPhase", () => {
   const defaultProps: CompletenessPhaseProps = {
     applicationId: "app-123",
     applicationIntakeComplete: true,
-    completenessComplete: false,
-    completenessIncomplete: false,
+    completenessPhaseStatus: "Started",
     completenessReviewDate: "2026-02-28",
     stateDeemedCompleteDate: "",
     completenessDocuments: [],
@@ -236,7 +235,7 @@ describe("CompletenessPhase", () => {
 
     it("clears all date pickers when phase is Incomplete even if a Completeness Letter document exists", () => {
       setup({
-        completenessIncomplete: true,
+        completenessPhaseStatus: "Incomplete",
         completenessDocuments: [mockCompletenessDoc, mockInternalDoc],
         stateDeemedCompleteDate: "",
       });
@@ -264,7 +263,7 @@ describe("CompletenessPhase", () => {
         <TestProvider>
           <CompletenessPhase
             {...defaultProps}
-            completenessIncomplete={true}
+            completenessPhaseStatus="Incomplete"
             completenessDocuments={[mockCompletenessDoc, mockInternalDoc]}
           />
         </TestProvider>
@@ -277,7 +276,7 @@ describe("CompletenessPhase", () => {
 
     it("disables Declare Incomplete button when completeness is complete", () => {
       setup({
-        completenessComplete: true,
+        completenessPhaseStatus: "Completed",
         completenessDocuments: [mockCompletenessDoc, mockInternalDoc],
         stateDeemedCompleteDate: "2026-02-05",
       });
@@ -384,8 +383,7 @@ describe("CompletenessPhase", () => {
             applicationId="app-123"
             applicationIntakeComplete={true}
             completenessReviewDate={reviewDate}
-            completenessComplete={false}
-            completenessIncomplete={false}
+            completenessPhaseStatus="Started"
             stateDeemedCompleteDate=""
             completenessDocuments={[]}
             setSelectedPhase={mockSetSelectedPhase}
@@ -413,8 +411,7 @@ describe("CompletenessPhase", () => {
             applicationId="app-123"
             applicationIntakeComplete={true}
             completenessReviewDate={undefined}
-            completenessComplete={true}
-            completenessIncomplete={false}
+            completenessPhaseStatus="Completed"
             stateDeemedCompleteDate=""
             completenessDocuments={[]}
             setSelectedPhase={mockSetSelectedPhase}

--- a/client/src/components/application/phases/CompletenessPhase.tsx
+++ b/client/src/components/application/phases/CompletenessPhase.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 
 import { Button, SecondaryButton } from "components/button";
 import { ExportIcon } from "components/icons";
@@ -12,6 +12,7 @@ import {
   ApplicationDateInput,
   LocalDate,
   PhaseName,
+  PhaseStatus,
 } from "demos-server";
 import { useDialog } from "components/dialog/DialogContext";
 import { useSetApplicationDates } from "components/application/date/dateQueries";
@@ -138,8 +139,7 @@ export const getApplicationCompletenessFromApplication = (
       applicationId={application.id}
       applicationIntakeComplete={applicationIntakePhase?.phaseStatus === "Completed"}
       completenessReviewDate={findDate("Completeness Review Due Date")}
-      completenessComplete={completenessPhase?.phaseStatus === "Completed"}
-      completenessIncomplete={completenessPhase?.phaseStatus === "Incomplete"}
+      completenessPhaseStatus={completenessPhase?.phaseStatus ?? "Not Started"}
       stateDeemedCompleteDate={findDate("State Application Deemed Complete")}
       completenessDocuments={completenessDocuments}
       setSelectedPhase={setSelectedPhase}
@@ -165,8 +165,7 @@ export interface CompletenessPhaseProps {
   applicationId: string;
   applicationIntakeComplete: boolean;
   completenessReviewDate?: string;
-  completenessComplete: boolean;
-  completenessIncomplete: boolean;
+  completenessPhaseStatus: PhaseStatus;
   stateDeemedCompleteDate: string;
   completenessDocuments: ApplicationWorkflowDocument[];
   setSelectedPhase: (phase: PhaseName) => void;
@@ -176,12 +175,14 @@ export const CompletenessPhase = ({
   applicationId,
   applicationIntakeComplete,
   completenessReviewDate,
-  completenessComplete,
-  completenessIncomplete,
+  completenessPhaseStatus,
   stateDeemedCompleteDate,
   completenessDocuments,
   setSelectedPhase,
 }: CompletenessPhaseProps) => {
+  const completenessComplete = completenessPhaseStatus === "Completed";
+  const completenessIncomplete = completenessPhaseStatus === "Incomplete";
+
   const { showCompletenessDocumentUploadDialog, showDeclareIncompleteDialog } = useDialog();
   const { showSuccess, showError } = useToast();
   const { setApplicationDates } = useSetApplicationDates();
@@ -191,19 +192,14 @@ export const CompletenessPhase = ({
   const [userSelectedStateDeemedCompleteDate, setUserSelectedStateDeemedCompleteDate] =
     useState("");
 
-  useEffect(() => {
-    if (completenessIncomplete) {
-      setUserSelectedStateDeemedCompleteDate("");
-    }
-  }, [completenessIncomplete]);
-
   const calculatedStateDeemedCompleteDate = calculateStateDeemedCompleteDate(
     stateDeemedCompleteDate,
     completenessDocuments,
     completenessIncomplete
   );
-  const stateDeemedComplete =
-    userSelectedStateDeemedCompleteDate || calculatedStateDeemedCompleteDate;
+  const stateDeemedComplete = completenessIncomplete
+    ? ""
+    : userSelectedStateDeemedCompleteDate || calculatedStateDeemedCompleteDate;
   const { federalStartDate, federalEndDate } =
     calculateFederalCommentPeriodDates(stateDeemedComplete);
 

--- a/client/src/components/application/phases/CompletenessPhase.tsx
+++ b/client/src/components/application/phases/CompletenessPhase.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 import { Button, SecondaryButton } from "components/button";
 import { ExportIcon } from "components/icons";
@@ -139,6 +139,7 @@ export const getApplicationCompletenessFromApplication = (
       applicationIntakeComplete={applicationIntakePhase?.phaseStatus === "Completed"}
       completenessReviewDate={findDate("Completeness Review Due Date")}
       completenessComplete={completenessPhase?.phaseStatus === "Completed"}
+      completenessIncomplete={completenessPhase?.phaseStatus === "Incomplete"}
       stateDeemedCompleteDate={findDate("State Application Deemed Complete")}
       completenessDocuments={completenessDocuments}
       setSelectedPhase={setSelectedPhase}
@@ -148,9 +149,11 @@ export const getApplicationCompletenessFromApplication = (
 
 const calculateStateDeemedCompleteDate = (
   stateDeemedCompleteDate: string,
-  completenessDocuments: ApplicationWorkflowDocument[]
+  completenessDocuments: ApplicationWorkflowDocument[],
+  completenessIncomplete: boolean
 ): string => {
   if (stateDeemedCompleteDate) return stateDeemedCompleteDate;
+  if (completenessIncomplete) return "";
   const applicationCompletenessLetter = completenessDocuments.find(
     (doc) => doc.documentType === "Application Completeness Letter"
   );
@@ -163,6 +166,7 @@ export interface CompletenessPhaseProps {
   applicationIntakeComplete: boolean;
   completenessReviewDate?: string;
   completenessComplete: boolean;
+  completenessIncomplete: boolean;
   stateDeemedCompleteDate: string;
   completenessDocuments: ApplicationWorkflowDocument[];
   setSelectedPhase: (phase: PhaseName) => void;
@@ -173,6 +177,7 @@ export const CompletenessPhase = ({
   applicationIntakeComplete,
   completenessReviewDate,
   completenessComplete,
+  completenessIncomplete,
   stateDeemedCompleteDate,
   completenessDocuments,
   setSelectedPhase,
@@ -186,9 +191,16 @@ export const CompletenessPhase = ({
   const [userSelectedStateDeemedCompleteDate, setUserSelectedStateDeemedCompleteDate] =
     useState("");
 
+  useEffect(() => {
+    if (completenessIncomplete) {
+      setUserSelectedStateDeemedCompleteDate("");
+    }
+  }, [completenessIncomplete]);
+
   const calculatedStateDeemedCompleteDate = calculateStateDeemedCompleteDate(
     stateDeemedCompleteDate,
-    completenessDocuments
+    completenessDocuments,
+    completenessIncomplete
   );
   const stateDeemedComplete =
     userSelectedStateDeemedCompleteDate || calculatedStateDeemedCompleteDate;


### PR DESCRIPTION
On Phase 3 (Completeness), clicking **Declare Incomplete** didn't clear the date pickers.

The server cleared the dates in the DB, but the client was auto-filling them again from the uploaded document's upload time.

Client-only change in `CompletenessPhase.tsx`: when the phase is `"Incomplete"`, skip the auto-fill and clear any date the user had typed in. No server changes, no new functions.


https://github.com/user-attachments/assets/8de16c29-45ac-439a-9190-eb27c98d8293

