### PR TITLE
DEMOS-1771: Close ConfirmApprovalDialog Upon Clicking "Approve" Button

### DIFF
--- a/client/src/components/dialog/ConfirmApproveDialog.test.tsx
+++ b/client/src/components/dialog/ConfirmApproveDialog.test.tsx
@@ -5,26 +5,19 @@ import { describe, it, expect, vi, beforeAll } from "vitest";
 
 import { ConfirmApproveDialog } from "./ConfirmApproveDialog";
 import { WorkflowApplicationType } from "components/application";
-
-beforeAll(() => {
-  HTMLDialogElement.prototype.showModal = vi.fn();
-  HTMLDialogElement.prototype.close = vi.fn();
-});
+import { DialogProvider } from "./DialogContext";
 
 describe("ConfirmApproveDialog", () => {
   const setup = (applicationType: WorkflowApplicationType = "demonstration") => {
-    const onClose = vi.fn();
     const onConfirm = vi.fn();
 
     render(
-      <ConfirmApproveDialog
-        onClose={onClose}
-        onConfirm={onConfirm}
-        applicationType={applicationType}
-      />
+      <DialogProvider>
+        <ConfirmApproveDialog onConfirm={onConfirm} applicationType={applicationType} />
+      </DialogProvider>
     );
 
-    return { onClose, onConfirm };
+    return { onConfirm };
   };
 
   it("renders dialog content", () => {
@@ -34,30 +27,7 @@ describe("ConfirmApproveDialog", () => {
     expect(
       screen.getByText(/final submission of this approved demonstration/i)
     ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("button-ca-dialog-approve")
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("button-ca-dialog-cancel")
-    ).toBeInTheDocument();
-  });
-
-  it("calls onClose when close (×) button is clicked", async () => {
-    const user = userEvent.setup();
-    const { onClose } = setup();
-
-    await user.click(screen.getByTestId("button-ca-dialog-close"));
-
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls onClose when cancel button is clicked", async () => {
-    const user = userEvent.setup();
-    const { onClose } = setup();
-
-    await user.click(screen.getByTestId("button-ca-dialog-cancel"));
-
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("button-ca-dialog-approve")).toBeInTheDocument();
   });
 
   it("calls onConfirm when submit button is clicked", async () => {
@@ -72,8 +42,6 @@ describe("ConfirmApproveDialog", () => {
   it("shows correct application type in message", () => {
     setup("amendment");
 
-    expect(
-      screen.getByText(/final submission of this approved amendment/i)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/final submission of this approved amendment/i)).toBeInTheDocument();
   });
 });

--- a/client/src/components/dialog/ConfirmApproveDialog.test.tsx
+++ b/client/src/components/dialog/ConfirmApproveDialog.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi, beforeAll } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { ConfirmApproveDialog } from "./ConfirmApproveDialog";
 import { WorkflowApplicationType } from "components/application";

--- a/client/src/components/dialog/ConfirmApproveDialog.tsx
+++ b/client/src/components/dialog/ConfirmApproveDialog.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useRef } from "react";
+import React from "react";
 
-import { Button, SecondaryButton } from "components/button";
-import { tw } from "tags/tw";
+import { Button } from "components/button";
 import { WorkflowApplicationType } from "components/application";
+import { BaseDialog } from "./BaseDialog";
 
 interface ConfirmApproveDialogProps {
   onClose: () => void;
@@ -10,55 +10,36 @@ interface ConfirmApproveDialogProps {
   applicationType: WorkflowApplicationType;
 }
 
-const STYLES = {
-  CONFIRMATION_DIALOG: tw`bg-surface-white border border-border-rules rounded w-[600px] shadow-md text-center backdrop:bg-black/40`,
-  CLOSE_BUTTON: tw`absolute top-xs right-sm text-[24px] text-text-placeholder hover:text-text-font cursor-pointer`,
-  TITLE: tw`text-[18px] font-bold self-start p-1 pl-2 pt-2`,
-  MESSAGE: tw`flex flex-col gap-1 border-y-1 border-border-rules p-2 items-start text-left`,
-  BUTTONS: tw`flex self-end gap-md p-1`,
-};
-
 export const ConfirmApproveDialog: React.FC<ConfirmApproveDialogProps> = ({
   onClose,
   onConfirm,
   applicationType,
 }) => {
-  const confirmDialogRef = useRef<HTMLDialogElement>(null);
-
-  useEffect(() => {
-    confirmDialogRef.current?.showModal();
-  }, []);
-
-  const handleBackdropClick = (e: React.MouseEvent<HTMLDialogElement>) => {
-    const dialog = confirmDialogRef.current;
-    if (dialog && e.target === dialog) {
-      onClose();
-    }
+  const handleSubmitClicked = () => {
+    onConfirm();
+    onClose();
   };
 
   return (
-    <dialog
-      ref={confirmDialogRef}
-      className={STYLES.CONFIRMATION_DIALOG}
-      onClick={handleBackdropClick}
+    <BaseDialog
+      name="button-ca-dialog-close"
+      title="ARE YOU SURE?"
+      onClose={onClose}
+      dialogHasChanges={false}
+      maxWidthClass="max-w-[600px]"
+      actionButton={
+        <Button name="button-ca-dialog-approve" onClick={handleSubmitClicked}>
+          Submit Approved Demonstration
+        </Button>
+      }
     >
-      <div className="flex flex-col">
-        <button data-testid="button-ca-dialog-close" onClick={onClose} className={STYLES.CLOSE_BUTTON} aria-label="Close dialog">
-          ×
-        </button>
-        <h2 className={STYLES.TITLE}>ARE YOU SURE?</h2>
-        <div className={STYLES.MESSAGE}>
-          <span>Are you sure? By hitting accept you will be making the final submission of this approved {applicationType}. This will finalize the approval process and move the demonstration to the deliverables phase.</span>
-        </div>
-        <div className={STYLES.BUTTONS}>
-          <SecondaryButton name="button-ca-dialog-cancel" onClick={onClose}>
-            Cancel
-          </SecondaryButton>
-          <Button name="button-ca-dialog-approve" onClick={onConfirm}>
-            Submit Approved Demonstration
-          </Button>
-        </div>
+      <div className="flex flex-col gap-1 items-start text-left">
+        <span>
+          Are you sure? By hitting accept you will be making the final submission of this approved{" "}
+          {applicationType}. This will finalize the approval process and move the demonstration to
+          the deliverables phase.
+        </span>
       </div>
-    </dialog>
+    </BaseDialog>
   );
 };

--- a/client/src/components/dialog/ConfirmApproveDialog.tsx
+++ b/client/src/components/dialog/ConfirmApproveDialog.tsx
@@ -3,29 +3,30 @@ import React from "react";
 import { Button } from "components/button";
 import { WorkflowApplicationType } from "components/application";
 import { BaseDialog } from "./BaseDialog";
+import { useDialog } from "./DialogContext";
 
 interface ConfirmApproveDialogProps {
-  onClose: () => void;
   onConfirm: () => void;
   applicationType: WorkflowApplicationType;
 }
 
 export const ConfirmApproveDialog: React.FC<ConfirmApproveDialogProps> = ({
-  onClose,
   onConfirm,
   applicationType,
 }) => {
+  const { closeDialog } = useDialog();
+
   const handleSubmitClicked = () => {
     onConfirm();
-    onClose();
+    closeDialog();
   };
 
   return (
     <BaseDialog
       name="button-ca-dialog-close"
       title="ARE YOU SURE?"
-      onClose={onClose}
       dialogHasChanges={false}
+      onClose={closeDialog}
       maxWidthClass="max-w-[600px]"
       actionButton={
         <Button name="button-ca-dialog-approve" onClick={handleSubmitClicked}>

--- a/client/src/components/dialog/DialogContext.test.tsx
+++ b/client/src/components/dialog/DialogContext.test.tsx
@@ -336,17 +336,6 @@ vi.mock("./ApplyTagsDialog", () => ({
   ),
 }));
 
-vi.mock("./ConfirmApproveDialog", () => ({
-  ConfirmApproveDialog: ({ onClose }: { onClose: () => void }) => (
-    <div data-testid="confirm-approve-dialog">
-      Confirm Approve Dialog
-      <button data-testid="close-confirm-approve-btn" onClick={onClose}>
-        Close
-      </button>
-    </div>
-  ),
-}));
-
 const mockRoles: ExistingContactType[] = [
   {
     id: "person-1",
@@ -871,22 +860,5 @@ describe("DialogContext", () => {
 
     await user.click(screen.getByTestId("close-apply-tags-btn"));
     expect(screen.queryByTestId("apply-tags-dialog")).not.toBeInTheDocument();
-  });
-  it("shows and hides ConfirmApproveDialog via context", async () => {
-    render(
-      <DialogProvider>
-        <TestConsumer />
-      </DialogProvider>
-    );
-
-    const user = userEvent.setup();
-
-    expect(screen.queryByTestId("confirm-approve-dialog")).not.toBeInTheDocument();
-
-    await user.click(screen.getByTestId("open-confirm-approve-btn"));
-    expect(screen.getByTestId("confirm-approve-dialog")).toBeInTheDocument();
-
-    await user.click(screen.getByTestId("close-confirm-approve-btn"));
-    expect(screen.queryByTestId("confirm-approve-dialog")).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/dialog/DialogContext.tsx
+++ b/client/src/components/dialog/DialogContext.tsx
@@ -225,11 +225,7 @@ export const useDialog = () => {
     applicationType: WorkflowApplicationType
   ) => {
     context.showDialog(
-      <ConfirmApproveDialog
-        onClose={context.hideDialog}
-        onConfirm={onConfirm}
-        applicationType={applicationType}
-      />
+      <ConfirmApproveDialog onConfirm={onConfirm} applicationType={applicationType} />
     );
   };
 

--- a/client/src/pages/debug/DialogSandbox.tsx
+++ b/client/src/pages/debug/DialogSandbox.tsx
@@ -40,6 +40,7 @@ export const DialogSandbox: React.FC = () => {
     showUpdateExtensionDialog,
     showUpdateAmendmentDialog,
     showAddDeliverableSlotDialog,
+    showConfirmApproveDialog,
   } = useDialog();
 
   const ID = "1";
@@ -208,6 +209,12 @@ export const DialogSandbox: React.FC = () => {
             }
           >
             Add Deliverable Slot(s)
+          </Button>
+          <Button
+            name="confirm-approve"
+            onClick={() => showConfirmApproveDialog(() => {}, "demonstration")}
+          >
+            Confirm Approve
           </Button>
         </div>
       </div>


### PR DESCRIPTION
Fix here was to utilize the `<BaseDialog>` component that handles this behavior already.

Good news is that the new `AGENTS.md` file would help prevent things like this in the future by making it clear to re-use this component


https://github.com/user-attachments/assets/e9f4d8cd-9e26-4a05-9f86-891c237f7143

