### PR TITLE
DEMOS-1878: Show "(Unapproved)" text next to demonstration types in the AddDeliverableSlotDialog

### DIFF
--- a/client/src/components/dialog/deliverable/AddDeliverableSlotDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/AddDeliverableSlotDialog.test.tsx
@@ -107,7 +107,9 @@ describe("AddDeliverableSlotDialog", () => {
     await user.click(screen.getByTestId(SELECT_DEMONSTRATION_TYPE_NAME));
 
     MOCK_DEMONSTRATION_TYPE_TAGS.forEach((type) => {
-      expect(screen.getByText(type.tagName)).toBeInTheDocument();
+      const displayText =
+        type.approvalStatus === "Unapproved" ? `${type.tagName} (Unapproved)` : type.tagName;
+      expect(screen.getByText(displayText)).toBeInTheDocument();
     });
   });
 });

--- a/client/src/components/dialog/deliverable/AddDeliverableSlotDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/AddDeliverableSlotDialog.test.tsx
@@ -12,14 +12,16 @@ import { SELECT_DEMONSTRATION_TYPE_NAME } from "components/dialog/deliverable/fi
 import { DELIVERABLE_TYPE_SELECT_NAME } from "components/dialog/deliverable/fields/DeliverableTypeField";
 import { personMocks } from "mock-data/personMocks";
 import { AddDeliverableSlotDemonstration } from "./AddDeliverableSlotDialog";
+import { Tag } from "demos-server";
 
-const MOCK_DEMONSTRATION_TYPES: string[] = [
-  "Aggregate Cap",
-  "Annual Limits",
-  "Basic Health Plan (BHP)",
+const MOCK_DEMONSTRATION_TYPE_TAGS: Tag[] = [
+  { tagName: "Aggregate Cap", approvalStatus: "Approved" },
+  { tagName: "Annual Limits", approvalStatus: "Unapproved" },
+  { tagName: "Basic Health Plan (BHP)", approvalStatus: "Approved" },
 ];
+
 const DEFAULT_DEMONSTRATION: AddDeliverableSlotDemonstration = {
-  demonstrationTypes: MOCK_DEMONSTRATION_TYPES,
+  demonstrationTypes: MOCK_DEMONSTRATION_TYPE_TAGS,
   effectiveDate: new Date("2024-01-01"),
   expirationDate: new Date("2026-12-31"),
 };
@@ -104,8 +106,8 @@ describe("AddDeliverableSlotDialog", () => {
 
     await user.click(screen.getByTestId(SELECT_DEMONSTRATION_TYPE_NAME));
 
-    MOCK_DEMONSTRATION_TYPES.forEach((type) => {
-      expect(screen.getByText(type)).toBeInTheDocument();
+    MOCK_DEMONSTRATION_TYPE_TAGS.forEach((type) => {
+      expect(screen.getByText(type.tagName)).toBeInTheDocument();
     });
   });
 });

--- a/client/src/components/dialog/deliverable/AddDeliverableSlotDialog.tsx
+++ b/client/src/components/dialog/deliverable/AddDeliverableSlotDialog.tsx
@@ -9,7 +9,7 @@ import { DemonstrationTypeField } from "./fields/DemonstrationTypeField";
 import { ScheduleType, ScheduleTypeField } from "./fields/schedule-type/ScheduleTypeField";
 import { SingleDeliverableScheduleType } from "./fields/schedule-type/SingleDeliverableScheduleType";
 import { QuarterlyDeliverableSchedule } from "./fields/schedule-type/QuarterlyDeliverableSchedule";
-import { Demonstration } from "demos-server";
+import { Demonstration, Tag } from "demos-server";
 
 export const ADD_DELIVERABLE_SLOT_DIALOG_TITLE = "Add New Deliverable Slot(s)";
 export const ADD_DELIVERABLE_SLOT_DIALOG_NAME = "add-deliverable-slot-dialog";
@@ -53,7 +53,7 @@ export type AddDeliverableSlotDemonstration = Pick<
   Demonstration,
   "effectiveDate" | "expirationDate"
 > & {
-  demonstrationTypes: string[];
+  demonstrationTypes: Tag[];
 };
 
 export const AddDeliverableSlotDialog = ({
@@ -113,8 +113,8 @@ export const AddDeliverableSlotDialog = ({
             onSelect={(cmsOwnerId) => setFormData((prev) => ({ ...prev, cmsOwnerId }))}
           />
           <DemonstrationTypeField
-            options={demonstration.demonstrationTypes}
-            values={formData.demonstrationTypes}
+            demonstrationTypeTags={demonstration.demonstrationTypes}
+            selectedValues={formData.demonstrationTypes}
             onSelect={(selectedTypes) =>
               setFormData((prev) => ({ ...prev, demonstrationTypes: selectedTypes }))
             }

--- a/client/src/components/dialog/deliverable/fields/DemonstrationTypeField.test.tsx
+++ b/client/src/components/dialog/deliverable/fields/DemonstrationTypeField.test.tsx
@@ -4,20 +4,25 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 
 import { DemonstrationTypeField, SELECT_DEMONSTRATION_TYPE_NAME } from "./DemonstrationTypeField";
+import { Tag } from "demos-server";
 
-const MOCK_OPTIONS = ["Aggregate Cap", "Annual Limits", "Basic Health Plan (BHP)"];
+const MOCK_OPTIONS: Tag[] = [
+  { tagName: "Aggregate Cap", approvalStatus: "Approved" },
+  { tagName: "Annual Limits", approvalStatus: "Unapproved" },
+  { tagName: "Basic Health Plan (BHP)", approvalStatus: "Approved" },
+];
 
 describe("DemonstrationTypeField", () => {
   const setup = ({
     options = MOCK_OPTIONS,
-    values = [],
+    selectedValues = [],
     onSelect = vi.fn(),
     isRequired = false,
   } = {}) => {
     render(
       <DemonstrationTypeField
-        options={options}
-        values={values}
+        demonstrationTypeTags={options}
+        selectedValues={selectedValues}
         onSelect={onSelect}
         isRequired={isRequired}
       />
@@ -56,7 +61,7 @@ describe("DemonstrationTypeField", () => {
     await user.click(screen.getByTestId(SELECT_DEMONSTRATION_TYPE_NAME));
 
     MOCK_OPTIONS.forEach((option) => {
-      expect(screen.getByText(option)).toBeInTheDocument();
+      expect(screen.getByText(option.tagName)).toBeInTheDocument();
     });
   });
 

--- a/client/src/components/dialog/deliverable/fields/DemonstrationTypeField.test.tsx
+++ b/client/src/components/dialog/deliverable/fields/DemonstrationTypeField.test.tsx
@@ -61,7 +61,11 @@ describe("DemonstrationTypeField", () => {
     await user.click(screen.getByTestId(SELECT_DEMONSTRATION_TYPE_NAME));
 
     MOCK_OPTIONS.forEach((option) => {
-      expect(screen.getByText(option.tagName)).toBeInTheDocument();
+      const displayText =
+        option.approvalStatus === "Unapproved"
+          ? `${option.tagName} (Unapproved)`
+          : option.tagName;
+      expect(screen.getByText(displayText)).toBeInTheDocument();
     });
   });
 
@@ -81,7 +85,7 @@ describe("DemonstrationTypeField", () => {
 
     await user.click(screen.getByTestId(SELECT_DEMONSTRATION_TYPE_NAME));
     await user.click(screen.getByText("Aggregate Cap"));
-    await user.click(screen.getByText("Annual Limits"));
+    await user.click(screen.getByText("Annual Limits (Unapproved)"));
 
     expect(onSelect).toHaveBeenLastCalledWith(["Aggregate Cap", "Annual Limits"]);
   });
@@ -92,7 +96,7 @@ describe("DemonstrationTypeField", () => {
 
     await user.type(screen.getByTestId(SELECT_DEMONSTRATION_TYPE_NAME), "Annual");
 
-    expect(screen.getByText("Annual Limits")).toBeInTheDocument();
+    expect(screen.getByText("Annual Limits (Unapproved)")).toBeInTheDocument();
     expect(screen.queryByText("Aggregate Cap")).not.toBeInTheDocument();
   });
 

--- a/client/src/components/dialog/deliverable/fields/DemonstrationTypeField.tsx
+++ b/client/src/components/dialog/deliverable/fields/DemonstrationTypeField.tsx
@@ -1,28 +1,37 @@
 import React from "react";
 
 import { AutoCompleteMultiselect } from "components/input/select/AutoCompleteMultiselect";
+import { Tag } from "demos-server";
+import { Option } from "components/input/select/Select";
 
 export const SELECT_DEMONSTRATION_TYPE_NAME = "select-demonstration-type";
 
+export const getOptionsFromTags = (tags: Tag[]): Option[] => {
+  return tags.map((tag) => ({
+    value: tag.tagName,
+    label: tag.approvalStatus == "Unapproved" ? `${tag.tagName} (Unapproved)` : tag.tagName,
+  }));
+};
+
 export const DemonstrationTypeField = ({
-  options,
-  values,
+  demonstrationTypeTags,
+  selectedValues,
   onSelect,
   isRequired = false,
 }: {
-  options: string[];
-  values: string[];
+  demonstrationTypeTags: Tag[];
+  selectedValues: string[];
   onSelect: (values: string[]) => void;
   isRequired?: boolean;
 }) => {
-  const selectOptions = options.map((type) => ({ label: type, value: type }));
+  const selectOptions = getOptionsFromTags(demonstrationTypeTags);
 
   return (
     <AutoCompleteMultiselect
       id={SELECT_DEMONSTRATION_TYPE_NAME}
       label="Demonstration Type"
       options={selectOptions}
-      values={values}
+      values={selectedValues}
       onSelect={onSelect}
       isRequired={isRequired}
       placeholder="Select demonstration type…"

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
@@ -21,6 +21,7 @@ import {
   Document,
   Person,
   PhaseName,
+  Tag,
 } from "demos-server";
 import { Tab, VerticalTabs } from "layout/Tabs";
 import { SummaryDetailsTab } from "./SummaryDetailsTab";
@@ -82,9 +83,10 @@ export const DemonstrationTab: React.FC<{ demonstration: DemonstrationTabDemonst
   const isDemonstrationApproved = demonstration.status === "Approved";
   const defaultTab = isDemonstrationApproved ? TAB.DELIVERABLES : TAB.APPLICATION;
   const postApprovalDeliverables = getDeliverablesForDemonstration(demonstration.name);
-  const demonstrationTypeNames: string[] = demonstration.demonstrationTypes.map(
-    (dt) => dt.demonstrationTypeName
-  );
+  const demonstrationTypeTags: Tag[] = demonstration.demonstrationTypes.map((dt) => ({
+    tagName: dt.demonstrationTypeName,
+    approvalStatus: dt.approvalStatus,
+  }));
 
   return (
     <div className="p-[16px]">
@@ -97,7 +99,7 @@ export const DemonstrationTab: React.FC<{ demonstration: DemonstrationTabDemonst
         >
           <DeliverablesTab
             parentDemonstration={{
-              demonstrationTypes: demonstrationTypeNames,
+              demonstrationTypes: demonstrationTypeTags,
               effectiveDate: demonstration.effectiveDate,
               expirationDate: demonstration.expirationDate,
             }}

--- a/client/src/pages/debug/DialogSandbox.tsx
+++ b/client/src/pages/debug/DialogSandbox.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { gql, useQuery } from "@apollo/client";
 import { useDialog } from "components/dialog/DialogContext";
 import { Button } from "components/button";
-import { DocumentType } from "demos-server";
+import { DocumentType, Tag } from "demos-server";
 import { ExistingContactType } from "components/dialog/ManageContactsDialog";
 
 const DIALOG_SANDBOX_ID_QUERY = gql`
@@ -18,6 +18,12 @@ type DialogSandboxIdQueryResult = {
     id: string;
   }[];
 };
+
+const TAGS: Tag[] = [
+  { tagName: "Demonstration Type: Type A", approvalStatus: "Approved" },
+  { tagName: "Demonstration Type: Type B", approvalStatus: "Unapproved" },
+  { tagName: "Demonstration Type: Type C", approvalStatus: "Approved" },
+];
 
 export const DialogSandbox: React.FC = () => {
   const {
@@ -203,7 +209,7 @@ export const DialogSandbox: React.FC = () => {
             name="add-deliverable-slot"
             onClick={() =>
               showAddDeliverableSlotDialog({
-                demonstrationTypes: ["Demo Type 1", "Demo Type 2", "Demo Type 3"],
+                demonstrationTypes: TAGS,
               })
             }
           >


### PR DESCRIPTION
Adds a `(Unapproved)` text next to the demonstration type tags in the `AddDeliverableSlotDialog`

https://github.com/user-attachments/assets/c26b6c68-120f-48f7-b3da-f87281399eaf

