### PR TITLE
DEMOS-1838: Create or Edit Demonstration - DEMO ID - Medicaid or CHIP Selection

### DIFF
--- a/client/src/components/dialog/demonstration/CreateDemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/CreateDemonstrationDialog.tsx
@@ -13,6 +13,7 @@ const DEFAULT_DEMONSTRATION_DIALOG_FIELDS: DemonstrationDialogFields = {
   description: "",
   stateId: "",
   projectOfficerId: "",
+  demoIds: [],
 };
 
 const SUCCESS_MESSAGE = "Your demonstration is ready.";

--- a/client/src/components/dialog/demonstration/DemonstrationDialog.test.tsx
+++ b/client/src/components/dialog/demonstration/DemonstrationDialog.test.tsx
@@ -23,6 +23,7 @@ const DEFAULT_DEMONSTRATION = {
   description: "",
   stateId: "",
   projectOfficerId: "",
+  demoIds: ["medicaid"],
 };
 
 const DEFAULT_PROPS = {
@@ -309,6 +310,7 @@ describe("DemonstrationDialog", () => {
       expirationDate: "2024-12-31",
       sdgDivision: "Division of System Reform Demonstrations",
       signatureLevel: "OA",
+      demoIds: ["medicaid"],
     };
 
     it("returns false when demonstrations are identical", () => {

--- a/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
@@ -104,7 +104,8 @@ export const checkFormHasChanges = (
     updatedDemonstration.expirationDate !== initialDemonstration.expirationDate ||
     updatedDemonstration.sdgDivision !== initialDemonstration.sdgDivision ||
     updatedDemonstration.signatureLevel !== initialDemonstration.signatureLevel ||
-    updatedDemonstration.demoIds.join(",") !== initialDemonstration.demoIds.join(",")
+    [...updatedDemonstration.demoIds].sort((a, b) => a.localeCompare(b)).join(",") !==
+      [...initialDemonstration.demoIds].sort((a, b) => a.localeCompare(b)).join(",")
   );
 };
 
@@ -118,7 +119,7 @@ export const checkFormIsValid = (demonstration: DemonstrationDialogFields) => {
   if (!demonstration.projectOfficerId) {
     return false;
   }
-  if (!demonstration.demoIds || demonstration.demoIds.length === 0) {
+  if (demonstration.demoIds.length === 0) {
     return false;
   }
   if (

--- a/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 
 import { BaseDialog } from "components/dialog/BaseDialog";
 import { Textarea } from "components/input";
+import { Checkbox } from "components/input/Checkbox";
 import { SelectSdgDivision } from "components/input/select/SelectSdgDivision";
 import { SelectSignatureLevel } from "components/input/select/SelectSignatureLevel";
 import { SelectUSAStates } from "components/input/select/SelectUSAStates";
@@ -11,29 +12,42 @@ import { Demonstration } from "demos-server";
 import { DatePicker } from "components/input/date/DatePicker";
 import { EXPIRATION_DATE_ERROR_MESSAGE } from "util/messages";
 import { SubmitButton } from "components/button/SubmitButton";
+import { HintIcon } from "components/icons/Input/HintIcon";
 import { isBefore } from "date-fns";
 
 export type DemonstrationDialogMode = "create" | "edit";
 
+export const DEMO_ID_MEDICAID = "medicaid";
+export const DEMO_ID_CHIP = "chip";
+
+export const DEMO_ID_OPTIONS = [
+  { label: "Medicaid Demonstration", value: DEMO_ID_MEDICAID },
+  { label: "Children's Health Insurance Program (CHIP)", value: DEMO_ID_CHIP },
+];
+
 export type DemonstrationDialogFields = Pick<
   Demonstration,
   "name" | "description" | "sdgDivision" | "signatureLevel"
-> & { stateId: string; projectOfficerId: string; effectiveDate: string; expirationDate: string };
+> & {
+  stateId: string;
+  projectOfficerId: string;
+  effectiveDate: string;
+  expirationDate: string;
+  demoIds: string[];
+};
 
 const DemonstrationDescriptionTextArea: React.FC<{
   description?: string;
   setDescription: (value: string) => void;
 }> = ({ description, setDescription }) => {
   return (
-    <>
-      <Textarea
-        name="description"
-        label="Demonstration Description"
-        placeholder="Enter description"
-        initialValue={description ?? ""}
-        onChange={(e) => setDescription(e.target.value)}
-      />
-    </>
+    <Textarea
+      name="description"
+      label="Demonstration Description"
+      placeholder="Enter description"
+      initialValue={description ?? ""}
+      onChange={(e) => setDescription(e.target.value)}
+    />
   );
 };
 
@@ -89,7 +103,8 @@ export const checkFormHasChanges = (
     updatedDemonstration.effectiveDate !== initialDemonstration.effectiveDate ||
     updatedDemonstration.expirationDate !== initialDemonstration.expirationDate ||
     updatedDemonstration.sdgDivision !== initialDemonstration.sdgDivision ||
-    updatedDemonstration.signatureLevel !== initialDemonstration.signatureLevel
+    updatedDemonstration.signatureLevel !== initialDemonstration.signatureLevel ||
+    updatedDemonstration.demoIds.join(",") !== initialDemonstration.demoIds.join(",")
   );
 };
 
@@ -103,6 +118,9 @@ export const checkFormIsValid = (demonstration: DemonstrationDialogFields) => {
   if (!demonstration.projectOfficerId) {
     return false;
   }
+  if (!demonstration.demoIds || demonstration.demoIds.length === 0) {
+    return false;
+  }
   if (
     demonstration.expirationDate &&
     demonstration.effectiveDate &&
@@ -111,6 +129,45 @@ export const checkFormIsValid = (demonstration: DemonstrationDialogFields) => {
     return false;
   }
   return true;
+};
+
+const DemoIdCheckboxes: React.FC<{
+  values: string[];
+  onChange: (values: string[]) => void;
+}> = ({ values, onChange }) => {
+  const toggle = (value: string) => {
+    if (values.includes(value)) {
+      onChange(values.filter((v) => v !== value));
+    } else {
+      onChange([...values, value]);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-xs">
+      <div className="text-text-font font-semibold text-field-label flex items-center gap-0-5">
+        <span className="text-text-warn">*</span>
+        <span>DEMO ID</span>
+        <span
+          className="cursor-help text-text-placeholder"
+          title="Select Medicaid Demonstration, CHIP, or both. Selecting CHIP will generate a unique CHIP ID."
+        >
+          <HintIcon />
+        </span>
+      </div>
+      <div className="flex gap-8 items-center flex-nowrap whitespace-nowrap">
+        {DEMO_ID_OPTIONS.map((option) => (
+          <Checkbox
+            key={option.value}
+            name={`checkbox-demo-id-${option.value}`}
+            label={option.label}
+            checked={values.includes(option.value)}
+            onChange={() => toggle(option.value)}
+          />
+        ))}
+      </div>
+    </div>
+  );
 };
 
 export const DemonstrationDialog: React.FC<{
@@ -214,6 +271,13 @@ export const DemonstrationDialog: React.FC<{
             onSelect={(signatureLevel) => handleChange({ ...activeDemonstration, signatureLevel })}
           />
         </div>
+
+        <DemoIdCheckboxes
+          values={activeDemonstration.demoIds}
+          onChange={(demoIds: string[]) =>
+            handleChange({ ...activeDemonstration, demoIds })
+          }
+        />
       </form>
     </BaseDialog>
   );

--- a/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
@@ -119,6 +119,7 @@ const getDemonstrationDialogFields = (demonstration: Demonstration): Demonstrati
   expirationDate: demonstration.expirationDate
     ? formatDateForServer(demonstration.expirationDate)
     : "",
+  demoIds: ["medicaid"],
 });
 
 const useUpdateDemonstration = () => {

--- a/client/src/components/table/tables/SummaryDetailsTable.tsx
+++ b/client/src/components/table/tables/SummaryDetailsTable.tsx
@@ -90,6 +90,16 @@ export const SummaryDetailsTable: React.FC<{ demonstrationId: string }> = ({ dem
       </div>
 
       <div className={FIELD_CONTAINER_CLASSES}>
+        <div className={LABEL_CLASSES}>Demonstration ID</div>
+        <div className={VALUE_CLASSES}>{demonstration.id}</div>
+      </div>
+
+      <div className={FIELD_CONTAINER_CLASSES}>
+        <div className={LABEL_CLASSES}>CHIP ID</div>
+        <div className={VALUE_CLASSES}>21-W-00014/8</div>
+      </div>
+
+      <div className={FIELD_CONTAINER_CLASSES}>
         <div className={LABEL_CLASSES}>Project Officer</div>
         <div className={VALUE_CLASSES}>{displayData.primaryProjectOfficerName}</div>
       </div>

--- a/client/src/pages/DemonstrationDetail/DemonstrationDetailHeader.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetailHeader.tsx
@@ -110,7 +110,7 @@ export const DemonstrationDetailHeader: React.FC<DemonstrationDetailHeaderProps>
               Demonstration List
             </a>
             {/* \u00A0 is unicode for non-breaking space */}
-            {"\u00A0 > \u00A0"} {demonstration.id}
+            {"\u00A0 > \u00A0"} {demonstration.id} {"\u00A0|\u00A0"} 21-W-00014/8
           </span>
           <div className="flex gap-1 items-center -ml-2">
             <div>


### PR DESCRIPTION
Adds a new required **DEMO ID** field to the Create/Edit Demonstration dialog, allowing users to select Medicaid Demonstration, CHIP, or both via two inline checkboxes. Displays a CHIP ID alongside the existing Demonstration ID in both the demonstration header breadcrumb and the Details tab summary.

This is **frontend-only** work. No backend/GraphQL schema changes were made. CHIP ID values and the Edit dialog's default `demoIds` are hardcoded placeholders until the backend lands.



Note: The "CHIP ID Alert" toast from the original story was removed per PM guidance — out of scope for this ticket.

<img width="884" height="638" alt="image" src="https://github.com/user-attachments/assets/b757479c-abdc-415e-a50f-6beb97b63927" />
<img width="1338" height="616" alt="image" src="https://github.com/user-attachments/assets/256d8c17-0e1f-401d-be03-f5cc437ba38b" />
<img width="1094" height="209" alt="image" src="https://github.com/user-attachments/assets/f112302b-35af-48cf-8b09-21549de5b9fb" />
