### PR TITLE
DEMOS 1834 Bugfixes for Phase 8

### DIFF
--- a/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.test.tsx
+++ b/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.test.tsx
@@ -128,37 +128,6 @@ describe("ApprovalSummaryPhase", () => {
     },
   };
 
-  // Mock for reset (mark incomplete)
-  const mockResetDemonstration = {
-    request: {
-      query: UPDATE_DEMONSTRATION_MUTATION,
-      variables: {
-        id: "demo-123",
-        input: {
-          effectiveDate: null,
-          expirationDate: null,
-          sdgDivision: undefined,
-          signatureLevel: undefined,
-        },
-      },
-    },
-    result: {
-      data: {
-        updateDemonstration: {
-          id: "demo-123",
-          name: "Test Demonstration",
-          description: "Test description",
-          effectiveDate: null,
-          expirationDate: null,
-          sdgDivision: null,
-          signatureLevel: null,
-          state: { id: "CA" },
-          primaryProjectOfficer: { id: "user-123" },
-        },
-      },
-    },
-  };
-
   const mockUpdateAmendment = {
     request: {
       query: UPDATE_AMENDMENT_MUTATION,
@@ -207,7 +176,7 @@ describe("ApprovalSummaryPhase", () => {
 
   const setup = (
     formData = buildInitialFormData(),
-    mocks: MockedResponse[] = [mockUpdateDemonstration, mockResetDemonstration],
+    mocks: MockedResponse[] = [mockUpdateDemonstration],
     initialTypes: DemonstrationDetailDemonstrationType[] = []
   ) => {
     render(
@@ -386,28 +355,8 @@ describe("ApprovalSummaryPhase", () => {
   });
 
   it("covers amendment mark incomplete path", async () => {
-    const mockResetAmendment = {
-      request: {
-        query: UPDATE_AMENDMENT_MUTATION,
-        variables: {
-          id: "demo-123",
-          input: {
-            effectiveDate: null,
-            expirationDate: null,
-            sdgDivision: undefined,
-            signatureLevel: undefined,
-          },
-        },
-      },
-      result: {
-        data: {
-          updateAmendment: { id: "demo-123" },
-        },
-      },
-    };
-
     render(
-      <MockedProvider mocks={[mockResetAmendment]} addTypename={false}>
+      <MockedProvider addTypename={false}>
         <TestProvider>
           <ApprovalSummaryPhase
             applicationId="demo-123"
@@ -438,28 +387,8 @@ describe("ApprovalSummaryPhase", () => {
   });
 
   it("covers extension mark incomplete path", async () => {
-    const mockResetExtension = {
-      request: {
-        query: UPDATE_EXTENSION_MUTATION,
-        variables: {
-          id: "demo-123",
-          input: {
-            effectiveDate: null,
-            expirationDate: null,
-            sdgDivision: undefined,
-            signatureLevel: undefined,
-          },
-        },
-      },
-      result: {
-        data: {
-          updateExtension: { id: "demo-123" },
-        },
-      },
-    };
-
     render(
-      <MockedProvider mocks={[mockResetExtension]} addTypename={false}>
+      <MockedProvider addTypename={false}>
         <TestProvider>
           <ApprovalSummaryPhase
             applicationId="demo-123"

--- a/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.tsx
+++ b/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.tsx
@@ -63,23 +63,6 @@ const UPDATE_EXTENSION_MUTATION = gql`
   }
 `;
 
-const RESET_DEMONSTRATION_INPUT: UpdateDemonstrationInput = {
-  effectiveDate: null,
-  expirationDate: null,
-  description: "",
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  sdgDivision: null as any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  signatureLevel: null as any,
-};
-
-const RESET_MODIFICATION_INPUT = {
-  effectiveDate: null,
-  description: "",
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  signatureLevel: null as any,
-};
-
 type ApprovalSummaryPhaseProps = {
   applicationId: string;
   demonstrationId: string;
@@ -394,46 +377,6 @@ export const ApprovalSummaryPhase = ({
 
   const handleMarkIncomplete = async () => {
     try {
-      if (approvalSummaryFormData.applicationType === "demonstration") {
-        await updateDemonstrationTrigger({
-          variables: {
-            id: applicationId,
-            input: RESET_DEMONSTRATION_INPUT,
-          },
-        });
-      } else if (approvalSummaryFormData.applicationType === "amendment") {
-        await updateAmendmentTrigger({
-          variables: {
-            id: applicationId,
-            input: RESET_MODIFICATION_INPUT,
-          },
-        });
-      } else {
-        await updateExtensionTrigger({
-          variables: {
-            id: applicationId,
-            input: RESET_MODIFICATION_INPUT,
-          },
-        });
-      }
-
-      setApprovalSummaryFormData((previousFormData) => ({
-        ...previousFormData,
-        effectiveDate: undefined,
-        expirationDate: undefined,
-        description: "",
-        sdgDivision: undefined,
-        signatureLevel: undefined,
-        readonlyFields: {
-          ...previousFormData.readonlyFields,
-          effectiveDate: false,
-          expirationDate: false,
-          description: false,
-          sdgDivision: false,
-          signatureLevel: false,
-        },
-      }));
-
       await setApplicationDate({
         applicationId: applicationId,
         dateType: "Application Details Marked Complete Date",
@@ -442,7 +385,7 @@ export const ApprovalSummaryPhase = ({
 
       setApplicationDetailsUIState(false);
     } catch (error) {
-      console.error("Failed to reset application details:", error);
+      console.error("Failed to set Completion Date:", error);
     }
   };
 

--- a/client/src/components/dialog/ConfirmApproveDialog.test.tsx
+++ b/client/src/components/dialog/ConfirmApproveDialog.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 
@@ -43,5 +43,35 @@ describe("ConfirmApproveDialog", () => {
     setup("amendment");
 
     expect(screen.getByText(/final submission of this approved amendment/i)).toBeInTheDocument();
+  });
+
+  it("shows finalize approval message for demonstration application type", () => {
+    setup("demonstration");
+
+    expect(
+      screen.getByText(/This will finalize the approval process and move the demonstration to the deliverables phase./i)
+    ).toBeInTheDocument();
+  });
+
+  it("does not show finalize approval message for non-demonstration application type", () => {
+    setup("extension");
+
+    expect(
+      screen.queryByText(/This will finalize the approval process and move the demonstration to the deliverables phase./i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show the correct button text based on application type", () => {
+    setup("amendment");
+    expect(screen.getByTestId("button-ca-dialog-approve")).toHaveTextContent("Submit Approved Amendment");
+    cleanup();
+
+    setup("extension");
+    expect(screen.getByTestId("button-ca-dialog-approve")).toHaveTextContent("Submit Approved Extension");
+    cleanup();
+
+    setup("demonstration");
+    expect(screen.getByTestId("button-ca-dialog-approve")).toHaveTextContent("Submit Approved Demonstration");
+    cleanup();
   });
 });

--- a/client/src/components/dialog/ConfirmApproveDialog.tsx
+++ b/client/src/components/dialog/ConfirmApproveDialog.tsx
@@ -30,15 +30,21 @@ export const ConfirmApproveDialog: React.FC<ConfirmApproveDialogProps> = ({
       maxWidthClass="max-w-[600px]"
       actionButton={
         <Button name="button-ca-dialog-approve" onClick={handleSubmitClicked}>
-          Submit Approved Demonstration
+          Submit Approved {applicationType.charAt(0).toUpperCase() + applicationType.slice(1)}
         </Button>
       }
     >
       <div className="flex flex-col gap-1 items-start text-left">
         <span>
           Are you sure? By hitting accept you will be making the final submission of this approved{" "}
-          {applicationType}. This will finalize the approval process and move the demonstration to
-          the deliverables phase.
+          {applicationType}.
+          {applicationType === "demonstration" && (
+            <>
+              {" "}
+              This will finalize the approval process and move the demonstration to the
+              deliverables phase.
+            </>
+          )}
         </span>
       </div>
     </BaseDialog>


### PR DESCRIPTION
- The behavior of reseting application details when the Application Details Section is marked incomplete was not intended, and has been removed
- The sentence "This will finalize the approval process... " was not intended to be displayed for amendments and extensions, and now conditionally renders based on the provided applicationType
- The "Submit Approved Demonstration" button was not respecting the provided applicationType, and now also conditionally renders based on this value

<img width="1419" height="650" alt="image" src="https://github.com/user-attachments/assets/b0cca9ca-5419-4b4a-9663-dd4755859a14" />
<img width="644" height="285" alt="image" src="https://github.com/user-attachments/assets/8deda6f6-6c3f-4c91-9feb-74cfba54243f" />
