### PR TITLE
DEMOS-1787 add default for state user contact type, remove All Users …

### DIFF
--- a/client/src/components/dialog/ManageContactsDialog.test.tsx
+++ b/client/src/components/dialog/ManageContactsDialog.test.tsx
@@ -65,6 +65,9 @@ const SEARCH_PEOPLE_MOCKS = [
   createSearchMock("jo"),
   createSearchMock("joh"),
   createSearchMock("john"),
+  createSearchMock("ja"),
+  createSearchMock("jan"),
+  createSearchMock("jane"),
 ];
 
 const SET_ROLES_MOCK = {
@@ -1208,6 +1211,37 @@ describe("ManageContactsDialog", () => {
 
       const stateContact = screen.getByText("State User");
       expect(stateContact).toBeInTheDocument();
+    });
+
+    it("defaults contact type to State Point of Contact when adding a state user", async () => {
+      const user = userEvent.setup();
+      const mocks = SEARCH_PEOPLE_MOCKS;
+
+      renderWithProviders(defaultProps, mocks);
+
+      const searchInput = screen.getByPlaceholderText("Search by name or email");
+
+      // Type to trigger search
+      await user.type(searchInput, "ja"); // matches Jane (state user)
+
+      await waitFor(() => {
+        expect(screen.getByText("Jane Smith")).toBeInTheDocument();
+      });
+
+      // Add the state user
+      const addButton = screen.getByText("Jane Smith");
+      await user.click(addButton);
+
+      // Verify they appear in the table
+      await waitFor(() => {
+        expect(screen.getByText("Jane Smith")).toBeInTheDocument();
+      });
+
+      // ✅ Assert default contact type is applied
+      expect(screen.getByDisplayValue("State Point of Contact")).toBeInTheDocument();
+
+      // (Optional but useful) verify no "Select Type…" placeholder exists
+      expect(screen.queryByDisplayValue("Select Type…")).not.toBeInTheDocument();
     });
   });
 

--- a/client/src/components/dialog/ManageContactsDialog.tsx
+++ b/client/src/components/dialog/ManageContactsDialog.tsx
@@ -196,9 +196,10 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
 
     setSelectedContacts((prev) => {
       const idmRoles = [person.personType];
+      const isStateUser = person.personType === "demos-state-user";
 
       const defaults: { contactType?: ContactType; isPrimary: boolean } = {
-        contactType: undefined,
+        contactType: isStateUser ? "State Point of Contact" : undefined,
         isPrimary: false,
       };
 

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -85,7 +85,13 @@ export const ROLES = [
 
 export const CONTACT_TYPES = ["DDME Analyst", "Project Officer", "State Point of Contact"] as const;
 
-export const ADMIN_DEMONSTRATION_ROLES = ROLES;
+export const ADMIN_DEMONSTRATION_ROLES = [
+  "Project Officer",
+  "State Point of Contact",
+  "DDME Analyst",
+  "Policy Technical Director",
+  "Monitoring & Evaluation Technical Director",
+] as const;
 
 export const CMS_USER_DEMONSTRATION_ROLES = [
   "Project Officer",


### PR DESCRIPTION
…from admin role options

Fixes 2 bugs with Manage Contacts Modal
1) Applies default contact type for state users
2) Removes a role that shouldn't have appeared for admin users