### PR TITLE
feature/DEMOS-1957-fix-display-of-demonstration-types-for-deliverables

### DIFF
--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -27,7 +27,6 @@ import {
   resolveDeliverableType,
   resolveDeliverableStatus,
   resolveDeliverableDueDateType,
-  resolveDeliverableDemonstrationTypes,
   resolveDemonstration,
   resolveDeliverableCmsOwner,
   resolveDeliverableCmsDocuments,
@@ -63,7 +62,10 @@ import { createDeliverable, getDeliverable, getManyDeliverables, updateDeliverab
 import { getApplication } from "../application";
 import { getUser } from "../user";
 import { getManyDocuments } from "../document";
-import { getDeliverableDemonstrationTypes } from "../deliverableDemonstrationType";
+import {
+  GetDeliverableDemonstrationTypeResult,
+  getDeliverableDemonstrationTypes,
+} from "../deliverableDemonstrationType";
 
 describe("deliverableResolvers", () => {
   const testDeliverableId = "82ef9a17-e8b9-48ab-9aaf-3d1787822b13";
@@ -221,29 +223,6 @@ describe("deliverableResolvers", () => {
     });
   });
 
-  describe("resolveDeliverableDemonstrationTypes", () => {
-    it("should query the demonstration types of the parent deliverable", async () => {
-      vi.mocked(getDeliverableDemonstrationTypes).mockResolvedValue([
-        {
-          demonstrationId: testDemonstrationId,
-          deliverableId: testDeliverableId,
-          demonstrationTypeTagNameId: "Free Insulin",
-        },
-        {
-          demonstrationId: testDemonstrationId,
-          deliverableId: testDeliverableId,
-          demonstrationTypeTagNameId: "Vitamin A Supplementation for Newborns",
-        },
-      ]);
-
-      const result = await resolveDeliverableDemonstrationTypes(
-        testDeliverable as PrismaDeliverable
-      );
-      expect(getDeliverableDemonstrationTypes).toHaveBeenCalledExactlyOnceWith(testDeliverableId);
-      expect(result).toStrictEqual(["Free Insulin", "Vitamin A Supplementation for Newborns"]);
-    });
-  });
-
   describe("resolveDemonstration", () => {
     it("should query the demonstration of the parent deliverable", async () => {
       await resolveDemonstration(testDeliverable as PrismaDeliverable);
@@ -314,6 +293,30 @@ describe("deliverableResolvers", () => {
           {} as GraphQLContext
         );
         expect(updateDeliverable).toHaveBeenCalledExactlyOnceWith(testDeliverableId, testInput, {});
+      });
+    });
+
+    describe("Deliverable.demonstrationTypes", () => {
+      it("should query the demonstration types of the parent deliverable", async () => {
+        const mockGetDeliverableDemonstrationTypeResult: GetDeliverableDemonstrationTypeResult[] = [
+          {
+            tagName: "Free Insulin",
+            approvalStatus: "Approved",
+          },
+          {
+            tagName: "Vitamin A Supplementation for Newborns",
+            approvalStatus: "Unapproved",
+          },
+        ];
+        vi.mocked(getDeliverableDemonstrationTypes).mockResolvedValue(
+          mockGetDeliverableDemonstrationTypeResult
+        );
+
+        const result = await deliverableResolvers.Deliverable.demonstrationTypes(
+          testDeliverable as PrismaDeliverable
+        );
+        expect(getDeliverableDemonstrationTypes).toHaveBeenCalledExactlyOnceWith(testDeliverableId);
+        expect(result).toStrictEqual(mockGetDeliverableDemonstrationTypeResult);
       });
     });
   });

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -13,7 +13,6 @@ import {
   DeliverableDueDateType,
   DeliverableStatus,
   DeliverableType,
-  TagName,
   UpdateDeliverableInput,
 } from "../../types";
 import { getApplication } from "../application";
@@ -87,14 +86,6 @@ export function resolveDeliverableDueDateType(parent: PrismaDeliverable): Delive
   return parent.dueDateTypeId as DeliverableDueDateType;
 }
 
-export async function resolveDeliverableDemonstrationTypes(
-  parent: PrismaDeliverable
-): Promise<TagName[]> {
-  return (await getDeliverableDemonstrationTypes(parent.id)).map(
-    (demonstrationType) => demonstrationType.demonstrationTypeTagNameId
-  );
-}
-
 export async function resolveDemonstration(
   parent: PrismaDeliverable
 ): Promise<PrismaDemonstration> {
@@ -149,7 +140,9 @@ export const deliverableResolvers = {
     status: resolveDeliverableStatus,
     cmsOwner: resolveDeliverableCmsOwner,
     dueDateType: resolveDeliverableDueDateType,
-    demonstrationTypes: resolveDeliverableDemonstrationTypes,
+    demonstrationTypes: async (parent: PrismaDeliverable) => {
+      return await getDeliverableDemonstrationTypes(parent.id);
+    },
     cmsDocuments: resolveDeliverableCmsDocuments,
     stateDocuments: resolveDeliverableStateDocuments,
   },

--- a/server/src/model/deliverable/deliverableSchema.ts
+++ b/server/src/model/deliverable/deliverableSchema.ts
@@ -7,6 +7,7 @@ import {
   Demonstration,
   Document,
   NonEmptyString,
+  Tag,
   TagName,
   User,
 } from "../../types";
@@ -21,7 +22,7 @@ export const deliverableSchema = gql`
     cmsOwner: User!
     dueDate: DateTime!
     dueDateType: DeliverableDueDateType!
-    demonstrationTypes: [TagName!]!
+    demonstrationTypes: [Tag!]!
     expectedToBeSubmitted: Boolean!
     cmsDocuments: [Document!]!
     stateDocuments: [Document!]!
@@ -70,7 +71,7 @@ export interface Deliverable {
   cmsOwner: User;
   dueDate: Date;
   dueDateType: DeliverableDueDateType;
-  demonstrationTypes: TagName[];
+  demonstrationTypes: Tag[];
   expectedToBeSubmitted: boolean;
   cmsDocuments: Document[];
   stateDocuments: Document[];

--- a/server/src/model/deliverable/updateDeliverableDemonstrationTypes.test.ts
+++ b/server/src/model/deliverable/updateDeliverableDemonstrationTypes.test.ts
@@ -2,11 +2,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Types
-import { TagName } from "../../types";
-import {
-  Deliverable as PrismaDeliverable,
-  DeliverableDemonstrationType as PrismaDeliverableDemonstrationType,
-} from "@prisma/client";
+import { TagName, TagStatus } from "../../types";
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
+import { GetDeliverableDemonstrationTypeResult } from "../deliverableDemonstrationType";
 
 // Functions under test
 import { updateDeliverableDemonstrationTypes } from "./updateDeliverableDemonstrationTypes";
@@ -37,16 +35,14 @@ describe("updateDeliverableDemonstrationTypes", () => {
     id: testDeliverableId,
     demonstrationId: mockDemonstrationId,
   };
-  const mockDeliverableDemonstrationTypes: PrismaDeliverableDemonstrationType[] = [
+  const mockDeliverableDemonstrationTypes: GetDeliverableDemonstrationTypeResult[] = [
     {
-      deliverableId: testDeliverableId,
-      demonstrationId: mockDemonstrationId,
-      demonstrationTypeTagNameId: "Free Insulin",
+      tagName: "Free Insulin",
+      approvalStatus: "Approved" satisfies TagStatus,
     },
     {
-      deliverableId: testDeliverableId,
-      demonstrationId: mockDemonstrationId,
-      demonstrationTypeTagNameId: "Low Cost Vitamin A Supplements for Newborns",
+      tagName: "Low Cost Vitamin A Supplements for Newborns",
+      approvalStatus: "Unapproved" satisfies TagStatus,
     },
   ];
 
@@ -140,6 +136,31 @@ describe("updateDeliverableDemonstrationTypes", () => {
         deliverableId: testDeliverableId,
         demonstrationId: mockDemonstrationId,
         demonstrationTypes: ["Free Insulin"],
+      },
+      mockTransaction
+    );
+  });
+
+  it("should treat empty demonstration types as a valid input to pass", async () => {
+    const testInput = {
+      name: "A deliverable!",
+      demonstrationTypes: new Set<TagName>(),
+    };
+
+    await updateDeliverableDemonstrationTypes(testDeliverableId, testInput, mockTransaction);
+    expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
+      { id: testDeliverableId },
+      mockTransaction
+    );
+    expect(getDeliverableDemonstrationTypes).toHaveBeenCalledExactlyOnceWith(
+      testDeliverableId,
+      mockTransaction
+    );
+    expect(setDeliverableDemonstrationTypes).toHaveBeenCalledExactlyOnceWith(
+      {
+        deliverableId: testDeliverableId,
+        demonstrationId: mockDemonstrationId,
+        demonstrationTypes: [],
       },
       mockTransaction
     );

--- a/server/src/model/deliverable/updateDeliverableDemonstrationTypes.ts
+++ b/server/src/model/deliverable/updateDeliverableDemonstrationTypes.ts
@@ -23,7 +23,7 @@ export async function updateDeliverableDemonstrationTypes(
   // Can turn these into a set because DB guarantees uniqueness
   const oldDemonstrationTypes: Set<TagName> = new Set(
     (await getDeliverableDemonstrationTypes(deliverableId, tx)).map(
-      (demonstrationType) => demonstrationType.demonstrationTypeTagNameId
+      (demonstrationType) => demonstrationType.tagName
     )
   );
 

--- a/server/src/model/deliverableDemonstrationType/deliverableDemonstrationTypeTypes.ts
+++ b/server/src/model/deliverableDemonstrationType/deliverableDemonstrationTypeTypes.ts
@@ -1,7 +1,0 @@
-import { TagName } from "../../types";
-
-export type SetDeliverableDemonstrationTypesInput = {
-  deliverableId: string;
-  demonstrationId: string;
-  demonstrationTypes: TagName[];
-};

--- a/server/src/model/deliverableDemonstrationType/index.ts
+++ b/server/src/model/deliverableDemonstrationType/index.ts
@@ -7,4 +7,5 @@ export { getDeliverableDemonstrationTypes } from "./queries/getDeliverableDemons
 export { insertDeliverableDemonstrationTypes } from "./queries/insertDeliverableDemonstrationTypes";
 
 // Types & Constants
-export type { SetDeliverableDemonstrationTypesInput } from "./deliverableDemonstrationTypeTypes";
+export type { SetDeliverableDemonstrationTypesInput } from "./setDeliverableDemonstrationTypes";
+export type { GetDeliverableDemonstrationTypeResult } from "./queries/getDeliverableDemonstrationTypes";

--- a/server/src/model/deliverableDemonstrationType/queries/getDeliverableDemonstrationTypes.test.ts
+++ b/server/src/model/deliverableDemonstrationType/queries/getDeliverableDemonstrationTypes.test.ts
@@ -2,6 +2,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Types
+import { TagStatus } from "../../../types";
+import { GetDeliverableDemonstrationTypeResult } from "..";
 
 // Functions under test
 import { getDeliverableDemonstrationTypes } from "./getDeliverableDemonstrationTypes";
@@ -37,15 +39,62 @@ describe("getDeliverableDemonstrationTypes", () => {
   const testDeliverableId = "c8697763-fdd8-4502-b538-9e3cde153b05";
   const expectedCall = {
     where: { deliverableId: testDeliverableId },
+    select: {
+      demonstrationTypeTagNameId: true,
+      demonstrationTypeTagAssignment: {
+        select: {
+          tag: {
+            select: {
+              statusId: true,
+            },
+          },
+        },
+      },
+    },
   };
+  const mockReturnValue = [
+    {
+      demonstrationTypeTagNameId: "Free Insulin",
+      demonstrationTypeTagAssignment: {
+        tag: {
+          statusId: "Approved",
+        },
+      },
+    },
+    {
+      demonstrationTypeTagNameId: "Reduced Cost Insulin Pump Supplies",
+      demonstrationTypeTagAssignment: {
+        tag: {
+          statusId: "Unapproved",
+        },
+      },
+    },
+  ];
+  const expectedResult: GetDeliverableDemonstrationTypeResult[] = [
+    {
+      tagName: "Free Insulin",
+      approvalStatus: "Approved",
+    },
+    {
+      tagName: "Reduced Cost Insulin Pump Supplies",
+      approvalStatus: "Unapproved",
+    },
+  ];
 
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
+    vi.mocked(mockPrismaClient.deliverableDemonstrationType.findMany).mockResolvedValue(
+      mockReturnValue
+    );
+    vi.mocked(mockTransaction.deliverableDemonstrationType.findMany).mockResolvedValue(
+      mockReturnValue
+    );
   });
 
   it("should get the deliverable demonstration types directly from the database directly if no transaction is given", async () => {
-    await getDeliverableDemonstrationTypes(testDeliverableId);
+    const result = await getDeliverableDemonstrationTypes(testDeliverableId);
+    expect(result).toStrictEqual(expectedResult);
     expect(regularMocks.deliverableDemonstrationType.findMany).toHaveBeenCalledExactlyOnceWith(
       expectedCall
     );
@@ -53,7 +102,8 @@ describe("getDeliverableDemonstrationTypes", () => {
   });
 
   it("should get the deliverable demonstration types via a transaction if one is given", async () => {
-    await getDeliverableDemonstrationTypes(testDeliverableId, mockTransaction);
+    const result = await getDeliverableDemonstrationTypes(testDeliverableId, mockTransaction);
+    expect(result).toStrictEqual(expectedResult);
     expect(regularMocks.deliverableDemonstrationType.findMany).not.toHaveBeenCalled();
     expect(transactionMocks.deliverableDemonstrationType.findMany).toHaveBeenCalledExactlyOnceWith(
       expectedCall

--- a/server/src/model/deliverableDemonstrationType/queries/getDeliverableDemonstrationTypes.ts
+++ b/server/src/model/deliverableDemonstrationType/queries/getDeliverableDemonstrationTypes.ts
@@ -31,7 +31,7 @@ export async function getDeliverableDemonstrationTypes(
 
   // Types enforced by database
   return results.map((result) => ({
-    tagName: result.demonstrationTypeTagNameId as TagName,
+    tagName: result.demonstrationTypeTagNameId,
     approvalStatus: result.demonstrationTypeTagAssignment.tag.statusId as TagStatus,
   }));
 }

--- a/server/src/model/deliverableDemonstrationType/queries/getDeliverableDemonstrationTypes.ts
+++ b/server/src/model/deliverableDemonstrationType/queries/getDeliverableDemonstrationTypes.ts
@@ -1,14 +1,37 @@
-import { DeliverableDemonstrationType as PrismaDeliverableDemonstrationType } from "@prisma/client";
 import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { TagName, TagStatus } from "../../../types";
+
+export type GetDeliverableDemonstrationTypeResult = {
+  tagName: TagName;
+  approvalStatus: TagStatus;
+};
 
 export async function getDeliverableDemonstrationTypes(
   deliverableId: string,
   tx?: PrismaTransactionClient
-): Promise<PrismaDeliverableDemonstrationType[]> {
+): Promise<GetDeliverableDemonstrationTypeResult[]> {
   const prismaClient = tx ?? prisma();
-  return await prismaClient.deliverableDemonstrationType.findMany({
+  const results = await prismaClient.deliverableDemonstrationType.findMany({
     where: {
       deliverableId: deliverableId,
     },
+    select: {
+      demonstrationTypeTagNameId: true,
+      demonstrationTypeTagAssignment: {
+        select: {
+          tag: {
+            select: {
+              statusId: true,
+            },
+          },
+        },
+      },
+    },
   });
+
+  // Types enforced by database
+  return results.map((result) => ({
+    tagName: result.demonstrationTypeTagNameId as TagName,
+    approvalStatus: result.demonstrationTypeTagAssignment.tag.statusId as TagStatus,
+  }));
 }

--- a/server/src/model/deliverableDemonstrationType/setDeliverableDemonstrationTypes.ts
+++ b/server/src/model/deliverableDemonstrationType/setDeliverableDemonstrationTypes.ts
@@ -1,11 +1,14 @@
 import { prisma, PrismaTransactionClient } from "../../prismaClient";
-import {
-  deleteAllDeliverableDemonstrationTypes,
-  insertDeliverableDemonstrationTypes,
-  SetDeliverableDemonstrationTypesInput,
-} from ".";
+import { TagName } from "../../types";
+import { deleteAllDeliverableDemonstrationTypes, insertDeliverableDemonstrationTypes } from ".";
 import { Deliverable as PrismaDeliverable } from "@prisma/client";
 import { getDeliverable } from "../deliverable";
+
+export type SetDeliverableDemonstrationTypesInput = {
+  deliverableId: string;
+  demonstrationId: string;
+  demonstrationTypes: TagName[];
+};
 
 export async function setDeliverableDemonstrationTypes(
   input: SetDeliverableDemonstrationTypesInput,


### PR DESCRIPTION
Updates the deliverable resolver to return a proper tag object rather than an array of strings for the demonstration types. Just an oversight from my larger PR already merged.