### PR TITLE
Demos 1988 import cleanup

### DIFF
--- a/server/src/auth/buildAuthorizationFilter.test.ts
+++ b/server/src/auth/buildAuthorizationFilter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { ContextUser } from "./auth.util";
+import type { ContextUser } from "./userContext";
 import { buildAuthorizationFilter, PermissionFilters } from "./buildAuthorizationFilter";
 import { ApplicationStatus, SignatureLevel } from "../types";
 
@@ -14,8 +14,8 @@ describe("buildAuthorizationFilter", () => {
   it("builds an OR filter from the permissions the user has", () => {
     const user: ContextUser = {
       id: "user-1",
-      sub: "sub-1",
-      role: "demos-admin",
+      cognitoSubject: "sub-1",
+      personTypeId: "demos-admin",
       permissions: ["View All Demonstrations", "View All Amendments"],
     };
 
@@ -35,8 +35,8 @@ describe("buildAuthorizationFilter", () => {
   it("returns null when the user has no matching permissions", () => {
     const user: ContextUser = {
       id: "user-2",
-      sub: "sub-2",
-      role: "demos-cms-user",
+      cognitoSubject: "sub-2",
+      personTypeId: "demos-cms-user",
       permissions: ["View All Extensions"],
     };
 
@@ -53,8 +53,8 @@ describe("buildAuthorizationFilter", () => {
   it("skips permission entries that are undefined", () => {
     const user: ContextUser = {
       id: "user-3",
-      sub: "sub-3",
-      role: "demos-state-user",
+      cognitoSubject: "sub-3",
+      personTypeId: "demos-state-user",
       permissions: ["View Assigned Demonstrations"],
     };
 

--- a/server/src/auth/index.ts
+++ b/server/src/auth/index.ts
@@ -1,0 +1,7 @@
+export { GraphQLContext } from "./auth.util";
+export { ContextUser } from "./userContext";
+export {
+  buildAuthorizationFilter,
+  isStatePointOfContactOnDemonstration,
+  PermissionFilters,
+} from "./buildAuthorizationFilter";

--- a/server/src/model/amendment/amendmentData.test.ts
+++ b/server/src/model/amendment/amendmentData.test.ts
@@ -1,20 +1,15 @@
 import { Amendment as PrismaAmendment, Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { buildAuthorizationFilter } from "../../auth/buildAuthorizationFilter.js";
-import { getAmendment, getManyAmendments } from "./amendmentData.js";
-import { selectAmendment } from "./queries/selectAmendment.js";
-import { selectManyAmendments } from "./queries/selectManyAmendments.js";
-import { ContextUser } from "../../auth/userContext.js";
+import { buildAuthorizationFilter, ContextUser } from "../../auth";
+import { getAmendment, getManyAmendments } from "./amendmentData";
+import { selectAmendment, selectManyAmendments } from "./queries";
 
-vi.mock("../../auth/buildAuthorizationFilter.js", () => ({
+vi.mock("../../auth", () => ({
   buildAuthorizationFilter: vi.fn(),
 }));
 
-vi.mock("./queries/selectAmendment.js", () => ({
+vi.mock("./queries", () => ({
   selectAmendment: vi.fn(),
-}));
-
-vi.mock("./queries/selectManyAmendments.js", () => ({
   selectManyAmendments: vi.fn(),
 }));
 

--- a/server/src/model/amendment/amendmentData.ts
+++ b/server/src/model/amendment/amendmentData.ts
@@ -3,10 +3,9 @@ import {
   buildAuthorizationFilter,
   isStatePointOfContactOnDemonstration,
   PermissionFilters,
-} from "../../auth/buildAuthorizationFilter.js";
-import { selectAmendment } from "./queries/selectAmendment.js";
-import { selectManyAmendments } from "./queries/selectManyAmendments.js";
-import { ContextUser } from "../../auth/userContext.js";
+  ContextUser,
+} from "../../auth";
+import { selectAmendment, selectManyAmendments } from "./queries";
 
 const getPermissionFilters = (userId: string) =>
   ({

--- a/server/src/model/amendment/amendmentResolvers.test.ts
+++ b/server/src/model/amendment/amendmentResolvers.test.ts
@@ -4,7 +4,7 @@ import {
   __updateAmendment,
   deleteAmendment,
   amendmentResolvers,
-} from "./amendmentResolvers.js";
+} from "./amendmentResolvers";
 import {
   ApplicationStatus,
   ApplicationType,
@@ -13,12 +13,12 @@ import {
   PhaseName,
   SignatureLevel,
   UpdateAmendmentInput,
-} from "../../types.js";
+} from "../../types";
 import { Amendment as PrismaAmendment } from "@prisma/client";
 import { TZDate } from "@date-fns/tz";
 
 // Mock imports
-import { prisma } from "../../prismaClient.js";
+import { prisma } from "../../prismaClient";
 import {
   deleteApplication,
   // None of these are tested but need to be exported to avoid mocking issues
@@ -26,32 +26,31 @@ import {
   resolveApplicationTags,
   resolveSuggestedApplicationTags,
 } from "../application";
-import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields.js";
-import { handlePrismaError } from "../../errors/handlePrismaError.js";
+import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
+import { handlePrismaError } from "../../errors/handlePrismaError";
 import {
   checkInputDateIsStartOfDay,
   checkInputDateIsEndOfDay,
-} from "../applicationDate/checkInputDateFunctions.js";
-import { EasternTZDate, parseDateTimeOrLocalDateToEasternTZDate } from "../../dateUtilities.js";
-import { ContextUser } from "../../auth/userContext.js";
-import { GraphQLContext } from "../../auth/auth.util.js";
-import { getDemonstration } from "../demonstration/demonstrationData.js";
-import { getAmendment, getManyAmendments } from "./amendmentData.js";
-import { getManyDocuments } from "../document/documentData.js";
-vi.mock("../../prismaClient.js", () => ({
+} from "../applicationDate/checkInputDateFunctions";
+import { EasternTZDate, parseDateTimeOrLocalDateToEasternTZDate } from "../../dateUtilities";
+import { ContextUser, GraphQLContext } from "../../auth";
+import { getDemonstration } from "../demonstration";
+import { getAmendment, getManyAmendments } from "./amendmentData";
+import { getManyDocuments } from "../document";
+vi.mock("../../prismaClient", () => ({
   prisma: vi.fn(),
 }));
 
-vi.mock("./amendmentData.js", () => ({
+vi.mock("./amendmentData", () => ({
   getAmendment: vi.fn(),
   getManyAmendments: vi.fn(),
 }));
 
-vi.mock("../document/documentData.js", () => ({
+vi.mock("../document", () => ({
   getManyDocuments: vi.fn(),
 }));
 
-vi.mock("../demonstration/demonstrationData.js", () => ({
+vi.mock("../demonstration", () => ({
   getDemonstration: vi.fn(),
 }));
 

--- a/server/src/model/amendment/amendmentResolvers.ts
+++ b/server/src/model/amendment/amendmentResolvers.ts
@@ -1,14 +1,14 @@
 import { Amendment as PrismaAmendment } from "@prisma/client";
-import { prisma } from "../../prismaClient.js";
+import { prisma } from "../../prismaClient";
 import {
   ApplicationStatus,
   ApplicationType,
   CreateAmendmentInput,
   PhaseName,
   UpdateAmendmentInput,
-} from "../../types.js";
-import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields.js";
-import { handlePrismaError } from "../../errors/handlePrismaError.js";
+} from "../../types";
+import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
+import { handlePrismaError } from "../../errors/handlePrismaError";
 import { parseAndValidateEffectiveAndExpirationDates } from "../applicationDate";
 import {
   deleteApplication,
@@ -16,10 +16,10 @@ import {
   resolveApplicationTags,
   resolveSuggestedApplicationTags,
 } from "../application";
-import { getDemonstration } from "../demonstration/demonstrationData.js";
-import { GraphQLContext } from "../../auth/auth.util.js";
-import { getAmendment, getManyAmendments } from "./amendmentData.js";
-import { getManyDocuments } from "../document/documentData.js";
+import { getDemonstration } from "../demonstration";
+import { GraphQLContext } from "../../auth";
+import { getAmendment, getManyAmendments } from "./amendmentData";
+import { getManyDocuments } from "../document";
 
 const amendmentApplicationType: ApplicationType = "Amendment";
 const conceptPhaseName: PhaseName = "Concept";

--- a/server/src/model/amendment/index.ts
+++ b/server/src/model/amendment/index.ts
@@ -1,0 +1,1 @@
+export { getAmendment, getManyAmendments } from "./amendmentData";

--- a/server/src/model/amendment/queries/index.ts
+++ b/server/src/model/amendment/queries/index.ts
@@ -1,0 +1,2 @@
+export { selectAmendment } from "./selectAmendment";
+export { selectManyAmendments } from "./selectManyAmendments";

--- a/server/src/model/applicationPhase/applicationPhaseResolvers.test.ts
+++ b/server/src/model/applicationPhase/applicationPhaseResolvers.test.ts
@@ -4,28 +4,28 @@ import {
   __resolveApplicationPhaseName,
   __resolveApplicationPhaseStatus,
   applicationPhaseResolvers,
-} from "./applicationPhaseResolvers.js";
+} from "./applicationPhaseResolvers";
 import { ApplicationPhase as PrismaApplicationPhase } from "@prisma/client";
-import { PhaseName, PhaseStatus } from "../../types.js";
+import { PhaseName, PhaseStatus } from "../../types";
 
 // Mock imports
-import { prisma } from "../../prismaClient.js";
-import { handlePrismaError } from "../../errors/handlePrismaError.js";
+import { prisma } from "../../prismaClient";
+import { handlePrismaError } from "../../errors/handlePrismaError";
 import { getApplication } from "../application";
 import { completePhase, declareCompletenessPhaseIncomplete, skipConceptPhase } from ".";
-import { GraphQLContext } from "../../auth/auth.util.js";
-import { getManyDocuments } from "../document/documentData.js";
+import { GraphQLContext } from "../../auth";
+import { getManyDocuments } from "../document";
 
-vi.mock("../../prismaClient.js", () => ({
+vi.mock("../../prismaClient", () => ({
   prisma: vi.fn(),
 }));
 
-vi.mock("../document/documentData.js", () => ({
+vi.mock("../document", () => ({
   getManyDocuments: vi.fn(),
 }));
 
 const testHandlePrismaError = new Error("Test handlePrismaError!");
-vi.mock("../../errors/handlePrismaError.js", () => ({
+vi.mock("../../errors/handlePrismaError", () => ({
   handlePrismaError: vi.fn(() => {
     throw testHandlePrismaError;
   }),

--- a/server/src/model/applicationPhase/applicationPhaseResolvers.ts
+++ b/server/src/model/applicationPhase/applicationPhaseResolvers.ts
@@ -1,16 +1,14 @@
-import {
-  ApplicationPhase as PrismaApplicationPhase,
-} from "@prisma/client";
-import { prisma } from "../../prismaClient.js";
+import { ApplicationPhase as PrismaApplicationPhase } from "@prisma/client";
+import { prisma } from "../../prismaClient";
 import {
   PrismaApplicationDateResults,
   completePhase,
   declareCompletenessPhaseIncomplete,
   skipConceptPhase,
 } from ".";
-import { PrismaApplicationNoteResults } from "./applicationPhaseTypes.js";
-import { GraphQLContext } from "../../auth/auth.util.js";
-import { getManyDocuments } from "../document/documentData.js";
+import { PrismaApplicationNoteResults } from "./applicationPhaseTypes";
+import { GraphQLContext } from "../../auth";
+import { getManyDocuments } from "../document";
 
 export async function __resolveApplicationPhaseDates(
   parent: PrismaApplicationPhase

--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -8,7 +8,7 @@ import {
   Document as PrismaDocument,
   User as PrismaUser,
 } from "@prisma/client";
-import { GraphQLContext } from "../../auth/auth.util";
+import { GraphQLContext } from "../../auth";
 import { GraphQLResolveInfo } from "graphql";
 import {
   CreateDeliverableInput,
@@ -48,7 +48,7 @@ vi.mock("../user", () => ({
   getUser: vi.fn(),
 }));
 
-vi.mock("../document/documentData.js", () => ({
+vi.mock("../document", () => ({
   getManyDocuments: vi.fn(),
 }));
 
@@ -59,7 +59,7 @@ vi.mock("../deliverableDemonstrationType", () => ({
 import { createDeliverable, getDeliverable, getManyDeliverables, updateDeliverable } from ".";
 import { getApplication } from "../application";
 import { getUser } from "../user";
-import { getManyDocuments } from "../document/documentData.js";
+import { getManyDocuments } from "../document";
 import {
   GetDeliverableDemonstrationTypeResult,
   getDeliverableDemonstrationTypes,

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -5,7 +5,7 @@ import {
   Prisma,
   User as PrismaUser,
 } from "@prisma/client";
-import { GraphQLContext } from "../../auth/auth.util";
+import { GraphQLContext } from "../../auth";
 import { GraphQLResolveInfo } from "graphql";
 import { createDeliverable, getDeliverable, getManyDeliverables, updateDeliverable } from ".";
 import {
@@ -17,7 +17,7 @@ import {
 } from "../../types";
 import { getApplication } from "../application";
 import { getUser } from "../user";
-import { getManyDocuments } from "../document/documentData";
+import { getManyDocuments } from "../document";
 import { getDeliverableDemonstrationTypes } from "../deliverableDemonstrationType";
 
 export async function resolveDeliverable(

--- a/server/src/model/demonstration/demonstrationData.test.ts
+++ b/server/src/model/demonstration/demonstrationData.test.ts
@@ -1,20 +1,15 @@
 import { Demonstration as PrismaDemonstration, Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { buildAuthorizationFilter } from "../../auth/buildAuthorizationFilter.js";
-import { getDemonstration, getManyDemonstrations } from "./demonstrationData.js";
-import { selectDemonstration } from "./queries/selectDemonstration.js";
-import { selectManyDemonstrations } from "./queries/selectManyDemonstrations.js";
-import { ContextUser } from "../../auth/userContext.js";
+import { buildAuthorizationFilter, ContextUser } from "../../auth";
+import { getDemonstration, getManyDemonstrations } from "./demonstrationData";
+import { selectDemonstration, selectManyDemonstrations } from "./queries";
 
-vi.mock("../../auth/buildAuthorizationFilter.js", () => ({
+vi.mock("../../auth", () => ({
   buildAuthorizationFilter: vi.fn(),
 }));
 
-vi.mock("./queries/selectDemonstration.js", () => ({
+vi.mock("./queries", () => ({
   selectDemonstration: vi.fn(),
-}));
-
-vi.mock("./queries/selectManyDemonstrations.js", () => ({
   selectManyDemonstrations: vi.fn(),
 }));
 

--- a/server/src/model/demonstration/demonstrationData.ts
+++ b/server/src/model/demonstration/demonstrationData.ts
@@ -3,10 +3,9 @@ import {
   buildAuthorizationFilter,
   isStatePointOfContactOnDemonstration,
   PermissionFilters,
-} from "../../auth/buildAuthorizationFilter.js";
-import { selectDemonstration } from "./queries/selectDemonstration.js";
-import { selectManyDemonstrations } from "./queries/selectManyDemonstrations.js";
-import { ContextUser } from "../../auth/userContext.js";
+  ContextUser,
+} from "../../auth";
+import { selectDemonstration, selectManyDemonstrations } from "./queries";
 
 const getPermissionFilters = (userId: string) =>
   ({

--- a/server/src/model/demonstration/demonstrationResolvers.test.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.test.ts
@@ -22,7 +22,7 @@ import {
   SdgDivision,
   SignatureLevel,
   UpdateDemonstrationInput,
-} from "../../types.js";
+} from "../../types";
 import {
   Demonstration as PrismaDemonstration,
   DemonstrationTypeTagAssignment as PrismaDemonstrationTypeTagAssignment,
@@ -31,13 +31,13 @@ import {
 import { TZDate } from "@date-fns/tz";
 
 // Mock imports
-import { prisma } from "../../prismaClient.js";
-import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields.js";
-import { handlePrismaError } from "../../errors/handlePrismaError.js";
+import { prisma } from "../../prismaClient";
+import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
+import { handlePrismaError } from "../../errors/handlePrismaError";
 import {
   checkInputDateIsStartOfDay,
   checkInputDateIsEndOfDay,
-} from "../applicationDate/checkInputDateFunctions.js";
+} from "../applicationDate/checkInputDateFunctions";
 import {
   deleteApplication,
   getApplication,
@@ -46,33 +46,32 @@ import {
   resolveApplicationTags,
   resolveSuggestedApplicationTags,
 } from "../application";
-import { parseDateTimeOrLocalDateToEasternTZDate, EasternTZDate } from "../../dateUtilities.js";
-import { determineDemonstrationTypeStatus } from "./determineDemonstrationTypeStatus.js";
-import { getDemonstration, getManyDemonstrations } from "./demonstrationData.js";
-import { ContextUser } from "../../auth/userContext.js";
-import { GraphQLContext } from "../../auth/auth.util.js";
-import { getManyAmendments } from "../amendment/amendmentData.js";
-import { getManyExtensions } from "../extension/extensionData.js";
-import { getManyDocuments } from "../document/documentData.js";
+import { parseDateTimeOrLocalDateToEasternTZDate, EasternTZDate } from "../../dateUtilities";
+import { determineDemonstrationTypeStatus } from "./determineDemonstrationTypeStatus";
+import { getDemonstration, getManyDemonstrations } from "./demonstrationData";
+import { ContextUser, GraphQLContext } from "../../auth";
+import { getManyAmendments } from "../amendment";
+import { getManyExtensions } from "../extension";
+import { getManyDocuments } from "../document";
 
-vi.mock("../../prismaClient.js", () => ({
+vi.mock("../../prismaClient", () => ({
   prisma: vi.fn(),
 }));
 
-vi.mock("./demonstrationData.js", () => ({
+vi.mock("./demonstrationData", () => ({
   getDemonstration: vi.fn(),
   getManyDemonstrations: vi.fn(),
 }));
 
-vi.mock("../document/documentData.js", () => ({
+vi.mock("../document", () => ({
   getManyDocuments: vi.fn(),
 }));
 
-vi.mock("../amendment/amendmentData.js", () => ({
+vi.mock("../amendment", () => ({
   getManyAmendments: vi.fn(),
 }));
 
-vi.mock("../extension/extensionData.js", () => ({
+vi.mock("../extension", () => ({
   getManyExtensions: vi.fn(),
 }));
 
@@ -84,27 +83,27 @@ vi.mock("../application", () => ({
   resolveSuggestedApplicationTags: vi.fn(),
 }));
 
-vi.mock("../../errors/checkOptionalNotNullFields.js", () => ({
+vi.mock("../../errors/checkOptionalNotNullFields", () => ({
   checkOptionalNotNullFields: vi.fn(),
 }));
 
 const testHandlePrismaError = new Error("Test handlePrismaError!");
-vi.mock("../../errors/handlePrismaError.js", () => ({
+vi.mock("../../errors/handlePrismaError", () => ({
   handlePrismaError: vi.fn(() => {
     throw testHandlePrismaError;
   }),
 }));
 
-vi.mock("../applicationDate/checkInputDateFunctions.js", () => ({
+vi.mock("../applicationDate/checkInputDateFunctions", () => ({
   checkInputDateIsStartOfDay: vi.fn(),
   checkInputDateIsEndOfDay: vi.fn(),
 }));
 
-vi.mock("../../dateUtilities.js", () => ({
+vi.mock("../../dateUtilities", () => ({
   parseDateTimeOrLocalDateToEasternTZDate: vi.fn(),
 }));
 
-vi.mock("./determineDemonstrationTypeStatus.js", () => ({
+vi.mock("./determineDemonstrationTypeStatus", () => ({
   determineDemonstrationTypeStatus: vi.fn(),
 }));
 

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -4,7 +4,7 @@ import {
   DemonstrationRoleAssignment as PrismaDemonstrationRoleAssignment,
   Person as PrismaPerson,
 } from "@prisma/client";
-import { prisma } from "../../prismaClient.js";
+import { prisma } from "../../prismaClient";
 import {
   ApplicationStatus,
   ApplicationType,
@@ -15,9 +15,9 @@ import {
   Role,
   TagStatus,
   UpdateDemonstrationInput,
-} from "../../types.js";
-import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields.js";
-import { handlePrismaError } from "../../errors/handlePrismaError.js";
+} from "../../types";
+import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
+import { handlePrismaError } from "../../errors/handlePrismaError";
 import { parseAndValidateEffectiveAndExpirationDates } from "../applicationDate";
 import {
   deleteApplication,
@@ -26,13 +26,13 @@ import {
   resolveApplicationTags,
   resolveSuggestedApplicationTags,
 } from "../application";
-import { determineDemonstrationTypeStatus } from "./determineDemonstrationTypeStatus.js";
+import { determineDemonstrationTypeStatus } from "./determineDemonstrationTypeStatus";
 import { resolveManyDeliverables } from "../deliverable";
-import { GraphQLContext } from "../../auth/auth.util.js";
-import { getDemonstration, getManyDemonstrations } from "./demonstrationData.js";
-import { getManyAmendments } from "../amendment/amendmentData.js";
-import { getManyExtensions } from "../extension/extensionData.js";
-import { getManyDocuments } from "../document/documentData.js";
+import { GraphQLContext } from "../../auth";
+import { getDemonstration, getManyDemonstrations } from "./demonstrationData";
+import { getManyAmendments } from "../amendment";
+import { getManyExtensions } from "../extension";
+import { getManyDocuments } from "../document";
 
 const grantLevelDemonstration: GrantLevel = "Demonstration";
 const roleProjectOfficer: Role = "Project Officer";

--- a/server/src/model/demonstration/index.ts
+++ b/server/src/model/demonstration/index.ts
@@ -1,0 +1,1 @@
+export { getDemonstration, getManyDemonstrations } from "./demonstrationData";

--- a/server/src/model/demonstration/queries/index.ts
+++ b/server/src/model/demonstration/queries/index.ts
@@ -1,0 +1,2 @@
+export { selectDemonstration } from "./selectDemonstration";
+export { selectManyDemonstrations } from "./selectManyDemonstrations";

--- a/server/src/model/document/documentData.test.ts
+++ b/server/src/model/document/documentData.test.ts
@@ -1,20 +1,15 @@
 import { Document as PrismaDocument, Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { buildAuthorizationFilter } from "../../auth/buildAuthorizationFilter.js";
-import { getDocument, getManyDocuments } from "./documentData.js";
-import { selectDocument } from "./queries/selectDocument.js";
-import { selectManyDocuments } from "./queries/selectManyDocuments.js";
-import { ContextUser } from "../../auth/userContext.js";
+import { buildAuthorizationFilter, ContextUser } from "../../auth";
+import { getDocument, getManyDocuments } from "./documentData";
+import { selectDocument, selectManyDocuments } from "./queries";
 
-vi.mock("../../auth/buildAuthorizationFilter.js", () => ({
+vi.mock("../../auth", () => ({
   buildAuthorizationFilter: vi.fn(),
 }));
 
-vi.mock("./queries/selectDocument.js", () => ({
+vi.mock("./queries", () => ({
   selectDocument: vi.fn(),
-}));
-
-vi.mock("./queries/selectManyDocuments.js", () => ({
   selectManyDocuments: vi.fn(),
 }));
 

--- a/server/src/model/document/documentData.ts
+++ b/server/src/model/document/documentData.ts
@@ -3,10 +3,9 @@ import {
   buildAuthorizationFilter,
   isStatePointOfContactOnDemonstration,
   PermissionFilters,
-} from "../../auth/buildAuthorizationFilter.js";
-import { selectDocument } from "./queries/selectDocument.js";
-import { selectManyDocuments } from "./queries/selectManyDocuments.js";
-import { ContextUser } from "../../auth/userContext.js";
+  ContextUser,
+} from "../../auth";
+import { selectDocument, selectManyDocuments } from "./queries";
 
 const getPermissionFilters = (userId: string) =>
   ({

--- a/server/src/model/document/documentResolvers.test.ts
+++ b/server/src/model/document/documentResolvers.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TZDate } from "@date-fns/tz";
 import { Document as PrismaDocument, User as PrismaUser } from "@prisma/client";
-import { GraphQLContext } from "../../auth/auth.util.js";
+import { GraphQLContext } from "../../auth";
 import {
   UpdateDocumentInput,
   UploadDocumentInput,
@@ -9,8 +9,8 @@ import {
   DocumentType,
   PhaseName,
 } from "../../types";
-import { prisma } from "../../prismaClient.js";
-import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields.js";
+import { prisma } from "../../prismaClient";
+import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
 import { getS3Adapter } from "../../adapters";
 import { EasternNow, getEasternNow } from "../../dateUtilities";
 import { getUser } from "../user";
@@ -29,9 +29,8 @@ import {
   resolveApplication,
   documentResolvers,
   resolveHasPendingUIPathResult,
-} from "./documentResolvers.js";
-import { getDocument } from "./documentData.js";
-import { mock } from "node:test";
+} from "./documentResolvers";
+import { getDocument } from "./documentData";
 
 // Mock dependencies
 vi.mock("../../prismaClient", () => ({
@@ -162,6 +161,10 @@ describe("documentResolvers", () => {
     };
 
     const mockEasternNow: EasternNow = {
+      "Current Time": {
+        easternTZDate: new TZDate("2025-01-15T12:34:56.789Z"),
+        isEasternTZDate: true,
+      },
       "End of Day": {
         easternTZDate: new TZDate("2025-01-15T23:59:59.999Z"),
         isEasternTZDate: true,

--- a/server/src/model/document/documentResolvers.ts
+++ b/server/src/model/document/documentResolvers.ts
@@ -1,5 +1,5 @@
 import { Document as PrismaDocument, User as PrismaUser } from "@prisma/client";
-import { GraphQLContext } from "../../auth/auth.util";
+import { GraphQLContext } from "../../auth";
 import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
 import { handlePrismaError } from "../../errors/handlePrismaError";
 import { prisma } from "../../prismaClient";

--- a/server/src/model/document/index.ts
+++ b/server/src/model/document/index.ts
@@ -1,6 +1,6 @@
 // Functions
 export { handleDeleteDocument } from "./handleDeleteDocument";
-
+export { getDocument, getManyDocuments } from "./documentData";
 // Queries
 export { deleteDocumentById } from "./queries/deleteDocumentById";
 export { selectDocument } from "./queries/selectDocument";

--- a/server/src/model/document/queries/index.ts
+++ b/server/src/model/document/queries/index.ts
@@ -1,0 +1,2 @@
+export { selectDocument } from "./selectDocument";
+export { selectManyDocuments } from "./selectManyDocuments";

--- a/server/src/model/extension/extensionData.test.ts
+++ b/server/src/model/extension/extensionData.test.ts
@@ -1,20 +1,15 @@
 import { Extension as PrismaExtension, Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { buildAuthorizationFilter } from "../../auth/buildAuthorizationFilter.js";
-import { getExtension, getManyExtensions } from "./extensionData.js";
-import { selectExtension } from "./queries/selectExtension.js";
-import { selectManyExtensions } from "./queries/selectManyExtensions.js";
-import { ContextUser } from "../../auth/userContext.js";
+import { buildAuthorizationFilter, ContextUser } from "../../auth";
+import { getExtension, getManyExtensions } from "./extensionData";
+import { selectExtension, selectManyExtensions } from "./queries";
 
-vi.mock("../../auth/buildAuthorizationFilter.js", () => ({
+vi.mock("../../auth", () => ({
   buildAuthorizationFilter: vi.fn(),
 }));
 
-vi.mock("./queries/selectExtension.js", () => ({
+vi.mock("./queries", () => ({
   selectExtension: vi.fn(),
-}));
-
-vi.mock("./queries/selectManyExtensions.js", () => ({
   selectManyExtensions: vi.fn(),
 }));
 

--- a/server/src/model/extension/extensionData.ts
+++ b/server/src/model/extension/extensionData.ts
@@ -3,10 +3,9 @@ import {
   buildAuthorizationFilter,
   isStatePointOfContactOnDemonstration,
   PermissionFilters,
-} from "../../auth/buildAuthorizationFilter.js";
-import { selectExtension } from "./queries/selectExtension.js";
-import { selectManyExtensions } from "./queries/selectManyExtensions.js";
-import { ContextUser } from "../../auth/userContext.js";
+  ContextUser,
+} from "../../auth";
+import { selectExtension, selectManyExtensions } from "./queries";
 
 const getPermissionFilters = (userId: string) =>
   ({

--- a/server/src/model/extension/extensionResolvers.test.ts
+++ b/server/src/model/extension/extensionResolvers.test.ts
@@ -4,7 +4,7 @@ import {
   __updateExtension,
   deleteExtension,
   extensionResolvers,
-} from "./extensionResolvers.js";
+} from "./extensionResolvers";
 import {
   ApplicationStatus,
   ApplicationType,
@@ -13,12 +13,12 @@ import {
   PhaseName,
   SignatureLevel,
   UpdateExtensionInput,
-} from "../../types.js";
+} from "../../types";
 import { Extension as PrismaExtension } from "@prisma/client";
 import { TZDate } from "@date-fns/tz";
 
 // Mock imports
-import { prisma } from "../../prismaClient.js";
+import { prisma } from "../../prismaClient";
 import {
   deleteApplication,
   // None of these are tested but need to be exported to avoid mocking issues
@@ -26,33 +26,32 @@ import {
   resolveApplicationTags,
   resolveSuggestedApplicationTags,
 } from "../application";
-import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields.js";
-import { handlePrismaError } from "../../errors/handlePrismaError.js";
+import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
+import { handlePrismaError } from "../../errors/handlePrismaError";
 import {
   checkInputDateIsStartOfDay,
   checkInputDateIsEndOfDay,
-} from "../applicationDate/checkInputDateFunctions.js";
-import { EasternTZDate, parseDateTimeOrLocalDateToEasternTZDate } from "../../dateUtilities.js";
-import { ContextUser } from "../../auth/userContext.js";
-import { GraphQLContext } from "../../auth/auth.util.js";
-import { getDemonstration } from "../demonstration/demonstrationData.js";
-import { getExtension, getManyExtensions } from "./extensionData.js";
-import { getManyDocuments } from "../document/documentData.js";
+} from "../applicationDate/checkInputDateFunctions";
+import { EasternTZDate, parseDateTimeOrLocalDateToEasternTZDate } from "../../dateUtilities";
+import { ContextUser, GraphQLContext } from "../../auth";
+import { getDemonstration } from "../demonstration";
+import { getExtension, getManyExtensions } from "./extensionData";
+import { getManyDocuments } from "../document";
 
-vi.mock("../../prismaClient.js", () => ({
+vi.mock("../../prismaClient", () => ({
   prisma: vi.fn(),
 }));
 
-vi.mock("./extensionData.js", () => ({
+vi.mock("./extensionData", () => ({
   getExtension: vi.fn(),
   getManyExtensions: vi.fn(),
 }));
 
-vi.mock("../document/documentData.js", () => ({
+vi.mock("../document/documentData", () => ({
   getManyDocuments: vi.fn(),
 }));
 
-vi.mock("../demonstration/demonstrationData.js", () => ({
+vi.mock("../demonstration/demonstrationData", () => ({
   getDemonstration: vi.fn(),
 }));
 
@@ -65,23 +64,23 @@ vi.mock("../application", () => ({
   resolveSuggestedApplicationTags: vi.fn(),
 }));
 
-vi.mock("../../errors/checkOptionalNotNullFields.js", () => ({
+vi.mock("../../errors/checkOptionalNotNullFields", () => ({
   checkOptionalNotNullFields: vi.fn(),
 }));
 
 const testHandlePrismaError = new Error("Test handlePrismaError!");
-vi.mock("../../errors/handlePrismaError.js", () => ({
+vi.mock("../../errors/handlePrismaError", () => ({
   handlePrismaError: vi.fn(() => {
     throw testHandlePrismaError;
   }),
 }));
 
-vi.mock("../applicationDate/checkInputDateFunctions.js", () => ({
+vi.mock("../applicationDate/checkInputDateFunctions", () => ({
   checkInputDateIsStartOfDay: vi.fn(),
   checkInputDateIsEndOfDay: vi.fn(),
 }));
 
-vi.mock("../../dateUtilities.js", () => ({
+vi.mock("../../dateUtilities", () => ({
   parseDateTimeOrLocalDateToEasternTZDate: vi.fn(),
 }));
 

--- a/server/src/model/extension/extensionResolvers.ts
+++ b/server/src/model/extension/extensionResolvers.ts
@@ -1,14 +1,14 @@
 import { Extension as PrismaExtension } from "@prisma/client";
-import { prisma } from "../../prismaClient.js";
+import { prisma } from "../../prismaClient";
 import {
   ApplicationStatus,
   ApplicationType,
   CreateExtensionInput,
   PhaseName,
   UpdateExtensionInput,
-} from "../../types.js";
-import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields.js";
-import { handlePrismaError } from "../../errors/handlePrismaError.js";
+} from "../../types";
+import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
+import { handlePrismaError } from "../../errors/handlePrismaError";
 import { parseAndValidateEffectiveAndExpirationDates } from "../applicationDate";
 import {
   deleteApplication,
@@ -16,10 +16,10 @@ import {
   resolveApplicationTags,
   resolveSuggestedApplicationTags,
 } from "../application";
-import { getDemonstration } from "../demonstration/demonstrationData.js";
-import { GraphQLContext } from "../../auth/auth.util.js";
-import { getExtension, getManyExtensions } from "./extensionData.js";
-import { getManyDocuments } from "../document/documentData.js";
+import { getDemonstration } from "../demonstration";
+import { GraphQLContext } from "../../auth";
+import { getExtension, getManyExtensions } from "./extensionData";
+import { getManyDocuments } from "../document";
 
 const extensionApplicationType: ApplicationType = "Extension";
 const conceptPhaseName: PhaseName = "Concept";

--- a/server/src/model/extension/index.ts
+++ b/server/src/model/extension/index.ts
@@ -1,0 +1,1 @@
+export { getExtension, getManyExtensions } from "./extensionData";

--- a/server/src/model/extension/queries/index.ts
+++ b/server/src/model/extension/queries/index.ts
@@ -1,0 +1,2 @@
+export { selectExtension } from "./selectExtension";
+export { selectManyExtensions } from "./selectManyExtensions";

--- a/server/src/model/user/userResolvers.test.ts
+++ b/server/src/model/user/userResolvers.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { User as PrismaUser } from "@prisma/client";
-import type { GraphQLContext } from "../../auth/auth.util.js";
+import type { GraphQLContext } from "../../auth";
 import { queryCurrentUser, resolvePerson, resolveEvents, userResolvers } from "./userResolvers";
 
 // Mock imports
-import { prisma } from "../../prismaClient.js";
-import { getManyDocuments } from "../document/documentData.js";
+import { prisma } from "../../prismaClient";
+import { getManyDocuments } from "../document";
 
-vi.mock("../../prismaClient.js", () => ({
+vi.mock("../../prismaClient", () => ({
   prisma: vi.fn(),
 }));
 
-vi.mock("../document/documentData.js", () => ({
+vi.mock("../document", () => ({
   getManyDocuments: vi.fn(),
 }));
 

--- a/server/src/model/user/userResolvers.ts
+++ b/server/src/model/user/userResolvers.ts
@@ -1,8 +1,8 @@
-import { prisma } from "../../prismaClient.js";
-import type { GraphQLContext } from "../../auth/auth.util.js";
+import { prisma } from "../../prismaClient";
+import type { GraphQLContext } from "../../auth";
 import { Event as PrismaEvent, Person as PrismaPerson, User as PrismaUser } from "@prisma/client";
 import { resolveManyDeliverables } from "../deliverable";
-import { getManyDocuments } from "../document/documentData.js";
+import { getManyDocuments } from "../document";
 
 export async function queryCurrentUser(
   parent: unknown,


### PR DESCRIPTION
Just a cleanup! removing the unneeded ".js" from imports, initialized index files for auth, queries, and main models. number of imports are reduced and grouped together