### PR TITLE
Demos 1986 row based auth application phase

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -477,6 +477,8 @@ export const PERMISSIONS = [
   "View All Documents",
   "View Documents on Assigned Demonstrations",
   "View Owned Documents",
+  "View All ApplicationPhases",
+  "View ApplicationPhases on Assigned Demonstrations",
 ] as const;
 
 export const SYSTEM_ROLES = ["Admin User", "CMS User", "State User"] as const;

--- a/server/src/model/amendment/amendmentResolvers.test.ts
+++ b/server/src/model/amendment/amendmentResolvers.test.ts
@@ -36,6 +36,7 @@ import { ContextUser, GraphQLContext } from "../../auth";
 import { getDemonstration } from "../demonstration";
 import { getAmendment, getManyAmendments } from "./amendmentData";
 import { getManyDocuments } from "../document";
+import { getManyApplicationPhases } from "../applicationPhase";
 vi.mock("../../prismaClient", () => ({
   prisma: vi.fn(),
 }));
@@ -51,6 +52,10 @@ vi.mock("../document", () => ({
 
 vi.mock("../demonstration", () => ({
   getDemonstration: vi.fn(),
+}));
+
+vi.mock("../applicationPhase", () => ({
+  getManyApplicationPhases: vi.fn(),
 }));
 
 vi.mock("../application", () => ({
@@ -161,6 +166,20 @@ describe("amendmentResolvers", () => {
         mockContext
       );
       expect(getDemonstration).toHaveBeenCalledExactlyOnceWith({ id: "abc123" }, mockUser);
+    });
+  });
+
+  describe("Amendment.phases", () => {
+    it("delegates to `applicationPhaseData.getManyApplicationPhases`", async () => {
+      await amendmentResolvers.Amendment.phases(
+        { id: "amendmentId" } as PrismaAmendment,
+        {},
+        mockContext
+      );
+      expect(getManyApplicationPhases).toHaveBeenCalledExactlyOnceWith(
+        { applicationId: "amendmentId" },
+        mockUser
+      );
     });
   });
 

--- a/server/src/model/amendment/amendmentResolvers.test.ts
+++ b/server/src/model/amendment/amendmentResolvers.test.ts
@@ -22,7 +22,6 @@ import { prisma } from "../../prismaClient";
 import {
   deleteApplication,
   // None of these are tested but need to be exported to avoid mocking issues
-  resolveApplicationPhases,
   resolveApplicationTags,
   resolveSuggestedApplicationTags,
 } from "../application";
@@ -58,7 +57,6 @@ vi.mock("../application", () => ({
   getApplication: vi.fn(),
   getManyApplications: vi.fn(),
   deleteApplication: vi.fn(),
-  resolveApplicationPhases: vi.fn(),
   resolveApplicationTags: vi.fn(),
   resolveSuggestedApplicationTags: vi.fn(),
 }));

--- a/server/src/model/amendment/amendmentResolvers.ts
+++ b/server/src/model/amendment/amendmentResolvers.ts
@@ -12,7 +12,6 @@ import { handlePrismaError } from "../../errors/handlePrismaError";
 import { parseAndValidateEffectiveAndExpirationDates } from "../applicationDate";
 import {
   deleteApplication,
-  resolveApplicationPhases,
   resolveApplicationTags,
   resolveSuggestedApplicationTags,
 } from "../application";
@@ -20,6 +19,7 @@ import { getDemonstration } from "../demonstration";
 import { GraphQLContext } from "../../auth";
 import { getAmendment, getManyAmendments } from "./amendmentData";
 import { getManyDocuments } from "../document";
+import { getManyApplicationPhases } from "../applicationPhase";
 
 const amendmentApplicationType: ApplicationType = "Amendment";
 const conceptPhaseName: PhaseName = "Concept";
@@ -106,7 +106,8 @@ export const amendmentResolvers = {
       getManyDocuments({ applicationId: parent.id }, context.user),
     currentPhaseName: (parent: PrismaAmendment) => parent.currentPhaseId,
     status: (parent: PrismaAmendment) => parent.statusId,
-    phases: resolveApplicationPhases,
+    phases: (parent: PrismaAmendment, args: unknown, context: GraphQLContext) =>
+      getManyApplicationPhases({ applicationId: parent.id }, context.user),
     clearanceLevel: (parent: PrismaAmendment) => parent.clearanceLevelId,
     tags: resolveApplicationTags,
     signatureLevel: (parent: PrismaAmendment) => parent.signatureLevelId,

--- a/server/src/model/application/applicationResolvers.test.ts
+++ b/server/src/model/application/applicationResolvers.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   resolveApplicationType,
-  resolveApplicationPhases,
   resolveApplicationTags,
   PrismaApplication,
   resolveSuggestedApplicationTags,
@@ -33,9 +32,6 @@ vi.mock("../applicationPhase", () => ({
 
 describe("applicationResolvers", () => {
   const regularMocks = {
-    applicationPhase: {
-      findMany: vi.fn(),
-    },
     applicationTagAssignment: {
       findMany: vi.fn(),
     },
@@ -44,9 +40,6 @@ describe("applicationResolvers", () => {
     }
   };
   const mockPrismaClient = {
-    applicationPhase: {
-      findMany: regularMocks.applicationPhase.findMany,
-    },
     applicationTagAssignment: {
       findMany: regularMocks.applicationTagAssignment.findMany,
     },
@@ -73,21 +66,6 @@ describe("applicationResolvers", () => {
       };
       const result = resolveApplicationType(input as PrismaApplication);
       expect(result).toBe(testDemonstrationApplicationTypeId);
-    });
-  });
-
-  describe("resolveApplicationPhases", () => {
-    it("should resolve the application phases", async () => {
-      const input: Partial<PrismaApplication> = {
-        id: testApplicationId,
-      };
-      const expectedCall = {
-        where: {
-          applicationId: testApplicationId,
-        },
-      };
-      await resolveApplicationPhases(input as PrismaApplication);
-      expect(regularMocks.applicationPhase.findMany).toHaveBeenCalledExactlyOnceWith(expectedCall);
     });
   });
 

--- a/server/src/model/application/applicationResolvers.ts
+++ b/server/src/model/application/applicationResolvers.ts
@@ -1,8 +1,5 @@
 import { prisma } from "../../prismaClient.js";
 import { TagStatus, UiPathResultStatus } from "../../types.js";
-import {
-  ApplicationPhase as PrismaApplicationPhase,
-} from "@prisma/client";
 import { setApplicationClearanceLevel, PrismaApplication } from ".";
 import { Tag } from "../tag";
 
@@ -10,17 +7,6 @@ export function resolveApplicationType(parent: PrismaApplication): string {
   return parent.applicationTypeId;
 }
 
-export async function resolveApplicationPhases(
-  parent: PrismaApplication
-): Promise<PrismaApplicationPhase[]> {
-  // The phases are prepopulated by the database so this is never null
-  const result = await prisma().applicationPhase.findMany({
-    where: {
-      applicationId: parent.id,
-    },
-  });
-  return result;
-}
 
 export async function resolveApplicationTags(parent: PrismaApplication): Promise<Tag[]> {
   const applicationTags = await prisma().applicationTagAssignment.findMany({

--- a/server/src/model/application/index.ts
+++ b/server/src/model/application/index.ts
@@ -2,7 +2,6 @@
 export { setApplicationClearanceLevel } from "./setApplicationClearanceLevel";
 export {
   resolveApplicationType,
-  resolveApplicationPhases,
   resolveApplicationTags,
   resolveSuggestedApplicationTags,
 } from "./applicationResolvers";

--- a/server/src/model/applicationPhase/applicationPhaseData.test.ts
+++ b/server/src/model/applicationPhase/applicationPhaseData.test.ts
@@ -1,0 +1,139 @@
+import { ApplicationPhase as PrismaApplicationPhase, Prisma } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildAuthorizationFilter, ContextUser } from "../../auth";
+import { getApplicationPhase, getManyApplicationPhases } from "./applicationPhaseData";
+import { selectApplicationPhase, selectManyApplicationPhases } from "./queries";
+
+vi.mock("../../auth", () => ({
+  buildAuthorizationFilter: vi.fn(),
+}));
+
+vi.mock("./queries", () => ({
+  selectApplicationPhase: vi.fn(),
+  selectManyApplicationPhases: vi.fn(),
+}));
+
+describe("applicationPhaseData", () => {
+  const user: ContextUser = {
+    id: "user-1",
+    cognitoSubject: "sub-1",
+    personTypeId: "demos-state-user",
+    permissions: ["View ApplicationPhases on Assigned Demonstrations"],
+  };
+
+  const where: Prisma.ApplicationPhaseWhereInput = {
+    applicationId: "application-1",
+  };
+
+  const authorizedWhereClause: Prisma.ApplicationPhaseWhereInput = {
+    application: {
+      demonstration: {
+        demonstrationRoleAssignments: {
+          some: {
+            personId: user.id,
+            roleId: "State Point of Contact",
+          },
+        },
+      },
+    },
+  };
+
+  const authFilter = {
+    OR: [authorizedWhereClause],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getApplicationPhase", () => {
+    it("returns null when authorization filter returns null", async () => {
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(null);
+
+      const result = await getApplicationPhase(where, user);
+
+      expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
+      expect(selectApplicationPhase).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("queries for a single applicationPhase with the authorization filter applied", async () => {
+      const applicationPhase = { applicationId: "application-1" } as PrismaApplicationPhase;
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      vi.mocked(selectApplicationPhase).mockResolvedValueOnce(applicationPhase);
+
+      const result = await getApplicationPhase(where, user);
+
+      expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
+      expect(buildAuthorizationFilter).toHaveBeenCalledWith(user, expect.any(Function));
+      expect(selectApplicationPhase).toHaveBeenCalledExactlyOnceWith(
+        {
+          AND: [where, authFilter],
+        },
+        undefined
+      );
+      expect(result).toBe(applicationPhase);
+    });
+
+    it("passes transaction client to selectApplicationPhase if provided", async () => {
+      const mockTransactionClient = {} as any;
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+
+      await getApplicationPhase(where, user, mockTransactionClient);
+      expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
+      expect(selectApplicationPhase).toHaveBeenCalledExactlyOnceWith(
+        {
+          AND: [where, authFilter],
+        },
+        mockTransactionClient
+      );
+    });
+  });
+
+  describe("getManyApplicationPhases", () => {
+    it("returns an empty array when authorization filter returns null", async () => {
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(null);
+
+      const result = await getManyApplicationPhases(where, user);
+
+      expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
+      expect(selectManyApplicationPhases).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
+    });
+
+    it("queries for many applicationPhases with the authorization filter applied", async () => {
+      const applicationPhases = [
+        { application: "application-1" },
+        { applicationId: "application-2" },
+      ] as PrismaApplicationPhase[];
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      vi.mocked(selectManyApplicationPhases).mockResolvedValueOnce(applicationPhases);
+
+      const result = await getManyApplicationPhases(where, user);
+
+      expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
+      expect(buildAuthorizationFilter).toHaveBeenCalledWith(user, expect.any(Function));
+      expect(selectManyApplicationPhases).toHaveBeenCalledExactlyOnceWith(
+        {
+          AND: [where, authFilter],
+        },
+        undefined
+      );
+      expect(result).toBe(applicationPhases);
+    });
+
+    it("passes transaction client to selectManyApplicationPhases if provided", async () => {
+      const mockTransactionClient = {} as any;
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+
+      await getManyApplicationPhases(where, user, mockTransactionClient);
+      expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
+      expect(selectManyApplicationPhases).toHaveBeenCalledExactlyOnceWith(
+        {
+          AND: [where, authFilter],
+        },
+        mockTransactionClient
+      );
+    });
+  });
+});

--- a/server/src/model/applicationPhase/applicationPhaseData.test.ts
+++ b/server/src/model/applicationPhase/applicationPhaseData.test.ts
@@ -13,7 +13,7 @@ vi.mock("./queries", () => ({
   selectManyApplicationPhases: vi.fn(),
 }));
 
-describe("applicationPhaseData", () => {
+describe("./applicationPhaseData", () => {
   const user: ContextUser = {
     id: "user-1",
     cognitoSubject: "sub-1",

--- a/server/src/model/applicationPhase/applicationPhaseData.ts
+++ b/server/src/model/applicationPhase/applicationPhaseData.ts
@@ -1,0 +1,82 @@
+import { Prisma, ApplicationPhase as PrismaApplicationPhase } from "@prisma/client";
+import {
+  buildAuthorizationFilter,
+  isStatePointOfContactOnDemonstration,
+  PermissionFilters,
+  ContextUser,
+} from "../../auth";
+import { selectApplicationPhase, selectManyApplicationPhases } from "./queries";
+import { PrismaTransactionClient } from "../../prismaClient";
+
+const getPermissionFilters = (userId: string) =>
+  ({
+    "View All ApplicationPhases": {
+      NOT: {
+        applicationId: {
+          in: [],
+        },
+      },
+    },
+    "View ApplicationPhases on Assigned Demonstrations": {
+      application: {
+        OR: [
+          {
+            demonstration: isStatePointOfContactOnDemonstration(userId),
+          },
+          {
+            amendment: {
+              demonstration: isStatePointOfContactOnDemonstration(userId),
+            },
+          },
+          {
+            extension: {
+              demonstration: isStatePointOfContactOnDemonstration(userId),
+            },
+          },
+        ],
+      },
+    },
+  }) satisfies PermissionFilters<Prisma.ApplicationPhaseWhereInput>;
+
+export async function getApplicationPhase(
+  where: Prisma.ApplicationPhaseWhereInput,
+  user: ContextUser,
+  tx?: PrismaTransactionClient
+): Promise<PrismaApplicationPhase | null> {
+  const authFilter = buildAuthorizationFilter<Prisma.ApplicationPhaseWhereInput>(
+    user,
+    getPermissionFilters
+  );
+
+  if (authFilter === null) {
+    return null;
+  }
+
+  return await selectApplicationPhase(
+    {
+      AND: [where, authFilter],
+    },
+    tx
+  );
+}
+
+export async function getManyApplicationPhases(
+  where: Prisma.ApplicationPhaseWhereInput,
+  user: ContextUser,
+  tx?: PrismaTransactionClient
+): Promise<PrismaApplicationPhase[]> {
+  const authFilter = buildAuthorizationFilter<Prisma.ApplicationPhaseWhereInput>(
+    user,
+    getPermissionFilters
+  );
+
+  if (authFilter === null) {
+    return [];
+  }
+  return await selectManyApplicationPhases(
+    {
+      AND: [where, authFilter],
+    },
+    tx
+  );
+}

--- a/server/src/model/applicationPhase/applicationPhaseResolvers.test.ts
+++ b/server/src/model/applicationPhase/applicationPhaseResolvers.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   __resolveApplicationPhaseDates,
-  __resolveApplicationPhaseName,
-  __resolveApplicationPhaseStatus,
   applicationPhaseResolvers,
 } from "./applicationPhaseResolvers";
 import { ApplicationPhase as PrismaApplicationPhase } from "@prisma/client";
@@ -115,20 +113,6 @@ describe("applicationPhaseResolvers", () => {
 
       await __resolveApplicationPhaseDates(testInput);
       expect(mockFindMany).toHaveBeenCalledExactlyOnceWith(expectedCall);
-    });
-  });
-
-  describe("__resolveApplicationPhaseName", () => {
-    it("should retrieve the phase name", async () => {
-      const result = __resolveApplicationPhaseName(testInput);
-      expect(result).toBe(testPhaseId);
-    });
-  });
-
-  describe("__resolveApplicationPhaseStatus", () => {
-    it("should retrieve the phase status", async () => {
-      const result = __resolveApplicationPhaseStatus(testInput);
-      expect(result).toBe(testPhaseStatusId);
     });
   });
 });

--- a/server/src/model/applicationPhase/applicationPhaseResolvers.test.ts
+++ b/server/src/model/applicationPhase/applicationPhaseResolvers.test.ts
@@ -94,6 +94,28 @@ describe("applicationPhaseResolvers", () => {
     });
   });
 
+  describe("ApplicationPhase.phaseName", () => {
+    it("returns phaseId", () => {
+      const applicationPhase = {
+        phaseId: "Approval Summary" satisfies PhaseName,
+      } as PrismaApplicationPhase;
+
+      const result = applicationPhaseResolvers.ApplicationPhase.phaseName(applicationPhase);
+      expect(result).toBe(applicationPhase.phaseId);
+    });
+  });
+
+  describe("ApplicationPhase.status", () => {
+    it("returns phaseStatusId", () => {
+      const applicationPhase = {
+        phaseStatusId: "Incomplete" satisfies PhaseStatus,
+      } as PrismaApplicationPhase;
+
+      const result = applicationPhaseResolvers.ApplicationPhase.phaseStatus(applicationPhase);
+      expect(result).toBe(applicationPhase.phaseStatusId);
+    });
+  });
+
   describe("__resolveApplicationPhaseDates", () => {
     it("should retrieve the requested dates for the phase and application", async () => {
       const expectedCall = {

--- a/server/src/model/applicationPhase/applicationPhaseResolvers.ts
+++ b/server/src/model/applicationPhase/applicationPhaseResolvers.ts
@@ -54,18 +54,10 @@ export async function __resolveApplicationPhaseNotes(
   return rows;
 }
 
-export function __resolveApplicationPhaseName(parent: PrismaApplicationPhase): string {
-  return parent.phaseId;
-}
-
-export function __resolveApplicationPhaseStatus(parent: PrismaApplicationPhase): string {
-  return parent.phaseStatusId;
-}
-
 export const applicationPhaseResolvers = {
   ApplicationPhase: {
-    phaseName: __resolveApplicationPhaseName,
-    phaseStatus: __resolveApplicationPhaseStatus,
+    phaseName: (parent: PrismaApplicationPhase) => parent.phaseId,
+    phaseStatus: (parent: PrismaApplicationPhase) => parent.phaseStatusId,
     phaseDates: __resolveApplicationPhaseDates,
     phaseNotes: __resolveApplicationPhaseNotes,
     documents: (parent: PrismaApplicationPhase, args: unknown, context: GraphQLContext) =>

--- a/server/src/model/applicationPhase/index.ts
+++ b/server/src/model/applicationPhase/index.ts
@@ -16,6 +16,8 @@ export { skipConceptPhase } from "./skipConceptPhase.js";
 export { declareCompletenessPhaseIncomplete } from "./declareCompletenessPhaseIncomplete.js";
 export { startPhasesByDates } from "./startPhasesByDates.js";
 export { startPhaseByDocument } from "./startPhaseByDocument.js";
+export { getApplicationPhase } from "./applicationPhaseData";
+export { getManyApplicationPhases } from "./applicationPhaseData";
 
 // Queries
 export { getApplicationPhaseDocumentTypes } from "./queries/getApplicationPhaseDocumentTypes.js";

--- a/server/src/model/applicationPhase/queries/index.ts
+++ b/server/src/model/applicationPhase/queries/index.ts
@@ -1,0 +1,2 @@
+export { selectApplicationPhase } from "./selectApplicationPhase";
+export { selectManyApplicationPhases } from "./selectManyApplicationPhases";

--- a/server/src/model/applicationPhase/queries/selectApplicationPhase.test.ts
+++ b/server/src/model/applicationPhase/queries/selectApplicationPhase.test.ts
@@ -1,0 +1,80 @@
+import { ApplicationPhase as PrismaApplicationPhase } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { selectApplicationPhase } from "./selectApplicationPhase";
+
+vi.mock("../../../prismaClient", () => ({
+  prisma: vi.fn(),
+}));
+
+describe("selectApplicationPhase", () => {
+  const regularMocks = {
+    applicationPhase: {
+      findAtMostOne: vi.fn(),
+    },
+  };
+  const mockPrismaClient = {
+    applicationPhase: {
+      findAtMostOne: regularMocks.applicationPhase.findAtMostOne,
+    },
+  };
+  const transactionMocks = {
+    applicationPhase: {
+      findAtMostOne: vi.fn(),
+    },
+  };
+  const mockTransaction = {
+    applicationPhase: {
+      findAtMostOne: transactionMocks.applicationPhase.findAtMostOne,
+    },
+  } as any;
+
+  const testApplicationId = "application-1";
+  const where = {
+    applicationId: testApplicationId,
+  };
+  const expectedCall = {
+    where: { applicationId: testApplicationId },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma).mockReturnValue(mockPrismaClient as never);
+  });
+
+  it("should get applicationPhase from the database directly if no transaction is given", async () => {
+    await selectApplicationPhase(where);
+    expect(regularMocks.applicationPhase.findAtMostOne).toHaveBeenCalledExactlyOnceWith(
+      expectedCall
+    );
+    expect(transactionMocks.applicationPhase.findAtMostOne).not.toHaveBeenCalled();
+  });
+
+  it("should get applicationPhase via a transaction if one is given", async () => {
+    await selectApplicationPhase(where, mockTransaction);
+    expect(regularMocks.applicationPhase.findAtMostOne).not.toHaveBeenCalled();
+    expect(transactionMocks.applicationPhase.findAtMostOne).toHaveBeenCalledExactlyOnceWith(
+      expectedCall
+    );
+  });
+
+  it("returns null when no applicationPhase is found", async () => {
+    regularMocks.applicationPhase.findAtMostOne.mockResolvedValueOnce(null);
+    const result = await selectApplicationPhase(where);
+    expect(regularMocks.applicationPhase.findAtMostOne).toHaveBeenCalledExactlyOnceWith(
+      expectedCall
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns applicationPhase that is found", async () => {
+    const applicationPhase = { applicationId: testApplicationId } as PrismaApplicationPhase;
+    regularMocks.applicationPhase.findAtMostOne.mockResolvedValueOnce(applicationPhase);
+
+    const result = await selectApplicationPhase(where);
+    expect(regularMocks.applicationPhase.findAtMostOne).toHaveBeenCalledExactlyOnceWith(
+      expectedCall
+    );
+    expect(result).toBe(applicationPhase);
+  });
+});

--- a/server/src/model/applicationPhase/queries/selectApplicationPhase.ts
+++ b/server/src/model/applicationPhase/queries/selectApplicationPhase.ts
@@ -1,0 +1,10 @@
+import { ApplicationPhase as PrismaApplicationPhase, Prisma } from "@prisma/client";
+import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+
+export async function selectApplicationPhase(
+  where: Prisma.ApplicationPhaseWhereInput,
+  tx?: PrismaTransactionClient
+): Promise<PrismaApplicationPhase | null> {
+  const prismaClient = tx ?? prisma();
+  return prismaClient.applicationPhase.findAtMostOne({ where });
+}

--- a/server/src/model/applicationPhase/queries/selectManyApplicationPhases.test.ts
+++ b/server/src/model/applicationPhase/queries/selectManyApplicationPhases.test.ts
@@ -1,0 +1,78 @@
+import { ApplicationPhase as PrismaApplicationPhase } from "@prisma/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { selectManyApplicationPhases } from "./selectManyApplicationPhases";
+
+vi.mock("../../../prismaClient", () => ({
+  prisma: vi.fn(),
+}));
+
+describe("selectManyApplicationPhases", () => {
+  const regularMocks = {
+    applicationPhase: {
+      findMany: vi.fn(),
+    },
+  };
+  const mockPrismaClient = {
+    applicationPhase: {
+      findMany: regularMocks.applicationPhase.findMany,
+    },
+  };
+  const transactionMocks = {
+    applicationPhase: {
+      findMany: vi.fn(),
+    },
+  };
+  const mockTransaction = {
+    applicationPhase: {
+      findMany: transactionMocks.applicationPhase.findMany,
+    },
+  } as any;
+
+  const testApplicationId = "application-1";
+  const testApplicationId2 = "application-2";
+  const where = {
+    applicationId: testApplicationId,
+  };
+  const expectedCall = {
+    where: { applicationId: testApplicationId },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma).mockReturnValue(mockPrismaClient as never);
+  });
+
+  it("should get applicationPhases from the database directly if no transaction is given", async () => {
+    await selectManyApplicationPhases(where);
+    expect(regularMocks.applicationPhase.findMany).toHaveBeenCalledExactlyOnceWith(expectedCall);
+    expect(transactionMocks.applicationPhase.findMany).not.toHaveBeenCalled();
+  });
+
+  it("should get applicationPhases via a transaction if one is given", async () => {
+    await selectManyApplicationPhases(where, mockTransaction);
+    expect(regularMocks.applicationPhase.findMany).not.toHaveBeenCalled();
+    expect(transactionMocks.applicationPhase.findMany).toHaveBeenCalledExactlyOnceWith(
+      expectedCall
+    );
+  });
+
+  it("returns an empty array when no applicationPhases are found", async () => {
+    regularMocks.applicationPhase.findMany.mockResolvedValueOnce([]);
+    const result = await selectManyApplicationPhases(where);
+    expect(regularMocks.applicationPhase.findMany).toHaveBeenCalledExactlyOnceWith(expectedCall);
+    expect(result).toEqual([]);
+  });
+
+  it("returns all applicationPhases that are found", async () => {
+    const applicationPhases = [
+      { applicationId: testApplicationId },
+      { applicationId: testApplicationId2 },
+    ] as PrismaApplicationPhase[];
+    regularMocks.applicationPhase.findMany.mockResolvedValueOnce(applicationPhases);
+
+    const result = await selectManyApplicationPhases(where);
+    expect(regularMocks.applicationPhase.findMany).toHaveBeenCalledExactlyOnceWith(expectedCall);
+    expect(result).toBe(applicationPhases);
+  });
+});

--- a/server/src/model/applicationPhase/queries/selectManyApplicationPhases.ts
+++ b/server/src/model/applicationPhase/queries/selectManyApplicationPhases.ts
@@ -1,0 +1,10 @@
+import { ApplicationPhase as PrismaApplicationPhase, Prisma } from "@prisma/client";
+import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+
+export async function selectManyApplicationPhases(
+  where: Prisma.ApplicationPhaseWhereInput,
+  tx?: PrismaTransactionClient
+): Promise<PrismaApplicationPhase[]> {
+  const prismaClient = tx ?? prisma();
+  return await prismaClient.applicationPhase.findMany({ where });
+}

--- a/server/src/model/demonstration/demonstrationResolvers.test.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.test.ts
@@ -52,6 +52,7 @@ import { ContextUser, GraphQLContext } from "../../auth";
 import { getManyAmendments } from "../amendment";
 import { getManyExtensions } from "../extension";
 import { getManyDocuments } from "../document";
+import { getManyApplicationPhases } from "../applicationPhase";
 
 vi.mock("../../prismaClient", () => ({
   prisma: vi.fn(),
@@ -72,6 +73,10 @@ vi.mock("../amendment", () => ({
 
 vi.mock("../extension", () => ({
   getManyExtensions: vi.fn(),
+}));
+
+vi.mock("../applicationPhase", () => ({
+  getManyApplicationPhases: vi.fn(),
 }));
 
 vi.mock("../application", () => ({
@@ -289,6 +294,20 @@ describe("demonstrationResolvers", () => {
       );
       expect(getManyExtensions).toHaveBeenCalledExactlyOnceWith(
         { demonstrationId: "demonstrationId" },
+        mockUser
+      );
+    });
+  });
+
+  describe("Demonstration.phases", () => {
+    it("delegates to `applicationPhaseData.getManyApplicationPhases`", async () => {
+      await demonstrationResolvers.Demonstration.phases(
+        { id: "demonstrationId" } as PrismaDemonstration,
+        {},
+        mockContext
+      );
+      expect(getManyApplicationPhases).toHaveBeenCalledExactlyOnceWith(
+        { applicationId: "demonstrationId" },
         mockUser
       );
     });

--- a/server/src/model/demonstration/demonstrationResolvers.test.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.test.ts
@@ -42,7 +42,6 @@ import {
   deleteApplication,
   getApplication,
   // None of these are tested but need to be exported to avoid mocking issues
-  resolveApplicationPhases,
   resolveApplicationTags,
   resolveSuggestedApplicationTags,
 } from "../application";
@@ -78,7 +77,6 @@ vi.mock("../extension", () => ({
 vi.mock("../application", () => ({
   getApplication: vi.fn(),
   deleteApplication: vi.fn(),
-  resolveApplicationPhases: vi.fn(),
   resolveApplicationTags: vi.fn(),
   resolveSuggestedApplicationTags: vi.fn(),
 }));

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -22,7 +22,6 @@ import { parseAndValidateEffectiveAndExpirationDates } from "../applicationDate"
 import {
   deleteApplication,
   getApplication,
-  resolveApplicationPhases,
   resolveApplicationTags,
   resolveSuggestedApplicationTags,
 } from "../application";
@@ -33,6 +32,7 @@ import { getDemonstration, getManyDemonstrations } from "./demonstrationData";
 import { getManyAmendments } from "../amendment";
 import { getManyExtensions } from "../extension";
 import { getManyDocuments } from "../document";
+import { getManyApplicationPhases } from "../applicationPhase";
 
 const grantLevelDemonstration: GrantLevel = "Demonstration";
 const roleProjectOfficer: Role = "Project Officer";
@@ -279,7 +279,8 @@ export const demonstrationResolvers = {
     currentPhaseName: (parent: PrismaDemonstration) => parent.currentPhaseId,
     roles: __resolveDemonstrationRoleAssignments,
     status: (parent: PrismaDemonstration) => parent.statusId,
-    phases: resolveApplicationPhases,
+    phases: (parent: PrismaDemonstration, args: unknown, context: GraphQLContext) =>
+      getManyApplicationPhases({ applicationId: parent.id }, context.user),
     primaryProjectOfficer: __resolveDemonstrationPrimaryProjectOfficer,
     clearanceLevel: (parent: PrismaDemonstration) => parent.clearanceLevelId,
     tags: resolveApplicationTags,

--- a/server/src/model/extension/extensionResolvers.test.ts
+++ b/server/src/model/extension/extensionResolvers.test.ts
@@ -36,6 +36,7 @@ import { ContextUser, GraphQLContext } from "../../auth";
 import { getDemonstration } from "../demonstration";
 import { getExtension, getManyExtensions } from "./extensionData";
 import { getManyDocuments } from "../document";
+import { getManyApplicationPhases } from "../applicationPhase";
 
 vi.mock("../../prismaClient", () => ({
   prisma: vi.fn(),
@@ -46,11 +47,15 @@ vi.mock("./extensionData", () => ({
   getManyExtensions: vi.fn(),
 }));
 
-vi.mock("../document/documentData", () => ({
+vi.mock("../document", () => ({
   getManyDocuments: vi.fn(),
 }));
 
-vi.mock("../demonstration/demonstrationData", () => ({
+vi.mock("../applicationPhase", () => ({
+  getManyApplicationPhases: vi.fn(),
+}));
+
+vi.mock("../demonstration", () => ({
   getDemonstration: vi.fn(),
 }));
 
@@ -153,6 +158,20 @@ describe("extensionResolvers", () => {
       await extensionResolvers.Extension.documents(mockExtension, undefined, mockContext);
       expect(getManyDocuments).toHaveBeenCalledExactlyOnceWith(
         { applicationId: "abc123" },
+        mockUser
+      );
+    });
+  });
+
+  describe("Extension.phases", () => {
+    it("delegates to `applicationPhaseData.getManyApplicationPhases`", async () => {
+      await extensionResolvers.Extension.phases(
+        { id: "extensionId" } as PrismaExtension,
+        {},
+        mockContext
+      );
+      expect(getManyApplicationPhases).toHaveBeenCalledExactlyOnceWith(
+        { applicationId: "extensionId" },
         mockUser
       );
     });

--- a/server/src/model/extension/extensionResolvers.test.ts
+++ b/server/src/model/extension/extensionResolvers.test.ts
@@ -22,7 +22,6 @@ import { prisma } from "../../prismaClient";
 import {
   deleteApplication,
   // None of these are tested but need to be exported to avoid mocking issues
-  resolveApplicationPhases,
   resolveApplicationTags,
   resolveSuggestedApplicationTags,
 } from "../application";
@@ -59,7 +58,6 @@ vi.mock("../application", () => ({
   getApplication: vi.fn(),
   getManyApplications: vi.fn(),
   deleteApplication: vi.fn(),
-  resolveApplicationPhases: vi.fn(),
   resolveApplicationTags: vi.fn(),
   resolveSuggestedApplicationTags: vi.fn(),
 }));

--- a/server/src/model/extension/extensionResolvers.ts
+++ b/server/src/model/extension/extensionResolvers.ts
@@ -12,7 +12,6 @@ import { handlePrismaError } from "../../errors/handlePrismaError";
 import { parseAndValidateEffectiveAndExpirationDates } from "../applicationDate";
 import {
   deleteApplication,
-  resolveApplicationPhases,
   resolveApplicationTags,
   resolveSuggestedApplicationTags,
 } from "../application";
@@ -20,6 +19,7 @@ import { getDemonstration } from "../demonstration";
 import { GraphQLContext } from "../../auth";
 import { getExtension, getManyExtensions } from "./extensionData";
 import { getManyDocuments } from "../document";
+import { getManyApplicationPhases } from "../applicationPhase";
 
 const extensionApplicationType: ApplicationType = "Extension";
 const conceptPhaseName: PhaseName = "Concept";
@@ -106,7 +106,8 @@ export const extensionResolvers = {
       getManyDocuments({ applicationId: parent.id }, context.user),
     currentPhaseName: (parent: PrismaExtension) => parent.currentPhaseId,
     status: (parent: PrismaExtension) => parent.statusId,
-    phases: resolveApplicationPhases,
+    phases: (parent: PrismaExtension, args: unknown, context: GraphQLContext) =>
+      getManyApplicationPhases({ applicationId: parent.id }, context.user),
     clearanceLevel: (parent: PrismaExtension) => parent.clearanceLevelId,
     tags: resolveApplicationTags,
     signatureLevel: (parent: PrismaExtension) => parent.signatureLevelId,

--- a/server/src/model/migrations/20260420155611_initialize_application_phase_permissions/migration.sql
+++ b/server/src/model/migrations/20260420155611_initialize_application_phase_permissions/migration.sql
@@ -1,0 +1,16 @@
+SET search_path TO demos_app;
+
+INSERT INTO "permission" 
+VALUES 
+  ('View All ApplicationPhases', 'System'),
+  ('View ApplicationPhases on Assigned Demonstrations', 'System')
+;
+
+INSERT INTO "role_permission" 
+VALUES 
+  ('Admin User', 'System', 'View All ApplicationPhases'),
+  ('Admin User', 'System', 'View ApplicationPhases on Assigned Demonstrations'),
+  ('CMS User', 'System', 'View All ApplicationPhases'),
+  ('CMS User', 'System', 'View ApplicationPhases on Assigned Demonstrations'),
+  ('State User', 'System', 'View ApplicationPhases on Assigned Demonstrations')
+;


### PR DESCRIPTION
More of the same, this time with applicationPhase.  this one was a little trickier to verify, but was able to manually remove the restrictions on Demonstration while keeping the restriction on ApplicationPhase. With that, was able to see that while i had access to every demonstration, i was only able to see the ApplicationPhases on the demonstration that was assigned to me. 

Followed the same patterns as introduced in the previous PR. Queries for the actual database fetching, Data functions for injecting permissions, and finally calling the data functions from the Resolvers. The only places this had to happen was in the Demonstration, Amendment, and Extension resolvers, as there is no way to query for applicationPhase directly; its always though another object. 