### PR TITLE
(1/4) DEMOS-1541: Collapse Comment Box

### DIFF
--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -59,6 +59,7 @@ This file provides instructions for AI agents to use when generating or editing 
 
 - Place tests next to implementation (`Foo.tsx` and `Foo.test.tsx`).
 - Use `@testing-library/react` with `vitest`; prefer `screen.getByTestId()` queries.
+- Often times `name` attributes are propagated to `data-test-id`, try this approach first.
 - Prefer real behavior over heavy mocking; use `vi.mock(...)` only at clear boundaries.
 - Run tests with `npm run test:once ...`
 - Prefer to keep mock data in test files for clarity / isolation rather than in `/mock-data`.

--- a/client/src/components/dialog/demonstration/CreateDemonstrationDialog.test.tsx
+++ b/client/src/components/dialog/demonstration/CreateDemonstrationDialog.test.tsx
@@ -11,6 +11,7 @@ import {
   CREATE_DEMONSTRATION_MUTATION,
 } from "./CreateDemonstrationDialog";
 import { DIALOG_CANCEL_BUTTON_NAME } from "components/dialog/BaseDialog";
+import { DEMONSTRATION_DIALOG_DESCRIPTION_NAME } from "./DemonstrationDialog";
 
 const DEFAULT_PROPS = {
   onClose: vi.fn(),
@@ -19,7 +20,6 @@ const DEFAULT_PROPS = {
 const SUBMIT_BUTTON_TEST_ID = "button-submit-demonstration-dialog";
 const TITLE_INPUT_TEST_ID = "input-demonstration-title";
 const STATE_SELECT_ID = "us-state"; // This is an id, not data-testid
-const DESCRIPTION_TEXTAREA_TEST_ID = "textarea-description";
 
 describe("CreateDemonstrationDialog", () => {
   const GET_USER_SELECT_OPTIONS_MOCK = {
@@ -98,7 +98,7 @@ describe("CreateDemonstrationDialog", () => {
 
     expect(screen.getByTestId(TITLE_INPUT_TEST_ID)).toBeInTheDocument();
     expect(document.getElementById(STATE_SELECT_ID)).toBeInTheDocument();
-    expect(screen.getByTestId(DESCRIPTION_TEXTAREA_TEST_ID)).toBeInTheDocument();
+    expect(screen.getByTestId(DEMONSTRATION_DIALOG_DESCRIPTION_NAME)).toBeInTheDocument();
   });
   it("enables Submit button when all required fields are filled", async () => {
     render(getCreateDemonstrationDialog());
@@ -133,7 +133,7 @@ describe("CreateDemonstrationDialog", () => {
     const titleInput = screen.getByTestId(TITLE_INPUT_TEST_ID);
     fireEvent.change(titleInput, { target: { value: "New Test Demonstration" } });
 
-    const descriptionTextarea = screen.getByTestId(DESCRIPTION_TEXTAREA_TEST_ID);
+    const descriptionTextarea = screen.getByTestId(DEMONSTRATION_DIALOG_DESCRIPTION_NAME);
     fireEvent.change(descriptionTextarea, { target: { value: "Test description" } });
 
     // Note: Full form submission would require selecting state and project officer

--- a/client/src/components/dialog/demonstration/DemonstrationDialog.test.tsx
+++ b/client/src/components/dialog/demonstration/DemonstrationDialog.test.tsx
@@ -10,6 +10,7 @@ import {
   checkFormHasChanges,
   DemonstrationDialogFields,
   checkFormIsValid,
+  DEMONSTRATION_DIALOG_DESCRIPTION_NAME,
 } from "./DemonstrationDialog";
 import userEvent from "@testing-library/user-event";
 import { SdgDivision, SignatureLevel } from "demos-server";
@@ -35,7 +36,6 @@ const DEFAULT_PROPS = {
 
 // Test ID constants
 const SUBMIT_BUTTON_TEST_ID = "button-submit-demonstration-dialog";
-const DESCRIPTION_TEXTAREA_TEST_ID = "textarea-description";
 const TITLE_INPUT_TEST_ID = "input-demonstration-title";
 const STATE_SELECT_TEST_ID = "select-us-state";
 const SELECT_USERS_TEST_ID = "select-users";
@@ -93,7 +93,7 @@ describe("DemonstrationDialog", () => {
 
   it("renders the description textarea", () => {
     render(getDemonstrationDialog());
-    expect(screen.getByTestId(DESCRIPTION_TEXTAREA_TEST_ID)).toBeInTheDocument();
+    expect(screen.getByTestId(DEMONSTRATION_DIALOG_DESCRIPTION_NAME)).toBeInTheDocument();
   });
 
   it("renders title input field", () => {
@@ -200,7 +200,7 @@ describe("DemonstrationDialog", () => {
 
   it("renders the description textarea", () => {
     render(getDemonstrationDialog());
-    expect(screen.getByTestId("textarea-description")).toBeInTheDocument();
+    expect(screen.getByTestId(DEMONSTRATION_DIALOG_DESCRIPTION_NAME)).toBeInTheDocument();
   });
 
   it("should enable submit button when form has changes and is valid", async () => {
@@ -253,7 +253,7 @@ describe("DemonstrationDialog", () => {
     const submitButton = getByTestId(SUBMIT_BUTTON_TEST_ID);
     expect(submitButton).toBeDisabled();
 
-    const descriptionInput = getByTestId(DESCRIPTION_TEXTAREA_TEST_ID);
+    const descriptionInput = getByTestId(DEMONSTRATION_DIALOG_DESCRIPTION_NAME);
     await user.clear(descriptionInput);
     await user.type(descriptionInput, "New Description");
     expect(submitButton).toBeEnabled();

--- a/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
@@ -15,6 +15,8 @@ import { SubmitButton } from "components/button/SubmitButton";
 import { HintIcon } from "components/icons/Input/HintIcon";
 import { isBefore } from "date-fns";
 
+export const DEMONSTRATION_DIALOG_DESCRIPTION_NAME = "textarea-demonstration-description";
+
 export type DemonstrationDialogMode = "create" | "edit";
 
 export const DEMO_ID_MEDICAID = "medicaid";
@@ -42,7 +44,7 @@ const DemonstrationDescriptionTextArea: React.FC<{
 }> = ({ description, setDescription }) => {
   return (
     <Textarea
-      name="description"
+      name={DEMONSTRATION_DIALOG_DESCRIPTION_NAME}
       label="Demonstration Description"
       placeholder="Enter description"
       initialValue={description ?? ""}

--- a/client/src/components/dialog/demonstration/EditDemonstrationDialog.test.tsx
+++ b/client/src/components/dialog/demonstration/EditDemonstrationDialog.test.tsx
@@ -12,6 +12,7 @@ import {
   UPDATE_DEMONSTRATION_MUTATION,
 } from "./EditDemonstrationDialog";
 import { DIALOG_CANCEL_BUTTON_NAME } from "components/dialog/BaseDialog";
+import { DEMONSTRATION_DIALOG_DESCRIPTION_NAME } from "./DemonstrationDialog";
 
 const DEFAULT_DEMONSTRATION = {
   name: "",
@@ -177,7 +178,7 @@ describe("EditDemonstrationDialog", () => {
 
     // Wait for loading to complete
     await waitFor(() => {
-      expect(screen.getByTestId("textarea-description")).toBeInTheDocument();
+      expect(screen.getByTestId(DEMONSTRATION_DIALOG_DESCRIPTION_NAME)).toBeInTheDocument();
     });
   });
 

--- a/client/src/components/input/Textarea.test.tsx
+++ b/client/src/components/input/Textarea.test.tsx
@@ -4,9 +4,10 @@ import { describe, it, expect, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { Textarea } from "./Textarea";
 
+const DEFAULT_TEXT_AREA_NAME = "description";
 describe("Textarea", () => {
   const defaultProps = {
-    name: "description",
+    name: DEFAULT_TEXT_AREA_NAME,
     label: "Description",
     initialValue: "",
     onChange: () => {},
@@ -16,7 +17,7 @@ describe("Textarea", () => {
     render(<Textarea {...defaultProps} />);
 
     expect(screen.getByLabelText("Description")).toBeInTheDocument();
-    expect(screen.getByTestId("textarea-description")).toBeInTheDocument();
+    expect(screen.getByTestId(DEFAULT_TEXT_AREA_NAME)).toBeInTheDocument();
   });
 
   it("shows required indicator when isRequired is true", () => {
@@ -34,7 +35,7 @@ describe("Textarea", () => {
   it("starts with 1 row by default", () => {
     render(<Textarea {...defaultProps} />);
 
-    const textarea = screen.getByTestId("textarea-description");
+    const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
     expect(textarea).toHaveAttribute("rows", "1");
   });
 
@@ -43,7 +44,7 @@ describe("Textarea", () => {
       const user = userEvent.setup();
       render(<Textarea {...defaultProps} />);
 
-      const textarea = screen.getByTestId("textarea-description");
+      const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
 
       // Initially 1 row
       expect(textarea).toHaveAttribute("rows", "1");
@@ -59,7 +60,7 @@ describe("Textarea", () => {
       const user = userEvent.setup();
       render(<Textarea {...defaultProps} />);
 
-      const textarea = screen.getByTestId("textarea-description");
+      const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
 
       // Type text with multiple line breaks
       await user.type(textarea, "Line 1{Enter}Line 2{Enter}Line 3{Enter}Line 4");
@@ -72,7 +73,7 @@ describe("Textarea", () => {
       const user = userEvent.setup();
       render(<Textarea {...defaultProps} />);
 
-      const textarea = screen.getByTestId("textarea-description");
+      const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
 
       // Type very long single line
       const longText =
@@ -87,7 +88,7 @@ describe("Textarea", () => {
       const user = userEvent.setup();
       render(<Textarea {...defaultProps} />);
 
-      const textarea = screen.getByTestId("textarea-description");
+      const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
 
       // Type multiline text
       await user.type(textarea, "Line 1{Enter}Line 2{Enter}Line 3");
@@ -136,14 +137,14 @@ describe("Textarea", () => {
     it("disables textarea when isDisabled is true", () => {
       render(<Textarea {...defaultProps} isDisabled />);
 
-      const textarea = screen.getByTestId("textarea-description");
+      const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
       expect(textarea).toBeDisabled();
     });
 
     it("applies disabled styling when disabled", () => {
       render(<Textarea {...defaultProps} isDisabled />);
 
-      const textarea = screen.getByTestId("textarea-description");
+      const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
       expect(textarea).toHaveClass("disabled:bg-surface-secondary");
     });
   });
@@ -153,16 +154,16 @@ describe("Textarea", () => {
       render(<Textarea {...defaultProps} />);
 
       const label = screen.getByText("Description");
-      const textarea = screen.getByTestId("textarea-description");
+      const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
 
-      expect(label).toHaveAttribute("for", "description");
-      expect(textarea).toHaveAttribute("id", "description");
+      expect(label).toHaveAttribute("for", DEFAULT_TEXT_AREA_NAME);
+      expect(textarea).toHaveAttribute("id", DEFAULT_TEXT_AREA_NAME);
     });
 
     it("sets required attribute when isRequired is true", () => {
       render(<Textarea {...defaultProps} isRequired />);
 
-      const textarea = screen.getByTestId("textarea-description");
+      const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
       expect(textarea).toHaveAttribute("required");
     });
   });
@@ -171,7 +172,7 @@ describe("Textarea", () => {
     it("handles empty string without errors", () => {
       render(<Textarea {...defaultProps} onChange={vi.fn()} />);
 
-      const textarea = screen.getByTestId("textarea-description");
+      const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
       expect(textarea).toHaveValue("");
       expect(textarea).toHaveAttribute("rows", "1");
     });
@@ -180,7 +181,7 @@ describe("Textarea", () => {
       const user = userEvent.setup();
       render(<Textarea {...defaultProps} />);
 
-      const textarea = screen.getByTestId("textarea-description");
+      const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
 
       // Type only line breaks
       await user.type(textarea, "{Enter}{Enter}");
@@ -193,7 +194,7 @@ describe("Textarea", () => {
       const user = userEvent.setup();
       render(<Textarea {...defaultProps} />);
 
-      const textarea = screen.getByTestId("textarea-description");
+      const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
 
       // Mix of text and line breaks
       await user.type(textarea, "Text{Enter}{Enter}More text{Enter}Final");

--- a/client/src/components/input/Textarea.tsx
+++ b/client/src/components/input/Textarea.tsx
@@ -51,7 +51,7 @@ export const Textarea: React.FC<TextareaProps> = ({
       <textarea
         id={name}
         name={name}
-        data-testid={`textarea-${name}`}
+        data-testid={name}
         className={`${TEXTAREA_BASE_CLASSES} ${getInputColors(validationMessage ?? "")}`}
         placeholder={placeholder ?? ""}
         required={isRequired ?? false}

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -69,9 +69,9 @@ export const DeliverableDetailsManagementPage: React.FC = () => {
           <DeliverableInfoFields deliverable={data.deliverable} />
           <DeliverableButtons />
         </div>
-        <div className="grid grid-cols-4 w-full gap-2 flex-1">
-          <div className="col-span-3"><FileAndHistoryTabs /></div>
-          <div className="col-span-1"><CommentBox /></div>
+        <div className="flex w-full gap-2 flex-1">
+          <div className="flex-1"><FileAndHistoryTabs /></div>
+          <div><CommentBox /></div>
         </div>
       </div>
     </div>

--- a/client/src/pages/deliverables/sections/CommentBox.test.tsx
+++ b/client/src/pages/deliverables/sections/CommentBox.test.tsx
@@ -1,10 +1,45 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { COMMENT_BOX_NAME, CommentBox } from "./CommentBox";
+import userEvent from "@testing-library/user-event";
+import { COLLAPSE_COMMENTS_BUTTON_NAME, COMMENT_BOX_NAME, COMMENT_BOX_TEXT_AREA_NAME, CommentBox } from "./CommentBox";
 
 describe("CommentBox", () => {
   it("renders without crashing", () => {
     render(<CommentBox />);
+    expect(screen.getByTestId(COMMENT_BOX_NAME)).toBeInTheDocument();
+  });
+
+  it("shows the full comment box by default", () => {
+    render(<CommentBox />);
+    expect(screen.getByTestId(COMMENT_BOX_TEXT_AREA_NAME)).toBeInTheDocument();
+    expect(screen.getByText("Comment History")).toBeInTheDocument();
+  });
+
+  it("collapses to a single icon button when the collapse button is clicked", async () => {
+    render(<CommentBox />);
+
+    await userEvent.click(screen.getByTestId(COLLAPSE_COMMENTS_BUTTON_NAME));
+
+    expect(screen.queryByTestId(COMMENT_BOX_TEXT_AREA_NAME)).not.toBeInTheDocument();
+    expect(screen.queryByText("Comment History")).not.toBeInTheDocument();
+    expect(screen.getByTestId(COMMENT_BOX_NAME)).toBeInTheDocument();
+  });
+
+  it("expands back when the collapsed icon button is clicked", async () => {
+    render(<CommentBox />);
+
+    await userEvent.click(screen.getByTestId(COLLAPSE_COMMENTS_BUTTON_NAME));
+    await userEvent.click(screen.getByTestId(COMMENT_BOX_NAME));
+
+    expect(screen.getByTestId(COMMENT_BOX_TEXT_AREA_NAME)).toBeInTheDocument();
+    expect(screen.getByText("Comment History")).toBeInTheDocument();
+  });
+
+  it("still renders the testid in collapsed state", async () => {
+    render(<CommentBox />);
+
+    await userEvent.click(screen.getByTestId(COLLAPSE_COMMENTS_BUTTON_NAME));
+
     expect(screen.getByTestId(COMMENT_BOX_NAME)).toBeInTheDocument();
   });
 });

--- a/client/src/pages/deliverables/sections/CommentBox.test.tsx
+++ b/client/src/pages/deliverables/sections/CommentBox.test.tsx
@@ -42,4 +42,14 @@ describe("CommentBox", () => {
 
     expect(screen.getByTestId(COMMENT_BOX_NAME)).toBeInTheDocument();
   });
+
+  it("preserves typed comment text after collapsing and expanding", async () => {
+    render(<CommentBox />);
+
+    await userEvent.type(screen.getByTestId(COMMENT_BOX_TEXT_AREA_NAME), "my draft comment");
+    await userEvent.click(screen.getByTestId(COLLAPSE_COMMENTS_BUTTON_NAME));
+    await userEvent.click(screen.getByTestId(COMMENT_BOX_NAME));
+
+    expect(screen.getByTestId(COMMENT_BOX_TEXT_AREA_NAME)).toHaveValue("my draft comment");
+  });
 });

--- a/client/src/pages/deliverables/sections/CommentBox.tsx
+++ b/client/src/pages/deliverables/sections/CommentBox.tsx
@@ -21,10 +21,10 @@ const CommentBoxHeader = ({ onCollapse }: { onCollapse: () => void }) => (
   </div>
 );
 
-const CommentBoxTextArea = () => {
+const CommentBoxTextArea = ({ value, onChange }: { value: string; onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void }) => {
   return (
     <div className="flex-1">
-      <Textarea label="Comments" initialValue="" name={COMMENT_BOX_TEXT_AREA_NAME} onChange={() => {}} />
+      <Textarea label="Comments" initialValue={value} name={COMMENT_BOX_TEXT_AREA_NAME} onChange={onChange} />
     </div>
   );
 };
@@ -38,6 +38,7 @@ const CommentBoxHistory = () => (
 
 export const CommentBox = () => {
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const [currentComment, setCurrentComment] = useState("");
 
   if (isCollapsed) {
     return (
@@ -55,7 +56,7 @@ export const CommentBox = () => {
   return (
     <div className="flex flex-col gap-1 bg-gray-primary-layout p-1 min-h-full min-w-[350px]" data-testid={COMMENT_BOX_NAME}>
       <CommentBoxHeader onCollapse={() => setIsCollapsed(true)} />
-      <CommentBoxTextArea />
+      <CommentBoxTextArea value={currentComment} onChange={(e) => setCurrentComment(e.target.value)} />
       <CommentBoxHistory />
     </div>
   );

--- a/client/src/pages/deliverables/sections/CommentBox.tsx
+++ b/client/src/pages/deliverables/sections/CommentBox.tsx
@@ -1,16 +1,23 @@
-import React from "react";
+import React, { useState } from "react";
 
-import { IconButton } from "components/button/IconButton";
 import { MenuCollapseRightIcon } from "components/icons/Navigation/MenuCollapseRightIcon";
 import { Textarea } from "components/input";
+import { CommentIcon } from "components/icons";
+import { SecondaryButton } from "components/button";
 
 export const COMMENT_BOX_NAME = "comment-box";
 export const COMMENT_BOX_TEXT_AREA_NAME = "textarea-comment-box";
+export const COLLAPSE_COMMENTS_BUTTON_NAME = "button-collapse-comments";
 
-const CommentBoxHeader = () => (
+const CommentBoxHeader = ({ onCollapse }: { onCollapse: () => void }) => (
   <div className="flex items-center justify-between pb-1 border-b border-gray-dark">
-    <span className="text-lg font-bold uppercase text-brand">Comments</span>
-    <IconButton size={"small"} name="collapse-comments" icon={<MenuCollapseRightIcon width={10} height={10} />} onClick={() => {}} aria-label="Collapse comments" />
+    <div className="flex gap-0-5 justify-center items-center">
+      <span className="text-lg font-bold uppercase text-brand">Comments</span>
+      <CommentIcon className="text-action" />
+    </div>
+    <SecondaryButton size="large" name={COLLAPSE_COMMENTS_BUTTON_NAME} data-testid={COLLAPSE_COMMENTS_BUTTON_NAME} onClick={onCollapse} aria-label="Collapse comments">
+      <MenuCollapseRightIcon className="w-[20px] h-[20px]" />
+    </SecondaryButton>
   </div>
 );
 
@@ -30,9 +37,24 @@ const CommentBoxHistory = () => (
 );
 
 export const CommentBox = () => {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  if (isCollapsed) {
+    return (
+      <SecondaryButton
+        size="large"
+        name={COMMENT_BOX_NAME}
+        onClick={() => setIsCollapsed(false)}
+        aria-label="Expand comments"
+      >
+        <CommentIcon className="w-[20px] h-[20px]" />
+      </SecondaryButton>
+    );
+  }
+
   return (
-    <div className="flex flex-col gap-1 bg-gray-primary-layout p-1 min-h-full" data-testid={COMMENT_BOX_NAME}>
-      <CommentBoxHeader />
+    <div className="flex flex-col gap-1 bg-gray-primary-layout p-1 min-h-full min-w-[350px]" data-testid={COMMENT_BOX_NAME}>
+      <CommentBoxHeader onCollapse={() => setIsCollapsed(true)} />
       <CommentBoxTextArea />
       <CommentBoxHistory />
     </div>


### PR DESCRIPTION
Per DEMOS-1541: This PR collapses the comment box while preserving the comment

**Note:** I also adjusted the `Textarea` name field to be a drop-in for the data-test-id to simplify this, we don't gain anything from prepending `textarea-` to it. I updated relevant tests to reflect this

https://github.com/user-attachments/assets/af0a96d9-d3dc-4ed2-9d34-e433aa5a0e6e

