### PR TITLE
DEMOS 1806 Allow CMS or Admin user to have more than one contact role for a demonstration 

### DIFF
--- a/client/src/components/dialog/ManageContactsDialog.test.tsx
+++ b/client/src/components/dialog/ManageContactsDialog.test.tsx
@@ -729,6 +729,28 @@ describe("ManageContactsDialog", () => {
     });
   });
 
+  it("shows warning message when contacts are missing contact types", async () => {
+    const user = userEvent.setup();
+    const mocks = [SEARCH_PEOPLE_MOCKS[0]];
+
+    renderWithProviders(defaultProps, mocks);
+
+    const searchInput = screen.getByPlaceholderText("Search by name or email");
+
+    await user.type(searchInput, "jo");
+
+    await waitFor(() => {
+      expect(screen.getByText("John Doe")).toBeInTheDocument();
+    });
+
+    const addButton = screen.getByText("John Doe").closest("button")!;
+    await user.click(addButton);
+
+    expect(
+      screen.getByText("Please select a contact type for all contacts before adding more.")
+    ).toBeInTheDocument();
+  });
+
   it("clears search results when search term is less than 2 characters", async () => {
     const user = userEvent.setup();
     const mocks = SEARCH_PEOPLE_MOCKS;

--- a/client/src/components/dialog/ManageContactsDialog.test.tsx
+++ b/client/src/components/dialog/ManageContactsDialog.test.tsx
@@ -685,6 +685,50 @@ describe("ManageContactsDialog", () => {
     expect(screen.queryByText("Project Officer")).not.toBeInTheDocument();
   });
 
+  it("filters out already-used contact types for the same person", async () => {
+    const user = userEvent.setup();
+    const mocks = SEARCH_PEOPLE_MOCKS;
+
+    renderWithProviders(defaultProps, mocks);
+
+    const searchInput = screen.getByPlaceholderText("Search by name or email");
+
+    // Add first instance
+    await user.type(searchInput, "jo");
+    await waitFor(() => {
+      expect(screen.getByTestId("search-results-dropdown")).toBeInTheDocument();
+    });
+    const searchResults1 = await screen.getByTestId("search-results-dropdown");
+
+    await user.click(
+      within(searchResults1).getByText("John Doe")
+    );
+
+    // Assign role so search re-enables
+    const firstSelect = await screen.getByTestId("contact-type-0");
+    await user.selectOptions(firstSelect, "Project Officer");
+
+    // Add same person again
+    await user.type(searchInput, "joh");
+    await waitFor(() => {
+      expect(screen.getByTestId("search-results-dropdown")).toBeInTheDocument();
+    });
+    const searchResults2 = await screen.getByTestId("search-results-dropdown");
+
+    await user.click(
+      within(searchResults2).getByText("John Doe")
+    );
+
+    // Now second row should exist
+    const secondSelect = screen.getByTestId("contact-type-1");
+
+    await waitFor(() => {
+      expect(
+        within(secondSelect).getAllByRole("option").map(o => o.textContent)
+      ).not.toContain("Project Officer");
+    });
+  });
+
   it("clears search results when search term is less than 2 characters", async () => {
     const user = userEvent.setup();
     const mocks = SEARCH_PEOPLE_MOCKS;

--- a/client/src/components/dialog/ManageContactsDialog.tsx
+++ b/client/src/components/dialog/ManageContactsDialog.tsx
@@ -186,7 +186,7 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
         (c) =>
           c.personId === personId &&
           c.contactType &&
-          c.id !== currentRowId // 👈 key fix
+          c.id !== currentRowId
       )
       .map((c) => c.contactType);
 

--- a/client/src/components/dialog/ManageContactsDialog.tsx
+++ b/client/src/components/dialog/ManageContactsDialog.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useCallback, useEffect, useMemo, useState } from "react";
+import React, { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "components/button";
 import { BaseDialog } from "components/dialog/BaseDialog";
@@ -92,7 +92,7 @@ export type ManageContactsDialogProps = {
 
 const mapExistingContacts = (arr: ManageContactsDialogProps["existingContacts"] = []) =>
   arr.map((contact) => ({
-    id: contact.id,
+    id: `${contact.person.id}-${contact.role}`,
     personId: contact.person.id,
     name: contact.person.fullName,
     email: contact.person.email,
@@ -106,6 +106,7 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
   demonstrationId,
   existingContacts = [],
 }) => {
+  const contactIdCounter = useRef(0);
   const { showSuccess, showError } = useToast();
 
   const [searchTerm, setSearchTerm] = useState("");
@@ -161,12 +162,35 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
     []
   );
 
-  const getFilteredContactTypeOptions = (idmRoles?: string[]) => {
+  const hasUnassignedContacts = useMemo(
+    () => selectedContacts.some((c) => !c.contactType),
+    [selectedContacts]
+  );
+
+  const getFilteredContactTypeOptions = (
+    idmRoles?: string[],
+    personId?: string,
+    currentRowId?: string
+  ) => {
     const roles = idmRoles ?? [];
-    if (roles.includes("demos-cms-user")) return optionsByRole["demos-cms-user"];
-    if (roles.includes("demos-state-user")) return optionsByRole["demos-state-user"];
-    if (roles.includes("demos-admin")) return optionsByRole["demos-admin"];
-    return optionsByRole.Default;
+    let options;
+    if (roles.includes("demos-cms-user")) options = optionsByRole["demos-cms-user"];
+    else if (roles.includes("demos-state-user")) options = optionsByRole["demos-state-user"];
+    else if (roles.includes("demos-admin")) options = optionsByRole["demos-admin"];
+    else options = optionsByRole.Default;
+
+    if (!personId) return options;
+
+    const usedRoles = selectedContacts
+      .filter(
+        (c) =>
+          c.personId === personId &&
+          c.contactType &&
+          c.id !== currentRowId // 👈 key fix
+      )
+      .map((c) => c.contactType);
+
+    return options.filter((opt) => !usedRoles.includes(opt.value));
   };
 
   const debouncedSearchTerm = useDebounced(searchTerm, 300);
@@ -192,46 +216,56 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
   };
 
   const handleAddContact = (person: PersonSearchResult) => {
-    if (selectedContacts.some((c) => c.personId === person.id)) return;
+    const idmRoles = [person.personType];
 
-    setSelectedContacts((prev) => {
-      const idmRoles = [person.personType];
-      const isStateUser = person.personType === "demos-state-user";
+    const allowedRoles = getFilteredContactTypeOptions(idmRoles).map((r) => r.value);
 
-      const defaults: { contactType?: ContactType; isPrimary: boolean } = {
-        contactType: isStateUser ? "State Point of Contact" : undefined,
+    const usedRoles = selectedContacts
+      .filter((c) => c.personId === person.id && c.contactType)
+      .map((c) => c.contactType);
+
+    const remainingRoles = allowedRoles.filter((role) => !usedRoles.includes(role));
+
+    if (remainingRoles.length === 0) return;
+
+    const isStateUser = idmRoles.includes("demos-state-user");
+
+    const defaultRole = isStateUser ? "State Point of Contact" : undefined;
+
+    const newId = `person-${contactIdCounter.current++}`;
+
+    setSelectedContacts((prev) => [
+      ...prev,
+      {
+        id: newId,
+        personId: person.id,
+        name: `${person.firstName} ${person.lastName}`,
+        email: person.email,
+        idmRoles,
+        contactType: defaultRole,
         isPrimary: false,
-      };
-
-      return [
-        ...prev,
-        {
-          id: person.id,
-          personId: person.id,
-          name: `${person.firstName} ${person.lastName}`,
-          email: person.email,
-          idmRoles: idmRoles,
-          ...defaults,
-        },
-      ];
-    });
+      },
+    ]);
 
     setSearchResults([]);
     setSearchTerm("");
   };
 
-  const handleContactTypeChange = useCallback((personId: string, newType?: ContactType) => {
+  const handleContactTypeChange = useCallback((id: string, newType?: ContactType) => {
     setSelectedContacts((previousContacts) => {
-      const targetContact = previousContacts.find((c) => c.personId === personId);
+      const targetContact = previousContacts.find((c) => c.id === id);
       if (!targetContact) return previousContacts;
 
       return previousContacts.map((contact) => {
-        if (contact.personId === personId) {
+        if (contact.id === id) {
           let newIsPrimary = false;
 
           if (newType === "Project Officer") {
             const existingPrimaryPOs = previousContacts.filter(
-              (c) => c.contactType === "Project Officer" && c.isPrimary && c.personId !== personId
+              (c) =>
+                c.contactType === "Project Officer" &&
+                c.isPrimary &&
+                c.id !== id
             );
             newIsPrimary = existingPrimaryPOs.length === 0;
           }
@@ -245,10 +279,10 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
           newType !== "Project Officer"
         ) {
           const otherPOs = previousContacts.filter(
-            (c) => c.contactType === "Project Officer" && c.personId !== personId
+            (c) => c.contactType === "Project Officer" && c.id !== id
           );
 
-          if (otherPOs.length > 0 && contact.personId === otherPOs[0].personId) {
+          if (otherPOs.length > 0 && contact.id === otherPOs[0].id) {
             return { ...contact, isPrimary: true };
           }
         }
@@ -258,14 +292,14 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
     });
   }, []);
 
-  const handlePrimaryToggle = useCallback((personId: string) => {
+  const handlePrimaryToggle = useCallback((id: string) => {
     setSelectedContacts((prev) => {
-      const target = prev.find((c) => c.personId === personId);
+      const target = prev.find((c) => c.id === id);
       if (!target || !target.contactType) return prev;
 
       const type = target.contactType;
       const existingPrimary = prev.find(
-        (c) => c.contactType === type && c.isPrimary && c.personId !== personId
+        (c) => c.contactType === type && c.isPrimary && c.id !== id
       );
 
       if (type === "Project Officer") {
@@ -282,7 +316,7 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
 
         return prev.map((contact) => {
           if (contact.contactType === "Project Officer") {
-            return { ...contact, isPrimary: contact.personId === personId };
+            return { ...contact, isPrimary: contact.id === id };
           }
           return contact;
         });
@@ -293,7 +327,7 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
 
         const willBePrimary = !target.isPrimary;
         return prev.map((contact) => {
-          if (contact.personId === personId) {
+          if (contact.id === id) {
             return { ...contact, isPrimary: willBePrimary };
           }
           if (contact.contactType === type) {
@@ -306,11 +340,11 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
   }, []);
 
   const handleRemoveContact = useCallback(
-    (personId: string) => {
-      const contactToRemove = selectedContacts.find((c) => c.personId === personId);
+    (id: string) => {
+      const contactToRemove = selectedContacts.find((c) => c.id === id);
       if (!contactToRemove) return;
 
-      setContactToDelete(personId);
+      setContactToDelete(id);
       setShowDeleteConfirm(true);
     },
     [selectedContacts]
@@ -319,17 +353,17 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
   const confirmDeleteContact = async () => {
     if (!contactToDelete) return;
 
-    const contactToRemove = selectedContacts.find((c) => c.personId === contactToDelete);
+    const contactToRemove = selectedContacts.find((c) => c.id === contactToDelete);
     if (!contactToRemove) return;
 
-    const updated = selectedContacts.filter((c) => c.personId !== contactToDelete);
+    const updated = selectedContacts.filter((c) => c.id !== contactToDelete);
 
     let finalUpdated = updated;
     if (contactToRemove.isPrimary && contactToRemove.contactType === "Project Officer") {
       const remainingPOs = updated.filter((c) => c.contactType === "Project Officer");
       if (remainingPOs.length > 0) {
         finalUpdated = updated.map((c) => {
-          if (c.personId === remainingPOs[0].personId) {
+          if (c.id === remainingPOs[0].id) {
             return { ...c, isPrimary: true };
           }
           return c;
@@ -549,14 +583,32 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
                 placeholder="Search by name or email"
                 value={searchTerm}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => handleSearch(e.target.value)}
+                disabled={hasUnassignedContacts}
                 aria-label="Search for contacts by name or email"
                 autoComplete="off"
               />
             </div>
+            {hasUnassignedContacts && (
+              <div className="text-sm">
+                Please select a contact type for all contacts before adding more.
+              </div>
+            )}
             {(() => {
-              let filteredResults = searchResults
-                .filter((p) => !selectedContacts.some((c) => c.personId === p.id))
-                .filter((p, index, arr) => arr.findIndex((item) => item.id === p.id) === index);
+              let filteredResults = searchResults.filter((p) => {
+                const idmRoles = [p.personType];
+
+                const allowedRoles = getFilteredContactTypeOptions(idmRoles).map((r) => r.value);
+
+                const alreadyUsedRoles = selectedContacts
+                  .filter((c) => c.personId === p.id && c.contactType)
+                  .map((c) => c.contactType);
+
+                const remainingRoles = allowedRoles.filter((role) => !alreadyUsedRoles.includes(role));
+
+                return remainingRoles.length > 0;
+              }).filter(
+                (p, index, arr) => arr.findIndex((item) => item.id === p.id) === index
+              );
 
               if (searchTerm.length >= 2) {
                 const searchTermLower = searchTerm.toLowerCase();

--- a/client/src/components/table/columns/ContactColumns.tsx
+++ b/client/src/components/table/columns/ContactColumns.tsx
@@ -24,10 +24,10 @@ export type ContactRow = {
 };
 
 type ContactColumnsProps = {
-  getFilteredContactTypeOptions: (idmRoles?: string[]) => Array<{ label: string; value: string }>;
-  onContactTypeChange: (personId: string, value: ContactType) => void;
-  onPrimaryToggle: (personId: string) => void;
-  onRemoveContact: (personId: string) => void;
+  getFilteredContactTypeOptions: (idmRoles?: string[], personId?: string, currentRowId?: string) => Array<{ label: string; value: string }>;
+  onContactTypeChange: (id: string, value: ContactType) => void;
+  onPrimaryToggle: (id: string) => void;
+  onRemoveContact: (id: string) => void;
 };
 
 export function ContactColumns({
@@ -65,11 +65,15 @@ export function ContactColumns({
             <Select
               id={`contact-type-${rowIndex}`}
               value={contact.contactType}
-              options={getFilteredContactTypeOptions(contact.idmRoles)}
+              options={getFilteredContactTypeOptions(
+                contact.idmRoles,
+                contact.personId,
+                contact.id
+              )}
               placeholder="Select Type…"
               onSelect={(value) => {
                 const typedValue = value as ContactType;
-                onContactTypeChange(contact.personId, typedValue);
+                onContactTypeChange(contact.id, typedValue);
               }}
               isRequired
               validationMessage={isInvalid ? "Contact Type is required" : ""}
@@ -87,7 +91,7 @@ export function ContactColumns({
           <div className="inline-flex items-center justify-center">
             <Switch
               checked={!!contact.isPrimary}
-              onChange={() => onPrimaryToggle(contact.personId)}
+              onChange={() => onPrimaryToggle(contact.id)}
               onColor="#6B7280"
               offColor="#E5E7EB"
               checkedIcon={false}
@@ -125,7 +129,7 @@ export function ContactColumns({
               ariaLabel="Delete Contact"
               tooltip={deleteTooltip}
               size="small"
-              onClick={() => onRemoveContact(contact.personId)}
+              onClick={() => onRemoveContact(contact.id)}
               disabled={deleteDisabled}
             >
               <DeleteIcon width="15" height="15" fill={deleteDisabled ? "#9CA3AF" : "#CD2026"} />


### PR DESCRIPTION


https://github.com/user-attachments/assets/c695a21d-5c7b-47c8-9172-e293de558b59

What I've implemented is roughly:
Another row for the user can be added by simply searching for the user and adding as you would the first row
The "Contact Types" options for the new row will be filtered to not include existing contact types. EG - If a user already has "Project Officer" as a contact type, that contact type will not be presented as an option for the next row.
If a user would have no available contact types (all of their options have been exhausted), the user will no longer appear in search results and cannot be added to the table again

One concern I had was that if a user were to add a bunch of rows for the same person without selecting a contact type, the above logic gets flaky. Example: Jeff has 4 available contact types. You add Jeff as a contact 5x while leaving contact type as "Select Type...", and then go and select the type for the first 4 instances. The fifth row gets into an unresolvable state where there are no options available. I was talking with Dipika about this before each of us left for vacation, and she said:

 "I think they need to assign a type and add the contact to the list before they search for the same or a different contact"
I interpreted this as "The Search Field should be disabled if there are unassigned contact types". I thought this would be a little confusing without any indication of why the search field is being disabled, so I added a line that says "Please select a contact type for all contacts before adding more."