### PR TITLE
(2/4) DEMOS-1541: Show Tabs under the CommentBox to only CMS / Admin Users (+ UserContext Improvements)

### DIFF
--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -87,3 +87,10 @@ vi.mock("@apollo/client", async () => {
 - `src/router/`: app-level providers and routing
 - `src/layout/`: layout and navigation shells
 - `src/mock-data/`: Apollo `MockedResponse` fixtures
+
+## Outdated Patterns
+
+Patterns that exist now that will likely be replaced in the future. Try not entrench these patterns further if avoidable and if not then implement them consistently with other usages to make for a simpler refactor.
+
+- `getCurrentUser` SHOULD NEVER return undefined for `currentUser`. If `getCurrentUser` cannot resolve a proper `currentUser` object then `<UserContext>` should show a relevant error page itself and cease operation.
+- `addTypename` on `<MockedProvider>` is deprecated and should be removed.

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -24,7 +24,7 @@ This file provides instructions for AI agents to use when generating or editing 
 ### Functions
 
 - Prefer writing functions that take sentinel values over optional / undefined. For instance `""` or `[]` can be the "base case" and used as "falsey"
-- Prefer to fail-fast over delaying error handling. Use guard / precondition statements if appropriate.
+- Prefer to fail-fast over delaying error handling. Use guard clauses as needed.
 
 ## React
 
@@ -63,6 +63,7 @@ This file provides instructions for AI agents to use when generating or editing 
 - Prefer real behavior over heavy mocking; use `vi.mock(...)` only at clear boundaries.
 - Run tests with `npm run test:once ...`
 - Prefer to keep mock data in test files for clarity / isolation rather than in `/mock-data`.
+- For testing behavior with different roles you can use the different variants of `npm run dev:mocks`
 
 ### Mocking Mutations
 

--- a/client/package.json
+++ b/client/package.json
@@ -62,6 +62,8 @@
     "depcheck": "depcheck",
     "dev": "vite --host",
     "dev:mocks": "VITE_USE_MOCKS=true npm run dev",
+    "dev:mocks:state": "VITE_MOCK_PERSON_TYPE=demos-state-user npm run dev:mocks",
+    "dev:mocks:admin": "VITE_MOCK_PERSON_TYPE=demos-admin npm run dev:mocks",
     "format": "prettier --write src",
     "format:check": "prettier --check src",
     "lint": "eslint src; npm run tsc",

--- a/client/package.json
+++ b/client/package.json
@@ -63,6 +63,7 @@
     "dev": "vite --host",
     "dev:mocks": "VITE_USE_MOCKS=true npm run dev",
     "dev:mocks:state": "VITE_MOCK_PERSON_TYPE=demos-state-user npm run dev:mocks",
+    "dev:mocks:cms": "VITE_MOCK_PERSON_TYPE=demos-cms-user npm run dev:mocks", 
     "dev:mocks:admin": "VITE_MOCK_PERSON_TYPE=demos-admin npm run dev:mocks",
     "format": "prettier --write src",
     "format:check": "prettier --check src",

--- a/client/src/components/user/UserContext.tsx
+++ b/client/src/components/user/UserContext.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "react-oidc-context";
 import { Person, User } from "demos-server";
 import { Loading } from "components/loading/Loading";
 
-type CurrentUser = Pick<User, "id" | "username"> & {
+export type CurrentUser = Pick<User, "id" | "username"> & {
   person: Pick<Person, "id" | "personType" | "fullName" | "firstName" | "lastName" | "email">;
 };
 
@@ -61,4 +61,14 @@ export function getCurrentUser() {
   }
 
   return ctx;
+}
+
+export function TestUserProvider({
+  children,
+  currentUser,
+}: {
+  children: React.ReactNode;
+  currentUser: CurrentUser;
+}) {
+  return <Ctx.Provider value={{ currentUser }}>{children}</Ctx.Provider>;
 }

--- a/client/src/config/env.ts
+++ b/client/src/config/env.ts
@@ -1,3 +1,6 @@
+import { PersonType } from "demos-server";
+import { PERSON_TYPES } from "demos-server-constants";
+
 const VALID_MODES = ["development", "test", "production"] as const;
 
 export type AppMode = (typeof VALID_MODES)[number];
@@ -35,4 +38,17 @@ export const shouldUseMocks = (): boolean => {
 export const getIdleTimeoutMs = (): number => {
   const n = Number(import.meta.env.VITE_IDLE_TIMEOUT);
   return Number.isFinite(n) ? n : 60 * 60 * 1000; // default 60 min per fisma
+};
+
+export const getMockPersonType = (): PersonType => {
+  const defaultMockPersonType: PersonType = "demos-cms-user";
+  const envMockPersonType = import.meta.env.VITE_MOCK_PERSON_TYPE;
+  if (!envMockPersonType) return defaultMockPersonType;
+
+  if (PERSON_TYPES.includes(envMockPersonType as PersonType)) {
+    return envMockPersonType as PersonType;
+  } else {
+    console.warn(`Invalid VITE_MOCK_PERSON_TYPE: ${envMockPersonType}. Defaulting to ${defaultMockPersonType}.`);
+    return defaultMockPersonType;
+  }
 };

--- a/client/src/mock-data/userMocks.ts
+++ b/client/src/mock-data/userMocks.ts
@@ -7,6 +7,7 @@ import { MockedResponse } from "@apollo/client/testing";
 import { GET_CURRENT_USER_QUERY } from "components/user/UserContext";
 import { mockPeople, MockPerson } from "./personMocks";
 import { mockStates } from "./stateMocks";
+import { getMockPersonType } from "config/env";
 
 const developmentMockUser: MockUser = {
   id: "999",
@@ -16,7 +17,7 @@ const developmentMockUser: MockUser = {
     firstName: "Mock",
     lastName: "User",
     fullName: "Mock User",
-    personType: "demos-cms-user",
+    personType: getMockPersonType(),
     email: "mock.user@email.com",
     states: mockStates,
   },

--- a/client/src/mock-data/userMocks.ts
+++ b/client/src/mock-data/userMocks.ts
@@ -9,7 +9,7 @@ import { mockPeople, MockPerson } from "./personMocks";
 import { mockStates } from "./stateMocks";
 import { getMockPersonType } from "config/env";
 
-const developmentMockUser: MockUser = {
+export const developmentMockUser: MockUser = {
   id: "999",
   username: "mock.dev.user",
   person: {
@@ -44,13 +44,6 @@ export const userMocks: MockedResponse[] = [
     result: {
       data: { currentUser: developmentMockUser },
     },
-  },
-  {
-    request: {
-      query: GET_CURRENT_USER_QUERY,
-    },
-    result: {
-      data: { currentUser: mockUsers[0] },
-    },
+    maxUsageCount: Number.POSITIVE_INFINITY,
   },
 ];

--- a/client/src/pages/DeliverablesPage.test.tsx
+++ b/client/src/pages/DeliverablesPage.test.tsx
@@ -1,22 +1,12 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import * as UserContext from "components/user/UserContext";
-
 import { MockedResponse } from "@apollo/client/testing";
 import { DELIVERABLES_PAGE_QUERY } from "components/table/tables/DeliverableTable";
 import { DeliverablesPage } from "./DeliverablesPage";
 import { MOCK_DELIVERABLE_TABLE_ROW } from "mock-data/deliverableMocks";
 import { mockUsers } from "mock-data/userMocks";
 import { TestProvider } from "test-utils/TestProvider";
-
-vi.mock("components/user/UserContext", async (importOriginal) => {
-  const actual = await importOriginal<typeof UserContext>();
-  return {
-    ...actual,
-    getCurrentUser: vi.fn(),
-  };
-});
 
 vi.mock("components/dialog/DialogContext", () => ({
   useDialog: () => ({ showEditDeliverableDialog: vi.fn() }),
@@ -51,11 +41,11 @@ const DELIVERABLES_TABLE_MOCKS: MockedResponse[] = [
 describe("DeliverablesPage tab persistence", () => {
   const TAB_KEY = "selectedDeliverableTab";
   const CURRENT_USER_ID = MOCK_DELIVERABLE_TABLE_ROW.cmsOwner.id;
-  const mockGetCurrentUser = vi.mocked(UserContext.getCurrentUser);
+  const DEFAULT_TEST_USER = { ...mockUsers[0], id: CURRENT_USER_ID };
 
-  const renderDeliverablesPage = async () => {
+  const renderDeliverablesPage = async (currentUser = DEFAULT_TEST_USER) => {
     render(
-      <TestProvider mocks={DELIVERABLES_TABLE_MOCKS}>
+      <TestProvider mocks={DELIVERABLES_TABLE_MOCKS} currentUser={currentUser}>
         <DeliverablesPage />
       </TestProvider>
     );
@@ -64,12 +54,6 @@ describe("DeliverablesPage tab persistence", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetCurrentUser.mockReturnValue({
-      currentUser: {
-        ...mockUsers[0],
-        id: CURRENT_USER_ID,
-      },
-    });
     sessionStorage.clear();
   });
 
@@ -139,17 +123,13 @@ describe("DeliverablesPage tab persistence", () => {
   });
 
   it("uses state-user table columns when current user is demos-state-user", async () => {
-    mockGetCurrentUser.mockReturnValue({
-      currentUser: {
-        ...mockUsers[0],
-        person: {
-          ...mockUsers[0].person,
-          personType: "demos-state-user",
-        },
+    await renderDeliverablesPage({
+      ...mockUsers[0],
+      person: {
+        ...mockUsers[0].person,
+        personType: "demos-state-user",
       },
     });
-
-    await renderDeliverablesPage();
 
     expect(
       screen.queryByRole("columnheader", { name: /State\/Territory/i })
@@ -159,35 +139,28 @@ describe("DeliverablesPage tab persistence", () => {
   });
 
   it("shows All Deliverables tab for demos-state-user", async () => {
-    mockGetCurrentUser.mockReturnValue({
-      currentUser: {
-        ...mockUsers[0],
-        person: {
-          ...mockUsers[0].person,
-          personType: "demos-state-user",
-        },
+    await renderDeliverablesPage({
+      ...mockUsers[0],
+      person: {
+        ...mockUsers[0].person,
+        personType: "demos-state-user",
       },
     });
-
-    await renderDeliverablesPage();
 
     expect(screen.getByTestId("button-deliverables")).toBeInTheDocument();
     expect(screen.getByTestId("button-my-deliverables")).toHaveAttribute("aria-selected", "true");
   });
 
   it("uses stored deliverables tab for demos-state-user", async () => {
-    mockGetCurrentUser.mockReturnValue({
-      currentUser: {
-        ...mockUsers[0],
-        person: {
-          ...mockUsers[0].person,
-          personType: "demos-state-user",
-        },
-      },
-    });
     sessionStorage.setItem(TAB_KEY, "deliverables");
 
-    await renderDeliverablesPage();
+    await renderDeliverablesPage({
+      ...mockUsers[0],
+      person: {
+        ...mockUsers[0].person,
+        personType: "demos-state-user",
+      },
+    });
 
     expect(sessionStorage.getItem(TAB_KEY)).toBe("deliverables");
     expect(screen.getByTestId("button-deliverables")).toHaveAttribute("aria-selected", "true");

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.test.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.test.tsx
@@ -1,24 +1,13 @@
 import React from "react";
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import * as UserContext from "components/user/UserContext";
-
 import { DemonstrationTab, DemonstrationTabDemonstration } from "./DemonstrationTab";
 import { TestProvider } from "test-utils/TestProvider";
 import { DialogProvider } from "components/dialog/DialogContext";
-import { mockUsers } from "mock-data/userMocks";
 import { deliverableMocks } from "mock-data/deliverableMocks";
-
-vi.mock("components/user/UserContext", async (importOriginal) => {
-  const actual = await importOriginal<typeof UserContext>();
-  return {
-    ...actual,
-    getCurrentUser: vi.fn(),
-  };
-});
 
 const mockDemonstration: DemonstrationTabDemonstration = {
   id: "demo-123",
@@ -79,15 +68,6 @@ const renderWithProvider = (component: React.ReactElement) => {
 };
 
 describe("DemonstrationTab", () => {
-  const mockGetCurrentUser = vi.mocked(UserContext.getCurrentUser);
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetCurrentUser.mockReturnValue({
-      currentUser: mockUsers[0],
-    });
-  });
-
   it("renders all tab labels with correct counts", () => {
     renderWithProvider(<DemonstrationTab demonstration={mockDemonstration} />);
 

--- a/client/src/pages/DemonstrationDetail/deliverables/DeliverablesTab.test.tsx
+++ b/client/src/pages/DemonstrationDetail/deliverables/DeliverablesTab.test.tsx
@@ -1,22 +1,12 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { DialogProvider } from "components/dialog/DialogContext";
 import { ADD_DELIVERABLE_SLOT_DIALOG_TITLE } from "components/dialog/deliverable";
 import { ADD_DELIVERABLE_SLOT_BUTTON_NAME, DeliverablesTab } from "./DeliverablesTab";
 import { TestProvider } from "test-utils/TestProvider";
 import { deliverableMocks } from "mock-data/deliverableMocks";
-import * as UserContext from "components/user/UserContext";
-import { mockUsers } from "mock-data/userMocks";
-
-vi.mock("components/user/UserContext", async (importOriginal) => {
-  const actual = await importOriginal<typeof UserContext>();
-  return {
-    ...actual,
-    getCurrentUser: vi.fn(),
-  };
-});
 
 const MOCK_PARENT_DEMONSTRATION = {
   id: "demo-1",
@@ -26,15 +16,6 @@ const MOCK_PARENT_DEMONSTRATION = {
 };
 
 describe("DeliverablesTab", () => {
-  const mockGetCurrentUser = vi.mocked(UserContext.getCurrentUser);
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetCurrentUser.mockReturnValue({
-      currentUser: mockUsers[0],
-    });
-  });
-
   it("renders Deliverables Management header and required columns", async () => {
     render(
       <TestProvider mocks={deliverableMocks}>

--- a/client/src/pages/deliverables/sections/CommentBox.test.tsx
+++ b/client/src/pages/deliverables/sections/CommentBox.test.tsx
@@ -2,21 +2,25 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { COLLAPSE_COMMENTS_BUTTON_NAME, COMMENT_BOX_NAME, COMMENT_BOX_TEXT_AREA_NAME, CommentBox } from "./CommentBox";
+import { TestProvider } from "test-utils/TestProvider";
+
+
+const renderCommentBox = () => render(<TestProvider><CommentBox /></TestProvider>);
 
 describe("CommentBox", () => {
   it("renders without crashing", () => {
-    render(<CommentBox />);
+    renderCommentBox();
     expect(screen.getByTestId(COMMENT_BOX_NAME)).toBeInTheDocument();
   });
 
   it("shows the full comment box by default", () => {
-    render(<CommentBox />);
+    renderCommentBox();
     expect(screen.getByTestId(COMMENT_BOX_TEXT_AREA_NAME)).toBeInTheDocument();
     expect(screen.getByText("Comment History")).toBeInTheDocument();
   });
 
   it("collapses to a single icon button when the collapse button is clicked", async () => {
-    render(<CommentBox />);
+    renderCommentBox();
 
     await userEvent.click(screen.getByTestId(COLLAPSE_COMMENTS_BUTTON_NAME));
 
@@ -26,7 +30,7 @@ describe("CommentBox", () => {
   });
 
   it("expands back when the collapsed icon button is clicked", async () => {
-    render(<CommentBox />);
+    renderCommentBox();
 
     await userEvent.click(screen.getByTestId(COLLAPSE_COMMENTS_BUTTON_NAME));
     await userEvent.click(screen.getByTestId(COMMENT_BOX_NAME));
@@ -36,7 +40,7 @@ describe("CommentBox", () => {
   });
 
   it("still renders the testid in collapsed state", async () => {
-    render(<CommentBox />);
+    renderCommentBox();
 
     await userEvent.click(screen.getByTestId(COLLAPSE_COMMENTS_BUTTON_NAME));
 
@@ -44,7 +48,7 @@ describe("CommentBox", () => {
   });
 
   it("preserves typed comment text after collapsing and expanding", async () => {
-    render(<CommentBox />);
+    renderCommentBox();
 
     await userEvent.type(screen.getByTestId(COMMENT_BOX_TEXT_AREA_NAME), "my draft comment");
     await userEvent.click(screen.getByTestId(COLLAPSE_COMMENTS_BUTTON_NAME));

--- a/client/src/pages/deliverables/sections/CommentBox.test.tsx
+++ b/client/src/pages/deliverables/sections/CommentBox.test.tsx
@@ -1,11 +1,17 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { COLLAPSE_COMMENTS_BUTTON_NAME, COMMENT_BOX_NAME, COMMENT_BOX_TEXT_AREA_NAME, CommentBox } from "./CommentBox";
+import { COLLAPSE_COMMENTS_BUTTON_NAME, COMMENT_BOX_NAME, COMMENT_BOX_TABS_NAME, COMMENT_BOX_TEXT_AREA_NAME, CommentBox } from "./CommentBox";
 import { TestProvider } from "test-utils/TestProvider";
+import { developmentMockUser } from "mock-data/userMocks";
+import { PersonType } from "demos-server";
+import { CurrentUser } from "components/user/UserContext";
 
 
-const renderCommentBox = () => render(<TestProvider><CommentBox /></TestProvider>);
+const renderCommentBox = (personType?: PersonType) => {
+  const currentUser: CurrentUser = {...developmentMockUser, person: { ...developmentMockUser.person, personType: personType || developmentMockUser.person.personType } };
+  render(<TestProvider currentUser={currentUser}><CommentBox /></TestProvider>);
+};
 
 describe("CommentBox", () => {
   it("renders without crashing", () => {
@@ -55,5 +61,20 @@ describe("CommentBox", () => {
     await userEvent.click(screen.getByTestId(COMMENT_BOX_NAME));
 
     expect(screen.getByTestId(COMMENT_BOX_TEXT_AREA_NAME)).toHaveValue("my draft comment");
+  });
+
+  it("renders comment box tabs for Admin users", () => {
+    renderCommentBox("demos-admin");
+    expect(screen.getByTestId(COMMENT_BOX_TABS_NAME)).toBeInTheDocument();
+  });
+
+  it("renders comment box tabs for CMS users", () => {
+    renderCommentBox("demos-cms-user");
+    expect(screen.getByTestId(COMMENT_BOX_TABS_NAME)).toBeInTheDocument();
+  });
+
+  it("does not render comment box tabs for state users", () => {
+    renderCommentBox("demos-state-user");
+    expect(screen.queryByTestId(COMMENT_BOX_TABS_NAME)).not.toBeInTheDocument();
   });
 });

--- a/client/src/pages/deliverables/sections/CommentBox.tsx
+++ b/client/src/pages/deliverables/sections/CommentBox.tsx
@@ -4,6 +4,8 @@ import { MenuCollapseRightIcon } from "components/icons/Navigation/MenuCollapseR
 import { Textarea } from "components/input";
 import { CommentIcon } from "components/icons";
 import { SecondaryButton } from "components/button";
+import { getCurrentUser } from "components/user/UserContext";
+import { PersonType } from "demos-server";
 
 export const COMMENT_BOX_NAME = "comment-box";
 export const COMMENT_BOX_TEXT_AREA_NAME = "textarea-comment-box";
@@ -29,6 +31,13 @@ const CommentBoxTextArea = ({ value, onChange }: { value: string; onChange: (e: 
   );
 };
 
+const CommentBoxTabs = () => (
+  <div data-testid="comment-box-tabs">
+    ONLY CMS / ADMIN USERS CAN SEE THIS TAB
+    {/* TODO: implement tab content */}
+  </div>
+);
+
 const CommentBoxHistory = () => (
   <>
     <span className="font-semibold">Comment History</span>
@@ -37,8 +46,16 @@ const CommentBoxHistory = () => (
 );
 
 export const CommentBox = () => {
+  const { currentUser } = getCurrentUser();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [currentComment, setCurrentComment] = useState("");
+
+  if (!currentUser) {
+    return null;
+  }
+
+  const userPersonType: PersonType = currentUser.person.personType;
+  const isCmsOrAdminUser = userPersonType === "demos-cms-user" || userPersonType === "demos-admin";
 
   if (isCollapsed) {
     return (
@@ -56,6 +73,7 @@ export const CommentBox = () => {
   return (
     <div className="flex flex-col gap-1 bg-gray-primary-layout p-1 min-h-full min-w-[350px]" data-testid={COMMENT_BOX_NAME}>
       <CommentBoxHeader onCollapse={() => setIsCollapsed(true)} />
+      {isCmsOrAdminUser && <CommentBoxTabs />}
       <CommentBoxTextArea value={currentComment} onChange={(e) => setCurrentComment(e.target.value)} />
       <CommentBoxHistory />
     </div>

--- a/client/src/pages/deliverables/sections/CommentBox.tsx
+++ b/client/src/pages/deliverables/sections/CommentBox.tsx
@@ -10,6 +10,7 @@ import { PersonType } from "demos-server";
 export const COMMENT_BOX_NAME = "comment-box";
 export const COMMENT_BOX_TEXT_AREA_NAME = "textarea-comment-box";
 export const COLLAPSE_COMMENTS_BUTTON_NAME = "button-collapse-comments";
+export const COMMENT_BOX_TABS_NAME = "comment-box-tabs";
 
 const CommentBoxHeader = ({ onCollapse }: { onCollapse: () => void }) => (
   <div className="flex items-center justify-between pb-1 border-b border-gray-dark">
@@ -32,8 +33,8 @@ const CommentBoxTextArea = ({ value, onChange }: { value: string; onChange: (e: 
 };
 
 const CommentBoxTabs = () => (
-  <div data-testid="comment-box-tabs">
-    ONLY CMS / ADMIN USERS CAN SEE THIS TAB
+  <div data-testid={COMMENT_BOX_TABS_NAME}>
+    ONLY CMS / ADMIN USERS CAN SEE THIS
     {/* TODO: implement tab content */}
   </div>
 );

--- a/client/src/test-utils/TestProvider.tsx
+++ b/client/src/test-utils/TestProvider.tsx
@@ -5,12 +5,15 @@ import { ToastProvider } from "components/toast/ToastContext";
 import { MockedProvider, MockedProviderProps } from "@apollo/client/testing";
 import { MemoryRouter, MemoryRouterProps } from "react-router-dom";
 import { ALL_MOCKS } from "mock-data";
+import { CurrentUser, TestUserProvider } from "components/user/UserContext";
+import { developmentMockUser } from "mock-data/userMocks";
 
 interface TestProviderProps {
   children: ReactNode;
   mocks?: MockedProviderProps["mocks"];
   addTypename?: boolean;
   routerEntries?: MemoryRouterProps["initialEntries"];
+  currentUser?: CurrentUser;
 }
 
 /**
@@ -36,12 +39,15 @@ export const TestProvider: React.FC<TestProviderProps> = ({
   mocks = ALL_MOCKS,
   addTypename = false,
   routerEntries = ["/"],
+  currentUser = developmentMockUser,
 }) => {
   return (
     <MemoryRouter initialEntries={routerEntries}>
       <ToastProvider>
         <MockedProvider mocks={mocks} addTypename={addTypename}>
-          {children}
+          <TestUserProvider currentUser={currentUser}>
+            {children}
+          </TestUserProvider>
         </MockedProvider>
       </ToastProvider>
     </MemoryRouter>

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -25,6 +25,7 @@ interface ImportMetaEnv {
   readonly VITE_APPLICATION_HOSTNAME: EnvironmentVariable;
   readonly VITE_API_URL_PREFIX: EnvironmentVariable;
   readonly VITE_IDLE_TIMEOUT: EnvironmentVariable;
+  readonly VITE_MOCK_PERSON_TYPE: EnvironmentVariable;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
For this PR I focused on the idea of "showing an element to one type of user and not another". Ended up coming up with a bunch of improvements to the way we handle `currentUser` and adding some tooling / documenting future improvements as well. Almost net-negative change after all is said and done!


https://github.com/user-attachments/assets/e34251ad-035d-47d5-ab4d-dd3f202ae6e0

