### PR TITLE
DEMOS-1603: Add Single deliverable query

### DIFF
--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -70,6 +70,13 @@ export async function resolveManyDeliverables(
   return results;
 }
 
+export async function queryDeliverable(
+  parent: unknown,
+  args: { id: string }
+): Promise<PrismaDeliverable | null> {
+  return await getDeliverable({ id: args.id });
+}
+
 export async function queryDeliverables(): Promise<PrismaDeliverable[]> {
   return await getManyDeliverables();
 }
@@ -98,6 +105,7 @@ export async function resolveDeliverableCmsOwner(parent: PrismaDeliverable): Pro
 
 export const deliverableResolvers = {
   Query: {
+    deliverable: queryDeliverable,
     deliverables: queryDeliverables,
   },
 

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -70,13 +70,6 @@ export async function resolveManyDeliverables(
   return results;
 }
 
-export async function queryDeliverable(
-  parent: unknown,
-  args: { id: string }
-): Promise<PrismaDeliverable | null> {
-  return await getDeliverable({ id: args.id });
-}
-
 export async function queryDeliverables(): Promise<PrismaDeliverable[]> {
   return await getManyDeliverables();
 }
@@ -105,7 +98,7 @@ export async function resolveDeliverableCmsOwner(parent: PrismaDeliverable): Pro
 
 export const deliverableResolvers = {
   Query: {
-    deliverable: queryDeliverable,
+    deliverable: async (parent: unknown, args: {id: string}) => await getDeliverable({ id: args.id }),
     deliverables: queryDeliverables,
   },
 

--- a/server/src/model/deliverable/deliverableSchema.ts
+++ b/server/src/model/deliverable/deliverableSchema.ts
@@ -53,6 +53,7 @@ export const deliverableSchema = gql`
   }
 
   type Query {
+    deliverable(id: ID!): Deliverable
     deliverables: [Deliverable!]!
   }
 

--- a/server/src/model/deliverable/deliverableSchema.ts
+++ b/server/src/model/deliverable/deliverableSchema.ts
@@ -53,7 +53,7 @@ export const deliverableSchema = gql`
   }
 
   type Query {
-    deliverable(id: ID!): Deliverable
+    deliverable(id: ID!): Deliverable!
     deliverables: [Deliverable!]!
   }
 


### PR DESCRIPTION
Adds a resolver / query to get a deliverable by id, supporting the demonstration detail management page


<img width="3363" height="1718" alt="Screenshot 2026-04-22 144338" src="https://github.com/user-attachments/assets/7cf4933d-869e-45cb-9be8-dca3864c7631" />
