### PR TITLE
DEMOS-1992: Fix years display

### DIFF
--- a/client/src/pages/DemonstrationDetail/DemonstrationDetail.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetail.tsx
@@ -44,6 +44,8 @@ export const DEMONSTRATION_DETAIL_QUERY = gql`
       name
       status
       currentPhaseName
+      effectiveDate
+      expirationDate
       amendments {
         name
         id
@@ -131,7 +133,7 @@ export type DemonstrationDetailModification = Pick<
     owner: { person: Pick<Person, "fullName"> };
   })[];
 };
-export type DemonstrationDetail = Pick<Demonstration, "id" | "name" | "status" | "currentPhaseName"> & {
+export type DemonstrationDetail = Pick<Demonstration, "id" | "name" | "status" | "currentPhaseName" | "effectiveDate" | "expirationDate"> & {
   amendments: DemonstrationDetailModification[];
   extensions: DemonstrationDetailModification[];
   demonstrationTypes: Pick<

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
@@ -45,9 +45,7 @@ export type DemonstrationDetailDemonstrationType = Pick<
   | "approvalStatus"
 >;
 
-export type DemonstrationTabDemonstration = Pick<Demonstration, "id" | "name" | "status"> & {
-  effectiveDate?: Demonstration["effectiveDate"];
-  expirationDate?: Demonstration["expirationDate"];
+export type DemonstrationTabDemonstration = Pick<Demonstration, "id" | "name" | "status" | "effectiveDate" | "expirationDate"> & {
   demonstrationTypes: DemonstrationDetailDemonstrationType[];
   documents: (Pick<Document, "id" | "name" | "description" | "documentType" | "createdAt"> & {
     owner: {


### PR DESCRIPTION
AddDeliverableSlots now shows the proper number of years given the effective / expiration dates

<img width="2709" height="1732" alt="Screenshot 2026-04-22 160807" src="https://github.com/user-attachments/assets/1ce6c9ea-fe0a-4f43-bcf4-64fdd82dcc59" />
<img width="2660" height="1582" alt="Screenshot 2026-04-22 160851" src="https://github.com/user-attachments/assets/3c1f2b9d-2c63-48bc-945e-5e422b77c836" />
