### PR TITLE
DEMOS-1573 — State User: Request Extension on Deliverable (Layout)

### DIFF
--- a/client/src/components/dialog/DialogContext.tsx
+++ b/client/src/components/dialog/DialogContext.tsx
@@ -26,6 +26,10 @@ import { UpdateAmendmentDialog } from "./modification/EditAmendmentDialog";
 import { ConfirmApproveDialog } from "./ConfirmApproveDialog";
 import { AddDeliverableSlotDialog } from "./deliverable";
 import { EditDeliverableDialog } from "./deliverable/EditDeliverableDialog";
+import {
+  RequestExtensionDeliverableDialog,
+  RequestExtensionDeliverableDialogDeliverable,
+} from "./deliverable/RequestExtensionDeliverableDialog";
 import type {
   EditDeliverableDialogDeliverable,
   EditDeliverableInput,
@@ -241,6 +245,14 @@ export const useDialog = () => {
     );
   };
 
+  const showRequestExtensionDeliverableDialog = (
+    deliverable: RequestExtensionDeliverableDialogDeliverable
+  ) => {
+    context.showDialog(
+      <RequestExtensionDeliverableDialog onClose={context.hideDialog} deliverable={deliverable} />
+    );
+  };
+
   const showEditDeliverableDialog = (
     deliverable: DeliverableTableRow,
     onSave?: (input: EditDeliverableInput, reasonForChange?: string) => Promise<void> | void
@@ -294,5 +306,6 @@ export const useDialog = () => {
     showConfirmApproveDialog,
     showAddDeliverableSlotDialog,
     showEditDeliverableDialog,
+    showRequestExtensionDeliverableDialog,
   };
 };

--- a/client/src/components/dialog/deliverable/RequestExtensionDeliverableDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/RequestExtensionDeliverableDialog.test.tsx
@@ -1,0 +1,293 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  EXTENSION_ELIGIBLE_STATUSES,
+  INITIAL_FORM_DATA,
+  REQUEST_EXTENSION_DATE_FIELD_NAME,
+  REQUEST_EXTENSION_DETAILS_FIELD_NAME,
+  REQUEST_EXTENSION_DIALOG_TITLE,
+  REQUEST_EXTENSION_REASON_FIELD_NAME,
+  REQUEST_EXTENSION_SUBMIT_BUTTON_NAME,
+  RequestExtensionDeliverableDialog,
+  RequestExtensionDeliverableDialogDeliverable,
+  canRequestExtension,
+  formHasChanges,
+  formIsValid,
+  getExtensionDateValidationMessage,
+} from "./RequestExtensionDeliverableDialog";
+import { DIALOG_CANCEL_BUTTON_NAME } from "components/dialog/BaseDialog";
+import { TestProvider } from "test-utils/TestProvider";
+import { DELIVERABLE_EXTENSION_REQUESTED_MESSAGE } from "util/messages";
+
+const mockShowSuccess = vi.fn();
+vi.mock("components/toast", () => ({
+  useToast: () => ({
+    showSuccess: mockShowSuccess,
+  }),
+}));
+
+const TEST_DELIVERABLE: RequestExtensionDeliverableDialogDeliverable = {
+  id: "deliverable-1",
+  dueDate: new Date("2026-02-12"),
+  demonstration: { expirationDate: new Date("2026-12-31") },
+};
+
+type OnSubmitFn = NonNullable<
+  React.ComponentProps<typeof RequestExtensionDeliverableDialog>["onSubmit"]
+>;
+
+const setup = (
+  overrides?: Partial<RequestExtensionDeliverableDialogDeliverable>,
+  onSubmit?: OnSubmitFn
+) => {
+  const onClose = vi.fn();
+  const deliverable = { ...TEST_DELIVERABLE, ...overrides };
+
+  render(
+    <TestProvider>
+      <RequestExtensionDeliverableDialog
+        deliverable={deliverable}
+        onClose={onClose}
+        onSubmit={onSubmit}
+      />
+    </TestProvider>
+  );
+
+  return { onClose };
+};
+
+describe("RequestExtensionDeliverableDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders with the correct title", () => {
+    setup();
+    expect(screen.getByText(REQUEST_EXTENSION_DIALOG_TITLE)).toBeInTheDocument();
+  });
+
+  it("renders the required Extension Date, Request Reason, and Details fields", () => {
+    setup();
+    expect(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME)).toBeRequired();
+    expect(screen.getByTestId(REQUEST_EXTENSION_REASON_FIELD_NAME)).toBeRequired();
+    expect(screen.getByTestId(REQUEST_EXTENSION_DETAILS_FIELD_NAME)).toBeRequired();
+  });
+
+  it("renders the request reason options", () => {
+    setup();
+    expect(
+      screen.getByTestId(`${REQUEST_EXTENSION_REASON_FIELD_NAME}-option-COVID-19`)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${REQUEST_EXTENSION_REASON_FIELD_NAME}-option-Technical Difficulties`)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${REQUEST_EXTENSION_REASON_FIELD_NAME}-option-Other`)
+    ).toBeInTheDocument();
+  });
+
+  it("renders both Submit and Cancel buttons", () => {
+    setup();
+    expect(screen.getByTestId(REQUEST_EXTENSION_SUBMIT_BUTTON_NAME)).toBeInTheDocument();
+    expect(screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME)).toBeInTheDocument();
+  });
+
+  it("disables Submit until all required fields are valid", async () => {
+    const user = userEvent.setup();
+    setup();
+    const submit = screen.getByTestId(REQUEST_EXTENSION_SUBMIT_BUTTON_NAME);
+
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME), {
+      target: { value: "2026-03-15" },
+    });
+    expect(submit).toBeDisabled();
+
+    await user.selectOptions(screen.getByTestId(REQUEST_EXTENSION_REASON_FIELD_NAME), "Other");
+    expect(submit).toBeDisabled();
+
+    await user.type(screen.getByTestId(REQUEST_EXTENSION_DETAILS_FIELD_NAME), "Need more time");
+    await waitFor(() => expect(submit).not.toBeDisabled());
+  });
+
+  it("keeps Submit disabled when the extension date is not after the current due date", async () => {
+    const user = userEvent.setup();
+    setup();
+
+    fireEvent.change(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME), {
+      target: { value: "2026-02-12" }, // equal to due date — invalid
+    });
+    await user.selectOptions(screen.getByTestId(REQUEST_EXTENSION_REASON_FIELD_NAME), "COVID-19");
+    await user.type(screen.getByTestId(REQUEST_EXTENSION_DETAILS_FIELD_NAME), "Delayed");
+
+    expect(screen.getByTestId(REQUEST_EXTENSION_SUBMIT_BUTTON_NAME)).toBeDisabled();
+    expect(
+      screen.getByText("Extension Date must be after the current Due Date.")
+    ).toBeInTheDocument();
+  });
+
+  it("keeps Submit disabled when the extension date is after the demonstration expiration", async () => {
+    const user = userEvent.setup();
+    setup();
+
+    fireEvent.change(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME), {
+      target: { value: "2027-01-15" }, // past expiration
+    });
+    await user.selectOptions(screen.getByTestId(REQUEST_EXTENSION_REASON_FIELD_NAME), "Other");
+    await user.type(screen.getByTestId(REQUEST_EXTENSION_DETAILS_FIELD_NAME), "x");
+
+    expect(screen.getByTestId(REQUEST_EXTENSION_SUBMIT_BUTTON_NAME)).toBeDisabled();
+    expect(
+      screen.getByText("Extension Date cannot be after the Demonstration Expiration Date.")
+    ).toBeInTheDocument();
+  });
+
+  it("submits the form, shows a success toast, and closes the dialog", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const { onClose } = setup(undefined, onSubmit);
+
+    fireEvent.change(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME), {
+      target: { value: "2026-03-15" },
+    });
+    await user.selectOptions(
+      screen.getByTestId(REQUEST_EXTENSION_REASON_FIELD_NAME),
+      "Technical Difficulties"
+    );
+    await user.type(
+      screen.getByTestId(REQUEST_EXTENSION_DETAILS_FIELD_NAME),
+      "  Vendor portal outage  "
+    );
+
+    await user.click(screen.getByTestId(REQUEST_EXTENSION_SUBMIT_BUTTON_NAME));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith({
+      deliverableId: "deliverable-1",
+      extensionDate: "2026-03-15",
+      requestReason: "Technical Difficulties",
+      details: "Vendor portal outage",
+    });
+    expect(mockShowSuccess).toHaveBeenCalledWith(DELIVERABLE_EXTENSION_REQUESTED_MESSAGE);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the cancellation confirmation when closing with unsaved changes", async () => {
+    const user = userEvent.setup();
+    const { onClose } = setup();
+
+    await user.type(screen.getByTestId(REQUEST_EXTENSION_DETAILS_FIELD_NAME), "partial");
+    await user.click(screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME));
+
+    expect(await screen.findByText("Are you sure?")).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes without confirmation when there are no unsaved changes", async () => {
+    const user = userEvent.setup();
+    const { onClose } = setup();
+
+    await user.click(screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("canRequestExtension", () => {
+  it.each(["Upcoming", "Past Due"] as const)("returns true for %s", (status) => {
+    expect(canRequestExtension(status)).toBe(true);
+    expect(EXTENSION_ELIGIBLE_STATUSES.has(status)).toBe(true);
+  });
+
+  it.each(["Submitted", "Under CMS Review", "Accepted", "Approved", "Received and Filed"] as const)(
+    "returns false for %s",
+    (status) => {
+      expect(canRequestExtension(status)).toBe(false);
+    }
+  );
+});
+
+describe("getExtensionDateValidationMessage", () => {
+  const dueDate = new Date("2026-02-12");
+  const expirationDate = new Date("2026-12-31");
+
+  it("returns empty for an empty value", () => {
+    expect(getExtensionDateValidationMessage("", dueDate, expirationDate)).toBe("");
+  });
+
+  it("flags dates not after the due date", () => {
+    expect(getExtensionDateValidationMessage("2026-02-12", dueDate, expirationDate)).toBe(
+      "Extension Date must be after the current Due Date."
+    );
+    expect(getExtensionDateValidationMessage("2026-01-01", dueDate, expirationDate)).toBe(
+      "Extension Date must be after the current Due Date."
+    );
+  });
+
+  it("flags dates beyond the demonstration expiration", () => {
+    expect(getExtensionDateValidationMessage("2027-01-15", dueDate, expirationDate)).toBe(
+      "Extension Date cannot be after the Demonstration Expiration Date."
+    );
+  });
+
+  it("skips the expiration check when no expiration date is known", () => {
+    expect(getExtensionDateValidationMessage("2099-01-01", dueDate, null)).toBe("");
+    expect(getExtensionDateValidationMessage("2099-01-01", dueDate, undefined)).toBe("");
+  });
+
+  it("accepts a valid date between due date and expiration", () => {
+    expect(getExtensionDateValidationMessage("2026-06-01", dueDate, expirationDate)).toBe("");
+  });
+});
+
+describe("formIsValid / formHasChanges", () => {
+  const dueDate = new Date("2026-02-12");
+
+  it("INITIAL_FORM_DATA has empty values", () => {
+    expect(INITIAL_FORM_DATA).toEqual({
+      extensionDate: "",
+      requestReason: "",
+      details: "",
+    });
+  });
+
+  it("formHasChanges returns false for the initial state", () => {
+    expect(formHasChanges(INITIAL_FORM_DATA)).toBe(false);
+  });
+
+  it("formHasChanges returns true when any field has been touched", () => {
+    expect(formHasChanges({ ...INITIAL_FORM_DATA, extensionDate: "2026-03-01" })).toBe(true);
+    expect(formHasChanges({ ...INITIAL_FORM_DATA, requestReason: "Other" })).toBe(true);
+    expect(formHasChanges({ ...INITIAL_FORM_DATA, details: "x" })).toBe(true);
+  });
+
+  it("formIsValid requires all three fields", () => {
+    expect(
+      formIsValid({ extensionDate: "", requestReason: "Other", details: "reason" }, dueDate, null)
+    ).toBe(false);
+    expect(
+      formIsValid(
+        { extensionDate: "2026-03-01", requestReason: "", details: "reason" },
+        dueDate,
+        null
+      )
+    ).toBe(false);
+    expect(
+      formIsValid(
+        { extensionDate: "2026-03-01", requestReason: "Other", details: "   " },
+        dueDate,
+        null
+      )
+    ).toBe(false);
+    expect(
+      formIsValid(
+        { extensionDate: "2026-03-01", requestReason: "Other", details: "reason" },
+        dueDate,
+        null
+      )
+    ).toBe(true);
+  });
+});

--- a/client/src/components/dialog/deliverable/RequestExtensionDeliverableDialog.tsx
+++ b/client/src/components/dialog/deliverable/RequestExtensionDeliverableDialog.tsx
@@ -1,0 +1,188 @@
+import React, { useState } from "react";
+
+import { Button } from "components/button";
+import { BaseDialog } from "components/dialog/BaseDialog";
+import { DatePicker } from "components/input/date/DatePicker";
+import { Select, Option } from "components/input/select/Select";
+import { Textarea } from "components/input/Textarea";
+import { useToast } from "components/toast";
+import { DeliverableExtensionReasonCode, DeliverableStatus } from "demos-server";
+import { DELIVERABLE_EXTENSION_REASON_CODES } from "demos-server-constants";
+import { isAfter, isValid, parseISO } from "date-fns";
+import { DELIVERABLE_EXTENSION_REQUESTED_MESSAGE } from "util/messages";
+
+export const REQUEST_EXTENSION_DIALOG_TITLE = "Request Extension";
+export const REQUEST_EXTENSION_DIALOG_NAME = "request-extension-dialog";
+export const REQUEST_EXTENSION_DATE_FIELD_NAME = "request-extension-date";
+export const REQUEST_EXTENSION_REASON_FIELD_NAME = "request-extension-reason";
+export const REQUEST_EXTENSION_DETAILS_FIELD_NAME = "request-extension-details";
+export const REQUEST_EXTENSION_SUBMIT_BUTTON_NAME = "button-request-extension-submit";
+
+export const EXTENSION_ELIGIBLE_STATUSES: ReadonlySet<DeliverableStatus> = new Set([
+  "Upcoming",
+  "Past Due",
+]);
+
+export const canRequestExtension = (status: DeliverableStatus): boolean =>
+  EXTENSION_ELIGIBLE_STATUSES.has(status);
+
+export const REQUEST_REASON_OPTIONS: Option[] = DELIVERABLE_EXTENSION_REASON_CODES.map((code) => ({
+  label: code,
+  value: code,
+}));
+
+export interface RequestExtensionDeliverableDialogDeliverable {
+  id: string;
+  dueDate: Date;
+  demonstration: { expirationDate?: Date | null };
+}
+
+export interface RequestExtensionFormData {
+  extensionDate: string;
+  requestReason: DeliverableExtensionReasonCode | "";
+  details: string;
+}
+
+export const INITIAL_FORM_DATA: RequestExtensionFormData = {
+  extensionDate: "",
+  requestReason: "",
+  details: "",
+};
+
+export const getExtensionDateValidationMessage = (
+  extensionDate: string,
+  dueDate: Date,
+  demonstrationExpirationDate: Date | null | undefined
+): string => {
+  if (extensionDate === "") return "";
+  const parsed = parseISO(extensionDate);
+  if (!isValid(parsed)) return "Enter a valid date.";
+  if (!isAfter(parsed, dueDate)) {
+    return "Extension Date must be after the current Due Date.";
+  }
+  if (demonstrationExpirationDate && isAfter(parsed, demonstrationExpirationDate)) {
+    return "Extension Date cannot be after the Demonstration Expiration Date.";
+  }
+  return "";
+};
+
+export const formIsValid = (
+  form: RequestExtensionFormData,
+  dueDate: Date,
+  demonstrationExpirationDate: Date | null | undefined
+): boolean => {
+  const extensionDateValid =
+    form.extensionDate.trim().length > 0 &&
+    getExtensionDateValidationMessage(form.extensionDate, dueDate, demonstrationExpirationDate) ===
+      "";
+  return extensionDateValid && form.requestReason.length > 0 && form.details.trim().length > 0;
+};
+
+export const formHasChanges = (form: RequestExtensionFormData): boolean =>
+  form.extensionDate.length > 0 || form.requestReason.length > 0 || form.details.trim().length > 0;
+
+export interface RequestExtensionDeliverableDialogProps {
+  onClose: () => void;
+  deliverable: RequestExtensionDeliverableDialogDeliverable;
+  onSubmit?: (input: {
+    deliverableId: string;
+    extensionDate: string;
+    requestReason: DeliverableExtensionReasonCode;
+    details: string;
+  }) => Promise<void> | void;
+}
+
+export const RequestExtensionDeliverableDialog: React.FC<
+  RequestExtensionDeliverableDialogProps
+> = ({ onClose, deliverable, onSubmit }) => {
+  const { showSuccess } = useToast();
+
+  const [formData, setFormData] = useState<RequestExtensionFormData>(INITIAL_FORM_DATA);
+  const [attemptedSubmit, setAttemptedSubmit] = useState(false);
+
+  const expirationDate = deliverable.demonstration.expirationDate ?? null;
+  const extensionDateError = getExtensionDateValidationMessage(
+    formData.extensionDate,
+    deliverable.dueDate,
+    expirationDate
+  );
+  const isValidForm = formIsValid(formData, deliverable.dueDate, expirationDate);
+  const hasChanges = formHasChanges(formData);
+
+  const handleSubmit = async () => {
+    setAttemptedSubmit(true);
+    if (!isValidForm || formData.requestReason === "") return;
+
+    await onSubmit?.({
+      deliverableId: deliverable.id,
+      extensionDate: formData.extensionDate,
+      requestReason: formData.requestReason,
+      details: formData.details.trim(),
+    });
+
+    showSuccess(DELIVERABLE_EXTENSION_REQUESTED_MESSAGE);
+    onClose();
+  };
+
+  return (
+    <BaseDialog
+      name={REQUEST_EXTENSION_DIALOG_NAME}
+      title={REQUEST_EXTENSION_DIALOG_TITLE}
+      onClose={onClose}
+      dialogHasChanges={hasChanges}
+      actionButton={
+        <Button
+          name={REQUEST_EXTENSION_SUBMIT_BUTTON_NAME}
+          onClick={handleSubmit}
+          disabled={!isValidForm}
+        >
+          Submit
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-sm">
+        <div className="grid grid-cols-2 gap-sm">
+          <DatePicker
+            name={REQUEST_EXTENSION_DATE_FIELD_NAME}
+            label="Extension Date"
+            isRequired
+            value={formData.extensionDate}
+            onChange={(extensionDate) => setFormData((prev) => ({ ...prev, extensionDate }))}
+            getValidationMessage={() =>
+              attemptedSubmit && formData.extensionDate === ""
+                ? "Extension Date is required."
+                : extensionDateError
+            }
+          />
+          <Select
+            id={REQUEST_EXTENSION_REASON_FIELD_NAME}
+            label="Request Reason"
+            isRequired
+            options={REQUEST_REASON_OPTIONS}
+            value={formData.requestReason}
+            onSelect={(value) =>
+              setFormData((prev) => ({
+                ...prev,
+                requestReason: value as DeliverableExtensionReasonCode | "",
+              }))
+            }
+            validationMessage={
+              attemptedSubmit && formData.requestReason === "" ? "Request Reason is required." : ""
+            }
+          />
+        </div>
+        <Textarea
+          name={REQUEST_EXTENSION_DETAILS_FIELD_NAME}
+          label="Details"
+          isRequired
+          initialValue={formData.details}
+          placeholder="Enter"
+          onChange={(event) => setFormData((prev) => ({ ...prev, details: event.target.value }))}
+          getValidationMessage={(value) =>
+            attemptedSubmit && value.trim() === "" ? "Details is required." : ""
+          }
+        />
+      </div>
+    </BaseDialog>
+  );
+};

--- a/client/src/components/dialog/deliverable/index.ts
+++ b/client/src/components/dialog/deliverable/index.ts
@@ -3,3 +3,8 @@ export {
   ADD_DELIVERABLE_SLOT_DIALOG_TITLE,
 } from "./AddDeliverableSlotDialog";
 export { EditDeliverableDialog, isDeliverableEditable } from "./EditDeliverableDialog";
+export {
+  RequestExtensionDeliverableDialog,
+  canRequestExtension,
+  REQUEST_EXTENSION_DIALOG_TITLE,
+} from "./RequestExtensionDeliverableDialog";

--- a/client/src/mock-data/deliverableMocks.ts
+++ b/client/src/mock-data/deliverableMocks.ts
@@ -4,7 +4,10 @@ import {
   DELIVERABLE_DETAILS_QUERY,
   DeliverableDetailsManagementDeliverable,
 } from "pages/deliverables/DeliverableDetailsManagementPage";
-import {DELIVERABLES_PAGE_QUERY, DeliverableTableRow} from "components/table/tables/DeliverableTable";
+import {
+  DELIVERABLES_PAGE_QUERY,
+  DeliverableTableRow,
+} from "components/table/tables/DeliverableTable";
 
 export const MOCK_DELIVERABLE_TABLE_ROW: DeliverableTableRow = {
   id: "8f3a0c8a-2f9f-4bf0-9a3a-6b7eac31f201",
@@ -36,6 +39,7 @@ export const MOCK_DELIVERABLE_1: DeliverableDetailsManagementDeliverable = {
   demonstration: {
     id: "1",
     name: "Demonstration 1",
+    expirationDate: new Date("2026-12-31"),
     state: {
       id: "CA",
     },

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
@@ -2,23 +2,29 @@ import React from "react";
 import { Route, Routes } from "react-router-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { DeliverableDetailsManagementPage, DELIVERABLE_DETAILS_QUERY } from "./DeliverableDetailsManagementPage";
+import {
+  DeliverableDetailsManagementPage,
+  DELIVERABLE_DETAILS_QUERY,
+} from "./DeliverableDetailsManagementPage";
 import { MOCK_DELIVERABLE_1 } from "mock-data/deliverableMocks";
 import { TestProvider } from "test-utils/TestProvider";
 import { COMMENT_BOX_NAME } from "./sections/CommentBox";
 import { DELIVERABLE_INFO_FIELDS_NAME } from "./sections/DeliverableInfoFields";
 import { FILE_AND_HISTORY_TABS_NAME } from "./sections/FileAndHistoryTabs";
 import { DELIVERABLE_BUTTONS_NAME } from "./sections/DeliverableButtons";
+import { DialogProvider } from "components/dialog/DialogContext";
 
 const renderAtRoute = (deliverableId: string) =>
   render(
     <TestProvider routerEntries={[`/deliverables/${deliverableId}`]}>
-      <Routes>
-        <Route
-          path="/deliverables/:deliverableId"
-          element={<DeliverableDetailsManagementPage />}
-        />
-      </Routes>
+      <DialogProvider>
+        <Routes>
+          <Route
+            path="/deliverables/:deliverableId"
+            element={<DeliverableDetailsManagementPage />}
+          />
+        </Routes>
+      </DialogProvider>
     </TestProvider>
   );
 
@@ -26,9 +32,7 @@ describe("DeliverableDetailsManagementPage", () => {
   it("renders the deliverable name heading", async () => {
     renderAtRoute("1");
 
-    await waitFor(() =>
-      expect(screen.getByText(MOCK_DELIVERABLE_1.name)).toBeInTheDocument()
-    );
+    await waitFor(() => expect(screen.getByText(MOCK_DELIVERABLE_1.name)).toBeInTheDocument());
   });
 
   it("renders DeliverableInfoFields", async () => {
@@ -42,25 +46,19 @@ describe("DeliverableDetailsManagementPage", () => {
   it("renders DeliverableButtons", async () => {
     renderAtRoute("1");
 
-    await waitFor(() =>
-      expect(screen.getByTestId(DELIVERABLE_BUTTONS_NAME)).toBeInTheDocument()
-    );
+    await waitFor(() => expect(screen.getByTestId(DELIVERABLE_BUTTONS_NAME)).toBeInTheDocument());
   });
 
   it("renders FileAndHistoryTabs", async () => {
     renderAtRoute("1");
 
-    await waitFor(() =>
-      expect(screen.getByTestId(FILE_AND_HISTORY_TABS_NAME)).toBeInTheDocument()
-    );
+    await waitFor(() => expect(screen.getByTestId(FILE_AND_HISTORY_TABS_NAME)).toBeInTheDocument());
   });
 
   it("renders CommentBox", async () => {
     renderAtRoute("1");
 
-    await waitFor(() =>
-      expect(screen.getByTestId(COMMENT_BOX_NAME)).toBeInTheDocument()
-    );
+    await waitFor(() => expect(screen.getByTestId(COMMENT_BOX_NAME)).toBeInTheDocument());
   });
 
   it("shows not found state", async () => {
@@ -72,14 +70,15 @@ describe("DeliverableDetailsManagementPage", () => {
     render(
       <TestProvider mocks={[notFoundMock]} routerEntries={["/deliverables/1"]}>
         <Routes>
-          <Route path="/deliverables/:deliverableId" element={<DeliverableDetailsManagementPage />} />
+          <Route
+            path="/deliverables/:deliverableId"
+            element={<DeliverableDetailsManagementPage />}
+          />
         </Routes>
       </TestProvider>
     );
 
-    await waitFor(() =>
-      expect(screen.getByText(/deliverable not found/i)).toBeInTheDocument()
-    );
+    await waitFor(() => expect(screen.getByText(/deliverable not found/i)).toBeInTheDocument());
   });
 
   it("shows error state", async () => {
@@ -91,13 +90,14 @@ describe("DeliverableDetailsManagementPage", () => {
     render(
       <TestProvider mocks={[errorMock]} routerEntries={["/deliverables/1"]}>
         <Routes>
-          <Route path="/deliverables/:deliverableId" element={<DeliverableDetailsManagementPage />} />
+          <Route
+            path="/deliverables/:deliverableId"
+            element={<DeliverableDetailsManagementPage />}
+          />
         </Routes>
       </TestProvider>
     );
 
-    await waitFor(() =>
-      expect(screen.getByText(/error loading deliverable/i)).toBeInTheDocument()
-    );
+    await waitFor(() => expect(screen.getByText(/error loading deliverable/i)).toBeInTheDocument());
   });
 });

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -34,10 +34,7 @@ export const DELIVERABLE_DETAILS_QUERY = gql`
   }
 `;
 
-export type DeliverableDetailsManagementDeliverable = Pick<
-  Deliverable,
-  "id" | "deliverableType" | "dueDate" | "status" | "name"
-> & {
+export type DeliverableDetailsManagementDeliverable = Pick<Deliverable, "id" | "deliverableType" | "dueDate" | "status" | "name" > & {
   demonstration: Pick<Demonstration, "id" | "name" | "expirationDate"> & { state: { id: string } };
   cmsOwner: { person: { fullName: string } };
 };

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -20,6 +20,7 @@ export const DELIVERABLE_DETAILS_QUERY = gql`
       demonstration {
         id
         name
+        expirationDate
         state {
           id
         }
@@ -33,20 +34,20 @@ export const DELIVERABLE_DETAILS_QUERY = gql`
   }
 `;
 
-
-export type DeliverableDetailsManagementDeliverable = Pick<Deliverable, "id" | "deliverableType" | "dueDate" | "status" | "name" > & {
-  demonstration: Pick<Demonstration, "id" | "name"> & { state: { id: string } };
+export type DeliverableDetailsManagementDeliverable = Pick<
+  Deliverable,
+  "id" | "deliverableType" | "dueDate" | "status" | "name"
+> & {
+  demonstration: Pick<Demonstration, "id" | "name" | "expirationDate"> & { state: { id: string } };
   cmsOwner: { person: { fullName: string } };
 };
-
 
 export const DeliverableDetailsManagementPage: React.FC = () => {
   const { deliverableId } = useParams<{ deliverableId: string }>();
 
-  const { data, loading, error } = useQuery<{ deliverable: DeliverableDetailsManagementDeliverable }>(
-    DELIVERABLE_DETAILS_QUERY,
-    { variables: { id: deliverableId } }
-  );
+  const { data, loading, error } = useQuery<{
+    deliverable: DeliverableDetailsManagementDeliverable;
+  }>(DELIVERABLE_DETAILS_QUERY, { variables: { id: deliverableId } });
 
   if (loading) {
     return <Loading />;
@@ -67,7 +68,7 @@ export const DeliverableDetailsManagementPage: React.FC = () => {
       <div className="flex flex-col gap-2 flex-1">
         <div className="flex justify-between items-start">
           <DeliverableInfoFields deliverable={data.deliverable} />
-          <DeliverableButtons />
+          <DeliverableButtons deliverable={data.deliverable} />
         </div>
         <div className="flex w-full gap-2 flex-1">
           <div className="flex-1"><FileAndHistoryTabs /></div>

--- a/client/src/pages/deliverables/sections/DeliverableButtons.test.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableButtons.test.tsx
@@ -1,17 +1,89 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { DeliverableButtons, REFERENCES_BUTTON_NAME, REQUEST_EXTENSION_BUTTON_NAME } from "./DeliverableButtons";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { DeliverableStatus } from "demos-server";
+
+import {
+  DeliverableButtons,
+  REFERENCES_BUTTON_NAME,
+  REQUEST_EXTENSION_BUTTON_NAME,
+} from "./DeliverableButtons";
+import { MOCK_DELIVERABLE_1 } from "mock-data/deliverableMocks";
+import { DeliverableDetailsManagementDeliverable } from "../DeliverableDetailsManagementPage";
+import { TestProvider } from "test-utils/TestProvider";
+import { DialogProvider } from "components/dialog/DialogContext";
+
+const mockShowRequestExtensionDeliverableDialog = vi.fn();
+vi.mock("components/dialog/DialogContext", async () => {
+  const actual = await vi.importActual<typeof import("components/dialog/DialogContext")>(
+    "components/dialog/DialogContext"
+  );
+  return {
+    ...actual,
+    useDialog: () => ({
+      ...actual.useDialog,
+      showRequestExtensionDeliverableDialog: mockShowRequestExtensionDeliverableDialog,
+      closeDialog: vi.fn(),
+    }),
+  };
+});
+
+const buildDeliverable = (
+  overrides?: Partial<DeliverableDetailsManagementDeliverable>
+): DeliverableDetailsManagementDeliverable => ({
+  ...MOCK_DELIVERABLE_1,
+  ...overrides,
+});
+
+const renderButtons = (deliverable: DeliverableDetailsManagementDeliverable) =>
+  render(
+    <TestProvider>
+      <DialogProvider>
+        <DeliverableButtons deliverable={deliverable} />
+      </DialogProvider>
+    </TestProvider>
+  );
 
 describe("DeliverableButtons", () => {
   it("renders the References button", () => {
-    render(<DeliverableButtons />);
-    expect(screen.getByTestId(REFERENCES_BUTTON_NAME)).toBeInTheDocument();
+    renderButtons(buildDeliverable());
     expect(screen.getByTestId(REFERENCES_BUTTON_NAME)).toHaveTextContent("References");
   });
 
-  it("renders the Request Extension button", () => {
-    render(<DeliverableButtons />);
+  it("renders the Request Extension button for Upcoming deliverables", () => {
+    renderButtons(buildDeliverable({ status: "Upcoming" }));
+    expect(screen.getByTestId(REQUEST_EXTENSION_BUTTON_NAME)).toHaveTextContent(
+      "Request Extension"
+    );
+  });
+
+  it("renders the Request Extension button for Past Due deliverables", () => {
+    renderButtons(buildDeliverable({ status: "Past Due" }));
     expect(screen.getByTestId(REQUEST_EXTENSION_BUTTON_NAME)).toBeInTheDocument();
-    expect(screen.getByTestId(REQUEST_EXTENSION_BUTTON_NAME)).toHaveTextContent("Request Extension");
+  });
+
+  it.each<DeliverableStatus>([
+    "Submitted",
+    "Under CMS Review",
+    "Accepted",
+    "Approved",
+    "Received and Filed",
+  ])("hides the Request Extension button when status is %s", (status) => {
+    renderButtons(buildDeliverable({ status }));
+    expect(screen.queryByTestId(REQUEST_EXTENSION_BUTTON_NAME)).not.toBeInTheDocument();
+  });
+
+  it("opens the Request Extension dialog when clicked", async () => {
+    const user = userEvent.setup();
+    renderButtons(buildDeliverable({ status: "Upcoming" }));
+
+    await user.click(screen.getByTestId(REQUEST_EXTENSION_BUTTON_NAME));
+
+    expect(mockShowRequestExtensionDeliverableDialog).toHaveBeenCalledWith({
+      id: MOCK_DELIVERABLE_1.id,
+      dueDate: MOCK_DELIVERABLE_1.dueDate,
+      demonstration: { expirationDate: MOCK_DELIVERABLE_1.demonstration.expirationDate },
+    });
   });
 });

--- a/client/src/pages/deliverables/sections/DeliverableButtons.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableButtons.tsx
@@ -1,15 +1,36 @@
 import React from "react";
 import { SecondaryButton, TertiaryButton } from "components/button";
+import { canRequestExtension } from "components/dialog/deliverable";
+import { useDialog } from "components/dialog/DialogContext";
+import { DeliverableDetailsManagementDeliverable } from "../DeliverableDetailsManagementPage";
 
 export const DELIVERABLE_BUTTONS_NAME = "deliverable-buttons";
 export const REFERENCES_BUTTON_NAME = "button-references";
 export const REQUEST_EXTENSION_BUTTON_NAME = "button-request-extension";
 
-export const DeliverableButtons = () => {
+export const DeliverableButtons = ({
+  deliverable,
+}: {
+  deliverable: DeliverableDetailsManagementDeliverable;
+}) => {
+  const { showRequestExtensionDeliverableDialog } = useDialog();
+
+  const handleRequestExtension = () => {
+    showRequestExtensionDeliverableDialog({
+      id: deliverable.id,
+      dueDate: deliverable.dueDate,
+      demonstration: { expirationDate: deliverable.demonstration.expirationDate },
+    });
+  };
+
   return (
     <div className="flex gap-2" data-testid={DELIVERABLE_BUTTONS_NAME}>
       <TertiaryButton name={REFERENCES_BUTTON_NAME}>References</TertiaryButton>
-      <SecondaryButton name={REQUEST_EXTENSION_BUTTON_NAME}>Request Extension</SecondaryButton>
+      {canRequestExtension(deliverable.status) && (
+        <SecondaryButton name={REQUEST_EXTENSION_BUTTON_NAME} onClick={handleRequestExtension}>
+          Request Extension
+        </SecondaryButton>
+      )}
     </div>
   );
 };

--- a/client/src/util/messages.ts
+++ b/client/src/util/messages.ts
@@ -23,3 +23,4 @@ export const getPhaseCompletedMessage = (phaseName: PhaseName) => {
 // Deliverable Messages
 export const DELIVERABLE_SLOTS_CREATED_MESSAGE = "Deliverable Slot(s) - have been added";
 export const DELIVERABLE_UPDATED_MESSAGE = "Changes have been saved to the deliverable";
+export const DELIVERABLE_EXTENSION_REQUESTED_MESSAGE = "Extension Request - has been Submitted";


### PR DESCRIPTION
Wires the Request Extension button on the deliverable detail page to a new modal. Button only shows for `Upcoming` / `Past Due`; hidden for `Submitted`, `Under CMS Review`, `Accepted`, `Approved`, `Received and Filed`.

## Changes

- **`components/dialog/deliverable/RequestExtensionDeliverableDialog.tsx`** (new) — `BaseDialog` + `DatePicker`, `Select`, `Textarea`. Reason options come from `DELIVERABLE_EXTENSION_REASON_CODES`. Validation: date must be after due date and not after demonstration expiration; all three fields required.
- **`components/dialog/DialogContext.tsx`** — adds `showRequestExtensionDeliverableDialog`.
- **`pages/deliverables/sections/DeliverableButtons.tsx`** — takes `deliverable`, gates the button on `canRequestExtension(status)`, opens the dialog on click.
- **`pages/deliverables/DeliverableDetailsManagementPage.tsx`** — query + type now include `demonstration.expirationDate`.
- **`util/messages.ts`** — adds `DELIVERABLE_EXTENSION_REQUESTED_MESSAGE`.
- **`mock-data/deliverableMocks.ts`** — mock now carries `expirationDate`.

## Notes

- Layout only — no server mutation yet. Dialog takes an optional `onSubmit`; success toast fires on client submit. Mirrors the DEMOS-1800 pattern.

https://github.com/user-attachments/assets/a0f5a8db-6978-4aac-a62f-b41771d96be2
