### PR TITLE
Install shared_library before running npm-updates

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,3 +37,9 @@ lambda:
 "lambda:deleteinfectedfile":
 - changed-files:
   - any-glob-to-any-file: lambdas/deleteinfectedfile/**
+"lambda:budgetNeutrality":
+- changed-files:
+  - any-glob-to-any-file: lambdas/budgetNeutrality/**
+"shared-library":
+- changed-files:
+  - any-glob-to-any-file: shared_library/**

--- a/pipelines/Jenkinsfile.npm-updates
+++ b/pipelines/Jenkinsfile.npm-updates
@@ -35,6 +35,7 @@ pipeline {
           npmUpdates(dir: 'lambdas/fileprocess')
           npmUpdates(dir: 'lambdas/deleteinfectedfile')
           npmUpdates(dir: 'lambdas/UIPath')
+          npmUpdates(dir: 'lambdas/budgetNeutrality')
         }
       }
     }

--- a/pipelines/Jenkinsfile.npm-updates
+++ b/pipelines/Jenkinsfile.npm-updates
@@ -1,7 +1,7 @@
 pipeline {
   agent {
-    kubernetes { 
-      yaml kubeBlock(containerNames:["node"])
+    kubernetes {
+      yaml kubeBlock(containerNames:['node'])
     }
   }
 
@@ -14,18 +14,27 @@ pipeline {
   }
 
   stages {
+    stage('Install shared library deps') {
+      steps {
+        dirCon('shared_library', 'node') {
+          sh 'npm ci'
+        }
+      }
+    }
+
     stage('Check for updates') {
       steps {
         script {
-          npmUpdates(dir: "client")          
-          npmUpdates(dir: "server")          
-          npmUpdates(dir: "deployment")          
-          npmUpdates(dir: "lambdas/authorizer")          
-          npmUpdates(dir: "lambdas/dbRoleManagement")          
-          npmUpdates(dir: "lambdas/emailer")          
-          npmUpdates(dir: "lambdas/fileprocess")          
-          npmUpdates(dir: "lambdas/deleteinfectedfile")          
-          npmUpdates(dir: "lambdas/UIPath")          
+          npmUpdates(dir: 'shared_library')
+          npmUpdates(dir: 'client')
+          npmUpdates(dir: 'server')
+          npmUpdates(dir: 'deployment')
+          npmUpdates(dir: 'lambdas/authorizer')
+          npmUpdates(dir: 'lambdas/dbRoleManagement')
+          npmUpdates(dir: 'lambdas/emailer')
+          npmUpdates(dir: 'lambdas/fileprocess')
+          npmUpdates(dir: 'lambdas/deleteinfectedfile')
+          npmUpdates(dir: 'lambdas/UIPath')
         }
       }
     }

--- a/pipelines/lib/vars/retentionPolicy.groovy
+++ b/pipelines/lib/vars/retentionPolicy.groovy
@@ -1,5 +1,4 @@
 def call(String branchName, Map config = [:]) {
-  
   Map defaults = [
     longNumKeep: '30',
     shortNumKeep: '2',
@@ -14,10 +13,21 @@ def call(String branchName, Map config = [:]) {
 
   def isLongRetentionBranch = config.longRetentionBranches.contains(branchName)
 
+  if (branchName.startsWith('gh-readonly-queue')) {
+    return logRotator(
+      numToKeepStr: '0',
+      artifactNumToKeepStr: '0',
+      daysToKeepStr: '0',
+      artifactDaysToKeepStr: '0',
+      removeLastBuild: true
+    )
+  }
+
   return logRotator(
-    numToKeepStr: isLongRetentionBranch ? config.longNumKeep : config.shortNumKeep, 
+    numToKeepStr: isLongRetentionBranch ? config.longNumKeep : config.shortNumKeep,
     artifactNumToKeepStr: isLongRetentionBranch ? config.longNumKeep : config.shortNumKeep,
-    daysToKeepStr: isLongRetentionBranch ? config.longDaysKeep : config.shortDaysKeep, 
-    artifactDaysToKeepStr: isLongRetentionBranch ? config.longDaysKeep : config.shortDaysKeep
+    daysToKeepStr: isLongRetentionBranch ? config.longDaysKeep : config.shortDaysKeep,
+    artifactDaysToKeepStr: isLongRetentionBranch ? config.longDaysKeep : config.shortDaysKeep,
+    removeLastBuild: !isLongRetentionBranch
   )
 }


### PR DESCRIPTION
The most recent npm-updates run failed because the shared_library dependencies hadn't been installed prior to running. This PR adds the install and also adds a check for updates in the shared_library package.

I have also updated the buildDiscarder configuration to delete Jenkins pipeline runs earlier for merge queue branches and PRs. The previous configuration would delete everything except the last build, so old builds would hang around longer than needed and take up too much Jenkins disk space. This update will make sure that merge queue branches are deleted immediately after completion, and PR runs will be deleted after 7 days.