### PR TITLE
DEMOS-2025-edit-deliverable-cleanup

### DIFF
--- a/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
@@ -3,8 +3,9 @@ import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { EasternTZDate, parseJSDateToEasternTZDate } from "../../dateUtilities";
 
 // Types
-import { ApplicationStatus, PersonType, TagName } from "../../types";
+import { ApplicationStatus, DeliverableStatus, PersonType, TagName } from "../../types";
 import {
+  Deliverable as PrismaDeliverable,
   Demonstration as PrismaDemonstration,
   DemonstrationTypeTagAssignment as PrismaDemonstrationTypeTagAssignment,
   User as PrismaUser,
@@ -13,6 +14,7 @@ import {
 // Functions under test
 import {
   checkDemonstrationStatus,
+  checkDeliverableStatusNotFinalized,
   checkForDuplicateDemonstrationTypes,
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
@@ -42,6 +44,78 @@ describe("checkDeliverableInputFunctions", () => {
         "Demonstration abc123 is not in Approved status; cannot create deliverable."
       );
     });
+  });
+
+  describe("checkDeliverableStatusNotFinalized", () => {
+    const checkDeliverableStatusInputs: [
+      DeliverableStatus,
+      Partial<PrismaDeliverable>,
+      string | undefined,
+    ][] = [
+      [
+        "Upcoming",
+        {
+          id: "abc123",
+          statusId: "Upcoming",
+        },
+        undefined,
+      ],
+      [
+        "Past Due",
+        {
+          id: "abc123",
+          statusId: "Past Due",
+        },
+        undefined,
+      ],
+      [
+        "Submitted",
+        {
+          id: "abc123",
+          statusId: "Submitted",
+        },
+        undefined,
+      ],
+      [
+        "Under CMS Review",
+        {
+          id: "abc123",
+          statusId: "Under CMS Review",
+        },
+        undefined,
+      ],
+      [
+        "Accepted",
+        {
+          id: "abc123",
+          statusId: "Accepted",
+        },
+        "Cannot modify deliverable abc123 as it has already been finalized.",
+      ],
+      [
+        "Approved",
+        {
+          id: "abc123",
+          statusId: "Approved",
+        },
+        "Cannot modify deliverable abc123 as it has already been finalized.",
+      ],
+      [
+        "Received and Filed",
+        {
+          id: "abc123",
+          statusId: "Received and Filed",
+        },
+        "Cannot modify deliverable abc123 as it has already been finalized.",
+      ],
+    ];
+    it.each(checkDeliverableStatusInputs)(
+      "properly checks the status (%s)",
+      (deliverableStatus, testDeliverable, expectedResult) => {
+        const result = checkDeliverableStatusNotFinalized(testDeliverable as PrismaDeliverable);
+        expect(result).toBe(expectedResult);
+      }
+    );
   });
 
   describe("checkOwnerPersonType", () => {

--- a/server/src/model/deliverable/checkDeliverableInputFunctions.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.ts
@@ -1,9 +1,10 @@
 import {
+  Deliverable as PrismaDeliverable,
   Demonstration as PrismaDemonstration,
   DemonstrationTypeTagAssignment as PrismaDemonstrationTypeTagAssignment,
   User as PrismaUser,
 } from "@prisma/client";
-import { ApplicationStatus, PersonType, TagName } from "../../types";
+import { ApplicationStatus, DeliverableStatus, PersonType, TagName } from "../../types";
 import { findDuplicates } from "../../validationUtilities";
 import { EasternTZDate, getEasternNow } from "../../dateUtilities";
 
@@ -11,6 +12,20 @@ export function checkDemonstrationStatus(demonstration: PrismaDemonstration): st
   const approvedStatus: ApplicationStatus = "Approved";
   if (demonstration.statusId !== approvedStatus) {
     return `Demonstration ${demonstration.id} is not in Approved status; cannot create deliverable.`;
+  }
+}
+
+export function checkDeliverableStatusNotFinalized(
+  deliverable: PrismaDeliverable
+): string | undefined {
+  const deliverableStatus = deliverable.statusId as DeliverableStatus;
+  const finalDeliverableStatuses: DeliverableStatus[] = [
+    "Approved",
+    "Accepted",
+    "Received and Filed",
+  ];
+  if (finalDeliverableStatuses.includes(deliverableStatus)) {
+    return `Cannot modify deliverable ${deliverable.id} as it has already been finalized.`;
   }
 }
 

--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -315,7 +315,6 @@ describe("deliverableResolvers", () => {
       it("should call the updateDeliverable function with the right arguments", async () => {
         const testInput: UpdateDeliverableInput = {
           name: "A name!",
-          deliverableType: "Close Out Report",
           cmsOwnerUserId: "161f3a85-7b6d-4217-abec-93494db3a207",
         };
 

--- a/server/src/model/deliverable/deliverableSchema.ts
+++ b/server/src/model/deliverable/deliverableSchema.ts
@@ -48,7 +48,6 @@ export const deliverableSchema = gql`
 
   input UpdateDeliverableInput {
     name: NonEmptyString
-    deliverableType: DeliverableType
     cmsOwnerUserId: ID
     dueDate: DeliverableDueDateUpdateInput
     demonstrationTypes: [TagName!]
@@ -99,7 +98,6 @@ export interface DeliverableDueDateUpdateInput {
 
 export interface UpdateDeliverableInput {
   name?: NonEmptyString;
-  deliverableType?: DeliverableType;
   cmsOwnerUserId?: string;
   dueDate?: DeliverableDueDateUpdateInput;
   demonstrationTypes?: TagName[];

--- a/server/src/model/deliverable/index.ts
+++ b/server/src/model/deliverable/index.ts
@@ -1,6 +1,7 @@
 // Functions
 export {
   checkDemonstrationStatus,
+  checkDeliverableStatusNotFinalized,
   checkDueDateInFuture,
   checkForDuplicateDemonstrationTypes,
   checkOwnerPersonType,

--- a/server/src/model/deliverable/parseDeliverableInputs.ts
+++ b/server/src/model/deliverable/parseDeliverableInputs.ts
@@ -1,6 +1,5 @@
 import {
   CreateDeliverableInput,
-  DeliverableStatus,
   DeliverableType,
   NonEmptyString,
   TagName,
@@ -30,7 +29,6 @@ export type ParsedUpdateDeliverableInput = {
   cmsOwnerUserId?: string;
   dueDate?: ParsedUpdateDueDate;
   demonstrationTypes?: Set<TagName>;
-  status?: DeliverableStatus;
 };
 
 export function parseCreateDeliverableInput(

--- a/server/src/model/deliverable/parseDeliverableInputs.ts
+++ b/server/src/model/deliverable/parseDeliverableInputs.ts
@@ -25,7 +25,6 @@ export type ParsedUpdateDueDate = {
 
 export type ParsedUpdateDeliverableInput = {
   name?: NonEmptyString;
-  deliverableType?: DeliverableType;
   cmsOwnerUserId?: string;
   dueDate?: ParsedUpdateDueDate;
   demonstrationTypes?: Set<TagName>;

--- a/server/src/model/deliverable/queries/editDeliverable.ts
+++ b/server/src/model/deliverable/queries/editDeliverable.ts
@@ -1,11 +1,10 @@
 import { Deliverable as PrismaDeliverable } from "@prisma/client";
 import { prisma, PrismaTransactionClient } from "../../../prismaClient";
-import { DeliverableStatus, DeliverableType, NonEmptyString } from "../../../types";
+import { DeliverableStatus, NonEmptyString } from "../../../types";
 
 export type EditDeliverableInput = {
   name?: NonEmptyString;
   statusId?: DeliverableStatus;
-  deliverableTypeId?: DeliverableType;
   cmsOwnerUserId?: string;
   dueDate?: Date;
 };

--- a/server/src/model/deliverable/updateDeliverable.test.ts
+++ b/server/src/model/deliverable/updateDeliverable.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TZDate } from "@date-fns/tz";
 
 // Types
-import { UpdateDeliverableInput, DateTimeOrLocalDate, DeliverableType } from "../../types";
+import { UpdateDeliverableInput } from "../../types";
 import { EditDeliverableInput, ParsedUpdateDeliverableInput } from ".";
 import { GraphQLContext } from "../../auth/auth.util";
 
@@ -43,7 +43,6 @@ describe("updateDeliverable", () => {
   // Test inputs
   const testDeliverableId = "2563ded3-b5c5-4d89-9ee4-0a9bc072e89e";
   const testName = "Test Input 1";
-  const testDeliverableType: DeliverableType = "Close Out Report";
   const testCmsOwnerUserId = "7643eef9-dc5e-4640-bc1f-b0a660034386";
   const testInput: UpdateDeliverableInput = {
     name: testName,
@@ -78,7 +77,7 @@ describe("updateDeliverable", () => {
   it("should check for non-null in all the fields", async () => {
     await updateDeliverable(testDeliverableId, testInput, testContext);
     expect(checkOptionalNotNullFields).toHaveBeenCalledExactlyOnceWith(
-      ["name", "deliverableType", "cmsOwnerUserId", "dueDate", "demonstrationTypes"],
+      ["name", "cmsOwnerUserId", "dueDate", "demonstrationTypes"],
       testInput
     );
   });
@@ -114,42 +113,14 @@ describe("updateDeliverable", () => {
     [
       ["name only", { name: testName }, { name: testName }],
       [
-        "deliverableType only",
-        { deliverableType: testDeliverableType },
-        { deliverableTypeId: testDeliverableType },
-      ],
-      [
         "cmsOwnerUserId only",
         { cmsOwnerUserId: testCmsOwnerUserId },
         { cmsOwnerUserId: testCmsOwnerUserId },
       ],
       [
-        "name + deliverableType",
-        { name: testName, deliverableType: testDeliverableType },
-        { name: testName, deliverableTypeId: testDeliverableType },
-      ],
-      [
         "name + cmsOwnerUserId",
         { name: testName, cmsOwnerUserId: testCmsOwnerUserId },
         { name: testName, cmsOwnerUserId: testCmsOwnerUserId },
-      ],
-      [
-        "deliverableType + cmsOwnerUserId",
-        { deliverableType: testDeliverableType, cmsOwnerUserId: testCmsOwnerUserId },
-        { deliverableTypeId: testDeliverableType, cmsOwnerUserId: testCmsOwnerUserId },
-      ],
-      [
-        "name + deliverableType + cmsOwnerUserId",
-        {
-          name: testName,
-          deliverableType: testDeliverableType,
-          cmsOwnerUserId: testCmsOwnerUserId,
-        },
-        {
-          name: testName,
-          deliverableTypeId: testDeliverableType,
-          cmsOwnerUserId: testCmsOwnerUserId,
-        },
       ],
     ];
   it.each(editDeliverableInputTests)(
@@ -168,7 +139,7 @@ describe("updateDeliverable", () => {
     }
   );
 
-  it("should not do a direct update if there is no new name, type, or owner", async () => {
+  it("should not do a direct update if there is no new name or owner", async () => {
     // Note that logic is based on results of parseUpdateDeliverableInput
     // That is why this mock is necessary
     const mockParseInputResult: ParsedUpdateDeliverableInput = {

--- a/server/src/model/deliverable/updateDeliverable.ts
+++ b/server/src/model/deliverable/updateDeliverable.ts
@@ -18,19 +18,15 @@ export async function updateDeliverable(
   input: UpdateDeliverableInput,
   context: GraphQLContext
 ): Promise<PrismaDeliverable> {
-  checkOptionalNotNullFields(
-    ["name", "deliverableType", "cmsOwnerUserId", "dueDate", "demonstrationTypes"],
-    input
-  );
+  checkOptionalNotNullFields(["name", "cmsOwnerUserId", "dueDate", "demonstrationTypes"], input);
   const parsedInput = parseUpdateDeliverableInput(input);
 
   const updatedDeliverable = await prisma().$transaction(async (tx) => {
     await validateUpdateDeliverableInput(deliverableId, parsedInput, tx);
 
-    // Directly edit name, deliverable type, and CMS owner
+    // Directly edit name and CMS owner
     const editInput: EditDeliverableInput = {};
     if (parsedInput.name) editInput.name = parsedInput.name;
-    if (parsedInput.deliverableType) editInput.deliverableTypeId = parsedInput.deliverableType;
     if (parsedInput.cmsOwnerUserId) editInput.cmsOwnerUserId = parsedInput.cmsOwnerUserId;
     if (Object.keys(editInput).length > 0) {
       await editDeliverable(deliverableId, editInput, tx);

--- a/server/src/model/deliverable/validateDeliverableInputs.test.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.test.ts
@@ -35,6 +35,7 @@ vi.mock("../demonstrationTypeTagAssignment", () => ({
 
 vi.mock(".", () => ({
   checkDemonstrationStatus: vi.fn(),
+  checkDeliverableStatusNotFinalized: vi.fn(),
   checkDueDateInFuture: vi.fn(),
   checkOwnerPersonType: vi.fn(),
   checkRequestedDeliverableDemonstrationType: vi.fn(),
@@ -46,6 +47,7 @@ import { getUser } from "../user";
 import { getDemonstrationTypeAssignments } from "../demonstrationTypeTagAssignment";
 import {
   checkDemonstrationStatus,
+  checkDeliverableStatusNotFinalized,
   checkDueDateInFuture,
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
@@ -317,6 +319,19 @@ describe("validateDeliverableInputs", () => {
       ).resolves.toBeUndefined();
     });
 
+    it("should always get the deliverable information from the DB", async () => {
+      const testInput: ParsedUpdateDeliverableInput = {
+        name: "A new name!",
+      };
+
+      await validateUpdateDeliverableInput(mockDeliverable.id!, testInput, mockTransaction);
+
+      expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
+        { id: mockDeliverable.id },
+        mockTransaction
+      );
+    });
+
     it("should not throw if none of the rules are violated", async () => {
       // Note: don't need to set returns to undefined, as this is what vi.fn() does already
       const testInput: ParsedUpdateDeliverableInput = {
@@ -383,9 +398,33 @@ describe("validateDeliverableInputs", () => {
       };
 
       await validateUpdateDeliverableInput(mockDeliverable.id!, testInput, mockTransaction);
-      expect(getDeliverable).not.toHaveBeenCalled();
       expect(getDemonstrationTypeAssignments).not.toHaveBeenCalled();
       expect(checkRequestedDeliverableDemonstrationType).not.toHaveBeenCalled();
+    });
+
+    it("should throw if the deliverable status check fails", async () => {
+      const testInput: ParsedUpdateDeliverableInput = {
+        name: "A new name!",
+        cmsOwnerUserId: "7d8fdea5-ca19-42e5-af50-98836b6d47db",
+      };
+      vi.mocked(checkDeliverableStatusNotFinalized).mockReturnValue(
+        "The deliverable finalized status check failed!"
+      );
+
+      try {
+        await validateUpdateDeliverableInput(mockDeliverable.id!, testInput, mockTransaction);
+        throw new Error("Expected validateUpdateDeliverableInput to throw, but it did not.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for updateDeliverable have failed."
+        );
+        expect(error.extensions.code).toBe("UPDATE_DELIVERABLE_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable finalized status check failed!",
+        ]);
+      }
     });
 
     it("should throw if the owner person type check runs and fails", async () => {
@@ -481,6 +520,9 @@ describe("validateDeliverableInputs", () => {
           dateChangeNote: "Note is required",
         },
       };
+      vi.mocked(checkDeliverableStatusNotFinalized).mockReturnValue(
+        "The deliverable finalized status check failed!"
+      );
       vi.mocked(checkOwnerPersonType).mockReturnValue("The owner person type check failed");
       vi.mocked(checkRequestedDeliverableDemonstrationType).mockReturnValueOnce(
         "The demonstration type check failed"
@@ -497,6 +539,7 @@ describe("validateDeliverableInputs", () => {
         );
         expect(error.extensions.code).toBe("UPDATE_DELIVERABLE_VALIDATION_FAILED");
         expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable finalized status check failed!",
           "The owner person type check failed",
           "The demonstration type check failed",
         ]);

--- a/server/src/model/deliverable/validateDeliverableInputs.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.ts
@@ -1,5 +1,6 @@
 import {
   checkDemonstrationStatus,
+  checkDeliverableStatusNotFinalized,
   checkDueDateInFuture,
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
@@ -63,7 +64,10 @@ export async function validateUpdateDeliverableInput(
   input: ParsedUpdateDeliverableInput,
   tx: PrismaTransactionClient
 ): Promise<void> {
+  const deliverable = await getDeliverable({ id: deliverableId }, tx);
   const errors: (string | undefined)[] = [];
+
+  errors.push(checkDeliverableStatusNotFinalized(deliverable));
 
   if (input.cmsOwnerUserId) {
     const cmsOwnerUser = await getUser({ id: input.cmsOwnerUserId }, tx);
@@ -71,7 +75,6 @@ export async function validateUpdateDeliverableInput(
   }
 
   if (input.demonstrationTypes && input.demonstrationTypes.size > 0) {
-    const deliverable = await getDeliverable({ id: deliverableId }, tx);
     const demonstrationTypeAssignments = await getDemonstrationTypeAssignments(
       {
         demonstrationId: deliverable.demonstrationId,

--- a/server/src/model/migrations/20260427152220_update_deliverable_action_configs/migration.sql
+++ b/server/src/model/migrations/20260427152220_update_deliverable_action_configs/migration.sql
@@ -1,0 +1,14 @@
+DELETE FROM
+    demos_app.deliverable_action_configuration
+WHERE
+    old_status_id IN (
+        'Accepted',
+        'Approved',
+        'Received and Filed'
+    )
+    AND action_type_id IN (
+        'Approved Extension Request',
+        'Denied Extension Request',
+        'Withdrew Extension Request',
+        'Manually Changed Due Date'
+    );

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -16,5 +16,5 @@
   "include": ["src/**/*.ts"],
   "exclude": [
     "src/**/*.test.ts"
-  ] 
+  ]
 }


### PR DESCRIPTION
This PR fixes some small items that changed in requirements discussions.

- Editing of deliverables is locked down after they are finalized.
- Changing the type of a deliverable is no longer possible after it is created.
- The action configuration is updated to disallow resolving extensions after the deliverable is finalized.
- The action configuration is updated to disallow manual date changes after the deliverable is finalized. This is also not accessible via the API as all changes are disallowed.