### PR TITLE
DEMOS-1959-adding-submit-mutator

### DIFF
--- a/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
@@ -3,11 +3,12 @@ import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { EasternTZDate, parseJSDateToEasternTZDate } from "../../dateUtilities";
 
 // Types
-import { ApplicationStatus, DeliverableStatus, PersonType, TagName } from "../../types";
+import { ApplicationStatus, DeliverableStatus, Document, PersonType, TagName } from "../../types";
 import {
   Deliverable as PrismaDeliverable,
   Demonstration as PrismaDemonstration,
   DemonstrationTypeTagAssignment as PrismaDemonstrationTypeTagAssignment,
+  Document as PrismaDocument,
   User as PrismaUser,
 } from "@prisma/client";
 
@@ -19,9 +20,15 @@ import {
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
   checkDueDateInFuture,
+  checkDeliverableHasAtLeastOneDocument,
 } from "./checkDeliverableInputFunctions";
 
 // Mock imports
+vi.mock("../document", () => ({
+  selectManyDocuments: vi.fn(),
+}));
+
+import { selectManyDocuments } from "../document";
 
 describe("checkDeliverableInputFunctions", () => {
   describe("checkDemonstrationStatus", () => {
@@ -90,7 +97,7 @@ describe("checkDeliverableInputFunctions", () => {
           id: "abc123",
           statusId: "Accepted",
         },
-        "Cannot modify deliverable abc123 as it has already been finalized.",
+        "Cannot submit or modify deliverable abc123 as it has already been finalized.",
       ],
       [
         "Approved",
@@ -98,7 +105,7 @@ describe("checkDeliverableInputFunctions", () => {
           id: "abc123",
           statusId: "Approved",
         },
-        "Cannot modify deliverable abc123 as it has already been finalized.",
+        "Cannot submit or modify deliverable abc123 as it has already been finalized.",
       ],
       [
         "Received and Filed",
@@ -106,7 +113,7 @@ describe("checkDeliverableInputFunctions", () => {
           id: "abc123",
           statusId: "Received and Filed",
         },
-        "Cannot modify deliverable abc123 as it has already been finalized.",
+        "Cannot submit or modify deliverable abc123 as it has already been finalized.",
       ],
     ];
     it.each(checkDeliverableStatusInputs)(
@@ -233,6 +240,52 @@ describe("checkDeliverableInputFunctions", () => {
       const result = checkDueDateInFuture(testInput);
       expect(result).toBe(
         "Cannot request a due date in the past; requested Sat Sep 16 2023 23:22:11 GMT-0400 (Eastern Daylight Time)"
+      );
+    });
+  });
+
+  describe("checkDeliverableHasAtLeastOneDocument", () => {
+    const testTransaction = "I'm a test transaction!" as any;
+    const testDeliverableId = "72c01127-bf42-4b9f-a902-1a237ecdf7b7";
+    const testDeliverable: Partial<PrismaDeliverable> = {
+      id: testDeliverableId,
+    };
+
+    const mockDocumentList: Partial<PrismaDocument>[] = [
+      { id: "document1", deliverableId: testDeliverableId },
+      { id: "document2", deliverableId: testDeliverableId },
+    ];
+
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it("should return undefined if there is at least one document", async () => {
+      vi.mocked(selectManyDocuments).mockResolvedValue(mockDocumentList as PrismaDocument[]);
+
+      const result = await checkDeliverableHasAtLeastOneDocument(
+        testDeliverable as PrismaDeliverable,
+        testTransaction
+      );
+      expect(result).toBeUndefined();
+      expect(selectManyDocuments).toHaveBeenCalledExactlyOnceWith(
+        {
+          deliverableId: testDeliverableId,
+          deliverableIsCmsAttachedFile: false,
+        },
+        testTransaction
+      );
+    });
+
+    it("should return an error message if there are no documents returned", async () => {
+      vi.mocked(selectManyDocuments).mockResolvedValue([] as PrismaDocument[]);
+
+      const result = await checkDeliverableHasAtLeastOneDocument(
+        testDeliverable as PrismaDeliverable,
+        testTransaction
+      );
+      expect(result).toBe(
+        `Cannot submit deliverable ${testDeliverableId} because it has no state documents attached.`
       );
     });
   });

--- a/server/src/model/deliverable/checkDeliverableInputFunctions.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.ts
@@ -4,9 +4,11 @@ import {
   DemonstrationTypeTagAssignment as PrismaDemonstrationTypeTagAssignment,
   User as PrismaUser,
 } from "@prisma/client";
+import { PrismaTransactionClient } from "../../prismaClient";
 import { ApplicationStatus, DeliverableStatus, PersonType, TagName } from "../../types";
 import { findDuplicates } from "../../validationUtilities";
 import { EasternTZDate, getEasternNow } from "../../dateUtilities";
+import { selectManyDocuments } from "../document";
 
 export function checkDemonstrationStatus(demonstration: PrismaDemonstration): string | undefined {
   const approvedStatus: ApplicationStatus = "Approved";
@@ -18,6 +20,7 @@ export function checkDemonstrationStatus(demonstration: PrismaDemonstration): st
 export function checkDeliverableStatusNotFinalized(
   deliverable: PrismaDeliverable
 ): string | undefined {
+  // Cast enforced by DB constraints
   const deliverableStatus = deliverable.statusId as DeliverableStatus;
   const finalDeliverableStatuses: DeliverableStatus[] = [
     "Approved",
@@ -25,12 +28,13 @@ export function checkDeliverableStatusNotFinalized(
     "Received and Filed",
   ];
   if (finalDeliverableStatuses.includes(deliverableStatus)) {
-    return `Cannot modify deliverable ${deliverable.id} as it has already been finalized.`;
+    return `Cannot submit or modify deliverable ${deliverable.id} as it has already been finalized.`;
   }
 }
 
 export function checkOwnerPersonType(ownerUser: PrismaUser): string | undefined {
   const permittedOwnerPersonTypes: readonly PersonType[] = ["demos-admin", "demos-cms-user"];
+  // Cast enforced by DB constraints
   if (!permittedOwnerPersonTypes.includes(ownerUser.personTypeId as PersonType)) {
     return `User ${ownerUser.id} is not a CMS user; cannot own deliverable.`;
   }
@@ -63,5 +67,19 @@ export function checkDueDateInFuture(dueDate: EasternTZDate): string | undefined
   const easternNow = getEasternNow()["Current Time"];
   if (dueDate.easternTZDate.valueOf() < easternNow.easternTZDate.valueOf()) {
     return `Cannot request a due date in the past; requested ${dueDate.easternTZDate}`;
+  }
+}
+
+export async function checkDeliverableHasAtLeastOneDocument(
+  deliverable: PrismaDeliverable,
+  tx: PrismaTransactionClient
+): Promise<string | undefined> {
+  const deliverableDocuments = await selectManyDocuments(
+    { deliverableId: deliverable.id, deliverableIsCmsAttachedFile: false },
+    tx
+  );
+
+  if (deliverableDocuments.length === 0) {
+    return `Cannot submit deliverable ${deliverable.id} because it has no state documents attached.`;
   }
 }

--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -40,6 +40,7 @@ vi.mock(".", () => ({
   createDeliverable: vi.fn(),
   getDeliverable: vi.fn(),
   getManyDeliverables: vi.fn(),
+  submitDeliverable: vi.fn(),
   updateDeliverable: vi.fn(),
 }));
 
@@ -63,7 +64,13 @@ vi.mock("../deliverableAction", () => ({
   getFormattedDeliverableActions: vi.fn(),
 }));
 
-import { createDeliverable, getDeliverable, getManyDeliverables, updateDeliverable } from ".";
+import {
+  createDeliverable,
+  getDeliverable,
+  getManyDeliverables,
+  submitDeliverable,
+  updateDeliverable,
+} from ".";
 import { getApplication } from "../application";
 import { getUser } from "../user";
 import { getManyDocuments } from "../document";
@@ -127,6 +134,17 @@ describe("deliverableResolvers", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+  });
+
+  describe("Mutation.submitDeliverable", () => {
+    it("calls submitDeliverable with appropriate arguments", async () => {
+      await deliverableResolvers.Mutation.submitDeliverable(
+        undefined,
+        { id: testDeliverableId },
+        testContext
+      );
+      expect(submitDeliverable).toHaveBeenCalledExactlyOnceWith(testDeliverableId, testContext);
+    });
   });
 
   describe("Deliverable.cmsDocuments", () => {

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -7,7 +7,13 @@ import {
 } from "@prisma/client";
 import { GraphQLContext } from "../../auth";
 import { GraphQLResolveInfo } from "graphql";
-import { createDeliverable, getDeliverable, getManyDeliverables, updateDeliverable } from ".";
+import {
+  createDeliverable,
+  getDeliverable,
+  getManyDeliverables,
+  submitDeliverable,
+  updateDeliverable,
+} from ".";
 import {
   CreateDeliverableInput,
   DeliverableAction,
@@ -119,6 +125,9 @@ export const deliverableResolvers = {
       context: GraphQLContext
     ) => {
       return await updateDeliverable(args.id, args.input, context);
+    },
+    submitDeliverable: async (parent: unknown, args: { id: string }, context: GraphQLContext) => {
+      return await submitDeliverable(args.id, context);
     },
   },
 

--- a/server/src/model/deliverable/deliverableSchema.ts
+++ b/server/src/model/deliverable/deliverableSchema.ts
@@ -61,6 +61,7 @@ export const deliverableSchema = gql`
   type Mutation {
     createDeliverable(input: CreateDeliverableInput): Deliverable
     updateDeliverable(id: ID!, input: UpdateDeliverableInput!): Deliverable
+    submitDeliverable(id: ID!): Deliverable
   }
 `;
 

--- a/server/src/model/deliverable/index.ts
+++ b/server/src/model/deliverable/index.ts
@@ -6,6 +6,7 @@ export {
   checkForDuplicateDemonstrationTypes,
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
+  checkDeliverableHasAtLeastOneDocument,
 } from "./checkDeliverableInputFunctions";
 export { createDeliverable } from "./createDeliverable";
 export { manuallyUpdateDeliverableDueDate } from "./manuallyUpdateDeliverableDueDate";
@@ -13,8 +14,10 @@ export { parseCreateDeliverableInput, parseUpdateDeliverableInput } from "./pars
 export { resolveDeliverable, resolveManyDeliverables } from "./deliverableResolvers";
 export {
   validateCreateDeliverableInput,
+  validateSubmitDeliverableInput,
   validateUpdateDeliverableInput,
 } from "./validateDeliverableInputs";
+export { submitDeliverable } from "./submitDeliverable";
 export { updateDeliverable } from "./updateDeliverable";
 export { updateDeliverableDemonstrationTypes } from "./updateDeliverableDemonstrationTypes";
 

--- a/server/src/model/deliverable/submitDeliverable.test.ts
+++ b/server/src/model/deliverable/submitDeliverable.test.ts
@@ -1,0 +1,116 @@
+// Vitest and other helpers
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Types
+import { GraphQLContext } from "../../auth";
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
+
+// Functions under test
+import { submitDeliverable } from "./submitDeliverable";
+
+// Mock imports
+vi.mock("../../prismaClient", () => ({
+  prisma: vi.fn(),
+}));
+
+vi.mock(".", () => ({
+  editDeliverable: vi.fn(),
+  getDeliverable: vi.fn(),
+  validateSubmitDeliverableInput: vi.fn(),
+}));
+
+vi.mock("../deliverableAction/queries", () => ({
+  insertDeliverableAction: vi.fn(),
+}));
+
+import { prisma } from "../../prismaClient";
+import { editDeliverable, getDeliverable, validateSubmitDeliverableInput } from ".";
+import { insertDeliverableAction } from "../deliverableAction/queries";
+
+describe("submitDeliverable", () => {
+  // Test inputs
+  const testDeliverableId = "b18cf1ce-3e41-4a71-b4f4-585f343bc74f";
+  const testContext: GraphQLContext = {
+    user: {
+      id: "57f92f14-7c5e-4c78-a774-5a54d7e9c2e7",
+      cognitoSubject: "82d0e8e4-82d0-447c-b1bb-52227e49cf51",
+      personTypeId: "demos-cms-user",
+      permissions: ["View All Demonstrations"],
+    },
+  };
+
+  // Mock results
+  const mockUnsubmittedDeliverable: Partial<PrismaDeliverable> = {
+    id: testDeliverableId,
+    statusId: "Upcoming",
+    dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
+  };
+  const mockSubmittedDeliverable: Partial<PrismaDeliverable> = {
+    id: testDeliverableId,
+    statusId: "Submitted",
+    dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
+  };
+  const mockNow = new Date(2026, 3, 27, 10, 4, 19, 232);
+
+  // Mock transaction
+  const mockTransaction: any = "Test!";
+  const mockPrismaClient = {
+    $transaction: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+    vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
+    vi.mocked(getDeliverable).mockResolvedValue(mockUnsubmittedDeliverable as PrismaDeliverable);
+    vi.mocked(editDeliverable).mockResolvedValue(mockSubmittedDeliverable as PrismaDeliverable);
+    mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should get the deliverable before making changes", async () => {
+    await submitDeliverable(testDeliverableId, testContext);
+    expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
+      { id: testDeliverableId },
+      mockTransaction
+    );
+  });
+
+  it("should call the validator on the unchanged deliverable", async () => {
+    await submitDeliverable(testDeliverableId, testContext);
+    expect(validateSubmitDeliverableInput).toHaveBeenCalledExactlyOnceWith(
+      mockUnsubmittedDeliverable,
+      mockTransaction
+    );
+  });
+
+  it("should call edit function to set the status to submitted", async () => {
+    await submitDeliverable(testDeliverableId, testContext);
+    expect(editDeliverable).toHaveBeenCalledExactlyOnceWith(
+      testDeliverableId,
+      { statusId: "Submitted" },
+      mockTransaction
+    );
+  });
+
+  it("should log an action for the submission", async () => {
+    await submitDeliverable(testDeliverableId, testContext);
+    expect(insertDeliverableAction).toHaveBeenCalledExactlyOnceWith(
+      {
+        deliverableId: testDeliverableId,
+        actionType: "Submitted Deliverable",
+        actionTime: mockNow,
+        oldStatus: mockUnsubmittedDeliverable.statusId,
+        newStatus: mockSubmittedDeliverable.statusId,
+        oldDueDate: mockUnsubmittedDeliverable.dueDate,
+        newDueDate: mockSubmittedDeliverable.dueDate,
+        userId: testContext.user.id,
+      },
+      mockTransaction
+    );
+  });
+});

--- a/server/src/model/deliverable/submitDeliverable.ts
+++ b/server/src/model/deliverable/submitDeliverable.ts
@@ -1,0 +1,39 @@
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
+import { GraphQLContext } from "../../auth/auth.util";
+import { DeliverableStatus } from "../../types";
+import { prisma } from "../../prismaClient";
+import { editDeliverable, getDeliverable, validateSubmitDeliverableInput } from ".";
+import { insertDeliverableAction } from "../deliverableAction/queries";
+
+export async function submitDeliverable(
+  deliverableId: string,
+  context: GraphQLContext
+): Promise<PrismaDeliverable> {
+  return await prisma().$transaction(async (tx) => {
+    const unsubmittedDeliverable = await getDeliverable({ id: deliverableId }, tx);
+    await validateSubmitDeliverableInput(unsubmittedDeliverable, tx);
+
+    const submittedDeliverable = await editDeliverable(
+      deliverableId,
+      { statusId: "Submitted" },
+      tx
+    );
+
+    // Casts below enforced by database
+    await insertDeliverableAction(
+      {
+        deliverableId: deliverableId,
+        actionType: "Submitted Deliverable",
+        actionTime: new Date(),
+        oldStatus: unsubmittedDeliverable.statusId as DeliverableStatus,
+        newStatus: submittedDeliverable.statusId as DeliverableStatus,
+        oldDueDate: unsubmittedDeliverable.dueDate,
+        newDueDate: submittedDeliverable.dueDate,
+        userId: context.user.id,
+      },
+      tx
+    );
+
+    return submittedDeliverable;
+  });
+}

--- a/server/src/model/deliverable/validateDeliverableInputs.test.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.test.ts
@@ -17,6 +17,7 @@ import { EasternTZDate } from "../../dateUtilities";
 // Functions under test
 import {
   validateCreateDeliverableInput,
+  validateSubmitDeliverableInput,
   validateUpdateDeliverableInput,
 } from "./validateDeliverableInputs";
 
@@ -39,6 +40,7 @@ vi.mock(".", () => ({
   checkDueDateInFuture: vi.fn(),
   checkOwnerPersonType: vi.fn(),
   checkRequestedDeliverableDemonstrationType: vi.fn(),
+  checkDeliverableHasAtLeastOneDocument: vi.fn(),
   getDeliverable: vi.fn(),
 }));
 
@@ -51,6 +53,7 @@ import {
   checkDueDateInFuture,
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
+  checkDeliverableHasAtLeastOneDocument,
   getDeliverable,
 } from ".";
 
@@ -542,6 +545,107 @@ describe("validateDeliverableInputs", () => {
           "The deliverable finalized status check failed!",
           "The owner person type check failed",
           "The demonstration type check failed",
+        ]);
+      }
+    });
+  });
+
+  describe("validateSubmitDeliverableInput", () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it("should not throw if none of the rules are violated", async () => {
+      // Note: don't need to set returns to undefined, as this is what vi.fn() does already
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Upcoming",
+        cmsOwnerUserId: "7d8fdea5-ca19-42e5-af50-98836b6d47db",
+      };
+
+      await expect(
+        validateSubmitDeliverableInput(testInput as PrismaDeliverable, mockTransaction)
+      ).resolves.toBeUndefined();
+    });
+
+    it("should throw if the deliverable status check fails", async () => {
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Approved",
+        cmsOwnerUserId: "7d8fdea5-ca19-42e5-af50-98836b6d47db",
+      };
+      vi.mocked(checkDeliverableStatusNotFinalized).mockReturnValue(
+        "The deliverable finalized status check failed!"
+      );
+
+      try {
+        await validateSubmitDeliverableInput(testInput as PrismaDeliverable, mockTransaction);
+        throw new Error("Expected validateSubmitDeliverableInput to throw, but it did not.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for submitDeliverable have failed."
+        );
+        expect(error.extensions.code).toBe("SUBMIT_DELIVERABLE_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable finalized status check failed!",
+        ]);
+      }
+    });
+
+    it("should throw if the deliverable document check failes", async () => {
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Submitted",
+        cmsOwnerUserId: "7d8fdea5-ca19-42e5-af50-98836b6d47db",
+      };
+      vi.mocked(checkDeliverableHasAtLeastOneDocument).mockResolvedValue(
+        "The deliverable document check has failed!"
+      );
+
+      try {
+        await validateSubmitDeliverableInput(testInput as PrismaDeliverable, mockTransaction);
+        throw new Error("Expected validateSubmitDeliverableInput to throw, but it did not.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for submitDeliverable have failed."
+        );
+        expect(error.extensions.code).toBe("SUBMIT_DELIVERABLE_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable document check has failed!",
+        ]);
+      }
+    });
+
+    it("should combine all errors into one object", async () => {
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Approved",
+        cmsOwnerUserId: "7d8fdea5-ca19-42e5-af50-98836b6d47db",
+      };
+      vi.mocked(checkDeliverableStatusNotFinalized).mockReturnValue(
+        "The deliverable finalized status check failed!"
+      );
+      vi.mocked(checkDeliverableHasAtLeastOneDocument).mockResolvedValue(
+        "The deliverable document check has failed!"
+      );
+
+      try {
+        await validateSubmitDeliverableInput(testInput as PrismaDeliverable, mockTransaction);
+        throw new Error("Expected validateSubmitDeliverableInput to throw, but it did not.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for submitDeliverable have failed."
+        );
+        expect(error.extensions.code).toBe("SUBMIT_DELIVERABLE_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable finalized status check failed!",
+          "The deliverable document check has failed!",
         ]);
       }
     });

--- a/server/src/model/deliverable/validateDeliverableInputs.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.ts
@@ -111,8 +111,10 @@ export async function validateSubmitDeliverableInput(
 ): Promise<void> {
   const errors: (string | undefined)[] = [];
 
-  errors.push(checkDeliverableStatusNotFinalized(deliverable));
-  errors.push(await checkDeliverableHasAtLeastOneDocument(deliverable, tx));
+  errors.push(
+    checkDeliverableStatusNotFinalized(deliverable),
+    await checkDeliverableHasAtLeastOneDocument(deliverable, tx)
+  );
 
   const cleanedErrors = errors.filter((e) => e !== undefined);
   if (cleanedErrors.length > 0) {

--- a/server/src/model/deliverable/validateDeliverableInputs.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.ts
@@ -1,6 +1,7 @@
 import {
-  checkDemonstrationStatus,
+  checkDeliverableHasAtLeastOneDocument,
   checkDeliverableStatusNotFinalized,
+  checkDemonstrationStatus,
   checkDueDateInFuture,
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
@@ -13,6 +14,7 @@ import { getApplication } from "../application";
 import { getUser } from "../user";
 import { getDemonstrationTypeAssignments } from "../demonstrationTypeTagAssignment";
 import { GraphQLError } from "graphql";
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
 
 export async function validateCreateDeliverableInput(
   input: ParsedCreateDeliverableInput,
@@ -97,6 +99,26 @@ export async function validateUpdateDeliverableInput(
     throw new GraphQLError("One or more validation checks for updateDeliverable have failed.", {
       extensions: {
         code: "UPDATE_DELIVERABLE_VALIDATION_FAILED",
+        originalMessages: cleanedErrors,
+      },
+    });
+  }
+}
+
+export async function validateSubmitDeliverableInput(
+  deliverable: PrismaDeliverable,
+  tx: PrismaTransactionClient
+): Promise<void> {
+  const errors: (string | undefined)[] = [];
+
+  errors.push(checkDeliverableStatusNotFinalized(deliverable));
+  errors.push(await checkDeliverableHasAtLeastOneDocument(deliverable, tx));
+
+  const cleanedErrors = errors.filter((e) => e !== undefined);
+  if (cleanedErrors.length > 0) {
+    throw new GraphQLError("One or more validation checks for submitDeliverable have failed.", {
+      extensions: {
+        code: "SUBMIT_DELIVERABLE_VALIDATION_FAILED",
         originalMessages: cleanedErrors,
       },
     });


### PR DESCRIPTION
This PR adds the `submitDeliverable` mutator, partially fulfilling the requirements of [DEMOS-1959](https://jiraent.cms.gov/browse/DEMOS-1959). It implements a set of simple checks that validate that the deliverable is in an allowed state (also enforced at the DB level), and that there exists at least _one_ document for that deliverable (per discussions with Dipika). Added test suite. Passing in SQ. Exercised the API locally and verified functionality.