### PR TITLE
(3/4) DEMOS-1541: Show comments + Textarea Improvements

### DIFF
--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -62,6 +62,7 @@ This file provides instructions for AI agents to use when generating or editing 
 - Often times `name` attributes are propagated to `data-test-id`, try this approach first.
 - Prefer real behavior over heavy mocking; use `vi.mock(...)` only at clear boundaries.
 - Run tests with `npm run test:once ...`
+- Run linting + typechecking with `npm run lint`
 - Prefer to keep mock data in test files for clarity / isolation rather than in `/mock-data`.
 - For testing behavior with different roles you can use the different variants of `npm run dev:mocks` - `dev:mocks:admin`, `dev:mocks:state`, etc. Some functionality is only available through certain roles. 
 

--- a/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
+++ b/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
@@ -274,9 +274,9 @@ export const ApplicationDetailsSection = ({
               name="description"
               label={`${capitalizedType} Description`}
               placeholder="Enter description"
-              initialValue={sectionFormData.description ?? ""}
+              value={sectionFormData.description ?? ""}
               isDisabled={isReadonly}
-              onChange={(e) => setSectionFormData({ ...sectionFormData, description: e.target.value })}
+              onChange={(value) => setSectionFormData({ ...sectionFormData, description: value })}
             />
           )}
         </div>

--- a/client/src/components/dialog/deliverable/RequestExtensionDeliverableDialog.tsx
+++ b/client/src/components/dialog/deliverable/RequestExtensionDeliverableDialog.tsx
@@ -175,9 +175,9 @@ export const RequestExtensionDeliverableDialog: React.FC<
           name={REQUEST_EXTENSION_DETAILS_FIELD_NAME}
           label="Details"
           isRequired
-          initialValue={formData.details}
+          value={formData.details}
           placeholder="Enter"
-          onChange={(event) => setFormData((prev) => ({ ...prev, details: event.target.value }))}
+          onChange={(value) => setFormData((prev) => ({ ...prev, details: value }))}
           getValidationMessage={(value) =>
             attemptedSubmit && value.trim() === "" ? "Details is required." : ""
           }

--- a/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
@@ -47,8 +47,8 @@ const DemonstrationDescriptionTextArea: React.FC<{
       name={DEMONSTRATION_DIALOG_DESCRIPTION_NAME}
       label="Demonstration Description"
       placeholder="Enter description"
-      initialValue={description ?? ""}
-      onChange={(e) => setDescription(e.target.value)}
+      value={description ?? ""}
+      onChange={setDescription}
     />
   );
 };

--- a/client/src/components/dialog/modification/ModificationForm.tsx
+++ b/client/src/components/dialog/modification/ModificationForm.tsx
@@ -117,12 +117,12 @@ export const ModificationForm: React.FC<{
       <Textarea
         name={"description"}
         label={`${modificationType} Description`}
-        onChange={(e) =>
+        onChange={(value) =>
           setModificationFormDataField({
-            description: e.target.value,
+            description: value,
           })
         }
-        initialValue={modificationFormData.description || ""}
+        value={modificationFormData.description || ""}
         placeholder={`Enter ${modificationType.toLowerCase()} description`}
       />
       <div className="w-1/2">

--- a/client/src/components/input/Textarea.test.tsx
+++ b/client/src/components/input/Textarea.test.tsx
@@ -9,8 +9,14 @@ describe("Textarea", () => {
   const defaultProps = {
     name: DEFAULT_TEXT_AREA_NAME,
     label: "Description",
-    initialValue: "",
+    value: "",
     onChange: () => {},
+  };
+
+  // Needed for tests that type into the textarea to test behavior
+  const ControlledTextarea: React.FC = () => {
+    const [value, setValue] = React.useState("");
+    return <Textarea name={DEFAULT_TEXT_AREA_NAME} label="Description" value={value} onChange={setValue} />;
   };
 
   it("renders with label and textarea", () => {
@@ -42,7 +48,7 @@ describe("Textarea", () => {
   describe("Auto-growing behavior", () => {
     it("grows to 2 rows when user adds one line break", async () => {
       const user = userEvent.setup();
-      render(<Textarea {...defaultProps} />);
+      render(<ControlledTextarea />);
 
       const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
 
@@ -58,7 +64,7 @@ describe("Textarea", () => {
 
     it("grows to 3 rows (max) with multiple line breaks", async () => {
       const user = userEvent.setup();
-      render(<Textarea {...defaultProps} />);
+      render(<ControlledTextarea />);
 
       const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
 
@@ -71,7 +77,7 @@ describe("Textarea", () => {
 
     it("does not grow on long single-line text", async () => {
       const user = userEvent.setup();
-      render(<Textarea {...defaultProps} />);
+      render(<ControlledTextarea />);
 
       const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
 
@@ -86,7 +92,7 @@ describe("Textarea", () => {
 
     it("shrinks back down when line breaks are removed", async () => {
       const user = userEvent.setup();
-      render(<Textarea {...defaultProps} />);
+      render(<ControlledTextarea />);
 
       const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
 
@@ -110,7 +116,7 @@ describe("Textarea", () => {
       render(
         <Textarea
           {...defaultProps}
-          initialValue="This is way too long"
+          value="This is way too long"
           getValidationMessage={getValidationMessage}
         />
       );
@@ -124,7 +130,7 @@ describe("Textarea", () => {
       render(
         <Textarea
           {...defaultProps}
-          initialValue="Short"
+          value="Short"
           getValidationMessage={getValidationMessage}
         />
       );
@@ -179,7 +185,7 @@ describe("Textarea", () => {
 
     it("handles text with only line breaks", async () => {
       const user = userEvent.setup();
-      render(<Textarea {...defaultProps} />);
+      render(<ControlledTextarea />);
 
       const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
 
@@ -192,7 +198,7 @@ describe("Textarea", () => {
 
     it("maintains row count with mixed content", async () => {
       const user = userEvent.setup();
-      render(<Textarea {...defaultProps} />);
+      render(<ControlledTextarea />);
 
       const textarea = screen.getByTestId(DEFAULT_TEXT_AREA_NAME);
 

--- a/client/src/components/input/Textarea.tsx
+++ b/client/src/components/input/Textarea.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 import { tw } from "tags/tw";
 
@@ -14,8 +14,8 @@ const VALIDATION_MESSAGE_CLASSES = tw`text-error-dark`;
 export interface TextareaProps {
   name: string;
   label: string;
-  initialValue: string;
-  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  value: string;
+  onChange: (newString: string) => void;
   isRequired?: boolean;
   isDisabled?: boolean;
   placeholder?: string;
@@ -25,22 +25,18 @@ export interface TextareaProps {
 export const Textarea: React.FC<TextareaProps> = ({
   name,
   label,
-  initialValue,
+  value,
   onChange,
   isRequired,
   isDisabled,
   placeholder,
   getValidationMessage,
 }) => {
-  const [value, setValue] = useState(initialValue);
   const validationMessage = getValidationMessage ? getValidationMessage(value) : "";
   const rowsToDisplay = Math.min(Math.max(value.split("\n").length, 1), MAX_ROWS);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setValue(e.target.value);
-    if (onChange) {
-      onChange(e);
-    }
+    onChange(e.target.value);
   };
   return (
     <div className="flex flex-col gap-xs">

--- a/client/src/pages/deliverables/sections/CommentBox.test.tsx
+++ b/client/src/pages/deliverables/sections/CommentBox.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { COLLAPSE_COMMENTS_BUTTON_NAME, COMMENT_BOX_NAME, COMMENT_BOX_TABS_NAME, COMMENT_BOX_TEXT_AREA_NAME, CommentBox } from "./CommentBox";
+import { COLLAPSE_COMMENTS_BUTTON_NAME, COMMENT_BOX_NAME, COMMENT_BOX_TABS_NAME, COMMENT_BOX_TEXT_AREA_NAME, ADD_COMMENT_BUTTON_NAME, CommentBox } from "./CommentBox";
 import { TestProvider } from "test-utils/TestProvider";
 import { developmentMockUser } from "mock-data/userMocks";
 import { PersonType } from "demos-server";
@@ -76,5 +76,45 @@ describe("CommentBox", () => {
   it("does not render comment box tabs for state users", () => {
     renderCommentBox("demos-state-user");
     expect(screen.queryByTestId(COMMENT_BOX_TABS_NAME)).not.toBeInTheDocument();
+  });
+
+  it("shows 'No comments yet' when there are no comments", () => {
+    renderCommentBox();
+    expect(screen.getByText("No comments yet.")).toBeInTheDocument();
+  });
+
+  it("adds a comment to the history when Add Comment is clicked", async () => {
+    renderCommentBox();
+
+    await userEvent.type(screen.getByTestId(COMMENT_BOX_TEXT_AREA_NAME), "hello world");
+    await userEvent.click(screen.getByTestId(ADD_COMMENT_BUTTON_NAME));
+
+    expect(screen.getByText(/hello world/)).toBeInTheDocument();
+  });
+
+  it("clears the textarea after adding a comment", async () => {
+    renderCommentBox();
+
+    await userEvent.type(screen.getByTestId(COMMENT_BOX_TEXT_AREA_NAME), "hello world");
+    await userEvent.click(screen.getByTestId(ADD_COMMENT_BUTTON_NAME));
+
+    expect(screen.getByTestId(COMMENT_BOX_TEXT_AREA_NAME)).toHaveValue("");
+  });
+
+  it("does not add a comment when the textarea is empty", async () => {
+    renderCommentBox();
+
+    await userEvent.click(screen.getByTestId(ADD_COMMENT_BUTTON_NAME));
+
+    expect(screen.getByText("No comments yet.")).toBeInTheDocument();
+  });
+
+  it("does not add a comment when the textarea contains only whitespace", async () => {
+    renderCommentBox();
+
+    await userEvent.type(screen.getByTestId(COMMENT_BOX_TEXT_AREA_NAME), "   ");
+    await userEvent.click(screen.getByTestId(ADD_COMMENT_BUTTON_NAME));
+
+    expect(screen.getByText("No comments yet.")).toBeInTheDocument();
   });
 });

--- a/client/src/pages/deliverables/sections/CommentBox.tsx
+++ b/client/src/pages/deliverables/sections/CommentBox.tsx
@@ -3,14 +3,23 @@ import React, { useState } from "react";
 import { MenuCollapseRightIcon } from "components/icons/Navigation/MenuCollapseRightIcon";
 import { Textarea } from "components/input";
 import { CommentIcon } from "components/icons";
-import { SecondaryButton } from "components/button";
+import { Button, SecondaryButton } from "components/button";
 import { getCurrentUser } from "components/user/UserContext";
 import { PersonType } from "demos-server";
+import { CommentBoxTabs } from "./CommentBoxTabs";
+import { format } from "date-fns";
 
 export const COMMENT_BOX_NAME = "comment-box";
 export const COMMENT_BOX_TEXT_AREA_NAME = "textarea-comment-box";
 export const COLLAPSE_COMMENTS_BUTTON_NAME = "button-collapse-comments";
 export const COMMENT_BOX_TABS_NAME = "comment-box-tabs";
+export const ADD_COMMENT_BUTTON_NAME = "button-add-comment";
+
+interface CommentBoxComment {
+  comment: string;
+  userFullName: string;
+  timestamp: Date;
+}
 
 const CommentBoxHeader = ({ onCollapse }: { onCollapse: () => void }) => (
   <div className="flex items-center justify-between pb-1 border-b border-gray-dark">
@@ -24,31 +33,57 @@ const CommentBoxHeader = ({ onCollapse }: { onCollapse: () => void }) => (
   </div>
 );
 
-const CommentBoxTextArea = ({ value, onChange }: { value: string; onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void }) => {
+const  CommentBoxTextArea = ({ addComment, currentComment, setCurrentComment }: { addComment: (newComment: CommentBoxComment) => void; currentComment: string; setCurrentComment: (value: string) => void }) => {
+  const {currentUser} = getCurrentUser();
+
+  if (!currentUser) {
+    throw new Error("Current user is required to render CommentBoxTextArea");
+  }
+
+  const handleAddComment = () => {
+    if (currentComment.trim() !== "") {
+      addComment({
+        comment: currentComment,
+        userFullName: currentUser.person.fullName,
+        timestamp: new Date(),
+      });
+      setCurrentComment("");
+    }
+  };
+
   return (
-    <div className="flex-1">
-      <Textarea label="Comments" initialValue={value} name={COMMENT_BOX_TEXT_AREA_NAME} onChange={onChange} />
+    <div className="flex-1 flex flex-col gap-1">
+      <Textarea label="Comments" value={currentComment} name={COMMENT_BOX_TEXT_AREA_NAME} onChange={setCurrentComment} />
+      <Button name={ADD_COMMENT_BUTTON_NAME} data-testid={ADD_COMMENT_BUTTON_NAME} onClick={handleAddComment}>Add Comment</Button>
     </div>
   );
 };
 
-const CommentBoxTabs = () => (
-  <div data-testid={COMMENT_BOX_TABS_NAME}>
-    ONLY CMS / ADMIN USERS CAN SEE THIS
-    {/* TODO: implement tab content */}
-  </div>
-);
+const Comment = ({ comment }: { comment: CommentBoxComment }) => {
+  const formattedDate = format(comment.timestamp, "MM/dd/yyyy, hh:mm:ss a");
 
-const CommentBoxHistory = () => (
+  return (
+    <div className="p-1 bg-gray-secondary-layout rounded">
+      {comment.userFullName} - {formattedDate}
+      {comment.comment}
+    </div>
+  );
+};
+
+const CommentBoxHistory = ({comments}: {comments: CommentBoxComment[]}) => (
   <>
     <span className="font-semibold">Comment History</span>
-    <span className="text-sm text-gray-500">No comments yet.</span>
+    {comments ? comments.map((comment, index) => (
+      <Comment key={index} comment={comment} />
+    )) :<span className="text-sm text-gray-500">No comments yet.</span>
+    }
   </>
 );
 
 export const CommentBox = () => {
   const { currentUser } = getCurrentUser();
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const [comments, setComments] = useState<CommentBoxComment[]>([]);
   const [currentComment, setCurrentComment] = useState("");
 
   if (!currentUser) {
@@ -57,6 +92,10 @@ export const CommentBox = () => {
 
   const userPersonType: PersonType = currentUser.person.personType;
   const isCmsOrAdminUser = userPersonType === "demos-cms-user" || userPersonType === "demos-admin";
+
+  const addComment = (newComment: CommentBoxComment) => {
+    setComments((prevComments) => [...prevComments, newComment]);
+  };
 
   if (isCollapsed) {
     return (
@@ -72,11 +111,11 @@ export const CommentBox = () => {
   }
 
   return (
-    <div className="flex flex-col gap-1 bg-gray-primary-layout p-1 min-h-full min-w-[350px]" data-testid={COMMENT_BOX_NAME}>
+    <div className="flex flex-col gap-1 bg-gray-primary-layout p-1 min-h-full min-w-87.5" data-testid={COMMENT_BOX_NAME}>
       <CommentBoxHeader onCollapse={() => setIsCollapsed(true)} />
       {isCmsOrAdminUser && <CommentBoxTabs />}
-      <CommentBoxTextArea value={currentComment} onChange={(e) => setCurrentComment(e.target.value)} />
-      <CommentBoxHistory />
+      <CommentBoxTextArea addComment={addComment} currentComment={currentComment} setCurrentComment={setCurrentComment} />
+      <CommentBoxHistory comments={comments} />
     </div>
   );
 };

--- a/client/src/pages/deliverables/sections/CommentBox.tsx
+++ b/client/src/pages/deliverables/sections/CommentBox.tsx
@@ -76,9 +76,9 @@ const Comment = ({ comment }: { comment: CommentBoxComment }) => {
 const CommentBoxHistory = ({comments}: {comments: CommentBoxComment[]}) => (
   <>
     <span className="font-semibold">Comment History</span>
-    {comments ? comments.map((comment, index) => (
+    {comments.length ? comments.map((comment, index) => (
       <Comment key={index} comment={comment} />
-    )) :<span className="text-sm text-gray-500">No comments yet.</span>
+    )) : <span className="text-sm text-gray-500">No comments yet.</span>
     }
   </>
 );

--- a/client/src/pages/deliverables/sections/CommentBox.tsx
+++ b/client/src/pages/deliverables/sections/CommentBox.tsx
@@ -19,7 +19,10 @@ interface CommentBoxComment {
   comment: string;
   userFullName: string;
   timestamp: Date;
+  commentVisibility?: CommentVisibility;
 }
+
+export type CommentVisibility = "public" | "private";
 
 const CommentBoxHeader = ({ onCollapse }: { onCollapse: () => void }) => (
   <div className="flex items-center justify-between pb-1 border-b border-gray-dark">
@@ -27,7 +30,7 @@ const CommentBoxHeader = ({ onCollapse }: { onCollapse: () => void }) => (
       <span className="text-lg font-bold uppercase text-brand">Comments</span>
       <CommentIcon className="text-action" />
     </div>
-    <SecondaryButton size="large" name={COLLAPSE_COMMENTS_BUTTON_NAME} data-testid={COLLAPSE_COMMENTS_BUTTON_NAME} onClick={onCollapse} aria-label="Collapse comments">
+    <SecondaryButton size="small" name={COLLAPSE_COMMENTS_BUTTON_NAME} data-testid={COLLAPSE_COMMENTS_BUTTON_NAME} onClick={onCollapse} aria-label="Collapse comments">
       <MenuCollapseRightIcon className="w-[20px] h-[20px]" />
     </SecondaryButton>
   </div>
@@ -85,6 +88,7 @@ export const CommentBox = () => {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [comments, setComments] = useState<CommentBoxComment[]>([]);
   const [currentComment, setCurrentComment] = useState("");
+  const [commentVisibility, setCommentVisibility] = useState<CommentVisibility>("public");
 
   if (!currentUser) {
     return null;
@@ -94,7 +98,12 @@ export const CommentBox = () => {
   const isCmsOrAdminUser = userPersonType === "demos-cms-user" || userPersonType === "demos-admin";
 
   const addComment = (newComment: CommentBoxComment) => {
-    setComments((prevComments) => [...prevComments, newComment]);
+    const commentWithVisibility = { ...newComment, commentVisibility };
+    // TODO: Eventually we will replace this with the actual API call to save the comment,
+    // and we might want to handle the visibility differently depending on the API design.
+    // For now, we are just adding it to the local state with the visibility included.
+    console.log("Adding comment:", commentWithVisibility);
+    setComments((prevComments) => [...prevComments, commentWithVisibility]);
   };
 
   if (isCollapsed) {
@@ -113,7 +122,7 @@ export const CommentBox = () => {
   return (
     <div className="flex flex-col gap-1 bg-gray-primary-layout p-1 min-h-full min-w-87.5" data-testid={COMMENT_BOX_NAME}>
       <CommentBoxHeader onCollapse={() => setIsCollapsed(true)} />
-      {isCmsOrAdminUser && <CommentBoxTabs />}
+      {isCmsOrAdminUser && <CommentBoxTabs setCommentVisibility={setCommentVisibility} />}
       <CommentBoxTextArea addComment={addComment} currentComment={currentComment} setCurrentComment={setCurrentComment} />
       <CommentBoxHistory comments={comments} />
     </div>

--- a/client/src/pages/deliverables/sections/CommentBoxTabs.test.tsx
+++ b/client/src/pages/deliverables/sections/CommentBoxTabs.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { TestProvider } from "test-utils/TestProvider";
+import { CommentBoxTabs } from "./CommentBoxTabs";
+
+const setup = (setCommentVisibility = vi.fn()) => {
+  render(
+    <TestProvider>
+      <CommentBoxTabs setCommentVisibility={setCommentVisibility} />
+    </TestProvider>
+  );
+  return { setCommentVisibility };
+};
+
+describe("CommentBoxTabs", () => {
+  it("renders the Public and Private tabs", () => {
+    setup();
+    expect(screen.getByTestId("button-public")).toBeInTheDocument();
+    expect(screen.getByTestId("button-private")).toBeInTheDocument();
+  });
+
+  it("has the Public tab selected by default", () => {
+    setup();
+    expect(screen.getByTestId("button-public")).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByTestId("button-private")).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("shows the public tab content by default", () => {
+    setup();
+    expect(screen.getByText("These comments wil be visible to the state")).toBeInTheDocument();
+  });
+  
+  it("calls setCommentVisibility with 'private' when the Private tab is clicked", async () => {
+    const { setCommentVisibility } = setup();
+    await userEvent.click(screen.getByTestId("button-private"));
+    expect(setCommentVisibility).toHaveBeenCalledWith("private");
+  });
+
+  it("calls setCommentVisibility with 'public' when switching back to the Public tab", async () => {
+    const { setCommentVisibility } = setup();
+    await userEvent.click(screen.getByTestId("button-private"));
+    await userEvent.click(screen.getByTestId("button-public"));
+    expect(setCommentVisibility).toHaveBeenLastCalledWith("public");
+  });
+});

--- a/client/src/pages/deliverables/sections/CommentBoxTabs.test.tsx
+++ b/client/src/pages/deliverables/sections/CommentBoxTabs.test.tsx
@@ -31,7 +31,7 @@ describe("CommentBoxTabs", () => {
     setup();
     expect(screen.getByText("These comments wil be visible to the state")).toBeInTheDocument();
   });
-  
+
   it("calls setCommentVisibility with 'private' when the Private tab is clicked", async () => {
     const { setCommentVisibility } = setup();
     await userEvent.click(screen.getByTestId("button-private"));

--- a/client/src/pages/deliverables/sections/CommentBoxTabs.tsx
+++ b/client/src/pages/deliverables/sections/CommentBoxTabs.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import { HorizontalSectionTabs, Tab } from "layout/Tabs";
+import { COMMENT_BOX_TABS_NAME } from "./CommentBox";
+
+const TABS = {
+  PUBLIC: "public",
+  PRIVATE: "private",
+};
+
+export const CommentBoxTabs = () => (
+  <div data-testid={COMMENT_BOX_TABS_NAME}>
+    <HorizontalSectionTabs defaultValue={TABS.PUBLIC}>
+      <Tab label="Public" value={TABS.PUBLIC}>
+        <div>Public Comments</div>
+      </Tab>
+      <Tab label="Private" value={TABS.PRIVATE}>
+        <div>Private Comments</div>
+      </Tab>
+    </HorizontalSectionTabs>
+  </div>
+);

--- a/client/src/pages/deliverables/sections/CommentBoxTabs.tsx
+++ b/client/src/pages/deliverables/sections/CommentBoxTabs.tsx
@@ -1,18 +1,23 @@
 import React from "react";
 
 import { HorizontalSectionTabs, Tab } from "layout/Tabs";
-import { COMMENT_BOX_TABS_NAME } from "./CommentBox";
+import { COMMENT_BOX_TABS_NAME, CommentVisibility } from "./CommentBox";
+import { AlertIcon } from "components/icons";
 
 const TABS = {
   PUBLIC: "public",
   PRIVATE: "private",
 };
 
-export const CommentBoxTabs = () => (
+export const CommentBoxTabs = (
+  {setCommentVisibility}: {setCommentVisibility: (newCommentVisibility: CommentVisibility) => void}
+) => (
   <div data-testid={COMMENT_BOX_TABS_NAME}>
-    <HorizontalSectionTabs defaultValue={TABS.PUBLIC}>
+    <HorizontalSectionTabs defaultValue={TABS.PUBLIC} onSelect={(value) => setCommentVisibility(value as CommentVisibility)}>
       <Tab label="Public" value={TABS.PUBLIC}>
-        <div>Public Comments</div>
+        <div className="bg-alt-lightest">
+          <AlertIcon /> These comments wil be visible to the state
+        </div>
       </Tab>
       <Tab label="Private" value={TABS.PRIVATE}>
         <div>Private Comments</div>

--- a/client/src/pages/deliverables/sections/CommentBoxTabs.tsx
+++ b/client/src/pages/deliverables/sections/CommentBoxTabs.tsx
@@ -20,7 +20,7 @@ export const CommentBoxTabs = (
         </div>
       </Tab>
       <Tab label="Private" value={TABS.PRIVATE}>
-        <div>Private Comments</div>
+        <div>{/* Empty Div because tabs need children */}</div>
       </Tab>
     </HorizontalSectionTabs>
   </div>


### PR DESCRIPTION
Per DEMOS-1541: This one adds the ability to add comments (locally until the endpoints are ready)

I simplified the  Textarea component types a bit as well,  now the handler it takes should just operate on a string. It also uses `value` instead of `initialValue`


https://github.com/user-attachments/assets/223e9900-d1bd-47bc-9b57-c873461a8af9

