### PR TITLE
(3/2) DEMOS-1881: "Close Admin" Navigates back to previous URL

### DIFF
--- a/client/src/pages/admin/AdminHeader.test.tsx
+++ b/client/src/pages/admin/AdminHeader.test.tsx
@@ -16,7 +16,8 @@ vi.mock("react-router-dom", async () => {
 describe("AdminHeader", () => {
   it("renders the Admin Dashboard title", () => {
     render(<MemoryRouter><AdminHeader /></MemoryRouter>);
-    expect(screen.getByText("Admin Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Admin")).toBeInTheDocument();
+    expect(screen.getByLabelText("Settings")).toBeInTheDocument();
   });
 
   it("renders the Close Admin button", () => {

--- a/client/src/pages/admin/AdminHeader.test.tsx
+++ b/client/src/pages/admin/AdminHeader.test.tsx
@@ -1,8 +1,17 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { AdminHeader } from "./AdminHeader";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 describe("AdminHeader", () => {
   it("renders the Admin Dashboard title", () => {
@@ -13,5 +22,11 @@ describe("AdminHeader", () => {
   it("renders the Close Admin button", () => {
     render(<MemoryRouter><AdminHeader /></MemoryRouter>);
     expect(screen.getByTestId("close-admin")).toBeInTheDocument();
+  });
+
+  it("navigates back when Close Admin is clicked", () => {
+    render(<MemoryRouter><AdminHeader /></MemoryRouter>);
+    fireEvent.click(screen.getByTestId("close-admin"));
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
   });
 });

--- a/client/src/pages/admin/AdminHeader.tsx
+++ b/client/src/pages/admin/AdminHeader.tsx
@@ -9,12 +9,12 @@ export const AdminHeader: React.FC = () => {
   return (
     <header className="w-full">
       <div className="w-full flex items-center justify-between">
-        <span className="text-2xl font-bold">Admin Dashboard</span>
+        <span className="text-xl font-bold">Admin</span>
         <IconButton
           icon={<ExitIcon />}
           name="close-admin"
           data-testid="close-admin"
-          onClick={() => navigate("/")}
+          onClick={() => navigate(-1)}
         >
           Close Admin
         </IconButton>

--- a/client/src/pages/admin/AdminHeader.tsx
+++ b/client/src/pages/admin/AdminHeader.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { IconButton } from "components/button";
-import { ExitIcon } from "components/icons";
+import { ExitIcon, SettingsIcon } from "components/icons";
 
 export const AdminHeader: React.FC = () => {
   const navigate = useNavigate();
@@ -9,7 +9,9 @@ export const AdminHeader: React.FC = () => {
   return (
     <header className="w-full">
       <div className="w-full flex items-center justify-between">
-        <span className="text-xl font-bold">Admin</span>
+        <div className="text-xl font-bold flex gap-0-5 items-baseline">
+          <SettingsIcon />Admin
+        </div>
         <IconButton
           icon={<ExitIcon />}
           name="close-admin"


### PR DESCRIPTION
New requirements came in for DEMOS-1881 to navigate back to the URL the user was previously at instead of home,  this does that. Also adds the settings icon to the header (not in screencap)


https://github.com/user-attachments/assets/cfe02326-d20b-463f-ab86-f49971541ef5

