### PR TITLE
DEMOS-1573 Fix: Request Extension button hidden instead of disabled

### DIFF
--- a/client/src/pages/deliverables/sections/DeliverableButtons.test.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableButtons.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DeliverableStatus } from "demos-server";
 
 import {
@@ -46,21 +46,25 @@ const renderButtons = (deliverable: DeliverableDetailsManagementDeliverable) =>
   );
 
 describe("DeliverableButtons", () => {
+  beforeEach(() => {
+    mockShowRequestExtensionDeliverableDialog.mockClear();
+  });
+
   it("renders the References button", () => {
     renderButtons(buildDeliverable());
     expect(screen.getByTestId(REFERENCES_BUTTON_NAME)).toHaveTextContent("References");
   });
 
-  it("renders the Request Extension button for Upcoming deliverables", () => {
+  it("renders the Request Extension button enabled for Upcoming deliverables", () => {
     renderButtons(buildDeliverable({ status: "Upcoming" }));
-    expect(screen.getByTestId(REQUEST_EXTENSION_BUTTON_NAME)).toHaveTextContent(
-      "Request Extension"
-    );
+    const button = screen.getByTestId(REQUEST_EXTENSION_BUTTON_NAME);
+    expect(button).toHaveTextContent("Request Extension");
+    expect(button).toBeEnabled();
   });
 
-  it("renders the Request Extension button for Past Due deliverables", () => {
+  it("renders the Request Extension button enabled for Past Due deliverables", () => {
     renderButtons(buildDeliverable({ status: "Past Due" }));
-    expect(screen.getByTestId(REQUEST_EXTENSION_BUTTON_NAME)).toBeInTheDocument();
+    expect(screen.getByTestId(REQUEST_EXTENSION_BUTTON_NAME)).toBeEnabled();
   });
 
   it.each<DeliverableStatus>([
@@ -69,9 +73,11 @@ describe("DeliverableButtons", () => {
     "Accepted",
     "Approved",
     "Received and Filed",
-  ])("hides the Request Extension button when status is %s", (status) => {
+  ])("disables the Request Extension button when status is %s", (status) => {
     renderButtons(buildDeliverable({ status }));
-    expect(screen.queryByTestId(REQUEST_EXTENSION_BUTTON_NAME)).not.toBeInTheDocument();
+    const button = screen.getByTestId(REQUEST_EXTENSION_BUTTON_NAME);
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
   });
 
   it("opens the Request Extension dialog when clicked", async () => {
@@ -85,5 +91,14 @@ describe("DeliverableButtons", () => {
       dueDate: MOCK_DELIVERABLE_1.dueDate,
       demonstration: { expirationDate: MOCK_DELIVERABLE_1.demonstration.expirationDate },
     });
+  });
+
+  it("does not open the Request Extension dialog when the button is disabled", async () => {
+    const user = userEvent.setup();
+    renderButtons(buildDeliverable({ status: "Approved" }));
+
+    await user.click(screen.getByTestId(REQUEST_EXTENSION_BUTTON_NAME));
+
+    expect(mockShowRequestExtensionDeliverableDialog).not.toHaveBeenCalled();
   });
 });

--- a/client/src/pages/deliverables/sections/DeliverableButtons.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableButtons.tsx
@@ -26,11 +26,13 @@ export const DeliverableButtons = ({
   return (
     <div className="flex gap-2" data-testid={DELIVERABLE_BUTTONS_NAME}>
       <TertiaryButton name={REFERENCES_BUTTON_NAME}>References</TertiaryButton>
-      {canRequestExtension(deliverable.status) && (
-        <SecondaryButton name={REQUEST_EXTENSION_BUTTON_NAME} onClick={handleRequestExtension}>
-          Request Extension
-        </SecondaryButton>
-      )}
+      <SecondaryButton
+        name={REQUEST_EXTENSION_BUTTON_NAME}
+        onClick={handleRequestExtension}
+        disabled={!canRequestExtension(deliverable.status)}
+      >
+        Request Extension
+      </SecondaryButton>
     </div>
   );
 };


### PR DESCRIPTION
QA finding on the merged DEMOS-1573 work: when a deliverable status is `Submitted`, `Under CMS Review`, `Accepted`, `Approved`, or `Received and Filed`, the **Request Extension** button was being hidden. Per the AC it should remain visible but disabled.

<img width="1921" height="881" alt="image" src="https://github.com/user-attachments/assets/a458e836-71e9-44bf-8a36-969b345c323f" />
