### PR TITLE
DEMOS-1959-adding-start-review-mutator

### DIFF
--- a/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
@@ -3,11 +3,12 @@ import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { EasternTZDate, parseJSDateToEasternTZDate } from "../../dateUtilities";
 
 // Types
-import { ApplicationStatus, DeliverableStatus, PersonType, TagName } from "../../types";
+import { ApplicationStatus, DeliverableStatus, Document, PersonType, TagName } from "../../types";
 import {
   Deliverable as PrismaDeliverable,
   Demonstration as PrismaDemonstration,
   DemonstrationTypeTagAssignment as PrismaDemonstrationTypeTagAssignment,
+  Document as PrismaDocument,
   User as PrismaUser,
 } from "@prisma/client";
 
@@ -19,9 +20,15 @@ import {
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
   checkDueDateInFuture,
+  checkDeliverableHasAtLeastOneDocument,
 } from "./checkDeliverableInputFunctions";
 
 // Mock imports
+vi.mock("../document", () => ({
+  selectManyDocuments: vi.fn(),
+}));
+
+import { selectManyDocuments } from "../document";
 
 describe("checkDeliverableInputFunctions", () => {
   describe("checkDemonstrationStatus", () => {
@@ -90,7 +97,7 @@ describe("checkDeliverableInputFunctions", () => {
           id: "abc123",
           statusId: "Accepted",
         },
-        "Cannot modify deliverable abc123 as it has already been finalized.",
+        "Cannot submit or modify deliverable abc123 as it has already been finalized.",
       ],
       [
         "Approved",
@@ -98,7 +105,7 @@ describe("checkDeliverableInputFunctions", () => {
           id: "abc123",
           statusId: "Approved",
         },
-        "Cannot modify deliverable abc123 as it has already been finalized.",
+        "Cannot submit or modify deliverable abc123 as it has already been finalized.",
       ],
       [
         "Received and Filed",
@@ -106,7 +113,7 @@ describe("checkDeliverableInputFunctions", () => {
           id: "abc123",
           statusId: "Received and Filed",
         },
-        "Cannot modify deliverable abc123 as it has already been finalized.",
+        "Cannot submit or modify deliverable abc123 as it has already been finalized.",
       ],
     ];
     it.each(checkDeliverableStatusInputs)(
@@ -233,6 +240,52 @@ describe("checkDeliverableInputFunctions", () => {
       const result = checkDueDateInFuture(testInput);
       expect(result).toBe(
         "Cannot request a due date in the past; requested Sat Sep 16 2023 23:22:11 GMT-0400 (Eastern Daylight Time)"
+      );
+    });
+  });
+
+  describe("checkDeliverableHasAtLeastOneDocument", () => {
+    const testTransaction = "I'm a test transaction!" as any;
+    const testDeliverableId = "72c01127-bf42-4b9f-a902-1a237ecdf7b7";
+    const testDeliverable: Partial<PrismaDeliverable> = {
+      id: testDeliverableId,
+    };
+
+    const mockDocumentList: Partial<PrismaDocument>[] = [
+      { id: "document1", deliverableId: testDeliverableId },
+      { id: "document2", deliverableId: testDeliverableId },
+    ];
+
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it("should return undefined if there is at least one document", async () => {
+      vi.mocked(selectManyDocuments).mockResolvedValue(mockDocumentList as PrismaDocument[]);
+
+      const result = await checkDeliverableHasAtLeastOneDocument(
+        testDeliverable as PrismaDeliverable,
+        testTransaction
+      );
+      expect(result).toBeUndefined();
+      expect(selectManyDocuments).toHaveBeenCalledExactlyOnceWith(
+        {
+          deliverableId: testDeliverableId,
+          deliverableIsCmsAttachedFile: false,
+        },
+        testTransaction
+      );
+    });
+
+    it("should return an error message if there are no documents returned", async () => {
+      vi.mocked(selectManyDocuments).mockResolvedValue([] as PrismaDocument[]);
+
+      const result = await checkDeliverableHasAtLeastOneDocument(
+        testDeliverable as PrismaDeliverable,
+        testTransaction
+      );
+      expect(result).toBe(
+        `Cannot submit deliverable ${testDeliverableId} because it has no state documents attached.`
       );
     });
   });

--- a/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
@@ -21,6 +21,7 @@ import {
   checkRequestedDeliverableDemonstrationType,
   checkDueDateInFuture,
   checkDeliverableHasAtLeastOneDocument,
+  checkDeliverableHasStatus,
 } from "./checkDeliverableInputFunctions";
 
 // Mock imports
@@ -286,6 +287,28 @@ describe("checkDeliverableInputFunctions", () => {
       );
       expect(result).toBe(
         `Cannot submit deliverable ${testDeliverableId} because it has no state documents attached.`
+      );
+    });
+  });
+
+  describe("checkDeliverableHasStatus", () => {
+    const testDeliverable: Partial<PrismaDeliverable> = {
+      id: "1e42da3a-9355-4c5d-a541-812a9f95ef56",
+      statusId: "Under CMS Review",
+    };
+
+    it("should return undefined if the passed status matches the object", async () => {
+      const result = checkDeliverableHasStatus(
+        testDeliverable as PrismaDeliverable,
+        "Under CMS Review"
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it("should return an error message the passed status does not match the object", async () => {
+      const result = checkDeliverableHasStatus(testDeliverable as PrismaDeliverable, "Approved");
+      expect(result).toBe(
+        "Deliverable expected to have status Approved; actual status was Under CMS Review."
       );
     });
   });

--- a/server/src/model/deliverable/checkDeliverableInputFunctions.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.ts
@@ -4,9 +4,11 @@ import {
   DemonstrationTypeTagAssignment as PrismaDemonstrationTypeTagAssignment,
   User as PrismaUser,
 } from "@prisma/client";
+import { PrismaTransactionClient } from "../../prismaClient";
 import { ApplicationStatus, DeliverableStatus, PersonType, TagName } from "../../types";
 import { findDuplicates } from "../../validationUtilities";
 import { EasternTZDate, getEasternNow } from "../../dateUtilities";
+import { selectManyDocuments } from "../document";
 
 export function checkDemonstrationStatus(demonstration: PrismaDemonstration): string | undefined {
   const approvedStatus: ApplicationStatus = "Approved";
@@ -18,6 +20,7 @@ export function checkDemonstrationStatus(demonstration: PrismaDemonstration): st
 export function checkDeliverableStatusNotFinalized(
   deliverable: PrismaDeliverable
 ): string | undefined {
+  // Cast enforced by DB constraints
   const deliverableStatus = deliverable.statusId as DeliverableStatus;
   const finalDeliverableStatuses: DeliverableStatus[] = [
     "Approved",
@@ -25,12 +28,13 @@ export function checkDeliverableStatusNotFinalized(
     "Received and Filed",
   ];
   if (finalDeliverableStatuses.includes(deliverableStatus)) {
-    return `Cannot modify deliverable ${deliverable.id} as it has already been finalized.`;
+    return `Cannot submit or modify deliverable ${deliverable.id} as it has already been finalized.`;
   }
 }
 
 export function checkOwnerPersonType(ownerUser: PrismaUser): string | undefined {
   const permittedOwnerPersonTypes: readonly PersonType[] = ["demos-admin", "demos-cms-user"];
+  // Cast enforced by DB constraints
   if (!permittedOwnerPersonTypes.includes(ownerUser.personTypeId as PersonType)) {
     return `User ${ownerUser.id} is not a CMS user; cannot own deliverable.`;
   }
@@ -63,5 +67,19 @@ export function checkDueDateInFuture(dueDate: EasternTZDate): string | undefined
   const easternNow = getEasternNow()["Current Time"];
   if (dueDate.easternTZDate.valueOf() < easternNow.easternTZDate.valueOf()) {
     return `Cannot request a due date in the past; requested ${dueDate.easternTZDate}`;
+  }
+}
+
+export async function checkDeliverableHasAtLeastOneDocument(
+  deliverable: PrismaDeliverable,
+  tx: PrismaTransactionClient
+): Promise<string | undefined> {
+  const deliverableDocuments = await selectManyDocuments(
+    { deliverableId: deliverable.id, deliverableIsCmsAttachedFile: false },
+    tx
+  );
+
+  if (deliverableDocuments.length === 0) {
+    return `Cannot submit deliverable ${deliverable.id} because it has no state documents attached.`;
   }
 }

--- a/server/src/model/deliverable/checkDeliverableInputFunctions.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.ts
@@ -83,3 +83,14 @@ export async function checkDeliverableHasAtLeastOneDocument(
     return `Cannot submit deliverable ${deliverable.id} because it has no state documents attached.`;
   }
 }
+
+export function checkDeliverableHasStatus(
+  deliverable: PrismaDeliverable,
+  expectedStatus: DeliverableStatus
+): string | undefined {
+  // Cast enforced by database constraints
+  const deliverableStatus = deliverable.statusId as DeliverableStatus;
+  if (deliverableStatus !== expectedStatus) {
+    return `Deliverable expected to have status ${expectedStatus}; actual status was ${deliverableStatus}.`;
+  }
+}

--- a/server/src/model/deliverable/createDeliverable.test.ts
+++ b/server/src/model/deliverable/createDeliverable.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TZDate } from "@date-fns/tz";
 
 // Types
+import { DeepPartial } from "../../testUtilities";
 import { CreateDeliverableInput, DateTimeOrLocalDate, DeliverableType } from "../../types";
 import { ParsedCreateDeliverableInput } from ".";
 import { Deliverable as PrismaDeliverable } from "@prisma/client";
@@ -44,12 +45,9 @@ describe("createDeliverable", () => {
     cmsOwnerUserId: "500e9bef-8745-4209-ac73-0a87fa5f888b",
     dueDate: "2025-11-21" as DateTimeOrLocalDate,
   };
-  const testContext: GraphQLContext = {
+  const testContext: DeepPartial<GraphQLContext> = {
     user: {
       id: "57f92f14-7c5e-4c78-a774-5a54d7e9c2e7",
-      cognitoSubject: "82d0e8e4-82d0-447c-b1bb-52227e49cf51",
-      personTypeId: "demos-cms-user",
-      permissions: ["View All Demonstrations"],
     },
   };
 
@@ -90,12 +88,12 @@ describe("createDeliverable", () => {
   });
 
   it("should parse the input to process dates", async () => {
-    await createDeliverable(testInput, testContext);
+    await createDeliverable(testInput, testContext as GraphQLContext);
     expect(parseCreateDeliverableInput).toHaveBeenCalledExactlyOnceWith(testInput);
   });
 
   it("should call the validation function with a transaction", async () => {
-    await createDeliverable(testInput, testContext);
+    await createDeliverable(testInput, testContext as GraphQLContext);
     expect(validateCreateDeliverableInput).toHaveBeenCalledExactlyOnceWith(
       mockParsedInput,
       mockTransaction
@@ -103,12 +101,12 @@ describe("createDeliverable", () => {
   });
 
   it("should call the insert function with a transaction", async () => {
-    await createDeliverable(testInput, testContext);
+    await createDeliverable(testInput, testContext as GraphQLContext);
     expect(insertDeliverable).toHaveBeenCalledExactlyOnceWith(mockParsedInput, mockTransaction);
   });
 
   it("should use an empty list if no demonstration types are passed", async () => {
-    await createDeliverable(testInput, testContext);
+    await createDeliverable(testInput, testContext as GraphQLContext);
     expect(setDeliverableDemonstrationTypes).toHaveBeenCalledExactlyOnceWith(
       {
         deliverableId: mockNewDeliverable.id,
@@ -130,7 +128,7 @@ describe("createDeliverable", () => {
     };
     vi.mocked(parseCreateDeliverableInput).mockReturnValue(expandedMockParsedInput);
 
-    await createDeliverable(expandedTestInput, testContext);
+    await createDeliverable(expandedTestInput, testContext as GraphQLContext);
     expect(setDeliverableDemonstrationTypes).toHaveBeenCalledExactlyOnceWith(
       {
         deliverableId: mockNewDeliverable.id,
@@ -142,7 +140,7 @@ describe("createDeliverable", () => {
   });
 
   it("should insert a deliverable action with a transaction", async () => {
-    await createDeliverable(testInput, testContext);
+    await createDeliverable(testInput, testContext as GraphQLContext);
     expect(insertDeliverableAction).toHaveBeenCalledExactlyOnceWith(
       {
         deliverableId: mockNewDeliverable.id,

--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Types
+import { DeepPartial } from "../../testUtilities";
 import {
   Deliverable as PrismaDeliverable,
   Demonstration as PrismaDemonstration,
@@ -40,6 +41,7 @@ vi.mock(".", () => ({
   createDeliverable: vi.fn(),
   getDeliverable: vi.fn(),
   getManyDeliverables: vi.fn(),
+  startDeliverableReview: vi.fn(),
   submitDeliverable: vi.fn(),
   updateDeliverable: vi.fn(),
 }));
@@ -68,6 +70,7 @@ import {
   createDeliverable,
   getDeliverable,
   getManyDeliverables,
+  startDeliverableReview,
   submitDeliverable,
   updateDeliverable,
 } from ".";
@@ -108,11 +111,11 @@ describe("deliverableResolvers", () => {
     },
   };
 
-  const testContext: GraphQLContext = {
+  const testContext: DeepPartial<GraphQLContext> = {
     user: {
       id: "testUserId",
     },
-  } as GraphQLContext;
+  };
 
   const testDocumentWithDeliverableParent: Partial<PrismaDocument> = {
     deliverableId: testDeliverableId,
@@ -141,16 +144,37 @@ describe("deliverableResolvers", () => {
       await deliverableResolvers.Mutation.submitDeliverable(
         undefined,
         { id: testDeliverableId },
+        testContext as GraphQLContext
+      );
+      expect(submitDeliverable).toHaveBeenCalledExactlyOnceWith(
+        testDeliverableId,
+        testContext as GraphQLContext
+      );
+    });
+  });
+
+  describe("Mutation.startDeliverableReview", () => {
+    it("calls startDeliverableReview with appropriate arguments", async () => {
+      await deliverableResolvers.Mutation.startDeliverableReview(
+        undefined,
+        { id: testDeliverableId },
+        testContext as GraphQLContext
+      );
+      expect(startDeliverableReview).toHaveBeenCalledExactlyOnceWith(
+        testDeliverableId,
         testContext
       );
-      expect(submitDeliverable).toHaveBeenCalledExactlyOnceWith(testDeliverableId, testContext);
     });
   });
 
   describe("Deliverable.cmsDocuments", () => {
     it("delegates to `documentData.getManyDocuments` with CMS filter as true", async () => {
       const mockDeliverable = { id: testDeliverableId } as PrismaDeliverable;
-      await deliverableResolvers.Deliverable.cmsDocuments(mockDeliverable, undefined, testContext);
+      await deliverableResolvers.Deliverable.cmsDocuments(
+        mockDeliverable,
+        undefined,
+        testContext as GraphQLContext
+      );
       expect(getManyDocuments).toHaveBeenCalledExactlyOnceWith(
         {
           AND: [{ deliverableId: testDeliverableId }, { deliverableIsCmsAttachedFile: true }],
@@ -166,7 +190,7 @@ describe("deliverableResolvers", () => {
       await deliverableResolvers.Deliverable.stateDocuments(
         mockDeliverable,
         undefined,
-        testContext
+        testContext as GraphQLContext
       );
       expect(getManyDocuments).toHaveBeenCalledExactlyOnceWith(
         {

--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -40,6 +40,7 @@ vi.mock(".", () => ({
   createDeliverable: vi.fn(),
   getDeliverable: vi.fn(),
   getManyDeliverables: vi.fn(),
+  submitDeliverable: vi.fn(),
   updateDeliverable: vi.fn(),
 }));
 
@@ -63,7 +64,13 @@ vi.mock("../deliverableAction", () => ({
   getFormattedDeliverableActions: vi.fn(),
 }));
 
-import { createDeliverable, getDeliverable, getManyDeliverables, updateDeliverable } from ".";
+import {
+  createDeliverable,
+  getDeliverable,
+  getManyDeliverables,
+  submitDeliverable,
+  updateDeliverable,
+} from ".";
 import { getApplication } from "../application";
 import { getUser } from "../user";
 import { getManyDocuments } from "../document";
@@ -127,6 +134,17 @@ describe("deliverableResolvers", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+  });
+
+  describe("Mutation.submitDeliverable", () => {
+    it("calls submitDeliverable with appropriate arguments", async () => {
+      await deliverableResolvers.Mutation.submitDeliverable(
+        undefined,
+        { id: testDeliverableId },
+        testContext
+      );
+      expect(submitDeliverable).toHaveBeenCalledExactlyOnceWith(testDeliverableId, testContext);
+    });
   });
 
   describe("Deliverable.cmsDocuments", () => {

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -7,7 +7,13 @@ import {
 } from "@prisma/client";
 import { GraphQLContext } from "../../auth";
 import { GraphQLResolveInfo } from "graphql";
-import { createDeliverable, getDeliverable, getManyDeliverables, updateDeliverable } from ".";
+import {
+  createDeliverable,
+  getDeliverable,
+  getManyDeliverables,
+  submitDeliverable,
+  updateDeliverable,
+} from ".";
 import {
   CreateDeliverableInput,
   DeliverableAction,
@@ -119,6 +125,9 @@ export const deliverableResolvers = {
       context: GraphQLContext
     ) => {
       return await updateDeliverable(args.id, args.input, context);
+    },
+    submitDeliverable: async (parent: unknown, args: { id: string }, context: GraphQLContext) => {
+      return await submitDeliverable(args.id, context);
     },
   },
 

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -11,6 +11,7 @@ import {
   createDeliverable,
   getDeliverable,
   getManyDeliverables,
+  startDeliverableReview,
   submitDeliverable,
   updateDeliverable,
 } from ".";
@@ -128,6 +129,13 @@ export const deliverableResolvers = {
     },
     submitDeliverable: async (parent: unknown, args: { id: string }, context: GraphQLContext) => {
       return await submitDeliverable(args.id, context);
+    },
+    startDeliverableReview: async (
+      parent: unknown,
+      args: { id: string },
+      context: GraphQLContext
+    ) => {
+      return await startDeliverableReview(args.id, context);
     },
   },
 

--- a/server/src/model/deliverable/deliverableSchema.ts
+++ b/server/src/model/deliverable/deliverableSchema.ts
@@ -62,6 +62,7 @@ export const deliverableSchema = gql`
     createDeliverable(input: CreateDeliverableInput): Deliverable
     updateDeliverable(id: ID!, input: UpdateDeliverableInput!): Deliverable
     submitDeliverable(id: ID!): Deliverable
+    startDeliverableReview(id: ID!): Deliverable
   }
 `;
 

--- a/server/src/model/deliverable/deliverableSchema.ts
+++ b/server/src/model/deliverable/deliverableSchema.ts
@@ -61,6 +61,7 @@ export const deliverableSchema = gql`
   type Mutation {
     createDeliverable(input: CreateDeliverableInput): Deliverable
     updateDeliverable(id: ID!, input: UpdateDeliverableInput!): Deliverable
+    submitDeliverable(id: ID!): Deliverable
   }
 `;
 

--- a/server/src/model/deliverable/index.ts
+++ b/server/src/model/deliverable/index.ts
@@ -6,6 +6,7 @@ export {
   checkForDuplicateDemonstrationTypes,
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
+  checkDeliverableHasAtLeastOneDocument,
 } from "./checkDeliverableInputFunctions";
 export { createDeliverable } from "./createDeliverable";
 export { manuallyUpdateDeliverableDueDate } from "./manuallyUpdateDeliverableDueDate";
@@ -13,8 +14,10 @@ export { parseCreateDeliverableInput, parseUpdateDeliverableInput } from "./pars
 export { resolveDeliverable, resolveManyDeliverables } from "./deliverableResolvers";
 export {
   validateCreateDeliverableInput,
+  validateSubmitDeliverableInput,
   validateUpdateDeliverableInput,
 } from "./validateDeliverableInputs";
+export { submitDeliverable } from "./submitDeliverable";
 export { updateDeliverable } from "./updateDeliverable";
 export { updateDeliverableDemonstrationTypes } from "./updateDeliverableDemonstrationTypes";
 

--- a/server/src/model/deliverable/index.ts
+++ b/server/src/model/deliverable/index.ts
@@ -7,6 +7,7 @@ export {
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
   checkDeliverableHasAtLeastOneDocument,
+  checkDeliverableHasStatus,
 } from "./checkDeliverableInputFunctions";
 export { createDeliverable } from "./createDeliverable";
 export { manuallyUpdateDeliverableDueDate } from "./manuallyUpdateDeliverableDueDate";
@@ -14,9 +15,11 @@ export { parseCreateDeliverableInput, parseUpdateDeliverableInput } from "./pars
 export { resolveDeliverable, resolveManyDeliverables } from "./deliverableResolvers";
 export {
   validateCreateDeliverableInput,
+  validateStartDeliverableReviewInput,
   validateSubmitDeliverableInput,
   validateUpdateDeliverableInput,
 } from "./validateDeliverableInputs";
+export { startDeliverableReview } from "./startDeliverableReview";
 export { submitDeliverable } from "./submitDeliverable";
 export { updateDeliverable } from "./updateDeliverable";
 export { updateDeliverableDemonstrationTypes } from "./updateDeliverableDemonstrationTypes";

--- a/server/src/model/deliverable/manuallyUpdateDeliverableDueDate.test.ts
+++ b/server/src/model/deliverable/manuallyUpdateDeliverableDueDate.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Types
+import { DeepPartial } from "../../testUtilities";
 import { GraphQLContext } from "../../auth/auth.util";
 import { Deliverable as PrismaDeliverable } from "@prisma/client";
 import { DeliverableStatus } from "../../types";
@@ -28,12 +29,9 @@ import { TZDate } from "@date-fns/tz";
 describe("manuallyUpdateDeliverableDueDate", () => {
   // Test inputs
   const testDeliverableId = "03cb9763-1dea-4a40-a449-dc9fbc969c50";
-  const testContext: GraphQLContext = {
+  const testContext: DeepPartial<GraphQLContext> = {
     user: {
       id: "57f92f14-7c5e-4c78-a774-5a54d7e9c2e7",
-      cognitoSubject: "82d0e8e4-82d0-447c-b1bb-52227e49cf51",
-      personTypeId: "demos-cms-user",
-      permissions: ["View All Demonstrations"],
     },
   };
 
@@ -70,7 +68,7 @@ describe("manuallyUpdateDeliverableDueDate", () => {
     const result = await manuallyUpdateDeliverableDueDate(
       testDeliverableId,
       testInput,
-      testContext,
+      testContext as GraphQLContext,
       mockTransaction
     );
     expect(result).toBeUndefined();
@@ -97,7 +95,7 @@ describe("manuallyUpdateDeliverableDueDate", () => {
       await manuallyUpdateDeliverableDueDate(
         testDeliverableId,
         testInput,
-        testContext,
+        testContext as GraphQLContext,
         mockTransaction
       );
       throw new Error("Expected manuallyUpdateDeliverableDueDate to throw, but it did not.");
@@ -127,7 +125,7 @@ describe("manuallyUpdateDeliverableDueDate", () => {
     await manuallyUpdateDeliverableDueDate(
       testDeliverableId,
       testInput,
-      testContext,
+      testContext as GraphQLContext,
       mockTransaction
     );
     expect(checkDueDateInFuture).toHaveBeenCalledExactlyOnceWith(testInput.dueDate!.newDueDate);
@@ -154,7 +152,7 @@ describe("manuallyUpdateDeliverableDueDate", () => {
     await manuallyUpdateDeliverableDueDate(
       testDeliverableId,
       testInput,
-      testContext,
+      testContext as GraphQLContext,
       mockTransaction
     );
     expect(checkDueDateInFuture).toHaveBeenCalledExactlyOnceWith(testInput.dueDate!.newDueDate);
@@ -180,7 +178,7 @@ describe("manuallyUpdateDeliverableDueDate", () => {
         note: testInput.dueDate!.dateChangeNote,
         oldDueDate: mockDeliverable.dueDate,
         newDueDate: testInput.dueDate!.newDueDate.easternTZDate,
-        userId: testContext.user.id,
+        userId: testContext.user!.id,
       },
       mockTransaction
     );
@@ -208,7 +206,7 @@ describe("manuallyUpdateDeliverableDueDate", () => {
     await manuallyUpdateDeliverableDueDate(
       testDeliverableId,
       testInput,
-      testContext,
+      testContext as GraphQLContext,
       mockTransaction
     );
     expect(checkDueDateInFuture).toHaveBeenCalledExactlyOnceWith(testInput.dueDate!.newDueDate);
@@ -234,7 +232,7 @@ describe("manuallyUpdateDeliverableDueDate", () => {
         note: testInput.dueDate!.dateChangeNote,
         oldDueDate: mockDeliverable.dueDate,
         newDueDate: testInput.dueDate!.newDueDate.easternTZDate,
-        userId: testContext.user.id,
+        userId: testContext.user!.id,
       },
       mockTransaction
     );

--- a/server/src/model/deliverable/startDeliverableReview.test.ts
+++ b/server/src/model/deliverable/startDeliverableReview.test.ts
@@ -1,0 +1,147 @@
+// Vitest and other helpers
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Types
+import { DeepPartial } from "../../testUtilities";
+import { GraphQLContext } from "../../auth";
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
+
+// Functions under test
+import { startDeliverableReview } from "./startDeliverableReview";
+
+// Mock imports
+vi.mock("../../prismaClient", () => ({
+  prisma: vi.fn(),
+}));
+
+vi.mock(".", () => ({
+  editDeliverable: vi.fn(),
+  getDeliverable: vi.fn(),
+  validateStartDeliverableReviewInput: vi.fn(),
+}));
+
+vi.mock("../deliverableAction/queries", () => ({
+  insertDeliverableAction: vi.fn(),
+}));
+
+import { prisma } from "../../prismaClient";
+import { editDeliverable, getDeliverable, validateStartDeliverableReviewInput } from ".";
+import { insertDeliverableAction } from "../deliverableAction/queries";
+
+describe("startDeliverableReview", () => {
+  // Test inputs
+  const testDeliverableId = "b18cf1ce-3e41-4a71-b4f4-585f343bc74f";
+  const testAdminUserContext: DeepPartial<GraphQLContext> = {
+    user: {
+      id: "0a3bd415-39a3-4f72-a067-418a5219216a",
+      personTypeId: "demos-admin",
+    },
+  };
+  const testCmsUserContext: DeepPartial<GraphQLContext> = {
+    user: {
+      id: "3f676b18-15cd-4eea-bf20-40281974a18e",
+      personTypeId: "demos-cms-user",
+    },
+  };
+  const testStateUserContext: DeepPartial<GraphQLContext> = {
+    user: {
+      id: "526903b0-badf-4154-95d3-3584b0351e90",
+      personTypeId: "demos-state-user",
+    },
+  };
+
+  // Mock results
+  const mockUnstartedDeliverable: Partial<PrismaDeliverable> = {
+    id: testDeliverableId,
+    statusId: "Submitted",
+    dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
+  };
+  const mockStartedDeliverable: Partial<PrismaDeliverable> = {
+    id: testDeliverableId,
+    statusId: "Under CMS Review",
+    dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
+  };
+  const mockNow = new Date(2026, 3, 27, 10, 4, 19, 232);
+
+  // Mock transaction
+  const mockTransaction: any = "Test!";
+  const mockPrismaClient = {
+    $transaction: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+    vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
+    vi.mocked(getDeliverable).mockResolvedValue(mockUnstartedDeliverable as PrismaDeliverable);
+    vi.mocked(editDeliverable).mockResolvedValue(mockStartedDeliverable as PrismaDeliverable);
+    mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should get the deliverable before making changes", async () => {
+    await startDeliverableReview(testDeliverableId, testAdminUserContext as GraphQLContext);
+    expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
+      { id: testDeliverableId },
+      mockTransaction
+    );
+  });
+
+  it("should not throw if the user context is an admin or CMS user", async () => {
+    expect(
+      startDeliverableReview(testDeliverableId, testAdminUserContext as GraphQLContext)
+    ).resolves.toBeDefined();
+
+    expect(
+      startDeliverableReview(testDeliverableId, testCmsUserContext as GraphQLContext)
+    ).resolves.toBeDefined();
+  });
+
+  it("should throw if the user context is a state user", async () => {
+    try {
+      await startDeliverableReview(testDeliverableId, testStateUserContext as GraphQLContext);
+      throw new Error("Expected startDeliverableReview to throw, but it did not.");
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      const error = e as Error;
+      expect(error.message).toBe("Only Admin Users and CMS Users may start the review process.");
+    }
+  });
+
+  it("should call the validator on the unchanged deliverable", async () => {
+    await startDeliverableReview(testDeliverableId, testCmsUserContext as GraphQLContext);
+    expect(validateStartDeliverableReviewInput).toHaveBeenCalledExactlyOnceWith(
+      mockUnstartedDeliverable
+    );
+  });
+
+  it("should call edit function to set the status to under CMS review", async () => {
+    await startDeliverableReview(testDeliverableId, testCmsUserContext as GraphQLContext);
+    expect(editDeliverable).toHaveBeenCalledExactlyOnceWith(
+      testDeliverableId,
+      { statusId: "Under CMS Review" },
+      mockTransaction
+    );
+  });
+
+  it("should log an action for the submission", async () => {
+    await startDeliverableReview(testDeliverableId, testCmsUserContext as GraphQLContext);
+    expect(insertDeliverableAction).toHaveBeenCalledExactlyOnceWith(
+      {
+        deliverableId: testDeliverableId,
+        actionType: "Started Review",
+        actionTime: mockNow,
+        oldStatus: mockUnstartedDeliverable.statusId,
+        newStatus: mockStartedDeliverable.statusId,
+        oldDueDate: mockUnstartedDeliverable.dueDate,
+        newDueDate: mockStartedDeliverable.dueDate,
+        userId: testCmsUserContext.user!.id,
+      },
+      mockTransaction
+    );
+  });
+});

--- a/server/src/model/deliverable/startDeliverableReview.ts
+++ b/server/src/model/deliverable/startDeliverableReview.ts
@@ -1,0 +1,45 @@
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
+import { GraphQLContext } from "../../auth/auth.util";
+import { DeliverableStatus, PersonType } from "../../types";
+import { prisma } from "../../prismaClient";
+import { editDeliverable, getDeliverable, validateStartDeliverableReviewInput } from ".";
+import { insertDeliverableAction } from "../deliverableAction/queries";
+
+export async function startDeliverableReview(
+  deliverableId: string,
+  context: GraphQLContext
+): Promise<PrismaDeliverable> {
+  // This probably will be modified when permissions are updated
+  const allowedPersonTypes: PersonType[] = ["demos-admin", "demos-cms-user"];
+  if (!allowedPersonTypes.includes(context.user.personTypeId)) {
+    throw new Error("Only Admin Users and CMS Users may start the review process.");
+  }
+
+  return await prisma().$transaction(async (tx) => {
+    const unstartedDeliverable = await getDeliverable({ id: deliverableId }, tx);
+    validateStartDeliverableReviewInput(unstartedDeliverable);
+
+    const startedDeliverable = await editDeliverable(
+      deliverableId,
+      { statusId: "Under CMS Review" },
+      tx
+    );
+
+    // Casts below enforced by database
+    await insertDeliverableAction(
+      {
+        deliverableId: deliverableId,
+        actionType: "Started Review",
+        actionTime: new Date(),
+        oldStatus: unstartedDeliverable.statusId as DeliverableStatus,
+        newStatus: startedDeliverable.statusId as DeliverableStatus,
+        oldDueDate: unstartedDeliverable.dueDate,
+        newDueDate: startedDeliverable.dueDate,
+        userId: context.user.id,
+      },
+      tx
+    );
+
+    return startedDeliverable;
+  });
+}

--- a/server/src/model/deliverable/submitDeliverable.test.ts
+++ b/server/src/model/deliverable/submitDeliverable.test.ts
@@ -1,0 +1,116 @@
+// Vitest and other helpers
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Types
+import { GraphQLContext } from "../../auth";
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
+
+// Functions under test
+import { submitDeliverable } from "./submitDeliverable";
+
+// Mock imports
+vi.mock("../../prismaClient", () => ({
+  prisma: vi.fn(),
+}));
+
+vi.mock(".", () => ({
+  editDeliverable: vi.fn(),
+  getDeliverable: vi.fn(),
+  validateSubmitDeliverableInput: vi.fn(),
+}));
+
+vi.mock("../deliverableAction/queries", () => ({
+  insertDeliverableAction: vi.fn(),
+}));
+
+import { prisma } from "../../prismaClient";
+import { editDeliverable, getDeliverable, validateSubmitDeliverableInput } from ".";
+import { insertDeliverableAction } from "../deliverableAction/queries";
+
+describe("submitDeliverable", () => {
+  // Test inputs
+  const testDeliverableId = "b18cf1ce-3e41-4a71-b4f4-585f343bc74f";
+  const testContext: GraphQLContext = {
+    user: {
+      id: "57f92f14-7c5e-4c78-a774-5a54d7e9c2e7",
+      cognitoSubject: "82d0e8e4-82d0-447c-b1bb-52227e49cf51",
+      personTypeId: "demos-cms-user",
+      permissions: ["View All Demonstrations"],
+    },
+  };
+
+  // Mock results
+  const mockUnsubmittedDeliverable: Partial<PrismaDeliverable> = {
+    id: testDeliverableId,
+    statusId: "Upcoming",
+    dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
+  };
+  const mockSubmittedDeliverable: Partial<PrismaDeliverable> = {
+    id: testDeliverableId,
+    statusId: "Submitted",
+    dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
+  };
+  const mockNow = new Date(2026, 3, 27, 10, 4, 19, 232);
+
+  // Mock transaction
+  const mockTransaction: any = "Test!";
+  const mockPrismaClient = {
+    $transaction: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+    vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
+    vi.mocked(getDeliverable).mockResolvedValue(mockUnsubmittedDeliverable as PrismaDeliverable);
+    vi.mocked(editDeliverable).mockResolvedValue(mockSubmittedDeliverable as PrismaDeliverable);
+    mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should get the deliverable before making changes", async () => {
+    await submitDeliverable(testDeliverableId, testContext);
+    expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
+      { id: testDeliverableId },
+      mockTransaction
+    );
+  });
+
+  it("should call the validator on the unchanged deliverable", async () => {
+    await submitDeliverable(testDeliverableId, testContext);
+    expect(validateSubmitDeliverableInput).toHaveBeenCalledExactlyOnceWith(
+      mockUnsubmittedDeliverable,
+      mockTransaction
+    );
+  });
+
+  it("should call edit function to set the status to submitted", async () => {
+    await submitDeliverable(testDeliverableId, testContext);
+    expect(editDeliverable).toHaveBeenCalledExactlyOnceWith(
+      testDeliverableId,
+      { statusId: "Submitted" },
+      mockTransaction
+    );
+  });
+
+  it("should log an action for the submission", async () => {
+    await submitDeliverable(testDeliverableId, testContext);
+    expect(insertDeliverableAction).toHaveBeenCalledExactlyOnceWith(
+      {
+        deliverableId: testDeliverableId,
+        actionType: "Submitted Deliverable",
+        actionTime: mockNow,
+        oldStatus: mockUnsubmittedDeliverable.statusId,
+        newStatus: mockSubmittedDeliverable.statusId,
+        oldDueDate: mockUnsubmittedDeliverable.dueDate,
+        newDueDate: mockSubmittedDeliverable.dueDate,
+        userId: testContext.user.id,
+      },
+      mockTransaction
+    );
+  });
+});

--- a/server/src/model/deliverable/submitDeliverable.test.ts
+++ b/server/src/model/deliverable/submitDeliverable.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Types
+import { DeepPartial } from "../../testUtilities";
 import { GraphQLContext } from "../../auth";
 import { Deliverable as PrismaDeliverable } from "@prisma/client";
 
@@ -30,12 +31,9 @@ import { insertDeliverableAction } from "../deliverableAction/queries";
 describe("submitDeliverable", () => {
   // Test inputs
   const testDeliverableId = "b18cf1ce-3e41-4a71-b4f4-585f343bc74f";
-  const testContext: GraphQLContext = {
+  const testContext: DeepPartial<GraphQLContext> = {
     user: {
       id: "57f92f14-7c5e-4c78-a774-5a54d7e9c2e7",
-      cognitoSubject: "82d0e8e4-82d0-447c-b1bb-52227e49cf51",
-      personTypeId: "demos-cms-user",
-      permissions: ["View All Demonstrations"],
     },
   };
 
@@ -73,7 +71,7 @@ describe("submitDeliverable", () => {
   });
 
   it("should get the deliverable before making changes", async () => {
-    await submitDeliverable(testDeliverableId, testContext);
+    await submitDeliverable(testDeliverableId, testContext as GraphQLContext);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
       mockTransaction
@@ -81,7 +79,7 @@ describe("submitDeliverable", () => {
   });
 
   it("should call the validator on the unchanged deliverable", async () => {
-    await submitDeliverable(testDeliverableId, testContext);
+    await submitDeliverable(testDeliverableId, testContext as GraphQLContext);
     expect(validateSubmitDeliverableInput).toHaveBeenCalledExactlyOnceWith(
       mockUnsubmittedDeliverable,
       mockTransaction
@@ -89,7 +87,7 @@ describe("submitDeliverable", () => {
   });
 
   it("should call edit function to set the status to submitted", async () => {
-    await submitDeliverable(testDeliverableId, testContext);
+    await submitDeliverable(testDeliverableId, testContext as GraphQLContext);
     expect(editDeliverable).toHaveBeenCalledExactlyOnceWith(
       testDeliverableId,
       { statusId: "Submitted" },
@@ -98,7 +96,7 @@ describe("submitDeliverable", () => {
   });
 
   it("should log an action for the submission", async () => {
-    await submitDeliverable(testDeliverableId, testContext);
+    await submitDeliverable(testDeliverableId, testContext as GraphQLContext);
     expect(insertDeliverableAction).toHaveBeenCalledExactlyOnceWith(
       {
         deliverableId: testDeliverableId,
@@ -108,7 +106,7 @@ describe("submitDeliverable", () => {
         newStatus: mockSubmittedDeliverable.statusId,
         oldDueDate: mockUnsubmittedDeliverable.dueDate,
         newDueDate: mockSubmittedDeliverable.dueDate,
-        userId: testContext.user.id,
+        userId: testContext.user!.id,
       },
       mockTransaction
     );

--- a/server/src/model/deliverable/submitDeliverable.ts
+++ b/server/src/model/deliverable/submitDeliverable.ts
@@ -1,0 +1,39 @@
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
+import { GraphQLContext } from "../../auth/auth.util";
+import { DeliverableStatus } from "../../types";
+import { prisma } from "../../prismaClient";
+import { editDeliverable, getDeliverable, validateSubmitDeliverableInput } from ".";
+import { insertDeliverableAction } from "../deliverableAction/queries";
+
+export async function submitDeliverable(
+  deliverableId: string,
+  context: GraphQLContext
+): Promise<PrismaDeliverable> {
+  return await prisma().$transaction(async (tx) => {
+    const unsubmittedDeliverable = await getDeliverable({ id: deliverableId }, tx);
+    await validateSubmitDeliverableInput(unsubmittedDeliverable, tx);
+
+    const submittedDeliverable = await editDeliverable(
+      deliverableId,
+      { statusId: "Submitted" },
+      tx
+    );
+
+    // Casts below enforced by database
+    await insertDeliverableAction(
+      {
+        deliverableId: deliverableId,
+        actionType: "Submitted Deliverable",
+        actionTime: new Date(),
+        oldStatus: unsubmittedDeliverable.statusId as DeliverableStatus,
+        newStatus: submittedDeliverable.statusId as DeliverableStatus,
+        oldDueDate: unsubmittedDeliverable.dueDate,
+        newDueDate: submittedDeliverable.dueDate,
+        userId: context.user.id,
+      },
+      tx
+    );
+
+    return submittedDeliverable;
+  });
+}

--- a/server/src/model/deliverable/updateDeliverable.test.ts
+++ b/server/src/model/deliverable/updateDeliverable.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TZDate } from "@date-fns/tz";
 
 // Types
+import { DeepPartial } from "../../testUtilities";
 import { UpdateDeliverableInput } from "../../types";
 import { EditDeliverableInput, ParsedUpdateDeliverableInput } from ".";
 import { GraphQLContext } from "../../auth/auth.util";
@@ -47,12 +48,9 @@ describe("updateDeliverable", () => {
   const testInput: UpdateDeliverableInput = {
     name: testName,
   };
-  const testContext: GraphQLContext = {
+  const testContext: DeepPartial<GraphQLContext> = {
     user: {
       id: "57f92f14-7c5e-4c78-a774-5a54d7e9c2e7",
-      cognitoSubject: "82d0e8e4-82d0-447c-b1bb-52227e49cf51",
-      personTypeId: "demos-cms-user",
-      permissions: ["View All Demonstrations"],
     },
   };
 
@@ -75,7 +73,7 @@ describe("updateDeliverable", () => {
   });
 
   it("should check for non-null in all the fields", async () => {
-    await updateDeliverable(testDeliverableId, testInput, testContext);
+    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
     expect(checkOptionalNotNullFields).toHaveBeenCalledExactlyOnceWith(
       ["name", "cmsOwnerUserId", "dueDate", "demonstrationTypes"],
       testInput
@@ -83,12 +81,12 @@ describe("updateDeliverable", () => {
   });
 
   it("should parse the input", async () => {
-    await updateDeliverable(testDeliverableId, testInput, testContext);
+    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
     expect(parseUpdateDeliverableInput).toHaveBeenCalledExactlyOnceWith(testInput);
   });
 
   it("should call the validation function with a transaction", async () => {
-    await updateDeliverable(testDeliverableId, testInput, testContext);
+    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
     expect(validateUpdateDeliverableInput).toHaveBeenCalledExactlyOnceWith(
       testDeliverableId,
       mockParseInputResult,
@@ -97,7 +95,7 @@ describe("updateDeliverable", () => {
   });
 
   it("should edit the deliverable and then fetch the final version within a transaction", async () => {
-    await updateDeliverable(testDeliverableId, testInput, testContext);
+    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
     expect(editDeliverable).toHaveBeenCalledExactlyOnceWith(
       testDeliverableId,
       { name: mockParseInputResult.name },
@@ -130,7 +128,7 @@ describe("updateDeliverable", () => {
       // That is why this mock is necessary, and needs to change for each set of parameters
       vi.mocked(parseUpdateDeliverableInput).mockReturnValue(mockParseInputResult);
 
-      await updateDeliverable(testDeliverableId, testInput, testContext);
+      await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
       expect(editDeliverable).toHaveBeenCalledWith(
         testDeliverableId,
         expectedEditInput,
@@ -153,7 +151,7 @@ describe("updateDeliverable", () => {
     };
     vi.mocked(parseUpdateDeliverableInput).mockReturnValue(mockParseInputResult);
 
-    await updateDeliverable(testDeliverableId, testInput, testContext);
+    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
     expect(editDeliverable).not.toHaveBeenCalled();
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
@@ -162,7 +160,7 @@ describe("updateDeliverable", () => {
   });
 
   it("should always call the demonstration type and due date update functions", async () => {
-    await updateDeliverable(testDeliverableId, testInput, testContext);
+    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
     expect(updateDeliverableDemonstrationTypes).toHaveBeenCalledExactlyOnceWith(
       testDeliverableId,
       mockParseInputResult,

--- a/server/src/model/deliverable/validateDeliverableInputs.test.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.test.ts
@@ -17,6 +17,7 @@ import { EasternTZDate } from "../../dateUtilities";
 // Functions under test
 import {
   validateCreateDeliverableInput,
+  validateSubmitDeliverableInput,
   validateUpdateDeliverableInput,
 } from "./validateDeliverableInputs";
 
@@ -39,6 +40,7 @@ vi.mock(".", () => ({
   checkDueDateInFuture: vi.fn(),
   checkOwnerPersonType: vi.fn(),
   checkRequestedDeliverableDemonstrationType: vi.fn(),
+  checkDeliverableHasAtLeastOneDocument: vi.fn(),
   getDeliverable: vi.fn(),
 }));
 
@@ -51,6 +53,7 @@ import {
   checkDueDateInFuture,
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
+  checkDeliverableHasAtLeastOneDocument,
   getDeliverable,
 } from ".";
 
@@ -542,6 +545,107 @@ describe("validateDeliverableInputs", () => {
           "The deliverable finalized status check failed!",
           "The owner person type check failed",
           "The demonstration type check failed",
+        ]);
+      }
+    });
+  });
+
+  describe("validateSubmitDeliverableInput", () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it("should not throw if none of the rules are violated", async () => {
+      // Note: don't need to set returns to undefined, as this is what vi.fn() does already
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Upcoming",
+        cmsOwnerUserId: "7d8fdea5-ca19-42e5-af50-98836b6d47db",
+      };
+
+      await expect(
+        validateSubmitDeliverableInput(testInput as PrismaDeliverable, mockTransaction)
+      ).resolves.toBeUndefined();
+    });
+
+    it("should throw if the deliverable status check fails", async () => {
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Approved",
+        cmsOwnerUserId: "7d8fdea5-ca19-42e5-af50-98836b6d47db",
+      };
+      vi.mocked(checkDeliverableStatusNotFinalized).mockReturnValue(
+        "The deliverable finalized status check failed!"
+      );
+
+      try {
+        await validateSubmitDeliverableInput(testInput as PrismaDeliverable, mockTransaction);
+        throw new Error("Expected validateSubmitDeliverableInput to throw, but it did not.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for submitDeliverable have failed."
+        );
+        expect(error.extensions.code).toBe("SUBMIT_DELIVERABLE_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable finalized status check failed!",
+        ]);
+      }
+    });
+
+    it("should throw if the deliverable document check failes", async () => {
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Submitted",
+        cmsOwnerUserId: "7d8fdea5-ca19-42e5-af50-98836b6d47db",
+      };
+      vi.mocked(checkDeliverableHasAtLeastOneDocument).mockResolvedValue(
+        "The deliverable document check has failed!"
+      );
+
+      try {
+        await validateSubmitDeliverableInput(testInput as PrismaDeliverable, mockTransaction);
+        throw new Error("Expected validateSubmitDeliverableInput to throw, but it did not.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for submitDeliverable have failed."
+        );
+        expect(error.extensions.code).toBe("SUBMIT_DELIVERABLE_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable document check has failed!",
+        ]);
+      }
+    });
+
+    it("should combine all errors into one object", async () => {
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Approved",
+        cmsOwnerUserId: "7d8fdea5-ca19-42e5-af50-98836b6d47db",
+      };
+      vi.mocked(checkDeliverableStatusNotFinalized).mockReturnValue(
+        "The deliverable finalized status check failed!"
+      );
+      vi.mocked(checkDeliverableHasAtLeastOneDocument).mockResolvedValue(
+        "The deliverable document check has failed!"
+      );
+
+      try {
+        await validateSubmitDeliverableInput(testInput as PrismaDeliverable, mockTransaction);
+        throw new Error("Expected validateSubmitDeliverableInput to throw, but it did not.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for submitDeliverable have failed."
+        );
+        expect(error.extensions.code).toBe("SUBMIT_DELIVERABLE_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable finalized status check failed!",
+          "The deliverable document check has failed!",
         ]);
       }
     });

--- a/server/src/model/deliverable/validateDeliverableInputs.test.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.test.ts
@@ -19,6 +19,7 @@ import {
   validateCreateDeliverableInput,
   validateSubmitDeliverableInput,
   validateUpdateDeliverableInput,
+  validateStartDeliverableReviewInput,
 } from "./validateDeliverableInputs";
 
 // Mock imports
@@ -41,6 +42,7 @@ vi.mock(".", () => ({
   checkOwnerPersonType: vi.fn(),
   checkRequestedDeliverableDemonstrationType: vi.fn(),
   checkDeliverableHasAtLeastOneDocument: vi.fn(),
+  checkDeliverableHasStatus: vi.fn(),
   getDeliverable: vi.fn(),
 }));
 
@@ -54,6 +56,7 @@ import {
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
   checkDeliverableHasAtLeastOneDocument,
+  checkDeliverableHasStatus,
   getDeliverable,
 } from ".";
 
@@ -646,6 +649,45 @@ describe("validateDeliverableInputs", () => {
         expect(error.extensions.originalMessages).toStrictEqual([
           "The deliverable finalized status check failed!",
           "The deliverable document check has failed!",
+        ]);
+      }
+    });
+  });
+
+  describe("validateStartDeliverableReviewInput", () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it("should not throw if none of the rules are violated", async () => {
+      // Note: don't need to set returns to undefined, as this is what vi.fn() does already
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Submitted",
+      };
+
+      expect(validateStartDeliverableReviewInput(testInput as PrismaDeliverable)).toBeUndefined();
+    });
+
+    it("should throw if the deliverable status check fails", async () => {
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Upcoming",
+      };
+      vi.mocked(checkDeliverableHasStatus).mockReturnValue("The deliverable status check failed!");
+
+      try {
+        validateStartDeliverableReviewInput(testInput as PrismaDeliverable);
+        throw new Error("Expected validateStartDeliverableReviewInput to throw, but it did not.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for startDeliverableReview have failed."
+        );
+        expect(error.extensions.code).toBe("START_DELIVERABLE_REVIEW_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable status check failed!",
         ]);
       }
     });

--- a/server/src/model/deliverable/validateDeliverableInputs.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.ts
@@ -111,8 +111,10 @@ export async function validateSubmitDeliverableInput(
 ): Promise<void> {
   const errors: (string | undefined)[] = [];
 
-  errors.push(checkDeliverableStatusNotFinalized(deliverable));
-  errors.push(await checkDeliverableHasAtLeastOneDocument(deliverable, tx));
+  errors.push(
+    checkDeliverableStatusNotFinalized(deliverable),
+    await checkDeliverableHasAtLeastOneDocument(deliverable, tx)
+  );
 
   const cleanedErrors = errors.filter((e) => e !== undefined);
   if (cleanedErrors.length > 0) {

--- a/server/src/model/deliverable/validateDeliverableInputs.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.ts
@@ -1,5 +1,6 @@
 import {
   checkDeliverableHasAtLeastOneDocument,
+  checkDeliverableHasStatus,
   checkDeliverableStatusNotFinalized,
   checkDemonstrationStatus,
   checkDueDateInFuture,
@@ -124,5 +125,24 @@ export async function validateSubmitDeliverableInput(
         originalMessages: cleanedErrors,
       },
     });
+  }
+}
+
+export function validateStartDeliverableReviewInput(deliverable: PrismaDeliverable): void {
+  const errors: (string | undefined)[] = [];
+
+  errors.push(checkDeliverableHasStatus(deliverable, "Submitted"));
+
+  const cleanedErrors = errors.filter((e) => e !== undefined);
+  if (cleanedErrors.length > 0) {
+    throw new GraphQLError(
+      "One or more validation checks for startDeliverableReview have failed.",
+      {
+        extensions: {
+          code: "START_DELIVERABLE_REVIEW_VALIDATION_FAILED",
+          originalMessages: cleanedErrors,
+        },
+      }
+    );
   }
 }

--- a/server/src/model/deliverable/validateDeliverableInputs.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.ts
@@ -1,6 +1,7 @@
 import {
-  checkDemonstrationStatus,
+  checkDeliverableHasAtLeastOneDocument,
   checkDeliverableStatusNotFinalized,
+  checkDemonstrationStatus,
   checkDueDateInFuture,
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
@@ -13,6 +14,7 @@ import { getApplication } from "../application";
 import { getUser } from "../user";
 import { getDemonstrationTypeAssignments } from "../demonstrationTypeTagAssignment";
 import { GraphQLError } from "graphql";
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
 
 export async function validateCreateDeliverableInput(
   input: ParsedCreateDeliverableInput,
@@ -97,6 +99,26 @@ export async function validateUpdateDeliverableInput(
     throw new GraphQLError("One or more validation checks for updateDeliverable have failed.", {
       extensions: {
         code: "UPDATE_DELIVERABLE_VALIDATION_FAILED",
+        originalMessages: cleanedErrors,
+      },
+    });
+  }
+}
+
+export async function validateSubmitDeliverableInput(
+  deliverable: PrismaDeliverable,
+  tx: PrismaTransactionClient
+): Promise<void> {
+  const errors: (string | undefined)[] = [];
+
+  errors.push(checkDeliverableStatusNotFinalized(deliverable));
+  errors.push(await checkDeliverableHasAtLeastOneDocument(deliverable, tx));
+
+  const cleanedErrors = errors.filter((e) => e !== undefined);
+  if (cleanedErrors.length > 0) {
+    throw new GraphQLError("One or more validation checks for submitDeliverable have failed.", {
+      extensions: {
+        code: "SUBMIT_DELIVERABLE_VALIDATION_FAILED",
         originalMessages: cleanedErrors,
       },
     });


### PR DESCRIPTION
This PR adds the mutator which starts the review process. It also mildly refactors a few tests to use the `DeepPartial` type added earlier.

I'm pretty sure there's going to be some redundancy in how I get all of the various deliverable items implemented right now. This will be ripe for a refactor later to make it more code efficient; there will be check functions that we can combine into more general approaches, etc. However, in the interests of time, I am going to continue going forward with things that potentially could be better abstracted for now.

Works locally in the API, tests passing, SQ passing.