### PR TITLE
DEMOS-1959-complete-deliverable-mutator

### DIFF
--- a/server/src/model/deliverable/completeDeliverable.test.ts
+++ b/server/src/model/deliverable/completeDeliverable.test.ts
@@ -1,0 +1,178 @@
+// Vitest and other helpers
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Types
+import { DeepPartial } from "../../testUtilities";
+import { GraphQLContext } from "../../auth";
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
+
+// Functions under test
+import { completeDeliverable } from "./completeDeliverable";
+
+// Mock imports
+vi.mock("../../prismaClient", () => ({
+  prisma: vi.fn(),
+}));
+
+vi.mock(".", () => ({
+  editDeliverable: vi.fn(),
+  getDeliverable: vi.fn(),
+  validateCompleteDeliverableInput: vi.fn(),
+  validateUserPersonTypeAllowed: vi.fn(),
+}));
+
+vi.mock("../deliverableAction/queries", () => ({
+  insertDeliverableAction: vi.fn(),
+}));
+
+import { prisma } from "../../prismaClient";
+import {
+  editDeliverable,
+  getDeliverable,
+  validateCompleteDeliverableInput,
+  validateUserPersonTypeAllowed,
+} from ".";
+import { insertDeliverableAction } from "../deliverableAction/queries";
+
+describe("completeDeliverable", () => {
+  // Test inputs
+  const testDeliverableId = "b18cf1ce-3e41-4a71-b4f4-585f343bc74f";
+  const testUserContext: DeepPartial<GraphQLContext> = {
+    user: {
+      id: "0a3bd415-39a3-4f72-a067-418a5219216a",
+      personTypeId: "demos-admin",
+    },
+  };
+
+  // Mock results
+  const mockIncompleteDeliverable: Partial<PrismaDeliverable> = {
+    id: testDeliverableId,
+    statusId: "Under CMS Review",
+    dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
+  };
+  const mockCompleteDeliverable: Partial<PrismaDeliverable> = {
+    id: testDeliverableId,
+    statusId: "Approved",
+    dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
+  };
+  const mockNow = new Date(2026, 3, 27, 10, 4, 19, 232);
+
+  // Mock transaction
+  const mockTransaction: any = "Test!";
+  const mockPrismaClient = {
+    $transaction: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+    vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
+    vi.mocked(getDeliverable).mockResolvedValue(mockIncompleteDeliverable as PrismaDeliverable);
+    vi.mocked(editDeliverable).mockResolvedValue(mockCompleteDeliverable as PrismaDeliverable);
+    mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should check that the user is allowed to do this operation", async () => {
+    await completeDeliverable(testDeliverableId, "Approved", testUserContext as GraphQLContext);
+    expect(validateUserPersonTypeAllowed).toHaveBeenCalledExactlyOnceWith(
+      testUserContext,
+      "completeDeliverable",
+      ["demos-admin", "demos-cms-user"]
+    );
+  });
+
+  it("should not create a transaction if the user is not permitted", async () => {
+    vi.mocked(validateUserPersonTypeAllowed).mockThrow("I'm throwing!");
+
+    try {
+      await completeDeliverable(testDeliverableId, "Approved", testUserContext as GraphQLContext);
+      throw new Error("Expected completeDeliverable to throw, but it did not.");
+    } catch (e) {
+      expect(prisma).not.toHaveBeenCalled();
+    }
+  });
+
+  it("should get the deliverable before making changes", async () => {
+    await completeDeliverable(testDeliverableId, "Approved", testUserContext as GraphQLContext);
+    expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
+      { id: testDeliverableId },
+      mockTransaction
+    );
+  });
+
+  it("should call the validator on the unchanged deliverable", async () => {
+    await completeDeliverable(testDeliverableId, "Approved", testUserContext as GraphQLContext);
+    expect(validateCompleteDeliverableInput).toHaveBeenCalledExactlyOnceWith(
+      mockIncompleteDeliverable
+    );
+  });
+
+  it("should call edit function to set the status to the passed value", async () => {
+    await completeDeliverable(testDeliverableId, "Approved", testUserContext as GraphQLContext);
+    expect(editDeliverable).toHaveBeenCalledExactlyOnceWith(
+      testDeliverableId,
+      { statusId: "Approved" },
+      mockTransaction
+    );
+  });
+
+  it("should log an action for the completion", async () => {
+    await completeDeliverable(testDeliverableId, "Approved", testUserContext as GraphQLContext);
+    expect(insertDeliverableAction).toHaveBeenCalledExactlyOnceWith(
+      {
+        deliverableId: testDeliverableId,
+        actionType: "Approved Deliverable",
+        actionTime: mockNow,
+        oldStatus: mockIncompleteDeliverable.statusId,
+        newStatus: mockCompleteDeliverable.statusId,
+        oldDueDate: mockIncompleteDeliverable.dueDate,
+        newDueDate: mockCompleteDeliverable.dueDate,
+        userId: testUserContext.user!.id,
+      },
+      mockTransaction
+    );
+  });
+
+  it("should map accepted to the correct action type", async () => {
+    await completeDeliverable(testDeliverableId, "Accepted", testUserContext as GraphQLContext);
+    expect(insertDeliverableAction).toHaveBeenCalledExactlyOnceWith(
+      {
+        deliverableId: testDeliverableId,
+        actionType: "Accepted Deliverable",
+        actionTime: mockNow,
+        oldStatus: mockIncompleteDeliverable.statusId,
+        newStatus: mockCompleteDeliverable.statusId,
+        oldDueDate: mockIncompleteDeliverable.dueDate,
+        newDueDate: mockCompleteDeliverable.dueDate,
+        userId: testUserContext.user!.id,
+      },
+      mockTransaction
+    );
+  });
+
+  it("should map received and filed to the correct action type", async () => {
+    await completeDeliverable(
+      testDeliverableId,
+      "Received and Filed",
+      testUserContext as GraphQLContext
+    );
+    expect(insertDeliverableAction).toHaveBeenCalledExactlyOnceWith(
+      {
+        deliverableId: testDeliverableId,
+        actionType: "Received and Filed Deliverable",
+        actionTime: mockNow,
+        oldStatus: mockIncompleteDeliverable.statusId,
+        newStatus: mockCompleteDeliverable.statusId,
+        oldDueDate: mockIncompleteDeliverable.dueDate,
+        newDueDate: mockCompleteDeliverable.dueDate,
+        userId: testUserContext.user!.id,
+      },
+      mockTransaction
+    );
+  });
+});

--- a/server/src/model/deliverable/completeDeliverable.ts
+++ b/server/src/model/deliverable/completeDeliverable.ts
@@ -1,0 +1,52 @@
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
+import { GraphQLContext } from "../../auth/auth.util";
+import { DeliverableStatus, FinalDeliverableStatus, DeliverableActionType } from "../../types";
+import { prisma } from "../../prismaClient";
+import {
+  editDeliverable,
+  getDeliverable,
+  validateCompleteDeliverableInput,
+  validateUserPersonTypeAllowed,
+} from ".";
+import { insertDeliverableAction } from "../deliverableAction/queries";
+
+export async function completeDeliverable(
+  deliverableId: string,
+  finalStatus: FinalDeliverableStatus,
+  context: GraphQLContext
+): Promise<PrismaDeliverable> {
+  validateUserPersonTypeAllowed(context, "completeDeliverable", ["demos-admin", "demos-cms-user"]);
+  return await prisma().$transaction(async (tx) => {
+    const incompleteDeliverable = await getDeliverable({ id: deliverableId }, tx);
+    validateCompleteDeliverableInput(incompleteDeliverable);
+
+    const completedDeliverable = await editDeliverable(
+      deliverableId,
+      { statusId: finalStatus },
+      tx
+    );
+
+    const statusToAction: Record<FinalDeliverableStatus, DeliverableActionType> = {
+      Accepted: "Accepted Deliverable",
+      Approved: "Approved Deliverable",
+      "Received and Filed": "Received and Filed Deliverable",
+    };
+
+    // Casts below enforced by database
+    await insertDeliverableAction(
+      {
+        deliverableId: deliverableId,
+        actionType: statusToAction[finalStatus],
+        actionTime: new Date(),
+        oldStatus: incompleteDeliverable.statusId as DeliverableStatus,
+        newStatus: completedDeliverable.statusId as DeliverableStatus,
+        oldDueDate: incompleteDeliverable.dueDate,
+        newDueDate: completedDeliverable.dueDate,
+        userId: context.user.id,
+      },
+      tx
+    );
+
+    return completedDeliverable;
+  });
+}

--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -44,6 +44,7 @@ vi.mock(".", () => ({
   startDeliverableReview: vi.fn(),
   submitDeliverable: vi.fn(),
   updateDeliverable: vi.fn(),
+  completeDeliverable: vi.fn(),
 }));
 
 vi.mock("../application", () => ({
@@ -73,6 +74,7 @@ import {
   startDeliverableReview,
   submitDeliverable,
   updateDeliverable,
+  completeDeliverable,
 } from ".";
 import { getApplication } from "../application";
 import { getUser } from "../user";
@@ -149,6 +151,21 @@ describe("deliverableResolvers", () => {
       expect(submitDeliverable).toHaveBeenCalledExactlyOnceWith(
         testDeliverableId,
         testContext as GraphQLContext
+      );
+    });
+  });
+
+  describe("Mutation.completeDeliverable", () => {
+    it("calls completeDeliverable with appropriate arguments", async () => {
+      await deliverableResolvers.Mutation.completeDeliverable(
+        undefined,
+        { id: testDeliverableId, finalStatus: "Approved" },
+        testContext as GraphQLContext
+      );
+      expect(completeDeliverable).toHaveBeenCalledExactlyOnceWith(
+        testDeliverableId,
+        "Approved",
+        testContext
       );
     });
   });

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -8,6 +8,7 @@ import {
 import { GraphQLContext } from "../../auth";
 import { GraphQLResolveInfo } from "graphql";
 import {
+  completeDeliverable,
   createDeliverable,
   getDeliverable,
   getManyDeliverables,
@@ -21,6 +22,7 @@ import {
   DeliverableDueDateType,
   DeliverableStatus,
   DeliverableType,
+  FinalDeliverableStatus,
   UpdateDeliverableInput,
 } from "../../types";
 import { getApplication } from "../application";
@@ -136,6 +138,13 @@ export const deliverableResolvers = {
       context: GraphQLContext
     ) => {
       return await startDeliverableReview(args.id, context);
+    },
+    completeDeliverable: async (
+      parent: unknown,
+      args: { id: string; finalStatus: FinalDeliverableStatus },
+      context: GraphQLContext
+    ) => {
+      return await completeDeliverable(args.id, args.finalStatus, context);
     },
   },
 

--- a/server/src/model/deliverable/deliverableSchema.ts
+++ b/server/src/model/deliverable/deliverableSchema.ts
@@ -63,6 +63,7 @@ export const deliverableSchema = gql`
     updateDeliverable(id: ID!, input: UpdateDeliverableInput!): Deliverable
     submitDeliverable(id: ID!): Deliverable
     startDeliverableReview(id: ID!): Deliverable
+    completeDeliverable(id: ID!, finalStatus: FinalDeliverableStatus!): Deliverable
   }
 `;
 

--- a/server/src/model/deliverable/index.ts
+++ b/server/src/model/deliverable/index.ts
@@ -10,10 +10,12 @@ export {
   checkDeliverableHasStatus,
 } from "./checkDeliverableInputFunctions";
 export { createDeliverable } from "./createDeliverable";
+export { completeDeliverable } from "./completeDeliverable";
 export { manuallyUpdateDeliverableDueDate } from "./manuallyUpdateDeliverableDueDate";
 export { parseCreateDeliverableInput, parseUpdateDeliverableInput } from "./parseDeliverableInputs";
 export { resolveDeliverable, resolveManyDeliverables } from "./deliverableResolvers";
 export {
+  validateCompleteDeliverableInput,
   validateCreateDeliverableInput,
   validateStartDeliverableReviewInput,
   validateSubmitDeliverableInput,

--- a/server/src/model/deliverable/validateDeliverableInputs.test.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.test.ts
@@ -23,6 +23,7 @@ import {
   validateSubmitDeliverableInput,
   validateUpdateDeliverableInput,
   validateUserPersonTypeAllowed,
+  validateCompleteDeliverableInput,
 } from "./validateDeliverableInputs";
 
 // Mock imports
@@ -722,6 +723,45 @@ describe("validateDeliverableInputs", () => {
           "One or more validation checks for startDeliverableReview have failed."
         );
         expect(error.extensions.code).toBe("START_DELIVERABLE_REVIEW_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable status check failed!",
+        ]);
+      }
+    });
+  });
+
+  describe("validateCompleteDeliverableInput", () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it("should not throw if none of the rules are violated", async () => {
+      // Note: don't need to set returns to undefined, as this is what vi.fn() does already
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Under CMS Review",
+      };
+
+      expect(validateCompleteDeliverableInput(testInput as PrismaDeliverable)).toBeUndefined();
+    });
+
+    it("should throw if the deliverable status check fails", async () => {
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Submitted",
+      };
+      vi.mocked(checkDeliverableHasStatus).mockReturnValue("The deliverable status check failed!");
+
+      try {
+        validateCompleteDeliverableInput(testInput as PrismaDeliverable);
+        throw new Error("Expected validateCompleteDeliverableInput to throw, but it did not.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for completeDeliverable have failed."
+        );
+        expect(error.extensions.code).toBe("COMPLETE_DELIVERABLE_VALIDATION_FAILED");
         expect(error.extensions.originalMessages).toStrictEqual([
           "The deliverable status check failed!",
         ]);

--- a/server/src/model/deliverable/validateDeliverableInputs.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.ts
@@ -163,3 +163,19 @@ export function validateStartDeliverableReviewInput(deliverable: PrismaDeliverab
     );
   }
 }
+
+export function validateCompleteDeliverableInput(deliverable: PrismaDeliverable): void {
+  const errors: (string | undefined)[] = [];
+
+  errors.push(checkDeliverableHasStatus(deliverable, "Under CMS Review"));
+
+  const cleanedErrors = errors.filter((e) => e !== undefined);
+  if (cleanedErrors.length > 0) {
+    throw new GraphQLError("One or more validation checks for completeDeliverable have failed.", {
+      extensions: {
+        code: "COMPLETE_DELIVERABLE_VALIDATION_FAILED",
+        originalMessages: cleanedErrors,
+      },
+    });
+  }
+}


### PR DESCRIPTION
This PR adds the ability to call `completeDeliverable` in the API to move a deliverable from `Under CMS Review` to `Approved`, `Accepted`, or `Received and Filed`. I thought I would need to add a separate TS check for whether there is an active extension but it turns out that the error at the DB level for that properly propagates up to the API level, so we only ended up needing to check that the user was an acceptable type and that we were moving from the right status.