### PR TITLE
DEMOS-1959-request-resubmission

### DIFF
--- a/server/.snyk
+++ b/server/.snyk
@@ -22,4 +22,9 @@ ignore:
         reason: No patch available
         expires: 2026-04-10T00:00:00.000Z
         created: 2026-03-27T12:16:37.263Z
+  SNYK-JS-APOLLOPROTOBUFJS-16321047:
+    - '*':
+        reason: No patch available
+        expires: 2026-05-06T03:59:59.999Z
+        created: 2026-04-29T04:00:00.000Z
 patch: {}

--- a/server/src/customScalarResolvers.ts
+++ b/server/src/customScalarResolvers.ts
@@ -93,9 +93,15 @@ export const DateTimeOrLocalDateResolver = new GraphQLScalarType({
   },
 });
 
+// This simple wrapper is necessary to use the logic of NonEmptyString with the TagName alias
+const TagNameResolver = new GraphQLScalarType({
+  ...NonEmptyStringResolver.toConfig(),
+  name: "TagName",
+});
+
 export const customScalarResolvers = {
   DateTime: DateTimeResolver,
   DateTimeOrLocalDate: DateTimeOrLocalDateResolver,
   NonEmptyString: NonEmptyStringResolver,
-  TagName: NonEmptyStringResolver,
+  TagName: TagNameResolver,
 };

--- a/server/src/model/applicationDate/validateInputDates.ts
+++ b/server/src/model/applicationDate/validateInputDates.ts
@@ -10,6 +10,7 @@ import {
   ApplicationDateMap,
   DateTypeValidationChecksRecord,
 } from ".";
+import { EasternTZDate } from "../../dateUtilities";
 
 export function makeEmptyValidations(): DateTypeValidationChecksRecord {
   const result = {} as DateTypeValidationChecksRecord;
@@ -111,35 +112,61 @@ VALIDATION_CHECKS["Federal Comment Period Start Date"]["offsetChecks"].push({
   },
 });
 
+function runExpectedTimestampCheck(
+  dateType: DateType,
+  dateValue: EasternTZDate,
+  check: DateTypeValidationChecksRecord[DateType]["expectedTimestamp"]
+): void {
+  if (check === "Start of Day") {
+    checkInputDateIsStartOfDay(dateType, dateValue);
+  }
+  if (check === "End of Day") {
+    checkInputDateIsEndOfDay(dateType, dateValue);
+  }
+}
+
+function runGreaterThanChecks(
+  datesToValidateMap: ApplicationDateMap,
+  dateType: DateType,
+  checks: DateTypeValidationChecksRecord[DateType]["greaterThanChecks"]
+): void {
+  for (const check of checks) {
+    checkInputDateGreaterThan(datesToValidateMap, dateType, check.dateTypeToCheck);
+  }
+}
+
+function runGreaterThanOrEqualChecks(
+  datesToValidateMap: ApplicationDateMap,
+  dateType: DateType,
+  checks: DateTypeValidationChecksRecord[DateType]["greaterThanOrEqualChecks"]
+): void {
+  for (const check of checks) {
+    checkInputDateGreaterThanOrEqual(datesToValidateMap, dateType, check.dateTypeToCheck);
+  }
+}
+
+function runOffsetChecks(
+  datesToValidateMap: ApplicationDateMap,
+  dateType: DateType,
+  checks: DateTypeValidationChecksRecord[DateType]["offsetChecks"]
+): void {
+  for (const check of checks) {
+    checkInputDateMeetsOffset(
+      datesToValidateMap,
+      dateType,
+      check.dateTypeToCheck,
+      check.dateOffset
+    );
+  }
+}
+
 export function validateInputDates(datesToValidate: ParsedApplicationDateInput[]): void {
   const datesToValidateMap = makeApplicationDateMapFromList(datesToValidate);
   for (const [dateType, dateValue] of datesToValidateMap.entries()) {
     const checks = VALIDATION_CHECKS[dateType];
-    if (checks.expectedTimestamp === "Start of Day") {
-      checkInputDateIsStartOfDay(dateType, dateValue);
-    }
-    if (checks.expectedTimestamp === "End of Day") {
-      checkInputDateIsEndOfDay(dateType, dateValue);
-    }
-    if (checks.greaterThanChecks.length !== 0) {
-      for (const check of checks.greaterThanChecks) {
-        checkInputDateGreaterThan(datesToValidateMap, dateType, check.dateTypeToCheck);
-      }
-    }
-    if (checks.greaterThanOrEqualChecks.length !== 0) {
-      for (const check of checks.greaterThanOrEqualChecks) {
-        checkInputDateGreaterThanOrEqual(datesToValidateMap, dateType, check.dateTypeToCheck);
-      }
-    }
-    if (checks.offsetChecks.length !== 0) {
-      for (const check of checks.offsetChecks) {
-        checkInputDateMeetsOffset(
-          datesToValidateMap,
-          dateType,
-          check.dateTypeToCheck,
-          check.dateOffset
-        );
-      }
-    }
+    runExpectedTimestampCheck(dateType, dateValue, checks.expectedTimestamp);
+    runGreaterThanChecks(datesToValidateMap, dateType, checks.greaterThanChecks);
+    runGreaterThanOrEqualChecks(datesToValidateMap, dateType, checks.greaterThanOrEqualChecks);
+    runOffsetChecks(datesToValidateMap, dateType, checks.offsetChecks);
   }
 }

--- a/server/src/model/applicationPhase/startPhaseByDocument.test.ts
+++ b/server/src/model/applicationPhase/startPhaseByDocument.test.ts
@@ -119,22 +119,4 @@ describe("startPhaseByDocument", () => {
     expect(createPhaseStartDate).not.toHaveBeenCalled();
     expect(result).toBeNull();
   });
-
-  it("should update the application status to under review if the phase is Application Intake", async () => {
-    vi.mocked(setPhaseToStarted).mockResolvedValue(true);
-    vi.mocked(createPhaseStartDate).mockReturnValue(mockPhaseStartDate);
-
-    const mockDocument: Pick<UploadDocumentInput, "phaseName"> = {
-      phaseName: "Application Intake",
-    };
-
-    await startPhaseByDocument(mockTransaction, testApplicationId, mockDocument, mockEasternNow);
-  });
-
-  it("should not update the application status to under review if the phase is not Application Intake", async () => {
-    vi.mocked(setPhaseToStarted).mockResolvedValue(true);
-    vi.mocked(createPhaseStartDate).mockReturnValue(mockPhaseStartDate);
-
-    await startPhaseByDocument(mockTransaction, testApplicationId, mockDocument, mockEasternNow);
-  });
 });

--- a/server/src/model/applicationPhase/startPhasesByDates.ts
+++ b/server/src/model/applicationPhase/startPhasesByDates.ts
@@ -1,5 +1,5 @@
 import { PrismaTransactionClient } from "../../prismaClient";
-import { PhaseName, ApplicationDateInput } from "../../types";
+import { ApplicationDateInput } from "../../types";
 import { EasternNow } from "../../dateUtilities";
 import { createPhaseStartDate } from "../applicationDate";
 import { getOrderedPhaseDateTypes } from "../phaseDateType";
@@ -31,8 +31,7 @@ export async function startPhasesByDates(
       throw new Error(`No phase found for date type ${date.dateType} `);
     }
 
-    // casting constrained by database
-    const phaseId = phase.phaseId as PhaseName;
+    const phaseId = phase.phaseId;
     const phaseStarted = await setPhaseToStarted(applicationId, phaseId, tx);
     if (phaseStarted) {
       const startDateForPhase = createPhaseStartDate(phaseId, easternNow);

--- a/server/src/model/applicationPhase/validatePhaseCompletion.ts
+++ b/server/src/model/applicationPhase/validatePhaseCompletion.ts
@@ -17,9 +17,8 @@ export async function validatePhaseCompletion(
   const applicationPhaseDocumentTypes = await getApplicationPhaseDocumentTypes(applicationId, tx);
   const applicationPhaseStatuses = await getApplicationPhaseStatuses(applicationId, tx);
   // casting enforced by database schema
-  const applicationClearanceLevel = (await (
-    await getApplication(applicationId)
-  ).clearanceLevelId) as ClearanceLevel;
+  const applicationClearanceLevel = (await getApplication(applicationId))
+    .clearanceLevelId as ClearanceLevel;
 
   checkPhaseCompletionRules(
     applicationId,

--- a/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
@@ -14,14 +14,15 @@ import {
 
 // Functions under test
 import {
-  checkDemonstrationStatus,
-  checkDeliverableStatusNotFinalized,
-  checkForDuplicateDemonstrationTypes,
-  checkOwnerPersonType,
-  checkRequestedDeliverableDemonstrationType,
-  checkDueDateInFuture,
   checkDeliverableHasAtLeastOneDocument,
   checkDeliverableHasStatus,
+  checkDeliverableStatusNotFinalized,
+  checkDemonstrationStatus,
+  checkDueDateInFuture,
+  checkForDuplicateDemonstrationTypes,
+  checkNewDueDateIsAtLeastCurrentDueDate,
+  checkOwnerPersonType,
+  checkRequestedDeliverableDemonstrationType,
 } from "./checkDeliverableInputFunctions";
 
 // Mock imports
@@ -50,6 +51,32 @@ describe("checkDeliverableInputFunctions", () => {
       const result = checkDemonstrationStatus(testInput as PrismaDemonstration);
       expect(result).toBe(
         "Demonstration abc123 is not in Approved status; cannot create deliverable."
+      );
+    });
+  });
+
+  describe("checkDeliverableHasStatus", () => {
+    const testDeliverable: Partial<PrismaDeliverable> = {
+      id: "1e42da3a-9355-4c5d-a541-812a9f95ef56",
+      statusId: "Under CMS Review",
+    };
+
+    it("should return undefined if the passed status matches the object", async () => {
+      const result = checkDeliverableHasStatus(testDeliverable as PrismaDeliverable, [
+        "Under CMS Review",
+      ]);
+      expect(result).toBeUndefined();
+    });
+
+    it("should return an error message the passed status does not match the object", async () => {
+      const result = checkDeliverableHasStatus(testDeliverable as PrismaDeliverable, [
+        "Approved",
+        "Accepted",
+        "Received and Filed",
+      ]);
+      expect(result).toBe(
+        "Deliverable expected to have one of status Approved, Accepted, " +
+          "Received and Filed; actual status was Under CMS Review."
       );
     });
   });
@@ -233,7 +260,7 @@ describe("checkDeliverableInputFunctions", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should return an appropriate error message if the eue date is in the past", () => {
+    it("should return an appropriate error message if the due date is in the past", () => {
       const testInput: EasternTZDate = parseJSDateToEasternTZDate(
         new Date(2023, 8, 17, 3, 22, 11, 13)
       );
@@ -241,6 +268,49 @@ describe("checkDeliverableInputFunctions", () => {
       const result = checkDueDateInFuture(testInput);
       expect(result).toBe(
         "Cannot request a due date in the past; requested Sat Sep 16 2023 23:22:11 GMT-0400 (Eastern Daylight Time)"
+      );
+    });
+  });
+
+  describe("checkNewDueDateIsAtLeastCurrentDueDate", () => {
+    const testDeliverable: Partial<PrismaDeliverable> = {
+      dueDate: new Date(2026, 11, 13, 4, 59, 59, 999),
+    };
+
+    it("should return undefined if the new date is equal to the current due date", () => {
+      const testInput: EasternTZDate = parseJSDateToEasternTZDate(testDeliverable.dueDate!);
+
+      const result = checkNewDueDateIsAtLeastCurrentDueDate(
+        testDeliverable as PrismaDeliverable,
+        testInput
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it("should return undefined if the new date is greater than the current due date", () => {
+      const testInput: EasternTZDate = parseJSDateToEasternTZDate(
+        new Date(2026, 11, 14, 4, 59, 59, 999)
+      );
+
+      const result = checkNewDueDateIsAtLeastCurrentDueDate(
+        testDeliverable as PrismaDeliverable,
+        testInput
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it("should return an appropriate error message if the new due date is less than the current due date", () => {
+      const testInput: EasternTZDate = parseJSDateToEasternTZDate(
+        new Date(2026, 11, 12, 4, 59, 59, 999)
+      );
+
+      const result = checkNewDueDateIsAtLeastCurrentDueDate(
+        testDeliverable as PrismaDeliverable,
+        testInput
+      );
+      expect(result).toBe(
+        "Newly requested due date cannot be less than the original due date; " +
+          "requested Fri Dec 11 2026 23:59:59 GMT-0500 (Eastern Standard Time)."
       );
     });
   });
@@ -287,28 +357,6 @@ describe("checkDeliverableInputFunctions", () => {
       );
       expect(result).toBe(
         `Cannot submit deliverable ${testDeliverableId} because it has no state documents attached.`
-      );
-    });
-  });
-
-  describe("checkDeliverableHasStatus", () => {
-    const testDeliverable: Partial<PrismaDeliverable> = {
-      id: "1e42da3a-9355-4c5d-a541-812a9f95ef56",
-      statusId: "Under CMS Review",
-    };
-
-    it("should return undefined if the passed status matches the object", async () => {
-      const result = checkDeliverableHasStatus(
-        testDeliverable as PrismaDeliverable,
-        "Under CMS Review"
-      );
-      expect(result).toBeUndefined();
-    });
-
-    it("should return an error message the passed status does not match the object", async () => {
-      const result = checkDeliverableHasStatus(testDeliverable as PrismaDeliverable, "Approved");
-      expect(result).toBe(
-        "Deliverable expected to have status Approved; actual status was Under CMS Review."
       );
     });
   });

--- a/server/src/model/deliverable/checkDeliverableInputFunctions.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.ts
@@ -17,17 +17,30 @@ export function checkDemonstrationStatus(demonstration: PrismaDemonstration): st
   }
 }
 
+export function checkDeliverableHasStatus(
+  deliverable: PrismaDeliverable,
+  expectedStatuses: DeliverableStatus[]
+): string | undefined {
+  // Cast enforced by database constraints
+  const deliverableStatus = deliverable.statusId as DeliverableStatus;
+  if (!expectedStatuses.includes(deliverableStatus)) {
+    return (
+      `Deliverable expected to have one of status ${expectedStatuses.join(", ")}; ` +
+      `actual status was ${deliverableStatus}.`
+    );
+  }
+}
+
 export function checkDeliverableStatusNotFinalized(
   deliverable: PrismaDeliverable
 ): string | undefined {
   // Cast enforced by DB constraints
-  const deliverableStatus = deliverable.statusId as DeliverableStatus;
-  const finalDeliverableStatuses: DeliverableStatus[] = [
+  const result = checkDeliverableHasStatus(deliverable, [
     "Approved",
     "Accepted",
     "Received and Filed",
-  ];
-  if (finalDeliverableStatuses.includes(deliverableStatus)) {
+  ]);
+  if (result === undefined) {
     return `Cannot submit or modify deliverable ${deliverable.id} as it has already been finalized.`;
   }
 }
@@ -70,6 +83,16 @@ export function checkDueDateInFuture(dueDate: EasternTZDate): string | undefined
   }
 }
 
+export function checkNewDueDateIsAtLeastCurrentDueDate(
+  deliverable: PrismaDeliverable,
+  newDueDate: EasternTZDate
+): string | undefined {
+  const currentDate = deliverable.dueDate;
+  if (newDueDate.easternTZDate.valueOf() < currentDate.valueOf()) {
+    return `Newly requested due date cannot be less than the original due date; requested ${newDueDate.easternTZDate}.`;
+  }
+}
+
 export async function checkDeliverableHasAtLeastOneDocument(
   deliverable: PrismaDeliverable,
   tx: PrismaTransactionClient
@@ -81,16 +104,5 @@ export async function checkDeliverableHasAtLeastOneDocument(
 
   if (deliverableDocuments.length === 0) {
     return `Cannot submit deliverable ${deliverable.id} because it has no state documents attached.`;
-  }
-}
-
-export function checkDeliverableHasStatus(
-  deliverable: PrismaDeliverable,
-  expectedStatus: DeliverableStatus
-): string | undefined {
-  // Cast enforced by database constraints
-  const deliverableStatus = deliverable.statusId as DeliverableStatus;
-  if (deliverableStatus !== expectedStatus) {
-    return `Deliverable expected to have status ${expectedStatus}; actual status was ${deliverableStatus}.`;
   }
 }

--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -38,13 +38,14 @@ import { getManyDeliverableDemonstrationTypes } from "../deliverableDemonstratio
 
 // Mock imports
 vi.mock(".", () => ({
+  completeDeliverable: vi.fn(),
   createDeliverable: vi.fn(),
   getDeliverable: vi.fn(),
   getManyDeliverables: vi.fn(),
+  requestDeliverableResubmission: vi.fn(),
   startDeliverableReview: vi.fn(),
   submitDeliverable: vi.fn(),
   updateDeliverable: vi.fn(),
-  completeDeliverable: vi.fn(),
 }));
 
 vi.mock("../application", () => ({
@@ -68,13 +69,14 @@ vi.mock("../deliverableAction", () => ({
 }));
 
 import {
+  completeDeliverable,
   createDeliverable,
   getDeliverable,
   getManyDeliverables,
+  requestDeliverableResubmission,
   startDeliverableReview,
   submitDeliverable,
   updateDeliverable,
-  completeDeliverable,
 } from ".";
 import { getApplication } from "../application";
 import { getUser } from "../user";
@@ -155,6 +157,20 @@ describe("deliverableResolvers", () => {
     });
   });
 
+  describe("Mutation.startDeliverableReview", () => {
+    it("calls startDeliverableReview with appropriate arguments", async () => {
+      await deliverableResolvers.Mutation.startDeliverableReview(
+        undefined,
+        { id: testDeliverableId },
+        testContext as GraphQLContext
+      );
+      expect(startDeliverableReview).toHaveBeenCalledExactlyOnceWith(
+        testDeliverableId,
+        testContext
+      );
+    });
+  });
+
   describe("Mutation.completeDeliverable", () => {
     it("calls completeDeliverable with appropriate arguments", async () => {
       await deliverableResolvers.Mutation.completeDeliverable(
@@ -170,15 +186,24 @@ describe("deliverableResolvers", () => {
     });
   });
 
-  describe("Mutation.startDeliverableReview", () => {
-    it("calls startDeliverableReview with appropriate arguments", async () => {
-      await deliverableResolvers.Mutation.startDeliverableReview(
+  describe("Mutation.requestDeliverableResubmission", () => {
+    it("calls requestDeliverableResubmission with appropriate arguments", async () => {
+      const testInput = {
+        details: "A change is gonna come",
+        newDueDate: "2025-11-13" as DateTimeOrLocalDate,
+      };
+
+      await deliverableResolvers.Mutation.requestDeliverableResubmission(
         undefined,
-        { id: testDeliverableId },
+        {
+          id: testDeliverableId,
+          input: testInput,
+        },
         testContext as GraphQLContext
       );
-      expect(startDeliverableReview).toHaveBeenCalledExactlyOnceWith(
+      expect(requestDeliverableResubmission).toHaveBeenCalledExactlyOnceWith(
         testDeliverableId,
+        testInput,
         testContext
       );
     });

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -12,6 +12,7 @@ import {
   createDeliverable,
   getDeliverable,
   getManyDeliverables,
+  requestDeliverableResubmission,
   startDeliverableReview,
   submitDeliverable,
   updateDeliverable,
@@ -23,6 +24,7 @@ import {
   DeliverableStatus,
   DeliverableType,
   FinalDeliverableStatus,
+  RequestDeliverableResubmissionInput,
   UpdateDeliverableInput,
 } from "../../types";
 import { getApplication } from "../application";
@@ -145,6 +147,13 @@ export const deliverableResolvers = {
       context: GraphQLContext
     ) => {
       return await completeDeliverable(args.id, args.finalStatus, context);
+    },
+    requestDeliverableResubmission: async (
+      parent: unknown,
+      args: { id: string; input: RequestDeliverableResubmissionInput },
+      context: GraphQLContext
+    ) => {
+      return await requestDeliverableResubmission(args.id, args.input, context);
     },
   },
 

--- a/server/src/model/deliverable/deliverableSchema.ts
+++ b/server/src/model/deliverable/deliverableSchema.ts
@@ -53,6 +53,11 @@ export const deliverableSchema = gql`
     demonstrationTypes: [TagName!]
   }
 
+  input RequestDeliverableResubmissionInput {
+    details: NonEmptyString!
+    newDueDate: DateTimeOrLocalDate!
+  }
+
   type Query {
     deliverable(id: ID!): Deliverable!
     deliverables: [Deliverable!]!
@@ -64,6 +69,10 @@ export const deliverableSchema = gql`
     submitDeliverable(id: ID!): Deliverable
     startDeliverableReview(id: ID!): Deliverable
     completeDeliverable(id: ID!, finalStatus: FinalDeliverableStatus!): Deliverable
+    requestDeliverableResubmission(
+      id: ID!
+      input: RequestDeliverableResubmissionInput!
+    ): Deliverable
   }
 `;
 
@@ -104,4 +113,9 @@ export interface UpdateDeliverableInput {
   cmsOwnerUserId?: string;
   dueDate?: DeliverableDueDateUpdateInput;
   demonstrationTypes?: TagName[];
+}
+
+export interface RequestDeliverableResubmissionInput {
+  details: NonEmptyString;
+  newDueDate: DateTimeOrLocalDate;
 }

--- a/server/src/model/deliverable/index.ts
+++ b/server/src/model/deliverable/index.ts
@@ -38,5 +38,6 @@ export type {
   ParsedCreateDeliverableInput,
   ParsedUpdateDeliverableInput,
   ParsedUpdateDueDate,
+  ParsedRequestDeliverableResubmissionInput,
 } from "./parseDeliverableInputs";
 export type { EditDeliverableInput } from "./queries/editDeliverable";

--- a/server/src/model/deliverable/index.ts
+++ b/server/src/model/deliverable/index.ts
@@ -1,43 +1,50 @@
 // Functions
 export {
-  checkDemonstrationStatus,
-  checkDeliverableStatusNotFinalized,
-  checkDueDateInFuture,
-  checkForDuplicateDemonstrationTypes,
-  checkOwnerPersonType,
-  checkRequestedDeliverableDemonstrationType,
   checkDeliverableHasAtLeastOneDocument,
   checkDeliverableHasStatus,
+  checkDeliverableStatusNotFinalized,
+  checkDemonstrationStatus,
+  checkDueDateInFuture,
+  checkForDuplicateDemonstrationTypes,
+  checkNewDueDateIsAtLeastCurrentDueDate,
+  checkOwnerPersonType,
+  checkRequestedDeliverableDemonstrationType,
 } from "./checkDeliverableInputFunctions";
-export { createDeliverable } from "./createDeliverable";
 export { completeDeliverable } from "./completeDeliverable";
-export { manuallyUpdateDeliverableDueDate } from "./manuallyUpdateDeliverableDueDate";
-export { parseCreateDeliverableInput, parseUpdateDeliverableInput } from "./parseDeliverableInputs";
+export { createDeliverable } from "./createDeliverable";
 export { resolveDeliverable, resolveManyDeliverables } from "./deliverableResolvers";
+export { manuallyUpdateDeliverableDueDate } from "./manuallyUpdateDeliverableDueDate";
+export {
+  parseCreateDeliverableInput,
+  parseRequestDeliverableResubmissionInput,
+  parseUpdateDeliverableInput,
+} from "./parseDeliverableInputs";
+export { requestDeliverableResubmission } from "./requestDeliverableResubmission";
+export { startDeliverableReview } from "./startDeliverableReview";
+export { submitDeliverable } from "./submitDeliverable";
+export { updateDeliverable } from "./updateDeliverable";
+export { updateDeliverableDemonstrationTypes } from "./updateDeliverableDemonstrationTypes";
 export {
   validateCompleteDeliverableInput,
   validateCreateDeliverableInput,
+  validateRequestDeliverableResubmissionInput,
   validateStartDeliverableReviewInput,
   validateSubmitDeliverableInput,
   validateUpdateDeliverableInput,
   validateUserPersonTypeAllowed,
 } from "./validateDeliverableInputs";
-export { startDeliverableReview } from "./startDeliverableReview";
-export { submitDeliverable } from "./submitDeliverable";
-export { updateDeliverable } from "./updateDeliverable";
-export { updateDeliverableDemonstrationTypes } from "./updateDeliverableDemonstrationTypes";
 
 // Queries
+export { editDeliverable } from "./queries/editDeliverable";
 export { getDeliverable } from "./queries/getDeliverable";
 export { getManyDeliverables } from "./queries/getManyDeliverables";
 export { insertDeliverable } from "./queries/insertDeliverable";
-export { editDeliverable } from "./queries/editDeliverable";
 
 // Types & Constants
+export type { EditDeliverableInput } from "./queries/editDeliverable";
 export type {
   ParsedCreateDeliverableInput,
   ParsedUpdateDeliverableInput,
   ParsedUpdateDueDate,
   ParsedRequestDeliverableResubmissionInput,
 } from "./parseDeliverableInputs";
-export type { EditDeliverableInput } from "./queries/editDeliverable";

--- a/server/src/model/deliverable/parseDeliverableInputs.test.ts
+++ b/server/src/model/deliverable/parseDeliverableInputs.test.ts
@@ -4,11 +4,20 @@ import { TZDate } from "@date-fns/tz";
 
 // Types
 import { EasternTZDate } from "../../dateUtilities";
-import { CreateDeliverableInput, DateTimeOrLocalDate, UpdateDeliverableInput } from "../../types";
+import {
+  CreateDeliverableInput,
+  DateTimeOrLocalDate,
+  RequestDeliverableResubmissionInput,
+  UpdateDeliverableInput,
+} from "../../types";
 import { ParsedCreateDeliverableInput, ParsedUpdateDeliverableInput } from ".";
 
 // Functions under test
-import { parseCreateDeliverableInput, parseUpdateDeliverableInput } from "./parseDeliverableInputs";
+import {
+  parseCreateDeliverableInput,
+  parseUpdateDeliverableInput,
+  parseRequestDeliverableResubmissionInput,
+} from "./parseDeliverableInputs";
 
 // Mock imports
 vi.mock("../../dateUtilities", () => ({
@@ -231,6 +240,26 @@ describe("parseDeliverableInputs", () => {
         const error = e as Error;
         expect(error.message).toBe("There are duplicates!!");
       }
+    });
+  });
+
+  describe("parseRequestDeliverableResubmissionInput", () => {
+    const testInput: RequestDeliverableResubmissionInput = {
+      details: "A set of details",
+      newDueDate: "2025-11-13" as DateTimeOrLocalDate,
+    };
+
+    it("should parse the input, check the date, and return the updated object", () => {
+      const result = parseRequestDeliverableResubmissionInput(testInput);
+      expect(parseDateTimeOrLocalDateToEasternTZDate).toHaveBeenCalledExactlyOnceWith(
+        testInput.newDueDate,
+        "End of Day"
+      );
+      expect(checkInputDateIsEndOfDay).toHaveBeenCalledExactlyOnceWith("dueDate", mockParsedDate);
+      expect(result).toStrictEqual({
+        details: testInput.details,
+        newDueDate: mockParsedDate,
+      });
     });
   });
 });

--- a/server/src/model/deliverable/parseDeliverableInputs.ts
+++ b/server/src/model/deliverable/parseDeliverableInputs.ts
@@ -4,6 +4,7 @@ import {
   NonEmptyString,
   TagName,
   UpdateDeliverableInput,
+  RequestDeliverableResubmissionInput,
 } from "../../types";
 import { EasternTZDate, parseDateTimeOrLocalDateToEasternTZDate } from "../../dateUtilities";
 import { checkInputDateIsEndOfDay } from "../applicationDate";
@@ -28,6 +29,11 @@ export type ParsedUpdateDeliverableInput = {
   cmsOwnerUserId?: string;
   dueDate?: ParsedUpdateDueDate;
   demonstrationTypes?: Set<TagName>;
+};
+
+export type ParsedRequestDeliverableResubmissionInput = {
+  details: NonEmptyString;
+  newDueDate: EasternTZDate;
 };
 
 export function parseCreateDeliverableInput(
@@ -82,4 +88,16 @@ export function parseUpdateDeliverableInput(
   }
 
   return result;
+}
+
+export function parseRequestDeliverableResubmissionInput(
+  input: RequestDeliverableResubmissionInput
+): ParsedRequestDeliverableResubmissionInput {
+  const parsedDueDate = parseDateTimeOrLocalDateToEasternTZDate(input.newDueDate, "End of Day");
+  checkInputDateIsEndOfDay("dueDate", parsedDueDate);
+
+  return {
+    details: input.details,
+    newDueDate: parsedDueDate,
+  };
 }

--- a/server/src/model/deliverable/requestDeliverableResubmission.test.ts
+++ b/server/src/model/deliverable/requestDeliverableResubmission.test.ts
@@ -1,0 +1,207 @@
+// Vitest and other helpers
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TZDate } from "@date-fns/tz";
+
+// Types
+import { DeepPartial } from "../../testUtilities";
+import { GraphQLContext } from "../../auth";
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
+import { DateTimeOrLocalDate, RequestDeliverableResubmissionInput } from "../../types";
+
+// Functions under test
+import { requestDeliverableResubmission } from "./requestDeliverableResubmission";
+
+// Mock imports
+vi.mock("../../prismaClient", () => ({
+  prisma: vi.fn(),
+}));
+
+vi.mock(".", () => ({
+  editDeliverable: vi.fn(),
+  getDeliverable: vi.fn(),
+  parseRequestDeliverableResubmissionInput: vi.fn(),
+  validateRequestDeliverableResubmissionInput: vi.fn(),
+  validateUserPersonTypeAllowed: vi.fn(),
+}));
+
+vi.mock("../deliverableAction/queries", () => ({
+  insertDeliverableAction: vi.fn(),
+}));
+
+import { prisma } from "../../prismaClient";
+import {
+  editDeliverable,
+  getDeliverable,
+  ParsedRequestDeliverableResubmissionInput,
+  parseRequestDeliverableResubmissionInput,
+  validateRequestDeliverableResubmissionInput,
+  validateUserPersonTypeAllowed,
+} from ".";
+import { insertDeliverableAction } from "../deliverableAction/queries";
+
+describe("requestDeliverableResubmission", () => {
+  // Test inputs
+  const testDeliverableId = "b18cf1ce-3e41-4a71-b4f4-585f343bc74f";
+  const testInput: RequestDeliverableResubmissionInput = {
+    details: "These are details",
+    newDueDate: "2026-11-13" as DateTimeOrLocalDate,
+  };
+  const testUserContext: DeepPartial<GraphQLContext> = {
+    user: {
+      id: "0a3bd415-39a3-4f72-a067-418a5219216a",
+      personTypeId: "demos-admin",
+    },
+  };
+
+  // Mock results
+  const mockUnrequestedDeliverable: Partial<PrismaDeliverable> = {
+    id: testDeliverableId,
+    statusId: "Submitted",
+    dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
+  };
+  const mockRequestedDeliverable: Partial<PrismaDeliverable> = {
+    id: testDeliverableId,
+    statusId: "Under CMS Review",
+    dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
+  };
+  const mockParsedInput: ParsedRequestDeliverableResubmissionInput = {
+    details: testInput.details,
+    newDueDate: {
+      isEasternTZDate: true,
+      easternTZDate: new TZDate(2026, 10, 13, 4, 59, 59, 999, "America/New_York"),
+    },
+  };
+  const mockNow = new Date(2026, 3, 27, 10, 4, 19, 232);
+
+  // Mock transaction
+  const mockTransaction: any = "Test!";
+  const mockPrismaClient = {
+    $transaction: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(mockNow);
+    vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
+    vi.mocked(parseRequestDeliverableResubmissionInput).mockReturnValue(mockParsedInput);
+    vi.mocked(getDeliverable).mockResolvedValue(mockUnrequestedDeliverable as PrismaDeliverable);
+    vi.mocked(editDeliverable).mockResolvedValue(mockRequestedDeliverable as PrismaDeliverable);
+    mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should check that the user is allowed to do this operation", async () => {
+    await requestDeliverableResubmission(
+      testDeliverableId,
+      testInput,
+      testUserContext as GraphQLContext
+    );
+    expect(validateUserPersonTypeAllowed).toHaveBeenCalledExactlyOnceWith(
+      testUserContext,
+      "requestDeliverableResubmission",
+      ["demos-admin", "demos-cms-user"]
+    );
+  });
+
+  it("should not create a transaction if the user is not permitted", async () => {
+    vi.mocked(validateUserPersonTypeAllowed).mockThrow("I'm throwing!");
+
+    try {
+      await requestDeliverableResubmission(
+        testDeliverableId,
+        testInput,
+        testUserContext as GraphQLContext
+      );
+      throw new Error("Expected requestDeliverableResubmission to throw, but it did not.");
+    } catch (e) {
+      expect(prisma).not.toHaveBeenCalled();
+    }
+  });
+
+  it("should parse the input received", async () => {
+    await requestDeliverableResubmission(
+      testDeliverableId,
+      testInput,
+      testUserContext as GraphQLContext
+    );
+    expect(parseRequestDeliverableResubmissionInput).toHaveBeenCalledExactlyOnceWith(testInput);
+  });
+
+  it("should not create a transaction parsing fails", async () => {
+    vi.mocked(parseRequestDeliverableResubmissionInput).mockThrow("I'm throwing!");
+
+    try {
+      await requestDeliverableResubmission(
+        testDeliverableId,
+        testInput,
+        testUserContext as GraphQLContext
+      );
+      throw new Error("Expected requestDeliverableResubmission to throw, but it did not.");
+    } catch (e) {
+      expect(prisma).not.toHaveBeenCalled();
+    }
+  });
+
+  it("should get the deliverable before making changes", async () => {
+    await requestDeliverableResubmission(
+      testDeliverableId,
+      testInput,
+      testUserContext as GraphQLContext
+    );
+    expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
+      { id: testDeliverableId },
+      mockTransaction
+    );
+  });
+
+  it("should call the validator on the unchanged deliverable", async () => {
+    await requestDeliverableResubmission(
+      testDeliverableId,
+      testInput,
+      testUserContext as GraphQLContext
+    );
+    expect(validateRequestDeliverableResubmissionInput).toHaveBeenCalledExactlyOnceWith(
+      mockUnrequestedDeliverable,
+      mockParsedInput
+    );
+  });
+
+  it("should call edit function to set the status to upcoming and the due date to the new value", async () => {
+    await requestDeliverableResubmission(
+      testDeliverableId,
+      testInput,
+      testUserContext as GraphQLContext
+    );
+    expect(editDeliverable).toHaveBeenCalledExactlyOnceWith(
+      testDeliverableId,
+      { statusId: "Upcoming", dueDate: mockParsedInput.newDueDate.easternTZDate },
+      mockTransaction
+    );
+  });
+
+  it("should log an action for the resubmission request", async () => {
+    await requestDeliverableResubmission(
+      testDeliverableId,
+      testInput,
+      testUserContext as GraphQLContext
+    );
+    expect(insertDeliverableAction).toHaveBeenCalledExactlyOnceWith(
+      {
+        deliverableId: testDeliverableId,
+        actionType: "Requested Resubmission",
+        actionTime: mockNow,
+        oldStatus: mockUnrequestedDeliverable.statusId,
+        newStatus: mockRequestedDeliverable.statusId,
+        note: mockParsedInput.details,
+        oldDueDate: mockUnrequestedDeliverable.dueDate,
+        newDueDate: mockRequestedDeliverable.dueDate,
+        userId: testUserContext.user!.id,
+      },
+      mockTransaction
+    );
+  });
+});

--- a/server/src/model/deliverable/requestDeliverableResubmission.ts
+++ b/server/src/model/deliverable/requestDeliverableResubmission.ts
@@ -1,0 +1,56 @@
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
+import { DeliverableStatus, RequestDeliverableResubmissionInput } from "../../types";
+import { GraphQLContext } from "../../auth/auth.util";
+import {
+  editDeliverable,
+  getDeliverable,
+  parseRequestDeliverableResubmissionInput,
+  validateRequestDeliverableResubmissionInput,
+  validateUserPersonTypeAllowed,
+} from ".";
+import { prisma } from "../../prismaClient";
+import { insertDeliverableAction } from "../deliverableAction/queries";
+
+export async function requestDeliverableResubmission(
+  deliverableId: string,
+  input: RequestDeliverableResubmissionInput,
+  context: GraphQLContext
+): Promise<PrismaDeliverable> {
+  validateUserPersonTypeAllowed(context, "requestDeliverableResubmission", [
+    "demos-admin",
+    "demos-cms-user",
+  ]);
+  const parsedInput = parseRequestDeliverableResubmissionInput(input);
+
+  return await prisma().$transaction(async (tx) => {
+    const unrequestedDeliverable = await getDeliverable({ id: deliverableId }, tx);
+    validateRequestDeliverableResubmissionInput(unrequestedDeliverable, parsedInput);
+
+    const requestedDeliverable = await editDeliverable(
+      deliverableId,
+      {
+        statusId: "Upcoming",
+        dueDate: parsedInput.newDueDate.easternTZDate,
+      },
+      tx
+    );
+
+    // Casts below enforced by database
+    await insertDeliverableAction(
+      {
+        deliverableId: deliverableId,
+        actionType: "Requested Resubmission",
+        actionTime: new Date(),
+        oldStatus: unrequestedDeliverable.statusId as DeliverableStatus,
+        newStatus: requestedDeliverable.statusId as DeliverableStatus,
+        note: input.details,
+        oldDueDate: unrequestedDeliverable.dueDate,
+        newDueDate: requestedDeliverable.dueDate,
+        userId: context.user.id,
+      },
+      tx
+    );
+
+    return requestedDeliverable;
+  });
+}

--- a/server/src/model/deliverable/validateDeliverableInputs.test.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.test.ts
@@ -6,7 +6,11 @@ import { TZDate } from "@date-fns/tz";
 import { GraphQLContext } from "../../auth";
 import { DeepPartial } from "../../testUtilities";
 import { ApplicationStatus, PersonType } from "../../types";
-import { ParsedCreateDeliverableInput, ParsedUpdateDeliverableInput } from ".";
+import {
+  ParsedCreateDeliverableInput,
+  ParsedRequestDeliverableResubmissionInput,
+  ParsedUpdateDeliverableInput,
+} from ".";
 import {
   Deliverable as PrismaDeliverable,
   Demonstration as PrismaDemonstration,
@@ -18,12 +22,13 @@ import { EasternTZDate } from "../../dateUtilities";
 
 // Functions under test
 import {
+  validateCompleteDeliverableInput,
   validateCreateDeliverableInput,
+  validateRequestDeliverableResubmissionInput,
   validateStartDeliverableReviewInput,
   validateSubmitDeliverableInput,
   validateUpdateDeliverableInput,
   validateUserPersonTypeAllowed,
-  validateCompleteDeliverableInput,
 } from "./validateDeliverableInputs";
 
 // Mock imports
@@ -40,13 +45,14 @@ vi.mock("../demonstrationTypeTagAssignment", () => ({
 }));
 
 vi.mock(".", () => ({
-  checkDemonstrationStatus: vi.fn(),
-  checkDeliverableStatusNotFinalized: vi.fn(),
-  checkDueDateInFuture: vi.fn(),
-  checkOwnerPersonType: vi.fn(),
-  checkRequestedDeliverableDemonstrationType: vi.fn(),
   checkDeliverableHasAtLeastOneDocument: vi.fn(),
   checkDeliverableHasStatus: vi.fn(),
+  checkDeliverableStatusNotFinalized: vi.fn(),
+  checkDemonstrationStatus: vi.fn(),
+  checkDueDateInFuture: vi.fn(),
+  checkNewDueDateIsAtLeastCurrentDueDate: vi.fn(),
+  checkOwnerPersonType: vi.fn(),
+  checkRequestedDeliverableDemonstrationType: vi.fn(),
   getDeliverable: vi.fn(),
 }));
 
@@ -54,13 +60,14 @@ import { getApplication } from "../application";
 import { getUser } from "../user";
 import { getDemonstrationTypeAssignments } from "../demonstrationTypeTagAssignment";
 import {
-  checkDemonstrationStatus,
-  checkDeliverableStatusNotFinalized,
-  checkDueDateInFuture,
-  checkOwnerPersonType,
-  checkRequestedDeliverableDemonstrationType,
   checkDeliverableHasAtLeastOneDocument,
   checkDeliverableHasStatus,
+  checkDeliverableStatusNotFinalized,
+  checkDemonstrationStatus,
+  checkDueDateInFuture,
+  checkNewDueDateIsAtLeastCurrentDueDate,
+  checkOwnerPersonType,
+  checkRequestedDeliverableDemonstrationType,
   getDeliverable,
 } from ".";
 
@@ -696,7 +703,7 @@ describe("validateDeliverableInputs", () => {
       vi.resetAllMocks();
     });
 
-    it("should not throw if none of the rules are violated", async () => {
+    it("should not throw if none of the rules are violated", () => {
       // Note: don't need to set returns to undefined, as this is what vi.fn() does already
       const testInput: Partial<PrismaDeliverable> = {
         id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
@@ -706,7 +713,7 @@ describe("validateDeliverableInputs", () => {
       expect(validateStartDeliverableReviewInput(testInput as PrismaDeliverable)).toBeUndefined();
     });
 
-    it("should throw if the deliverable status check fails", async () => {
+    it("should throw if the deliverable status check fails", () => {
       const testInput: Partial<PrismaDeliverable> = {
         id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
         statusId: "Upcoming",
@@ -735,7 +742,7 @@ describe("validateDeliverableInputs", () => {
       vi.resetAllMocks();
     });
 
-    it("should not throw if none of the rules are violated", async () => {
+    it("should not throw if none of the rules are violated", () => {
       // Note: don't need to set returns to undefined, as this is what vi.fn() does already
       const testInput: Partial<PrismaDeliverable> = {
         id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
@@ -745,7 +752,7 @@ describe("validateDeliverableInputs", () => {
       expect(validateCompleteDeliverableInput(testInput as PrismaDeliverable)).toBeUndefined();
     });
 
-    it("should throw if the deliverable status check fails", async () => {
+    it("should throw if the deliverable status check fails", () => {
       const testInput: Partial<PrismaDeliverable> = {
         id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
         statusId: "Submitted",
@@ -764,6 +771,134 @@ describe("validateDeliverableInputs", () => {
         expect(error.extensions.code).toBe("COMPLETE_DELIVERABLE_VALIDATION_FAILED");
         expect(error.extensions.originalMessages).toStrictEqual([
           "The deliverable status check failed!",
+        ]);
+      }
+    });
+  });
+
+  describe("validateRequestDeliverableResubmissionInput", () => {
+    const testDeliverable: Partial<PrismaDeliverable> = {
+      id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+    };
+    const testInput: ParsedRequestDeliverableResubmissionInput = {
+      details: "Some details",
+      newDueDate: {
+        isEasternTZDate: true,
+        easternTZDate: new TZDate(2026, 11, 1, 0, 0, 0, 0, "America/New_York"),
+      },
+    };
+
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it("should not throw if none of the rules are violated", () => {
+      // Note: don't need to set returns to undefined, as this is what vi.fn() does already
+      expect(
+        validateRequestDeliverableResubmissionInput(testDeliverable as PrismaDeliverable, testInput)
+      ).toBeUndefined();
+    });
+
+    it("should throw if the deliverable status check fails", () => {
+      vi.mocked(checkDeliverableHasStatus).mockReturnValue("The deliverable status check failed!");
+
+      try {
+        validateRequestDeliverableResubmissionInput(
+          testDeliverable as PrismaDeliverable,
+          testInput
+        );
+        throw new Error(
+          "Expected validateRequestDeliverableResubmissionInput to throw, but it did not."
+        );
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for requestDeliverableResubmission have failed."
+        );
+        expect(error.extensions.code).toBe("REQUEST_DELIVERABLE_RESUBMISSION_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable status check failed!",
+        ]);
+      }
+    });
+
+    it("should throw if the future due date check fails", () => {
+      vi.mocked(checkDueDateInFuture).mockReturnValue("The future due date check failed!");
+
+      try {
+        validateRequestDeliverableResubmissionInput(
+          testDeliverable as PrismaDeliverable,
+          testInput
+        );
+        throw new Error(
+          "Expected validateRequestDeliverableResubmissionInput to throw, but it did not."
+        );
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for requestDeliverableResubmission have failed."
+        );
+        expect(error.extensions.code).toBe("REQUEST_DELIVERABLE_RESUBMISSION_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The future due date check failed!",
+        ]);
+      }
+    });
+
+    it("should throw if the current vs new due date check fails", () => {
+      vi.mocked(checkNewDueDateIsAtLeastCurrentDueDate).mockReturnValue(
+        "The current and new due date check failed!"
+      );
+
+      try {
+        validateRequestDeliverableResubmissionInput(
+          testDeliverable as PrismaDeliverable,
+          testInput
+        );
+        throw new Error(
+          "Expected validateRequestDeliverableResubmissionInput to throw, but it did not."
+        );
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for requestDeliverableResubmission have failed."
+        );
+        expect(error.extensions.code).toBe("REQUEST_DELIVERABLE_RESUBMISSION_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The current and new due date check failed!",
+        ]);
+      }
+    });
+
+    it("should combine all errors into one object", async () => {
+      vi.mocked(checkDeliverableHasStatus).mockReturnValue("The deliverable status check failed!");
+      vi.mocked(checkDueDateInFuture).mockReturnValue("The future due date check failed!");
+      vi.mocked(checkNewDueDateIsAtLeastCurrentDueDate).mockReturnValue(
+        "The current and new due date check failed!"
+      );
+
+      try {
+        validateRequestDeliverableResubmissionInput(
+          testDeliverable as PrismaDeliverable,
+          testInput
+        );
+        throw new Error(
+          "Expected validateRequestDeliverableResubmissionInput to throw, but it did not."
+        );
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for requestDeliverableResubmission have failed."
+        );
+        expect(error.extensions.code).toBe("REQUEST_DELIVERABLE_RESUBMISSION_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable status check failed!",
+          "The future due date check failed!",
+          "The current and new due date check failed!",
         ]);
       }
     });

--- a/server/src/model/deliverable/validateDeliverableInputs.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.ts
@@ -4,10 +4,12 @@ import {
   checkDeliverableStatusNotFinalized,
   checkDemonstrationStatus,
   checkDueDateInFuture,
+  checkNewDueDateIsAtLeastCurrentDueDate,
   checkOwnerPersonType,
   checkRequestedDeliverableDemonstrationType,
   getDeliverable,
   ParsedCreateDeliverableInput,
+  ParsedRequestDeliverableResubmissionInput,
   ParsedUpdateDeliverableInput,
 } from ".";
 import { PrismaTransactionClient } from "../../prismaClient";
@@ -148,7 +150,7 @@ export async function validateSubmitDeliverableInput(
 export function validateStartDeliverableReviewInput(deliverable: PrismaDeliverable): void {
   const errors: (string | undefined)[] = [];
 
-  errors.push(checkDeliverableHasStatus(deliverable, "Submitted"));
+  errors.push(checkDeliverableHasStatus(deliverable, ["Submitted"]));
 
   const cleanedErrors = errors.filter((e) => e !== undefined);
   if (cleanedErrors.length > 0) {
@@ -167,7 +169,7 @@ export function validateStartDeliverableReviewInput(deliverable: PrismaDeliverab
 export function validateCompleteDeliverableInput(deliverable: PrismaDeliverable): void {
   const errors: (string | undefined)[] = [];
 
-  errors.push(checkDeliverableHasStatus(deliverable, "Under CMS Review"));
+  errors.push(checkDeliverableHasStatus(deliverable, ["Under CMS Review"]));
 
   const cleanedErrors = errors.filter((e) => e !== undefined);
   if (cleanedErrors.length > 0) {
@@ -177,5 +179,31 @@ export function validateCompleteDeliverableInput(deliverable: PrismaDeliverable)
         originalMessages: cleanedErrors,
       },
     });
+  }
+}
+
+export function validateRequestDeliverableResubmissionInput(
+  deliverable: PrismaDeliverable,
+  input: ParsedRequestDeliverableResubmissionInput
+): void {
+  const errors: (string | undefined)[] = [];
+
+  errors.push(
+    checkDeliverableHasStatus(deliverable, ["Submitted", "Under CMS Review"]),
+    checkDueDateInFuture(input.newDueDate),
+    checkNewDueDateIsAtLeastCurrentDueDate(deliverable, input.newDueDate)
+  );
+
+  const cleanedErrors = errors.filter((e) => e !== undefined);
+  if (cleanedErrors.length > 0) {
+    throw new GraphQLError(
+      "One or more validation checks for requestDeliverableResubmission have failed.",
+      {
+        extensions: {
+          code: "REQUEST_DELIVERABLE_RESUBMISSION_VALIDATION_FAILED",
+          originalMessages: cleanedErrors,
+        },
+      }
+    );
   }
 }

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -113,6 +113,7 @@ export type {
   CreateDeliverableInput,
   UpdateDeliverableInput,
   DeliverableDueDateUpdateInput,
+  RequestDeliverableResubmissionInput,
 } from "./model/deliverable/deliverableSchema";
 
 export type { DeliverableAction } from "./model/deliverableAction/deliverableActionSchema";


### PR DESCRIPTION
This PR adds the `requestDeliverableResubmission` mutator to allow requesting resubmission. There's also a few small little cleanup items I rolled in, listed below.

- Tweaks how the `TagName` scalar is implemented with the `NonEmptyStringResolver` to ensure that the API documentation reporting out lists the right type.
- Refactors `validateInputDates.ts` to lower the cognitive complexity by breaking out the various different kind of date validations into separate function calls, encapsulating the looping within.
- Removes two empty tests from `startPhaseByDocument.test.ts` that were leftover remnants of a previous version that did this; the tests have no assertions and upon reading this functionality was moved to the database.
- Removes an unnecessary assertion from `startPhaseByDates.ts`; this type was already `PhaseName` in the source object, making the as statement redundant and unneeded.
- Removes an excess `await` statement in `validatePhaseCompletion.ts`; the outside `await` statement had no affect since the inside was already being awaited.

Tests pass, exercised API locally successfully, SQ has no issues.