### PR TITLE
DEMOS-1625: added the submit/request extension button back

### DIFF
--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -134,7 +134,10 @@ export const DeliverableDetailsManagementPage: React.FC<{
             onToggleAdditionalDetails={handleToggleAdditionalDetails}
           />
           {/* I'm sure these go somewhere but they arent in my spec sheet. Uncomment at your leisure */}
-          <DeliverableButtons deliverable={data.deliverable} />
+          <DeliverableButtons
+            deliverable={data.deliverable}
+            onRequestResubmission={() => {}}
+          />
           <EditAndDeleteButtonGroup
             onDelete={handleDeleteDeliverable}
             onEdit={handleEditDeliverable}

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -7,6 +7,7 @@ import { CommentBox } from "./sections/comment_box";
 import { DeliverableInfoFields } from "./sections/DeliverableInfoFields";
 import { FileAndHistoryTabs } from "./sections/FileAndHistoryTabs";
 import { PendingReviewNotice } from "./sections/PendingReviewNotice";
+import { DeliverableButtons } from "./sections/DeliverableButtons";
 import type { DeliverableFileRow } from "./sections/DeliverableFileTypes";
 import { EditAndDeleteButtonGroup } from "./sections/EditAndDeleteButtonGroup";
 
@@ -133,7 +134,7 @@ export const DeliverableDetailsManagementPage: React.FC<{
             onToggleAdditionalDetails={handleToggleAdditionalDetails}
           />
           {/* I'm sure these go somewhere but they arent in my spec sheet. Uncomment at your leisure */}
-          {/* <DeliverableButtons deliverable={data.deliverable} /> */}
+          <DeliverableButtons deliverable={data.deliverable} />
           <EditAndDeleteButtonGroup
             onDelete={handleDeleteDeliverable}
             onEdit={handleEditDeliverable}

--- a/client/src/pages/deliverables/sections/DeliverableButtons.test.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableButtons.test.tsx
@@ -5,14 +5,17 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DeliverableStatus } from "demos-server";
 
 import {
+  canRequestResubmission,
   DeliverableButtons,
-  REFERENCES_BUTTON_NAME,
   REQUEST_EXTENSION_BUTTON_NAME,
+  REQUEST_RESUBMISSION_BUTTON_NAME,
 } from "./DeliverableButtons";
 import { MOCK_DELIVERABLE_1 } from "mock-data/deliverableMocks";
 import { DeliverableDetailsManagementDeliverable } from "../DeliverableDetailsManagementPage";
 import { TestProvider } from "test-utils/TestProvider";
 import { DialogProvider } from "components/dialog/DialogContext";
+import { CurrentUser } from "components/user/UserContext";
+import { developmentMockUser } from "mock-data/userMocks";
 
 const mockShowRequestExtensionDeliverableDialog = vi.fn();
 vi.mock("components/dialog/DialogContext", async () => {
@@ -36,11 +39,27 @@ const buildDeliverable = (
   ...overrides,
 });
 
-const renderButtons = (deliverable: DeliverableDetailsManagementDeliverable) =>
+const buildCurrentUser = (personType: CurrentUser["person"]["personType"]): CurrentUser => ({
+  ...developmentMockUser,
+  person: {
+    ...developmentMockUser.person,
+    personType,
+  },
+});
+
+const mockOnRequestResubmission = vi.fn();
+
+const renderButtons = (
+  deliverable: DeliverableDetailsManagementDeliverable,
+  personType: CurrentUser["person"]["personType"] = "demos-state-user"
+) =>
   render(
-    <TestProvider>
+    <TestProvider currentUser={buildCurrentUser(personType)}>
       <DialogProvider>
-        <DeliverableButtons deliverable={deliverable} />
+        <DeliverableButtons
+          deliverable={deliverable}
+          onRequestResubmission={mockOnRequestResubmission}
+        />
       </DialogProvider>
     </TestProvider>
   );
@@ -48,11 +67,23 @@ const renderButtons = (deliverable: DeliverableDetailsManagementDeliverable) =>
 describe("DeliverableButtons", () => {
   beforeEach(() => {
     mockShowRequestExtensionDeliverableDialog.mockClear();
+    mockOnRequestResubmission.mockClear();
   });
 
-  it("renders the References button", () => {
-    renderButtons(buildDeliverable());
-    expect(screen.getByTestId(REFERENCES_BUTTON_NAME)).toHaveTextContent("References");
+  it("renders the Request Extension button for state users", () => {
+    renderButtons(buildDeliverable(), "demos-state-user");
+    expect(screen.getByTestId(REQUEST_EXTENSION_BUTTON_NAME)).toHaveTextContent(
+      "Request Extension"
+    );
+    expect(screen.queryByTestId(REQUEST_RESUBMISSION_BUTTON_NAME)).not.toBeInTheDocument();
+  });
+
+  it("renders the Request Resubmission button for CMS users", () => {
+    renderButtons(buildDeliverable({ status: "Submitted" }), "demos-cms-user");
+    expect(screen.getByTestId(REQUEST_RESUBMISSION_BUTTON_NAME)).toHaveTextContent(
+      "Request Resubmission"
+    );
+    expect(screen.queryByTestId(REQUEST_EXTENSION_BUTTON_NAME)).not.toBeInTheDocument();
   });
 
   it("renders the Request Extension button enabled for Upcoming deliverables", () => {
@@ -80,6 +111,25 @@ describe("DeliverableButtons", () => {
     expect(button).toBeDisabled();
   });
 
+  it.each<DeliverableStatus>(["Submitted", "Under CMS Review"])(
+    "renders the Request Resubmission button enabled when status is %s",
+    (status) => {
+      renderButtons(buildDeliverable({ status }), "demos-cms-user");
+      expect(screen.getByTestId(REQUEST_RESUBMISSION_BUTTON_NAME)).toBeEnabled();
+    }
+  );
+
+  it.each<DeliverableStatus>([
+    "Upcoming",
+    "Past Due",
+    "Accepted",
+    "Approved",
+    "Received and Filed",
+  ])("disables the Request Resubmission button when status is %s", (status) => {
+    renderButtons(buildDeliverable({ status }), "demos-cms-user");
+    expect(screen.getByTestId(REQUEST_RESUBMISSION_BUTTON_NAME)).toBeDisabled();
+  });
+
   it("opens the Request Extension dialog when clicked", async () => {
     const user = userEvent.setup();
     renderButtons(buildDeliverable({ status: "Upcoming" }));
@@ -100,5 +150,40 @@ describe("DeliverableButtons", () => {
     await user.click(screen.getByTestId(REQUEST_EXTENSION_BUTTON_NAME));
 
     expect(mockShowRequestExtensionDeliverableDialog).not.toHaveBeenCalled();
+  });
+
+  it("calls onRequestResubmission when the Request Resubmission button is clicked", async () => {
+    const user = userEvent.setup();
+    const deliverable = buildDeliverable({ status: "Submitted" });
+    renderButtons(deliverable, "demos-cms-user");
+
+    await user.click(screen.getByTestId(REQUEST_RESUBMISSION_BUTTON_NAME));
+
+    expect(mockOnRequestResubmission).toHaveBeenCalledWith(deliverable);
+  });
+
+  it("does not call onRequestResubmission when the button is disabled", async () => {
+    const user = userEvent.setup();
+    renderButtons(buildDeliverable({ status: "Approved" }), "demos-cms-user");
+
+    await user.click(screen.getByTestId(REQUEST_RESUBMISSION_BUTTON_NAME));
+
+    expect(mockOnRequestResubmission).not.toHaveBeenCalled();
+  });
+});
+
+describe("canRequestResubmission", () => {
+  it.each<DeliverableStatus>(["Submitted", "Under CMS Review"])("returns true for %s", (status) => {
+    expect(canRequestResubmission(status)).toBe(true);
+  });
+
+  it.each<DeliverableStatus>([
+    "Upcoming",
+    "Past Due",
+    "Accepted",
+    "Approved",
+    "Received and Filed",
+  ])("returns false for %s", (status) => {
+    expect(canRequestResubmission(status)).toBe(false);
   });
 });

--- a/client/src/pages/deliverables/sections/DeliverableButtons.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableButtons.tsx
@@ -1,19 +1,28 @@
 import React from "react";
-import { SecondaryButton, TertiaryButton } from "components/button";
+import { SecondaryButton } from "components/button";
 import { canRequestExtension } from "components/dialog/deliverable";
 import { useDialog } from "components/dialog/DialogContext";
+import { getCurrentUser } from "components/user/UserContext";
+import { DeliverableStatus } from "demos-server";
 import { DeliverableDetailsManagementDeliverable } from "../DeliverableDetailsManagementPage";
 
 export const DELIVERABLE_BUTTONS_NAME = "deliverable-buttons";
-export const REFERENCES_BUTTON_NAME = "button-references";
 export const REQUEST_EXTENSION_BUTTON_NAME = "button-request-extension";
+export const REQUEST_RESUBMISSION_BUTTON_NAME = "button-request-resubmission";
+
+export const canRequestResubmission = (status: DeliverableStatus): boolean =>
+  status === "Submitted" || status === "Under CMS Review";
 
 export const DeliverableButtons = ({
   deliverable,
+  onRequestResubmission,
 }: {
   deliverable: DeliverableDetailsManagementDeliverable;
+  onRequestResubmission: (deliverable: DeliverableDetailsManagementDeliverable) => void;
 }) => {
   const { showRequestExtensionDeliverableDialog } = useDialog();
+  const { currentUser } = getCurrentUser();
+  const userPersonType = currentUser?.person.personType;
 
   const handleRequestExtension = () => {
     showRequestExtensionDeliverableDialog({
@@ -25,14 +34,24 @@ export const DeliverableButtons = ({
 
   return (
     <div className="flex gap-2" data-testid={DELIVERABLE_BUTTONS_NAME}>
-      <TertiaryButton name={REFERENCES_BUTTON_NAME}>References</TertiaryButton>
-      <SecondaryButton
-        name={REQUEST_EXTENSION_BUTTON_NAME}
-        onClick={handleRequestExtension}
-        disabled={!canRequestExtension(deliverable.status)}
-      >
-        Request Extension
-      </SecondaryButton>
+      {userPersonType === "demos-state-user" ? (
+        <SecondaryButton
+          name={REQUEST_EXTENSION_BUTTON_NAME}
+          onClick={handleRequestExtension}
+          disabled={!canRequestExtension(deliverable.status)}
+        >
+          Request Extension
+        </SecondaryButton>
+      ) : null}
+      {userPersonType === "demos-cms-user" ? (
+        <SecondaryButton
+          name={REQUEST_RESUBMISSION_BUTTON_NAME}
+          onClick={() => onRequestResubmission(deliverable)}
+          disabled={!canRequestResubmission(deliverable.status)}
+        >
+          Request Resubmission
+        </SecondaryButton>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
Reenabled the Deliverable Button. Sans references
Right now idk where to put it. 
Alos added logic to switch the type between state user and CMS user. 
 
<img width="1496" height="406" alt="Screenshot 2026-04-30 at 14 01 07" src="https://github.com/user-attachments/assets/4a8313cb-43cd-4395-8b1f-383f7972d106" />

I do not where this goes. But ppl need to dev off this, 