### PR TITLE
DEMOS-1956-sort-order-for-deliverable-actions

### DIFF
--- a/server/src/model/deliverableAction/queries/selectManyDeliverableActions.test.ts
+++ b/server/src/model/deliverableAction/queries/selectManyDeliverableActions.test.ts
@@ -40,6 +40,9 @@ describe("selectManyDeliverableActions", () => {
   // Expected calls
   const expectedUnfilteredCall = {
     where: {},
+    orderBy: {
+      actionTimestamp: "asc",
+    },
     include: {
       user: {
         include: {
@@ -53,6 +56,9 @@ describe("selectManyDeliverableActions", () => {
   const expectedFilteredCall = {
     where: {
       id: "56e3b26d-f629-4bd2-b419-d4d4a5bb751b",
+    },
+    orderBy: {
+      actionTimestamp: "asc",
     },
     include: {
       user: {

--- a/server/src/model/deliverableAction/queries/selectManyDeliverableActions.ts
+++ b/server/src/model/deliverableAction/queries/selectManyDeliverableActions.ts
@@ -20,6 +20,9 @@ export async function selectManyDeliverableActions(
   const prismaClient = tx ?? prisma();
   const deliverableActions = await prismaClient.deliverableAction.findMany({
     where: where,
+    orderBy: {
+      actionTimestamp: "asc",
+    },
     include: {
       user: {
         include: {


### PR DESCRIPTION
Tiny fix; ensures that deliverable actions are ordered by timestamp when returned. Almost always this is the desired ordering because we get a single deliverable at a time.