### PR TITLE
DEMOS-2066: Add userId to authorizer logs

### DIFF
--- a/lambdas/authorizer/index.ts
+++ b/lambdas/authorizer/index.ts
@@ -19,6 +19,19 @@ function getKey(header: JwtHeader, callback: SigningKeyCallback) {
 }
 /* v8 ignore stop */
 
+function redactEmailAddress(address: string): string {
+
+  const [local, domain] = address.split("@");
+  if (!domain) return address;
+
+  const visible = local.slice(0, 2);
+
+  const redactedEmail = `${visible}****@${domain}`;
+  
+  return redactedEmail;
+  
+}
+
 export const handler = async (event: APIGatewayTokenAuthorizerEvent, context: Context) =>
   als.run(store, async () => {
     reqIdChild(context.awsRequestId);
@@ -53,10 +66,16 @@ export const handler = async (event: APIGatewayTokenAuthorizerEvent, context: Co
 
     const roles = decoded["custom:roles"] as string | undefined;
 
+    const userId = decoded.identities?.[0]?.userId ?? decoded.email;
+    if (decoded.identities?.[0]?.userId === undefined) {
+      log.warn({sub: decoded.sub, userId: redactEmailAddress(userId)}, "user does not have a standard idm user id")
+    }
+
     if (!roles) {
       log.info(
         {
           sub: decoded.sub,
+          userId,
         },
         "unauthorized: user has no roles"
       );
@@ -70,6 +89,7 @@ export const handler = async (event: APIGatewayTokenAuthorizerEvent, context: Co
         {
           sub: decoded.sub,
           roles: roles ?? "none",
+          userId: redactEmailAddress(userId),
         },
         "unauthorized: user has invalid roles"
       );
@@ -80,11 +100,11 @@ export const handler = async (event: APIGatewayTokenAuthorizerEvent, context: Co
       {
         sub: decoded.sub,
         roles: roles,
+        userId: redactEmailAddress(userId),
       },
       "success: user authorized"
     );
 
-    const userId = decoded.identities?.[0]?.userId ?? decoded.email;
 
     return generatePolicy(decoded.sub, "Allow", event.methodArn, {
       sub: decoded.sub,


### PR DESCRIPTION
Adds additional data to the authorizer logs in order to have more usable user-review dashboards. Without this change, only the UUID for the users are available which requires multiple steps to identify users.

The userID should be available for all users coming through IDM. The fallback is to use the email, which should only happen for normal cognito logins, which should only be possible on DEV. Because of that, I added a warn log that we could use for alerts if any users in higher envs come through without the IDM username

If an email is what comes through, it is partially redacted in the logs.