### PR TITLE
DEMOS-2082: Set npmrc min-release-age to 7 days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7 # days


### PR DESCRIPTION
This PR adds min-release-age to a top-level `.npmrc` file. This prevents npm from installing packages that were released within the last 7 days.

This change was made based on a recommendation from MAC-FC during a recent call. The change will give a buffer between new package releases and their installation in DEMOS to provide a window for the discovery of malicious changes prior to using them.