### PR TITLE
DEMOS-2015-add-deletion-path-for-deliverables

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -23,6 +23,7 @@ export const DELIVERABLE_ACTION_TYPES = [
   "Accepted Deliverable",
   "Approved Deliverable",
   "Received and Filed Deliverable",
+  "Deleted Deliverable",
 ] as const;
 
 export const DELIVERABLE_TYPES = [
@@ -68,16 +69,25 @@ export const DELIVERABLE_STATUSES = [
   "Accepted",
   "Approved",
   "Received and Filed",
+  "Deleted",
 ] as const;
 export type DeliverableStatus = (typeof DELIVERABLE_STATUSES)[number];
+
+export const ACTIVE_DELIVERABLE_STATUSES = [
+  "Upcoming",
+  "Past Due",
+  "Submitted",
+  "Under CMS Review",
+] as const satisfies DeliverableStatus[];
 
 export const FINAL_DELIVERABLE_STATUSES = [
   "Accepted",
   "Approved",
   "Received and Filed",
 ] as const satisfies DeliverableStatus[];
-
 export type FinalDeliverableStatus = (typeof FINAL_DELIVERABLE_STATUSES)[number];
+
+export const DELETED_DELIVERABLE_STATUS = "Deleted" as const satisfies DeliverableStatus;
 
 export const DEMONSTRATION_TYPE_STATUSES = ["Expired", "Pending", "Active"] as const;
 

--- a/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
@@ -25,7 +25,6 @@ import {
   checkDeliverableHasAtLeastOneDocument,
   checkDeliverableHasNoActiveExtension,
   checkDeliverableHasStatus,
-  checkDeliverableStatusNotFinalized,
   checkDemonstrationStatus,
   checkDueDateInFuture,
   checkForDuplicateDemonstrationTypes,
@@ -94,78 +93,6 @@ describe("checkDeliverableInputFunctions", () => {
           "Received and Filed; actual status was Under CMS Review."
       );
     });
-  });
-
-  describe("checkDeliverableStatusNotFinalized", () => {
-    const checkDeliverableStatusInputs: [
-      DeliverableStatus,
-      Partial<PrismaDeliverable>,
-      string | undefined,
-    ][] = [
-      [
-        "Upcoming",
-        {
-          id: "abc123",
-          statusId: "Upcoming",
-        },
-        undefined,
-      ],
-      [
-        "Past Due",
-        {
-          id: "abc123",
-          statusId: "Past Due",
-        },
-        undefined,
-      ],
-      [
-        "Submitted",
-        {
-          id: "abc123",
-          statusId: "Submitted",
-        },
-        undefined,
-      ],
-      [
-        "Under CMS Review",
-        {
-          id: "abc123",
-          statusId: "Under CMS Review",
-        },
-        undefined,
-      ],
-      [
-        "Accepted",
-        {
-          id: "abc123",
-          statusId: "Accepted",
-        },
-        "Cannot submit or modify deliverable abc123 as it has already been finalized.",
-      ],
-      [
-        "Approved",
-        {
-          id: "abc123",
-          statusId: "Approved",
-        },
-        "Cannot submit or modify deliverable abc123 as it has already been finalized.",
-      ],
-      [
-        "Received and Filed",
-        {
-          id: "abc123",
-          statusId: "Received and Filed",
-        },
-        "Cannot submit or modify deliverable abc123 as it has already been finalized.",
-      ],
-    ];
-    it.each(checkDeliverableStatusInputs)(
-      "properly checks the status (%s)",
-      (deliverableStatus, testDeliverable, expectedResult) => {
-        const result = checkDeliverableStatusNotFinalized(testDeliverable as PrismaDeliverable);
-        expect(result).toBe(expectedResult);
-      }
-    );
   });
 
   describe("checkOwnerPersonType", () => {

--- a/server/src/model/deliverable/checkDeliverableInputFunctions.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.ts
@@ -39,20 +39,6 @@ export function checkDeliverableHasStatus(
   }
 }
 
-export function checkDeliverableStatusNotFinalized(
-  deliverable: PrismaDeliverable
-): string | undefined {
-  // Cast enforced by DB constraints
-  const result = checkDeliverableHasStatus(deliverable, [
-    "Approved",
-    "Accepted",
-    "Received and Filed",
-  ]);
-  if (result === undefined) {
-    return `Cannot submit or modify deliverable ${deliverable.id} as it has already been finalized.`;
-  }
-}
-
 export function checkOwnerPersonType(ownerUser: PrismaUser): string | undefined {
   const permittedOwnerPersonTypes: readonly PersonType[] = ["demos-admin", "demos-cms-user"];
   // Cast enforced by DB constraints

--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -94,6 +94,7 @@ import { getManyDocuments } from "../document";
 import { getManyDeliverableDemonstrationTypes } from "../deliverableDemonstrationType";
 import { getFormattedDeliverableActions } from "../deliverableAction";
 import { selectManyDeliverableExtensions } from "../deliverableExtension/queries";
+import { DELETED_DELIVERABLE_STATUS } from "../../constants";
 
 describe("deliverableResolvers", () => {
   const testDeliverableId = "82ef9a17-e8b9-48ab-9aaf-3d1787822b13";
@@ -369,7 +370,10 @@ describe("deliverableResolvers", () => {
           {} as GraphQLContext,
           testDocumentInfo as GraphQLResolveInfo
         );
-        expect(getDeliverable).toHaveBeenCalledExactlyOnceWith({ id: testDeliverableId });
+        expect(getDeliverable).toHaveBeenCalledExactlyOnceWith({
+          id: testDeliverableId,
+          NOT: { statusId: DELETED_DELIVERABLE_STATUS },
+        });
       });
     });
   });
@@ -397,6 +401,7 @@ describe("deliverableResolvers", () => {
         );
         expect(getManyDeliverables).toHaveBeenCalledExactlyOnceWith({
           demonstrationId: testDemonstrationId,
+          NOT: { statusId: DELETED_DELIVERABLE_STATUS },
         });
       });
     });
@@ -411,6 +416,7 @@ describe("deliverableResolvers", () => {
         );
         expect(getManyDeliverables).toHaveBeenCalledExactlyOnceWith({
           cmsOwnerUserId: testUserId,
+          NOT: { statusId: DELETED_DELIVERABLE_STATUS },
         });
       });
     });
@@ -419,7 +425,9 @@ describe("deliverableResolvers", () => {
   describe("queryDeliverables", () => {
     it("should query all the deliverables", async () => {
       await queryDeliverables();
-      expect(getManyDeliverables).toHaveBeenCalledExactlyOnceWith();
+      expect(getManyDeliverables).toHaveBeenCalledExactlyOnceWith({
+        NOT: { statusId: DELETED_DELIVERABLE_STATUS },
+      });
     });
   });
 

--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -364,7 +364,13 @@ describe("deliverableResolvers", () => {
       });
 
       it("should query if there is a deliverable ID", async () => {
-        await resolveDeliverable(
+        const mockDeliverable: Partial<PrismaDeliverable> = {
+          id: "abc123",
+          statusId: "Upcoming",
+        };
+        vi.mocked(getDeliverable).mockResolvedValue(mockDeliverable as PrismaDeliverable);
+
+        const result = await resolveDeliverable(
           testDocumentWithDeliverableParent as PrismaDocument,
           {} as unknown,
           {} as GraphQLContext,
@@ -372,8 +378,27 @@ describe("deliverableResolvers", () => {
         );
         expect(getDeliverable).toHaveBeenCalledExactlyOnceWith({
           id: testDeliverableId,
-          NOT: { statusId: DELETED_DELIVERABLE_STATUS },
         });
+        expect(result).toBe(mockDeliverable);
+      });
+
+      it("should filter out deleted deliverables", async () => {
+        const mockDeliverable: Partial<PrismaDeliverable> = {
+          id: "abc123",
+          statusId: "Deleted",
+        };
+        vi.mocked(getDeliverable).mockResolvedValue(mockDeliverable as PrismaDeliverable);
+
+        const result = await resolveDeliverable(
+          testDocumentWithDeliverableParent as PrismaDocument,
+          {} as unknown,
+          {} as GraphQLContext,
+          testDocumentInfo as GraphQLResolveInfo
+        );
+        expect(getDeliverable).toHaveBeenCalledExactlyOnceWith({
+          id: testDeliverableId,
+        });
+        expect(result).toBeNull();
       });
     });
   });

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -40,6 +40,7 @@ import { getManyDocuments } from "../document";
 import { getFormattedDeliverableActions } from "../deliverableAction";
 import { getManyDeliverableDemonstrationTypes } from "../deliverableDemonstrationType";
 import { selectManyDeliverableExtensions } from "../deliverableExtension/queries";
+import { DELETED_DELIVERABLE_STATUS } from "../../constants";
 
 export async function resolveDeliverable(
   parent: PrismaDocument,
@@ -52,7 +53,7 @@ export async function resolveDeliverable(
 
   if (parentType === Prisma.ModelName.Document) {
     if (parent.deliverableId) {
-      filter = { id: parent.deliverableId };
+      filter = { id: parent.deliverableId, NOT: { statusId: DELETED_DELIVERABLE_STATUS } };
     } else {
       filter = null;
     }
@@ -78,10 +79,10 @@ export async function resolveManyDeliverables(
 
   switch (parentType) {
     case Prisma.ModelName.Demonstration:
-      filter = { demonstrationId: parent.id };
+      filter = { demonstrationId: parent.id, NOT: { statusId: DELETED_DELIVERABLE_STATUS } };
       break;
     case Prisma.ModelName.User:
-      filter = { cmsOwnerUserId: parent.id };
+      filter = { cmsOwnerUserId: parent.id, NOT: { statusId: DELETED_DELIVERABLE_STATUS } };
       break;
     default:
       throw new Error(`Unsupported parent type: ${parentType}`);
@@ -92,7 +93,7 @@ export async function resolveManyDeliverables(
 }
 
 export async function queryDeliverables(): Promise<PrismaDeliverable[]> {
-  return await getManyDeliverables();
+  return await getManyDeliverables({ NOT: { statusId: DELETED_DELIVERABLE_STATUS } });
 }
 
 export function resolveDeliverableType(parent: PrismaDeliverable): DeliverableType {

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -53,7 +53,7 @@ export async function resolveDeliverable(
 
   if (parentType === Prisma.ModelName.Document) {
     if (parent.deliverableId) {
-      filter = { id: parent.deliverableId, NOT: { statusId: DELETED_DELIVERABLE_STATUS } };
+      filter = { id: parent.deliverableId };
     } else {
       filter = null;
     }
@@ -65,6 +65,11 @@ export async function resolveDeliverable(
     return null;
   }
   const result = await getDeliverable(filter);
+  // We add the filter here to handle soft-deleted records
+  // Do it here instead of in Prisma filter to avoid throwing when returning no records
+  if (result.statusId === DELETED_DELIVERABLE_STATUS) {
+    return null;
+  }
   return result;
 }
 

--- a/server/src/model/deliverable/index.ts
+++ b/server/src/model/deliverable/index.ts
@@ -5,7 +5,6 @@ export {
   checkDeliverableHasAtLeastOneDocument,
   checkDeliverableHasNoActiveExtension,
   checkDeliverableHasStatus,
-  checkDeliverableStatusNotFinalized,
   checkDemonstrationStatus,
   checkDueDateInFuture,
   checkForDuplicateDemonstrationTypes,

--- a/server/src/model/deliverable/validateDeliverableInputs.test.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.test.ts
@@ -55,7 +55,6 @@ vi.mock(".", () => ({
   checkDeliverableHasAtLeastOneDocument: vi.fn(),
   checkDeliverableHasNoActiveExtension: vi.fn(),
   checkDeliverableHasStatus: vi.fn(),
-  checkDeliverableStatusNotFinalized: vi.fn(),
   checkDemonstrationStatus: vi.fn(),
   checkDueDateInFuture: vi.fn(),
   checkNewDueDateIsAtLeastCurrentDueDate: vi.fn(),
@@ -73,7 +72,6 @@ import {
   checkDeliverableHasAtLeastOneDocument,
   checkDeliverableHasNoActiveExtension,
   checkDeliverableHasStatus,
-  checkDeliverableStatusNotFinalized,
   checkDemonstrationStatus,
   checkDueDateInFuture,
   checkNewDueDateIsAtLeastCurrentDueDate,
@@ -82,6 +80,7 @@ import {
   checkRequestedDeliverableDemonstrationType,
   getDeliverable,
 } from ".";
+import { ACTIVE_DELIVERABLE_STATUSES } from "../../constants";
 
 describe("validateDeliverableInputs", () => {
   const testEasternDate: EasternTZDate = {
@@ -407,6 +406,18 @@ describe("validateDeliverableInputs", () => {
       ).resolves.toBeUndefined();
     });
 
+    it("should always check the deliverable status", async () => {
+      const testInput: ParsedUpdateDeliverableInput = {
+        name: "A new name!",
+      };
+
+      await validateUpdateDeliverableInput(mockDeliverable.id!, testInput, mockTransaction);
+      expect(checkDeliverableHasStatus).toHaveBeenCalledExactlyOnceWith(
+        mockDeliverable,
+        ACTIVE_DELIVERABLE_STATUSES
+      );
+    });
+
     it("should get the user info if a new owner is passed, and call the check function", async () => {
       const testInput: ParsedUpdateDeliverableInput = {
         name: "A new name!",
@@ -469,9 +480,7 @@ describe("validateDeliverableInputs", () => {
         name: "A new name!",
         cmsOwnerUserId: "7d8fdea5-ca19-42e5-af50-98836b6d47db",
       };
-      vi.mocked(checkDeliverableStatusNotFinalized).mockReturnValue(
-        "The deliverable finalized status check failed!"
-      );
+      vi.mocked(checkDeliverableHasStatus).mockReturnValue("The deliverable status check failed!");
 
       try {
         await validateUpdateDeliverableInput(mockDeliverable.id!, testInput, mockTransaction);
@@ -484,7 +493,7 @@ describe("validateDeliverableInputs", () => {
         );
         expect(error.extensions.code).toBe("UPDATE_DELIVERABLE_VALIDATION_FAILED");
         expect(error.extensions.originalMessages).toStrictEqual([
-          "The deliverable finalized status check failed!",
+          "The deliverable status check failed!",
         ]);
       }
     });
@@ -582,9 +591,7 @@ describe("validateDeliverableInputs", () => {
           dateChangeNote: "Note is required",
         },
       };
-      vi.mocked(checkDeliverableStatusNotFinalized).mockReturnValue(
-        "The deliverable finalized status check failed!"
-      );
+      vi.mocked(checkDeliverableHasStatus).mockReturnValue("The deliverable status check failed!");
       vi.mocked(checkOwnerPersonType).mockReturnValue("The owner person type check failed");
       vi.mocked(checkRequestedDeliverableDemonstrationType).mockReturnValueOnce(
         "The demonstration type check failed"
@@ -601,7 +608,7 @@ describe("validateDeliverableInputs", () => {
         );
         expect(error.extensions.code).toBe("UPDATE_DELIVERABLE_VALIDATION_FAILED");
         expect(error.extensions.originalMessages).toStrictEqual([
-          "The deliverable finalized status check failed!",
+          "The deliverable status check failed!",
           "The owner person type check failed",
           "The demonstration type check failed",
         ]);
@@ -627,15 +634,31 @@ describe("validateDeliverableInputs", () => {
       ).resolves.toBeUndefined();
     });
 
+    it("should call the check functions", async () => {
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Upcoming",
+        cmsOwnerUserId: "7d8fdea5-ca19-42e5-af50-98836b6d47db",
+      };
+
+      await validateSubmitDeliverableInput(testInput as PrismaDeliverable, mockTransaction);
+      expect(checkDeliverableHasStatus).toHaveBeenCalledExactlyOnceWith(
+        testInput,
+        ACTIVE_DELIVERABLE_STATUSES
+      );
+      expect(checkDeliverableHasAtLeastOneDocument).toHaveBeenCalledExactlyOnceWith(
+        testInput,
+        mockTransaction
+      );
+    });
+
     it("should throw if the deliverable status check fails", async () => {
       const testInput: Partial<PrismaDeliverable> = {
         id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
         statusId: "Approved",
         cmsOwnerUserId: "7d8fdea5-ca19-42e5-af50-98836b6d47db",
       };
-      vi.mocked(checkDeliverableStatusNotFinalized).mockReturnValue(
-        "The deliverable finalized status check failed!"
-      );
+      vi.mocked(checkDeliverableHasStatus).mockReturnValue("The deliverable status check failed!");
 
       try {
         await validateSubmitDeliverableInput(testInput as PrismaDeliverable, mockTransaction);
@@ -648,7 +671,7 @@ describe("validateDeliverableInputs", () => {
         );
         expect(error.extensions.code).toBe("SUBMIT_DELIVERABLE_VALIDATION_FAILED");
         expect(error.extensions.originalMessages).toStrictEqual([
-          "The deliverable finalized status check failed!",
+          "The deliverable status check failed!",
         ]);
       }
     });
@@ -685,9 +708,7 @@ describe("validateDeliverableInputs", () => {
         statusId: "Approved",
         cmsOwnerUserId: "7d8fdea5-ca19-42e5-af50-98836b6d47db",
       };
-      vi.mocked(checkDeliverableStatusNotFinalized).mockReturnValue(
-        "The deliverable finalized status check failed!"
-      );
+      vi.mocked(checkDeliverableHasStatus).mockReturnValue("The deliverable status check failed!");
       vi.mocked(checkDeliverableHasAtLeastOneDocument).mockResolvedValue(
         "The deliverable document check has failed!"
       );
@@ -703,7 +724,7 @@ describe("validateDeliverableInputs", () => {
         );
         expect(error.extensions.code).toBe("SUBMIT_DELIVERABLE_VALIDATION_FAILED");
         expect(error.extensions.originalMessages).toStrictEqual([
-          "The deliverable finalized status check failed!",
+          "The deliverable status check failed!",
           "The deliverable document check has failed!",
         ]);
       }
@@ -723,6 +744,16 @@ describe("validateDeliverableInputs", () => {
       };
 
       expect(validateStartDeliverableReviewInput(testInput as PrismaDeliverable)).toBeUndefined();
+    });
+
+    it("should call the check functions", () => {
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Submitted",
+      };
+
+      validateStartDeliverableReviewInput(testInput as PrismaDeliverable);
+      expect(checkDeliverableHasStatus).toHaveBeenCalledExactlyOnceWith(testInput, ["Submitted"]);
     });
 
     it("should throw if the deliverable status check fails", () => {
@@ -762,6 +793,18 @@ describe("validateDeliverableInputs", () => {
       };
 
       expect(validateCompleteDeliverableInput(testInput as PrismaDeliverable)).toBeUndefined();
+    });
+
+    it("should call the check functions", () => {
+      const testInput: Partial<PrismaDeliverable> = {
+        id: "86e6a9f2-ea55-40de-a802-507d5b2cd852",
+        statusId: "Under CMS Review",
+      };
+
+      validateCompleteDeliverableInput(testInput as PrismaDeliverable);
+      expect(checkDeliverableHasStatus).toHaveBeenCalledExactlyOnceWith(testInput, [
+        "Under CMS Review",
+      ]);
     });
 
     it("should throw if the deliverable status check fails", () => {
@@ -809,6 +852,19 @@ describe("validateDeliverableInputs", () => {
       expect(
         validateRequestDeliverableResubmissionInput(testDeliverable as PrismaDeliverable, testInput)
       ).toBeUndefined();
+    });
+
+    it("should call the check functions", () => {
+      validateRequestDeliverableResubmissionInput(testDeliverable as PrismaDeliverable, testInput);
+      expect(checkDeliverableHasStatus).toHaveBeenCalledExactlyOnceWith(testDeliverable, [
+        "Submitted",
+        "Under CMS Review",
+      ]);
+      expect(checkDueDateInFuture).toHaveBeenCalledExactlyOnceWith(testInput.newDueDate);
+      expect(checkNewDueDateIsAtLeastCurrentDueDate).toHaveBeenCalledExactlyOnceWith(
+        testDeliverable,
+        testInput.newDueDate
+      );
     });
 
     it("should throw if the deliverable status check fails", () => {
@@ -944,6 +1000,23 @@ describe("validateDeliverableInputs", () => {
       ).resolves.toBeUndefined();
     });
 
+    it("should call the check functions", async () => {
+      await validateRequestDeliverableExtensionInput(
+        testDeliverable as PrismaDeliverable,
+        testInput,
+        mockTransaction
+      );
+      expect(checkDeliverableHasStatus).toHaveBeenCalledExactlyOnceWith(testDeliverable, [
+        "Upcoming",
+        "Past Due",
+      ]);
+      expect(checkDueDateInFuture).toHaveBeenCalledExactlyOnceWith(testInput.requestedDueDate);
+      expect(checkNewDueDateIsGreaterThanCurrentDueDate).toHaveBeenCalledExactlyOnceWith(
+        testDeliverable,
+        testInput.requestedDueDate
+      );
+    });
+
     it("should throw if the active extension check fails", async () => {
       vi.mocked(checkDeliverableHasNoActiveExtension).mockResolvedValue(
         "The active extenson check failed!"
@@ -1075,8 +1148,8 @@ describe("validateDeliverableInputs", () => {
         );
         expect(error.extensions.code).toBe("REQUEST_DELIVERABLE_EXTENSION_VALIDATION_FAILED");
         expect(error.extensions.originalMessages).toStrictEqual([
-          "The active extenson check failed!",
           "The deliverable status check failed!",
+          "The active extenson check failed!",
           "The future due date check failed!",
           "The current and new due date check failed!",
         ]);
@@ -1112,6 +1185,23 @@ describe("validateDeliverableInputs", () => {
           testInput
         )
       ).toBeUndefined();
+    });
+
+    it("should call the check functions", () => {
+      validateApproveDeliverableExtensionInput(
+        testDeliverable as PrismaDeliverable,
+        testDeliverableExtension as PrismaDeliverableExtension,
+        testInput
+      );
+      expect(checkDeliverableHasStatus).toHaveBeenCalledExactlyOnceWith(
+        testDeliverable,
+        ACTIVE_DELIVERABLE_STATUSES
+      );
+      expect(checkDeliverableExtensionHasStatus).toHaveBeenCalledExactlyOnceWith(
+        testDeliverableExtension,
+        ["Requested"]
+      );
+      expect(checkDueDateInFuture).toHaveBeenCalledExactlyOnceWith(testInput.finalDateGranted);
     });
 
     it("should throw if the deliverable status check fails", () => {
@@ -1243,6 +1333,21 @@ describe("validateDeliverableInputs", () => {
           testDeliverableExtension as PrismaDeliverableExtension
         )
       ).toBeUndefined();
+    });
+
+    it("should call the check functions", () => {
+      validateDenyDeliverableExtensionInput(
+        testDeliverable as PrismaDeliverable,
+        testDeliverableExtension as PrismaDeliverableExtension
+      );
+      expect(checkDeliverableHasStatus).toHaveBeenCalledExactlyOnceWith(
+        testDeliverable,
+        ACTIVE_DELIVERABLE_STATUSES
+      );
+      expect(checkDeliverableExtensionHasStatus).toHaveBeenCalledExactlyOnceWith(
+        testDeliverableExtension,
+        ["Requested"]
+      );
     });
 
     it("should throw if the deliverable status check fails", () => {

--- a/server/src/model/deliverable/validateDeliverableInputs.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.ts
@@ -3,7 +3,6 @@ import {
   checkDeliverableHasAtLeastOneDocument,
   checkDeliverableHasNoActiveExtension,
   checkDeliverableHasStatus,
-  checkDeliverableStatusNotFinalized,
   checkDemonstrationStatus,
   checkDueDateInFuture,
   checkNewDueDateIsAtLeastCurrentDueDate,
@@ -28,6 +27,7 @@ import {
 } from "@prisma/client";
 import { GraphQLContext } from "../../auth";
 import { PersonType } from "../../types";
+import { ACTIVE_DELIVERABLE_STATUSES } from "../../constants";
 
 function cleanErrorsAndThrow(errors: (string | undefined)[], mutator: string, code: string): void {
   const cleanedErrors = errors.filter((e) => e !== undefined);
@@ -100,7 +100,8 @@ export async function validateUpdateDeliverableInput(
   const deliverable = await getDeliverable({ id: deliverableId }, tx);
   const errors: (string | undefined)[] = [];
 
-  errors.push(checkDeliverableStatusNotFinalized(deliverable));
+  // Updates can be performed on all active deliverables
+  errors.push(checkDeliverableHasStatus(deliverable, ACTIVE_DELIVERABLE_STATUSES));
 
   if (input.cmsOwnerUserId) {
     const cmsOwnerUser = await getUser({ id: input.cmsOwnerUserId }, tx);
@@ -134,7 +135,8 @@ export async function validateSubmitDeliverableInput(
   const errors: (string | undefined)[] = [];
 
   errors.push(
-    checkDeliverableStatusNotFinalized(deliverable),
+    // Users may submit on all active deliverables
+    checkDeliverableHasStatus(deliverable, ACTIVE_DELIVERABLE_STATUSES),
     await checkDeliverableHasAtLeastOneDocument(deliverable, tx)
   );
   cleanErrorsAndThrow(errors, "submitDeliverable", "SUBMIT_DELIVERABLE_VALIDATION_FAILED");
@@ -143,6 +145,7 @@ export async function validateSubmitDeliverableInput(
 export function validateStartDeliverableReviewInput(deliverable: PrismaDeliverable): void {
   const errors: (string | undefined)[] = [];
 
+  // Review can only be started when the deliverable is submitted
   errors.push(checkDeliverableHasStatus(deliverable, ["Submitted"]));
   cleanErrorsAndThrow(
     errors,
@@ -154,6 +157,7 @@ export function validateStartDeliverableReviewInput(deliverable: PrismaDeliverab
 export function validateCompleteDeliverableInput(deliverable: PrismaDeliverable): void {
   const errors: (string | undefined)[] = [];
 
+  // Deliverables may only be completed from review status
   errors.push(checkDeliverableHasStatus(deliverable, ["Under CMS Review"]));
   cleanErrorsAndThrow(errors, "completeDeliverable", "COMPLETE_DELIVERABLE_VALIDATION_FAILED");
 }
@@ -164,6 +168,7 @@ export function validateRequestDeliverableResubmissionInput(
 ): void {
   const errors: (string | undefined)[] = [];
 
+  // Resubmissions may be requested from submitted or under review status
   errors.push(
     checkDeliverableHasStatus(deliverable, ["Submitted", "Under CMS Review"]),
     checkDueDateInFuture(input.newDueDate),
@@ -184,8 +189,9 @@ export async function validateRequestDeliverableExtensionInput(
   const errors: (string | undefined)[] = [];
 
   errors.push(
-    await checkDeliverableHasNoActiveExtension(deliverable, tx),
+    // Extensions may only be requested prior to submission
     checkDeliverableHasStatus(deliverable, ["Upcoming", "Past Due"]),
+    await checkDeliverableHasNoActiveExtension(deliverable, tx),
     checkDueDateInFuture(input.requestedDueDate),
     checkNewDueDateIsGreaterThanCurrentDueDate(deliverable, input.requestedDueDate)
   );
@@ -204,12 +210,8 @@ export function validateApproveDeliverableExtensionInput(
   const errors: (string | undefined)[] = [];
 
   errors.push(
-    checkDeliverableHasStatus(deliverable, [
-      "Upcoming",
-      "Past Due",
-      "Submitted",
-      "Under CMS Review",
-    ]),
+    // Extensions may be processed for any active deliverable
+    checkDeliverableHasStatus(deliverable, ACTIVE_DELIVERABLE_STATUSES),
     checkDeliverableExtensionHasStatus(deliverableExtension, ["Requested"]),
     checkDueDateInFuture(input.finalDateGranted)
   );
@@ -227,12 +229,8 @@ export function validateDenyDeliverableExtensionInput(
   const errors: (string | undefined)[] = [];
 
   errors.push(
-    checkDeliverableHasStatus(deliverable, [
-      "Upcoming",
-      "Past Due",
-      "Submitted",
-      "Under CMS Review",
-    ]),
+    // Extensions may be processed for any active deliverable
+    checkDeliverableHasStatus(deliverable, ACTIVE_DELIVERABLE_STATUSES),
     checkDeliverableExtensionHasStatus(deliverableExtension, ["Requested"])
   );
   cleanErrorsAndThrow(

--- a/server/src/model/migrations/20260507165859_add_deliverable_deletion_path/migration.sql
+++ b/server/src/model/migrations/20260507165859_add_deliverable_deletion_path/migration.sql
@@ -1,0 +1,17 @@
+SET search_path TO demos_app;
+
+INSERT INTO
+    demos_app.deliverable_status
+VALUES
+    ('Deleted');
+
+INSERT INTO
+    demos_app.deliverable_action_type
+VALUES
+    ('Deleted Deliverable', false, false, true, true);
+
+INSERT INTO
+    demos_app.deliverable_action_configuration
+VALUES
+    ('Deleted Deliverable', 'Upcoming', 'Deleted'),
+    ('Deleted Deliverable', 'Past Due', 'Deleted');


### PR DESCRIPTION
This PR adds the basic ability to soft-delete deliverables by adding a new deliverable status and action for deletion. The actual implementation of deletion will be done in a separate PR; this one focuses on refining some of the checks and adding appropriate records to the database.