### PR TITLE
DEMOS-1998: updated string for collapsable detials

### DIFF
--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
@@ -81,12 +81,12 @@ describe("DeliverableDetailsManagementPage", () => {
     const user = userEvent.setup();
     renderAtRoute("1");
 
-    expect(await screen.findByText("Show Additional Details")).toBeInTheDocument();
+    expect(await screen.findByText("See Additional Details")).toBeInTheDocument();
     expect(screen.queryByTestId("deliverable-CMS Owner")).not.toBeInTheDocument();
 
-    await user.click(screen.getByText("Show Additional Details"));
+    await user.click(screen.getByText("See Additional Details"));
 
-    expect(screen.getByText("Hide Additional Details")).toBeInTheDocument();
+    expect(screen.getByText("Less Details")).toBeInTheDocument();
     expect(screen.getByTestId("deliverable-CMS Owner")).toHaveTextContent("Mock User");
   });
 

--- a/client/src/pages/deliverables/sections/DeliverableInfoFields.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableInfoFields.tsx
@@ -97,13 +97,13 @@ export const DeliverableInfoFields = ({
                 onClick={onToggleAdditionalDetails}
                 className="inline-flex items-center gap-[4px] text-action underline underline-offset-2"
               >
-                {showAdditionalDetails ? "Hide Additional Details" : "Show Additional Details"}
+                {showAdditionalDetails ? "Less Details" : "See Additional Details"}
                 <span
                   className={`transition-transform duration-200 ${
                     showAdditionalDetails ? "rotate-180" : "rotate-0"
                   }`}
                 >
-                  <ChevronDownIcon className="w-[10px] h-[10px]" />
+                  <ChevronDownIcon />
                 </span>
               </button>
             </>


### PR DESCRIPTION
The show additional detials metadata hidable string needed some details updated. Including the string and the size of the chevron per the spec.

<img width="1187" height="591" alt="Screenshot 2026-05-11 at 10 41 53" src="https://github.com/user-attachments/assets/a6709a81-d5c4-4344-abca-bd5c7c5eec3d" />

<img width="1756" height="624" alt="Screenshot 2026-05-11 at 10 42 41" src="https://github.com/user-attachments/assets/da45287c-8d7a-486f-94e5-180bcbb25a5f" />
