### PR TITLE
DEMOS-1958-delete-deliverable

### DIFF
--- a/server/src/model/deliverable/approveDeliverableExtension.test.ts
+++ b/server/src/model/deliverable/approveDeliverableExtension.test.ts
@@ -171,8 +171,10 @@ describe("approveDeliverableExtension", () => {
       testUserContext as GraphQLContext
     );
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
-      { id: testDeliverableId },
-      mockTransaction
+      {
+        id: testDeliverableId,
+      },
+      { tx: mockTransaction }
     );
   });
 

--- a/server/src/model/deliverable/approveDeliverableExtension.test.ts
+++ b/server/src/model/deliverable/approveDeliverableExtension.test.ts
@@ -1,5 +1,5 @@
 // Vitest and other helpers
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TZDate } from "@date-fns/tz";
 import { DeepPartial } from "../../testUtilities";
 
@@ -93,7 +93,6 @@ describe("approveDeliverableExtension", () => {
       easternTZDate: new TZDate(2026, 9, 28, 23, 59, 59, 999, "America/New_York"),
     },
   };
-  const mockNow = new Date(2026, 3, 27, 10, 4, 19, 232);
 
   // Mock transaction
   const mockTransaction: any = "Test!";
@@ -103,8 +102,6 @@ describe("approveDeliverableExtension", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.useFakeTimers();
-    vi.setSystemTime(mockNow);
     vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
     vi.mocked(getDeliverable).mockResolvedValue(mockUnapprovedDeliverable as PrismaDeliverable);
     vi.mocked(selectDeliverableExtension).mockResolvedValue(
@@ -113,10 +110,6 @@ describe("approveDeliverableExtension", () => {
     vi.mocked(parseApproveDeliverableExtensionInput).mockReturnValue(mockParsedInput);
     vi.mocked(editDeliverable).mockResolvedValue(mockApprovedDeliverable as PrismaDeliverable);
     mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
   it("should check that the user is allowed to do this operation", async () => {
@@ -270,7 +263,6 @@ describe("approveDeliverableExtension", () => {
       {
         deliverableId: testDeliverableId,
         actionType: "Approved Extension Request",
-        actionTime: mockNow,
         oldStatus: mockUnapprovedDeliverable.statusId,
         newStatus: mockApprovedDeliverable.statusId,
         oldDueDate: mockUnapprovedDeliverable.dueDate,

--- a/server/src/model/deliverable/approveDeliverableExtension.ts
+++ b/server/src/model/deliverable/approveDeliverableExtension.ts
@@ -68,7 +68,6 @@ export async function approveDeliverableExtension(
       {
         deliverableId: deliverableId,
         actionType: "Approved Extension Request",
-        actionTime: new Date(),
         oldStatus: unapprovedDeliverable.statusId as DeliverableStatus,
         newStatus: approvedDeliverable.statusId as DeliverableStatus,
         oldDueDate: unapprovedDeliverable.dueDate,

--- a/server/src/model/deliverable/approveDeliverableExtension.ts
+++ b/server/src/model/deliverable/approveDeliverableExtension.ts
@@ -30,7 +30,7 @@ export async function approveDeliverableExtension(
   return await prisma().$transaction(async (tx) => {
     // Note that parsing is inside tx here because we need to get the extension first
     // This is passed to the parser to give back the final date to use
-    const unapprovedDeliverable = await getDeliverable({ id: deliverableId }, tx);
+    const unapprovedDeliverable = await getDeliverable({ id: deliverableId }, { tx: tx });
     const unapprovedDeliverableExtension = await selectDeliverableExtension(
       { id: input.deliverableExtensionId },
       true,

--- a/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
@@ -11,11 +11,13 @@ import {
   TagName,
 } from "../../types";
 import {
-  DeliverableExtension as PrismaDeliverableExtension,
   Deliverable as PrismaDeliverable,
+  DeliverableExtension as PrismaDeliverableExtension,
   Demonstration as PrismaDemonstration,
   DemonstrationTypeTagAssignment as PrismaDemonstrationTypeTagAssignment,
   Document as PrismaDocument,
+  PrivateComment as PrismaPrivateComment,
+  PublicComment as PrismaPublicComment,
   User as PrismaUser,
 } from "@prisma/client";
 
@@ -24,6 +26,8 @@ import {
   checkDeliverableExtensionHasStatus,
   checkDeliverableHasAtLeastOneDocument,
   checkDeliverableHasNoActiveExtension,
+  checkDeliverableHasNoComments,
+  checkDeliverableHasNoDocuments,
   checkDeliverableHasStatus,
   checkDemonstrationStatus,
   checkDueDateInFuture,
@@ -43,8 +47,18 @@ vi.mock("../deliverableExtension/queries", () => ({
   selectManyDeliverableExtensions: vi.fn(),
 }));
 
+vi.mock("../publicComment/queries", () => ({
+  selectManyPublicComments: vi.fn(),
+}));
+
+vi.mock("../privateComment/queries", () => ({
+  selectManyPrivateComments: vi.fn(),
+}));
+
 import { selectManyDocuments } from "../document";
 import { selectManyDeliverableExtensions } from "../deliverableExtension/queries";
+import { selectManyPublicComments } from "../publicComment/queries";
+import { selectManyPrivateComments } from "../privateComment/queries";
 
 describe("checkDeliverableInputFunctions", () => {
   describe("checkDemonstrationStatus", () => {
@@ -75,14 +89,14 @@ describe("checkDeliverableInputFunctions", () => {
       statusId: "Under CMS Review",
     };
 
-    it("should return undefined if the passed status matches the object", async () => {
+    it("should return undefined if the passed status matches the object", () => {
       const result = checkDeliverableHasStatus(testDeliverable as PrismaDeliverable, [
         "Under CMS Review",
       ]);
       expect(result).toBeUndefined();
     });
 
-    it("should return an error message the passed status does not match the object", async () => {
+    it("should return an error message the passed status does not match the object", () => {
       const result = checkDeliverableHasStatus(testDeliverable as PrismaDeliverable, [
         "Approved",
         "Accepted",
@@ -406,7 +420,7 @@ describe("checkDeliverableInputFunctions", () => {
       statusId: "Denied" satisfies DeliverableExtensionStatus,
     };
 
-    it("should return undefined if the passed status matches the object", async () => {
+    it("should return undefined if the passed status matches the object", () => {
       const result = checkDeliverableExtensionHasStatus(
         testDeliverableExtension as PrismaDeliverableExtension,
         ["Denied"]
@@ -414,7 +428,7 @@ describe("checkDeliverableInputFunctions", () => {
       expect(result).toBeUndefined();
     });
 
-    it("should return an error message the passed status does not match the object", async () => {
+    it("should return an error message the passed status does not match the object", () => {
       const result = checkDeliverableExtensionHasStatus(
         testDeliverableExtension as PrismaDeliverableExtension,
         ["Approved", "Requested"]
@@ -422,6 +436,106 @@ describe("checkDeliverableInputFunctions", () => {
       expect(result).toBe(
         "Deliverable extension expected to have one of status Approved, Requested; " +
           "actual status was Denied."
+      );
+    });
+  });
+
+  describe("checkDeliverableHasNoDocuments", () => {
+    const testDeliverable: Partial<PrismaDeliverable> = {
+      id: "3d802d02-f464-44e0-b789-53a9aa249979",
+      statusId: "Upcoming" satisfies DeliverableStatus,
+    };
+    const testTransaction = "I'm a test transaction!" as any;
+
+    it("should return undefined if no documents are returned", async () => {
+      vi.mocked(selectManyDocuments).mockResolvedValue([]);
+
+      const result = await checkDeliverableHasNoDocuments(
+        testDeliverable as PrismaDeliverable,
+        testTransaction
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it("should return an error message if documents are returned", async () => {
+      vi.mocked(selectManyDocuments).mockResolvedValue([{ id: "abc123" }] as PrismaDocument[]);
+
+      const result = await checkDeliverableHasNoDocuments(
+        testDeliverable as PrismaDeliverable,
+        testTransaction
+      );
+      expect(result).toBe(
+        `Expected deliverable ${testDeliverable.id} to have no ` +
+          "documents attached, but documents were found."
+      );
+    });
+  });
+
+  describe("checkDeliverableHasNoComments", () => {
+    const testDeliverable: Partial<PrismaDeliverable> = {
+      id: "45f7753b-9d83-425c-9274-dad2cf5d551e",
+      statusId: "Past Due" satisfies DeliverableStatus,
+    };
+    const testTransaction = "I'm a test transaction!" as any;
+
+    it("should return undefined if no comments are returned", async () => {
+      vi.mocked(selectManyPublicComments).mockResolvedValue([]);
+      vi.mocked(selectManyPrivateComments).mockResolvedValue([]);
+
+      const result = await checkDeliverableHasNoComments(
+        testDeliverable as PrismaDeliverable,
+        testTransaction
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it("should return an error message if private comments are found", async () => {
+      vi.mocked(selectManyPublicComments).mockResolvedValue([]);
+      vi.mocked(selectManyPrivateComments).mockResolvedValue([
+        { id: "abc123" },
+      ] as PrismaPrivateComment[]);
+
+      const result = await checkDeliverableHasNoComments(
+        testDeliverable as PrismaDeliverable,
+        testTransaction
+      );
+      expect(result).toBe(
+        `Expected deliverable ${testDeliverable.id} to have no ` +
+          "comments, but public or private comments were found."
+      );
+    });
+
+    it("should return an error message if public comments are found", async () => {
+      vi.mocked(selectManyPublicComments).mockResolvedValue([
+        { id: "abc123" },
+      ] as PrismaPrivateComment[]);
+      vi.mocked(selectManyPrivateComments).mockResolvedValue([]);
+
+      const result = await checkDeliverableHasNoComments(
+        testDeliverable as PrismaDeliverable,
+        testTransaction
+      );
+      expect(result).toBe(
+        `Expected deliverable ${testDeliverable.id} to have no ` +
+          "comments, but public or private comments were found."
+      );
+    });
+
+    it("should return an error message if both type of comments are found", async () => {
+      vi.mocked(selectManyPublicComments).mockResolvedValue([
+        { id: "abc123" },
+      ] as PrismaPrivateComment[]);
+      vi.mocked(selectManyPrivateComments).mockResolvedValue([
+        { id: "def456" },
+      ] as PrismaPrivateComment[]);
+
+      const result = await checkDeliverableHasNoComments(
+        testDeliverable as PrismaDeliverable,
+        testTransaction
+      );
+      expect(result).toBe(
+        `Expected deliverable ${testDeliverable.id} to have no ` +
+          "comments, but public or private comments were found."
       );
     });
   });

--- a/server/src/model/deliverable/checkDeliverableInputFunctions.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.ts
@@ -17,6 +17,8 @@ import { findDuplicates } from "../../validationUtilities";
 import { EasternTZDate, getEasternNow } from "../../dateUtilities";
 import { selectManyDocuments } from "../document";
 import { selectManyDeliverableExtensions } from "../deliverableExtension/queries";
+import { selectManyPublicComments } from "../publicComment/queries";
+import { selectManyPrivateComments } from "../privateComment/queries";
 
 export function checkDemonstrationStatus(demonstration: PrismaDemonstration): string | undefined {
   const approvedStatus: ApplicationStatus = "Approved";
@@ -136,5 +138,26 @@ export function checkDeliverableExtensionHasStatus(
       `Deliverable extension expected to have one of status ${expectedStatuses.join(", ")}; ` +
       `actual status was ${deliverableExtensionStatus}.`
     );
+  }
+}
+
+export async function checkDeliverableHasNoDocuments(
+  deliverable: PrismaDeliverable,
+  tx: PrismaTransactionClient
+): Promise<string | undefined> {
+  const deliverableDocuments = await selectManyDocuments({ deliverableId: deliverable.id }, tx);
+  if (deliverableDocuments.length > 0) {
+    return `Expected deliverable ${deliverable.id} to have no documents attached, but documents were found.`;
+  }
+}
+
+export async function checkDeliverableHasNoComments(
+  deliverable: PrismaDeliverable,
+  tx: PrismaTransactionClient
+): Promise<string | undefined> {
+  const publicComments = await selectManyPublicComments({ deliverableId: deliverable.id }, tx);
+  const privateComments = await selectManyPrivateComments({ deliverableId: deliverable.id }, tx);
+  if (publicComments.length > 0 || privateComments.length > 0) {
+    return `Expected deliverable ${deliverable.id} to have no comments, but public or private comments were found.`;
   }
 }

--- a/server/src/model/deliverable/completeDeliverable.test.ts
+++ b/server/src/model/deliverable/completeDeliverable.test.ts
@@ -1,5 +1,5 @@
 // Vitest and other helpers
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DeepPartial } from "../../testUtilities";
 
 // Types
@@ -55,7 +55,6 @@ describe("completeDeliverable", () => {
     statusId: "Approved",
     dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
   };
-  const mockNow = new Date(2026, 3, 27, 10, 4, 19, 232);
 
   // Mock transaction
   const mockTransaction: any = "Test!";
@@ -65,16 +64,10 @@ describe("completeDeliverable", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.useFakeTimers();
-    vi.setSystemTime(mockNow);
     vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
     vi.mocked(getDeliverable).mockResolvedValue(mockIncompleteDeliverable as PrismaDeliverable);
     vi.mocked(editDeliverable).mockResolvedValue(mockCompleteDeliverable as PrismaDeliverable);
     mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
   it("should check that the user is allowed to do this operation", async () => {
@@ -127,7 +120,6 @@ describe("completeDeliverable", () => {
       {
         deliverableId: testDeliverableId,
         actionType: "Approved Deliverable",
-        actionTime: mockNow,
         oldStatus: mockIncompleteDeliverable.statusId,
         newStatus: mockCompleteDeliverable.statusId,
         oldDueDate: mockIncompleteDeliverable.dueDate,
@@ -144,7 +136,6 @@ describe("completeDeliverable", () => {
       {
         deliverableId: testDeliverableId,
         actionType: "Accepted Deliverable",
-        actionTime: mockNow,
         oldStatus: mockIncompleteDeliverable.statusId,
         newStatus: mockCompleteDeliverable.statusId,
         oldDueDate: mockIncompleteDeliverable.dueDate,
@@ -165,7 +156,6 @@ describe("completeDeliverable", () => {
       {
         deliverableId: testDeliverableId,
         actionType: "Received and Filed Deliverable",
-        actionTime: mockNow,
         oldStatus: mockIncompleteDeliverable.statusId,
         newStatus: mockCompleteDeliverable.statusId,
         oldDueDate: mockIncompleteDeliverable.dueDate,

--- a/server/src/model/deliverable/completeDeliverable.test.ts
+++ b/server/src/model/deliverable/completeDeliverable.test.ts
@@ -94,7 +94,7 @@ describe("completeDeliverable", () => {
     await completeDeliverable(testDeliverableId, "Approved", testUserContext as GraphQLContext);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
   });
 

--- a/server/src/model/deliverable/completeDeliverable.ts
+++ b/server/src/model/deliverable/completeDeliverable.ts
@@ -37,7 +37,6 @@ export async function completeDeliverable(
       {
         deliverableId: deliverableId,
         actionType: statusToAction[finalStatus],
-        actionTime: new Date(),
         oldStatus: incompleteDeliverable.statusId as DeliverableStatus,
         newStatus: completedDeliverable.statusId as DeliverableStatus,
         oldDueDate: incompleteDeliverable.dueDate,

--- a/server/src/model/deliverable/completeDeliverable.ts
+++ b/server/src/model/deliverable/completeDeliverable.ts
@@ -17,7 +17,7 @@ export async function completeDeliverable(
 ): Promise<PrismaDeliverable> {
   validateUserPersonTypeAllowed(context, "completeDeliverable", ["demos-admin", "demos-cms-user"]);
   return await prisma().$transaction(async (tx) => {
-    const incompleteDeliverable = await getDeliverable({ id: deliverableId }, tx);
+    const incompleteDeliverable = await getDeliverable({ id: deliverableId }, { tx: tx });
     validateCompleteDeliverableInput(incompleteDeliverable);
 
     const completedDeliverable = await editDeliverable(

--- a/server/src/model/deliverable/createDeliverable.test.ts
+++ b/server/src/model/deliverable/createDeliverable.test.ts
@@ -1,5 +1,5 @@
 // Vitest and other helpers
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TZDate } from "@date-fns/tz";
 import { DeepPartial } from "../../testUtilities";
 
@@ -59,7 +59,6 @@ describe("createDeliverable", () => {
   };
 
   // Mock return values
-  const mockCurrentDate = new Date(2025, 3, 17, 14, 33, 19, 205);
   const mockParsedInput: ParsedCreateDeliverableInput = {
     name: testInput.name,
     deliverableType: testInput.deliverableType,
@@ -82,16 +81,10 @@ describe("createDeliverable", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.useFakeTimers();
-    vi.setSystemTime(mockCurrentDate);
     vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
     vi.mocked(parseCreateDeliverableInput).mockReturnValue(mockParsedInput);
     vi.mocked(insertDeliverable).mockResolvedValue(mockNewDeliverable as PrismaDeliverable);
     mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
   it("should check that the user is allowed to do this operation", async () => {
@@ -172,7 +165,6 @@ describe("createDeliverable", () => {
       {
         deliverableId: mockNewDeliverable.id,
         actionType: "Created Deliverable Slot",
-        actionTime: mockCurrentDate,
         oldStatus: "Upcoming",
         newStatus: "Upcoming",
         oldDueDate: mockParsedInput.dueDate.easternTZDate,

--- a/server/src/model/deliverable/createDeliverable.ts
+++ b/server/src/model/deliverable/createDeliverable.ts
@@ -19,7 +19,6 @@ export async function createDeliverable(
   validateUserPersonTypeAllowed(context, "createDeliverable", ["demos-admin", "demos-cms-user"]);
   const parsedInput = parseCreateDeliverableInput(input);
   const createdDeliverable = await prisma().$transaction(async (tx) => {
-    const actionTime = new Date();
     await validateCreateDeliverableInput(parsedInput, tx);
 
     const newDeliverable = await insertDeliverable(parsedInput, tx);
@@ -38,7 +37,6 @@ export async function createDeliverable(
       {
         deliverableId: newDeliverable.id,
         actionType: "Created Deliverable Slot",
-        actionTime: actionTime,
         oldStatus: "Upcoming",
         newStatus: "Upcoming",
         oldDueDate: parsedInput.dueDate.easternTZDate,

--- a/server/src/model/deliverable/deleteDeliverable.test.ts
+++ b/server/src/model/deliverable/deleteDeliverable.test.ts
@@ -7,7 +7,7 @@ import { GraphQLContext } from "../../auth";
 import { Deliverable as PrismaDeliverable } from "@prisma/client";
 
 // Functions under test
-import { startDeliverableReview } from "./startDeliverableReview";
+import { deleteDeliverable } from "./deleteDeliverable";
 
 // Mock imports
 vi.mock("../../prismaClient", () => ({
@@ -17,7 +17,7 @@ vi.mock("../../prismaClient", () => ({
 vi.mock(".", () => ({
   editDeliverable: vi.fn(),
   getDeliverable: vi.fn(),
-  validateStartDeliverableReviewInput: vi.fn(),
+  validateDeleteDeliverableInput: vi.fn(),
   validateUserPersonTypeAllowed: vi.fn(),
 }));
 
@@ -29,31 +29,26 @@ import { prisma } from "../../prismaClient";
 import {
   editDeliverable,
   getDeliverable,
-  validateStartDeliverableReviewInput,
+  validateDeleteDeliverableInput,
   validateUserPersonTypeAllowed,
 } from ".";
 import { insertDeliverableAction } from "../deliverableAction/queries";
 
-describe("startDeliverableReview", () => {
+describe("deleteDeliverable", () => {
   // Test inputs
   const testDeliverableId = "b18cf1ce-3e41-4a71-b4f4-585f343bc74f";
   const testUserContext: DeepPartial<GraphQLContext> = {
     user: {
-      id: "0a3bd415-39a3-4f72-a067-418a5219216a",
+      id: "7c1f216a-a51e-472a-a480-aa9dcdb3de7f",
       personTypeId: "demos-admin",
     },
   };
 
   // Mock results
-  const mockUnstartedDeliverable: Partial<PrismaDeliverable> = {
+  const mockDeliverable: Partial<PrismaDeliverable> = {
     id: testDeliverableId,
-    statusId: "Submitted",
-    dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
-  };
-  const mockStartedDeliverable: Partial<PrismaDeliverable> = {
-    id: testDeliverableId,
-    statusId: "Under CMS Review",
-    dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
+    statusId: "Upcoming",
+    dueDate: new Date(2027, 1, 13, 2, 55, 19, 11),
   };
 
   // Mock transaction
@@ -65,16 +60,15 @@ describe("startDeliverableReview", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
-    vi.mocked(getDeliverable).mockResolvedValue(mockUnstartedDeliverable as PrismaDeliverable);
-    vi.mocked(editDeliverable).mockResolvedValue(mockStartedDeliverable as PrismaDeliverable);
+    vi.mocked(getDeliverable).mockResolvedValue(mockDeliverable as PrismaDeliverable);
     mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
   });
 
   it("should check that the user is allowed to do this operation", async () => {
-    await startDeliverableReview(testDeliverableId, testUserContext as GraphQLContext);
+    await deleteDeliverable(testDeliverableId, testUserContext as GraphQLContext);
     expect(validateUserPersonTypeAllowed).toHaveBeenCalledExactlyOnceWith(
       testUserContext,
-      "startDeliverableReview",
+      "deleteDeliverable",
       ["demos-admin", "demos-cms-user"]
     );
   });
@@ -83,15 +77,15 @@ describe("startDeliverableReview", () => {
     vi.mocked(validateUserPersonTypeAllowed).mockThrow("I'm throwing!");
 
     try {
-      await startDeliverableReview(testDeliverableId, testUserContext as GraphQLContext);
-      throw new Error("Expected startDeliverableReview to throw, but it did not.");
+      await deleteDeliverable(testDeliverableId, testUserContext as GraphQLContext);
+      throw new Error("Expected deleteDeliverable to throw, but it did not.");
     } catch (e) {
       expect(prisma).not.toHaveBeenCalled();
     }
   });
 
   it("should get the deliverable before making changes", async () => {
-    await startDeliverableReview(testDeliverableId, testUserContext as GraphQLContext);
+    await deleteDeliverable(testDeliverableId, testUserContext as GraphQLContext);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
       mockTransaction
@@ -99,31 +93,32 @@ describe("startDeliverableReview", () => {
   });
 
   it("should call the validator on the unchanged deliverable", async () => {
-    await startDeliverableReview(testDeliverableId, testUserContext as GraphQLContext);
-    expect(validateStartDeliverableReviewInput).toHaveBeenCalledExactlyOnceWith(
-      mockUnstartedDeliverable
-    );
-  });
-
-  it("should call edit function to set the status to under CMS review", async () => {
-    await startDeliverableReview(testDeliverableId, testUserContext as GraphQLContext);
-    expect(editDeliverable).toHaveBeenCalledExactlyOnceWith(
-      testDeliverableId,
-      { statusId: "Under CMS Review" },
+    await deleteDeliverable(testDeliverableId, testUserContext as GraphQLContext);
+    expect(validateDeleteDeliverableInput).toHaveBeenCalledExactlyOnceWith(
+      mockDeliverable,
       mockTransaction
     );
   });
 
-  it("should log an action for the submission", async () => {
-    await startDeliverableReview(testDeliverableId, testUserContext as GraphQLContext);
+  it("should call edit function to set the status to the passed value", async () => {
+    await deleteDeliverable(testDeliverableId, testUserContext as GraphQLContext);
+    expect(editDeliverable).toHaveBeenCalledExactlyOnceWith(
+      testDeliverableId,
+      { statusId: "Deleted" },
+      mockTransaction
+    );
+  });
+
+  it("should log an action for the completion", async () => {
+    await deleteDeliverable(testDeliverableId, testUserContext as GraphQLContext);
     expect(insertDeliverableAction).toHaveBeenCalledExactlyOnceWith(
       {
         deliverableId: testDeliverableId,
-        actionType: "Started Review",
-        oldStatus: mockUnstartedDeliverable.statusId,
-        newStatus: mockStartedDeliverable.statusId,
-        oldDueDate: mockUnstartedDeliverable.dueDate,
-        newDueDate: mockStartedDeliverable.dueDate,
+        actionType: "Deleted Deliverable",
+        oldStatus: mockDeliverable.statusId,
+        newStatus: "Deleted",
+        oldDueDate: mockDeliverable.dueDate,
+        newDueDate: mockDeliverable.dueDate,
         userId: testUserContext.user!.id,
       },
       mockTransaction

--- a/server/src/model/deliverable/deleteDeliverable.test.ts
+++ b/server/src/model/deliverable/deleteDeliverable.test.ts
@@ -88,7 +88,7 @@ describe("deleteDeliverable", () => {
     await deleteDeliverable(testDeliverableId, testUserContext as GraphQLContext);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
   });
 

--- a/server/src/model/deliverable/deleteDeliverable.ts
+++ b/server/src/model/deliverable/deleteDeliverable.ts
@@ -17,7 +17,7 @@ export async function deleteDeliverable(
   validateUserPersonTypeAllowed(context, "deleteDeliverable", ["demos-admin", "demos-cms-user"]);
 
   return await prisma().$transaction(async (tx) => {
-    const deliverable = await getDeliverable({ id: deliverableId }, tx);
+    const deliverable = await getDeliverable({ id: deliverableId }, { tx: tx });
     await validateDeleteDeliverableInput(deliverable, tx);
 
     await editDeliverable(deliverableId, { statusId: "Deleted" }, tx);

--- a/server/src/model/deliverable/deleteDeliverable.ts
+++ b/server/src/model/deliverable/deleteDeliverable.ts
@@ -1,0 +1,38 @@
+import { Deliverable as PrismaDeliverable } from "@prisma/client";
+import { GraphQLContext } from "../../auth";
+import { DeliverableStatus } from "../../types";
+import { prisma } from "../../prismaClient";
+import {
+  editDeliverable,
+  getDeliverable,
+  validateDeleteDeliverableInput,
+  validateUserPersonTypeAllowed,
+} from ".";
+import { insertDeliverableAction } from "../deliverableAction/queries";
+
+export async function deleteDeliverable(
+  deliverableId: string,
+  context: GraphQLContext
+): Promise<PrismaDeliverable> {
+  validateUserPersonTypeAllowed(context, "deleteDeliverable", ["demos-admin", "demos-cms-user"]);
+
+  return await prisma().$transaction(async (tx) => {
+    const deliverable = await getDeliverable({ id: deliverableId }, tx);
+    await validateDeleteDeliverableInput(deliverable, tx);
+
+    await editDeliverable(deliverableId, { statusId: "Deleted" }, tx);
+    await insertDeliverableAction(
+      {
+        deliverableId: deliverable.id,
+        actionType: "Deleted Deliverable",
+        oldStatus: deliverable.statusId as DeliverableStatus,
+        newStatus: "Deleted",
+        oldDueDate: deliverable.dueDate,
+        newDueDate: deliverable.dueDate,
+        userId: context.user.id,
+      },
+      tx
+    );
+    return deliverable;
+  });
+}

--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -523,7 +523,6 @@ describe("deliverableResolvers", () => {
         );
         expect(getManyDeliverables).toHaveBeenCalledExactlyOnceWith({
           demonstrationId: testDemonstrationId,
-          NOT: { statusId: DELETED_DELIVERABLE_STATUS },
         });
       });
     });
@@ -538,7 +537,6 @@ describe("deliverableResolvers", () => {
         );
         expect(getManyDeliverables).toHaveBeenCalledExactlyOnceWith({
           cmsOwnerUserId: testUserId,
-          NOT: { statusId: DELETED_DELIVERABLE_STATUS },
         });
       });
     });
@@ -547,9 +545,7 @@ describe("deliverableResolvers", () => {
   describe("queryDeliverables", () => {
     it("should query all the deliverables", async () => {
       await queryDeliverables();
-      expect(getManyDeliverables).toHaveBeenCalledExactlyOnceWith({
-        NOT: { statusId: DELETED_DELIVERABLE_STATUS },
-      });
+      expect(getManyDeliverables).toHaveBeenCalledExactlyOnceWith();
     });
   });
 

--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -44,6 +44,7 @@ vi.mock(".", () => ({
   approveDeliverableExtension: vi.fn(),
   completeDeliverable: vi.fn(),
   createDeliverable: vi.fn(),
+  deleteDeliverable: vi.fn(),
   denyDeliverableExtension: vi.fn(),
   getDeliverable: vi.fn(),
   getManyDeliverables: vi.fn(),
@@ -90,6 +91,7 @@ import {
   approveDeliverableExtension,
   completeDeliverable,
   createDeliverable,
+  deleteDeliverable,
   denyDeliverableExtension,
   getDeliverable,
   getManyDeliverables,
@@ -301,6 +303,19 @@ describe("deliverableResolvers", () => {
         testInput,
         testContext
       );
+    });
+  });
+
+  describe("Mutation.deleteDeliverable", () => {
+    it("calls deleteDeliverable with appropriate arguments", async () => {
+      await deliverableResolvers.Mutation.deleteDeliverable(
+        undefined,
+        {
+          id: testDeliverableId,
+        },
+        testContext as GraphQLContext
+      );
+      expect(deleteDeliverable).toHaveBeenCalledExactlyOnceWith(testDeliverableId, testContext);
     });
   });
 

--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -397,9 +397,12 @@ describe("deliverableResolvers", () => {
         {} as GraphQLContext,
         testDocumentInfo as GraphQLResolveInfo
       );
-      expect(getDeliverable).toHaveBeenCalledExactlyOnceWith({
-        id: testDeliverableId,
-      });
+      expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
+        {
+          id: testDeliverableId,
+        },
+        { includeDeleted: true }
+      );
       expect(result).toBeNull();
     });
 
@@ -428,9 +431,12 @@ describe("deliverableResolvers", () => {
           {} as GraphQLContext,
           testDocumentInfo as GraphQLResolveInfo
         );
-        expect(getDeliverable).toHaveBeenCalledExactlyOnceWith({
-          id: testDeliverableId,
-        });
+        expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
+          {
+            id: testDeliverableId,
+          },
+          { includeDeleted: true }
+        );
         expect(result).toBe(mockDeliverable);
       });
     });
@@ -454,9 +460,12 @@ describe("deliverableResolvers", () => {
           {} as GraphQLContext,
           testCommentInfo as GraphQLResolveInfo
         );
-        expect(getDeliverable).toHaveBeenCalledExactlyOnceWith({
-          id: testPublicComment.deliverableId,
-        });
+        expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
+          {
+            id: testPublicComment.deliverableId,
+          },
+          { includeDeleted: true }
+        );
         expect(result).toBe(mockDeliverable);
       });
     });
@@ -480,9 +489,12 @@ describe("deliverableResolvers", () => {
           {} as GraphQLContext,
           testCommentInfo as GraphQLResolveInfo
         );
-        expect(getDeliverable).toHaveBeenCalledExactlyOnceWith({
-          id: testPrivateComment.deliverableId,
-        });
+        expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
+          {
+            id: testPrivateComment.deliverableId,
+          },
+          { includeDeleted: true }
+        );
         expect(result).toBe(mockDeliverable);
       });
     });

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -94,10 +94,10 @@ export async function resolveManyDeliverables(
 
   switch (parentType) {
     case Prisma.ModelName.Demonstration:
-      filter = { demonstrationId: parent.id, NOT: { statusId: DELETED_DELIVERABLE_STATUS } };
+      filter = { demonstrationId: parent.id };
       break;
     case Prisma.ModelName.User:
-      filter = { cmsOwnerUserId: parent.id, NOT: { statusId: DELETED_DELIVERABLE_STATUS } };
+      filter = { cmsOwnerUserId: parent.id };
       break;
     default:
       throw new Error(`Unsupported parent type: ${parentType}`);
@@ -108,7 +108,7 @@ export async function resolveManyDeliverables(
 }
 
 export async function queryDeliverables(): Promise<PrismaDeliverable[]> {
-  return await getManyDeliverables({ NOT: { statusId: DELETED_DELIVERABLE_STATUS } });
+  return await getManyDeliverables();
 }
 
 export function resolveDeliverableType(parent: PrismaDeliverable): DeliverableType {

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -74,7 +74,7 @@ export async function resolveDeliverable(
   if (filter === null) {
     return null;
   }
-  const result = await getDeliverable(filter);
+  const result = await getDeliverable(filter, { includeDeleted: true });
   // We add the filter here to handle soft-deleted records
   // Do it here instead of in Prisma filter to avoid throwing when returning no records
   if (result.statusId === DELETED_DELIVERABLE_STATUS) {

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -14,6 +14,7 @@ import {
   approveDeliverableExtension,
   completeDeliverable,
   createDeliverable,
+  deleteDeliverable,
   denyDeliverableExtension,
   getDeliverable,
   getManyDeliverables,
@@ -194,6 +195,9 @@ export const deliverableResolvers = {
       context: GraphQLContext
     ) => {
       return await denyDeliverableExtension(args.deliverableId, args.input, context);
+    },
+    deleteDeliverable: async (parent: unknown, args: { id: string }, context: GraphQLContext) => {
+      return await deleteDeliverable(args.id, context);
     },
   },
 

--- a/server/src/model/deliverable/deliverableSchema.ts
+++ b/server/src/model/deliverable/deliverableSchema.ts
@@ -104,6 +104,7 @@ export const deliverableSchema = gql`
       input: ApproveDeliverableExtensionInput!
     ): Deliverable
     denyDeliverableExtension(deliverableId: ID!, input: DenyDeliverableExtensionInput!): Deliverable
+    deleteDeliverable(id: ID!): Deliverable
   }
 `;
 

--- a/server/src/model/deliverable/denyDeliverableExtension.test.ts
+++ b/server/src/model/deliverable/denyDeliverableExtension.test.ts
@@ -1,5 +1,5 @@
 // Vitest and other helpers
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DeepPartial } from "../../testUtilities";
 
 // Types
@@ -70,7 +70,6 @@ describe("denyDeliverableExtension", () => {
     id: testDeliverableExtensionId,
     statusId: "Requested" satisfies DeliverableExtensionStatus,
   };
-  const mockNow = new Date(2026, 3, 27, 10, 4, 19, 232);
 
   // Mock transaction
   const mockTransaction: any = "Test!";
@@ -80,18 +79,12 @@ describe("denyDeliverableExtension", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.useFakeTimers();
-    vi.setSystemTime(mockNow);
     vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
     vi.mocked(getDeliverable).mockResolvedValue(mockDeliverable as PrismaDeliverable);
     vi.mocked(selectDeliverableExtension).mockResolvedValue(
       mockDeliverableExtension as PrismaDeliverableExtension
     );
     mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
   it("should check that the user is allowed to do this operation", async () => {
@@ -149,7 +142,6 @@ describe("denyDeliverableExtension", () => {
       {
         deliverableId: testDeliverableId,
         actionType: "Denied Extension Request",
-        actionTime: mockNow,
         oldStatus: mockDeliverable.statusId,
         newStatus: mockDeliverable.statusId,
         note: testInput.details,

--- a/server/src/model/deliverable/denyDeliverableExtension.test.ts
+++ b/server/src/model/deliverable/denyDeliverableExtension.test.ts
@@ -115,7 +115,7 @@ describe("denyDeliverableExtension", () => {
     await denyDeliverableExtension(testDeliverableId, testInput, testUserContext as GraphQLContext);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
   });
 

--- a/server/src/model/deliverable/denyDeliverableExtension.ts
+++ b/server/src/model/deliverable/denyDeliverableExtension.ts
@@ -40,7 +40,6 @@ export async function denyDeliverableExtension(
       {
         deliverableId: deliverableId,
         actionType: "Denied Extension Request",
-        actionTime: new Date(),
         oldStatus: deliverable.statusId as DeliverableStatus,
         newStatus: deliverable.statusId as DeliverableStatus,
         note: input.details,

--- a/server/src/model/deliverable/denyDeliverableExtension.ts
+++ b/server/src/model/deliverable/denyDeliverableExtension.ts
@@ -24,7 +24,7 @@ export async function denyDeliverableExtension(
   ]);
 
   return await prisma().$transaction(async (tx) => {
-    const deliverable = await getDeliverable({ id: deliverableId }, tx);
+    const deliverable = await getDeliverable({ id: deliverableId }, { tx: tx });
     const deliverableExtension = await selectDeliverableExtension(
       { id: input.deliverableExtensionId },
       true,

--- a/server/src/model/deliverable/index.ts
+++ b/server/src/model/deliverable/index.ts
@@ -4,6 +4,8 @@ export {
   checkDeliverableExtensionHasStatus,
   checkDeliverableHasAtLeastOneDocument,
   checkDeliverableHasNoActiveExtension,
+  checkDeliverableHasNoComments,
+  checkDeliverableHasNoDocuments,
   checkDeliverableHasStatus,
   checkDemonstrationStatus,
   checkDueDateInFuture,
@@ -15,6 +17,7 @@ export {
 } from "./checkDeliverableInputFunctions";
 export { completeDeliverable } from "./completeDeliverable";
 export { createDeliverable } from "./createDeliverable";
+export { deleteDeliverable } from "./deleteDeliverable";
 export { denyDeliverableExtension } from "./denyDeliverableExtension";
 export { resolveDeliverable, resolveManyDeliverables } from "./deliverableResolvers";
 export { manuallyUpdateDeliverableDueDate } from "./manuallyUpdateDeliverableDueDate";
@@ -35,6 +38,7 @@ export {
   validateApproveDeliverableExtensionInput,
   validateCompleteDeliverableInput,
   validateCreateDeliverableInput,
+  validateDeleteDeliverableInput,
   validateDenyDeliverableExtensionInput,
   validateRequestDeliverableExtensionInput,
   validateRequestDeliverableResubmissionInput,

--- a/server/src/model/deliverable/manuallyUpdateDeliverableDueDate.test.ts
+++ b/server/src/model/deliverable/manuallyUpdateDeliverableDueDate.test.ts
@@ -127,7 +127,7 @@ describe("manuallyUpdateDeliverableDueDate", () => {
     expect(checkDueDateInFuture).toHaveBeenCalledExactlyOnceWith(testInput.dueDate!.newDueDate);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
     expect(editDeliverable).not.toHaveBeenCalled();
     expect(insertDeliverableAction).not.toHaveBeenCalled();
@@ -154,7 +154,7 @@ describe("manuallyUpdateDeliverableDueDate", () => {
     expect(checkDueDateInFuture).toHaveBeenCalledExactlyOnceWith(testInput.dueDate!.newDueDate);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
     expect(editDeliverable).toHaveBeenCalledExactlyOnceWith(
       testDeliverableId,
@@ -207,7 +207,7 @@ describe("manuallyUpdateDeliverableDueDate", () => {
     expect(checkDueDateInFuture).toHaveBeenCalledExactlyOnceWith(testInput.dueDate!.newDueDate);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
     expect(editDeliverable).toHaveBeenCalledExactlyOnceWith(
       testDeliverableId,

--- a/server/src/model/deliverable/manuallyUpdateDeliverableDueDate.test.ts
+++ b/server/src/model/deliverable/manuallyUpdateDeliverableDueDate.test.ts
@@ -1,5 +1,5 @@
 // Vitest and other helpers
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DeepPartial } from "../../testUtilities";
 
 // Types
@@ -54,10 +54,6 @@ describe("manuallyUpdateDeliverableDueDate", () => {
     vi.useFakeTimers();
     vi.setSystemTime(mockCurrentDate);
     vi.mocked(getDeliverable).mockResolvedValue(mockDeliverable as PrismaDeliverable);
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
   it("should do nothing if the test input has no due date", async () => {
@@ -172,7 +168,6 @@ describe("manuallyUpdateDeliverableDueDate", () => {
       {
         deliverableId: testDeliverableId,
         actionType: "Manually Changed Due Date",
-        actionTime: mockCurrentDate,
         oldStatus: mockDeliverable.statusId,
         newStatus: mockDeliverable.statusId,
         note: testInput.dueDate!.dateChangeNote,
@@ -226,7 +221,6 @@ describe("manuallyUpdateDeliverableDueDate", () => {
       {
         deliverableId: testDeliverableId,
         actionType: "Manually Changed Due Date",
-        actionTime: mockCurrentDate,
         oldStatus: "Past Due",
         newStatus: "Upcoming",
         note: testInput.dueDate!.dateChangeNote,

--- a/server/src/model/deliverable/manuallyUpdateDeliverableDueDate.ts
+++ b/server/src/model/deliverable/manuallyUpdateDeliverableDueDate.ts
@@ -27,7 +27,7 @@ export async function manuallyUpdateDeliverableDueDate(
   }
 
   // Get current record to check dates, and check if they match
-  const currentDeliverable = await getDeliverable({ id: deliverableId }, tx);
+  const currentDeliverable = await getDeliverable({ id: deliverableId }, { tx: tx });
   const datesMatch =
     currentDeliverable.dueDate.valueOf() === input.dueDate.newDueDate.easternTZDate.valueOf();
 

--- a/server/src/model/deliverable/manuallyUpdateDeliverableDueDate.ts
+++ b/server/src/model/deliverable/manuallyUpdateDeliverableDueDate.ts
@@ -53,7 +53,6 @@ export async function manuallyUpdateDeliverableDueDate(
       {
         deliverableId: deliverableId,
         actionType: "Manually Changed Due Date",
-        actionTime: new Date(),
         oldStatus: currentDeliverable.statusId as DeliverableStatus,
         newStatus: newStatus,
         note: input.dueDate.dateChangeNote,

--- a/server/src/model/deliverable/queries/getDeliverable.test.ts
+++ b/server/src/model/deliverable/queries/getDeliverable.test.ts
@@ -3,6 +3,7 @@ import { getDeliverable } from "./getDeliverable";
 
 // Mock imports
 import { prisma } from "../../../prismaClient";
+import { DELETED_DELIVERABLE_STATUS } from "../../../constants";
 
 vi.mock("../../../prismaClient", () => ({
   prisma: vi.fn(),
@@ -30,7 +31,10 @@ describe("getDeliverable", () => {
     },
   } as any;
   const testDeliverableId = "c8697763-fdd8-4502-b538-9e3cde153b05";
-  const expectedCall = {
+  const expectedFilteredCall = {
+    where: { id: testDeliverableId, NOT: { statusId: DELETED_DELIVERABLE_STATUS } },
+  };
+  const expectedUnfilteredCall = {
     where: { id: testDeliverableId },
   };
 
@@ -41,17 +45,28 @@ describe("getDeliverable", () => {
 
   it("should get the deliverable directly from the database directly if no transaction is given", async () => {
     await getDeliverable({ id: testDeliverableId });
+    expect(prisma).toHaveBeenCalled();
     expect(regularMocks.deliverable.findUniqueOrThrow).toHaveBeenCalledExactlyOnceWith(
-      expectedCall
+      expectedFilteredCall
     );
     expect(transactionMocks.deliverable.findUniqueOrThrow).not.toHaveBeenCalled();
   });
 
   it("should get the deliverable via a transaction if one is given", async () => {
-    await getDeliverable({ id: testDeliverableId }, mockTransaction);
+    await getDeliverable({ id: testDeliverableId }, { tx: mockTransaction });
+    expect(prisma).not.toHaveBeenCalled();
     expect(regularMocks.deliverable.findUniqueOrThrow).not.toHaveBeenCalled();
     expect(transactionMocks.deliverable.findUniqueOrThrow).toHaveBeenCalledExactlyOnceWith(
-      expectedCall
+      expectedFilteredCall
     );
+  });
+
+  it("should not filter out deleted records if passed the right option", async () => {
+    await getDeliverable({ id: testDeliverableId }, { includeDeleted: true });
+    expect(prisma).toHaveBeenCalled();
+    expect(regularMocks.deliverable.findUniqueOrThrow).toHaveBeenCalledExactlyOnceWith(
+      expectedUnfilteredCall
+    );
+    expect(transactionMocks.deliverable.findUniqueOrThrow).not.toHaveBeenCalled();
   });
 });

--- a/server/src/model/deliverable/queries/getDeliverable.ts
+++ b/server/src/model/deliverable/queries/getDeliverable.ts
@@ -1,12 +1,23 @@
 import { Prisma, Deliverable as PrismaDeliverable } from "@prisma/client";
 import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { DELETED_DELIVERABLE_STATUS } from "../../../constants";
 
 export async function getDeliverable(
   filter: Prisma.DeliverableWhereUniqueInput,
-  tx?: PrismaTransactionClient
+  options: {
+    includeDeleted?: boolean;
+    tx?: PrismaTransactionClient;
+  } = {}
 ): Promise<PrismaDeliverable> {
-  const prismaClient = tx ?? prisma();
+  const prismaClient = options.tx ?? prisma();
+  let finalFilter = filter;
+  if (!options.includeDeleted) {
+    finalFilter = {
+      ...filter,
+      NOT: { statusId: DELETED_DELIVERABLE_STATUS },
+    };
+  }
   return await prismaClient.deliverable.findUniqueOrThrow({
-    where: { ...filter },
+    where: { ...finalFilter },
   });
 }

--- a/server/src/model/deliverable/queries/getManyDeliverables.test.ts
+++ b/server/src/model/deliverable/queries/getManyDeliverables.test.ts
@@ -3,6 +3,7 @@ import { getManyDeliverables } from "./getManyDeliverables";
 
 // Mock imports
 import { prisma } from "../../../prismaClient";
+import { DELETED_DELIVERABLE_STATUS } from "../../../constants";
 
 vi.mock("../../../prismaClient", () => ({
   prisma: vi.fn(),
@@ -30,7 +31,13 @@ describe("getManyDeliverables", () => {
     },
   } as any;
   const testDemonstrationId = "7cc7f95d-cf7d-477b-acd7-ebae7109a631";
-  const expectedCall = {
+  const expectedEmptyFilteredCall = {
+    where: { NOT: { statusId: DELETED_DELIVERABLE_STATUS } },
+  };
+  const expectedFilteredCall = {
+    where: { demonstrationId: testDemonstrationId, NOT: { statusId: DELETED_DELIVERABLE_STATUS } },
+  };
+  const expectedUnfilteredCall = {
     where: { demonstrationId: testDemonstrationId },
   };
 
@@ -39,27 +46,49 @@ describe("getManyDeliverables", () => {
     vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
   });
 
-  it("should not filter if nothing is passed to the function", async () => {
+  it("should only filter by the deleted flag if nothing else is passed to the function", async () => {
     await getManyDeliverables();
-    expect(regularMocks.deliverable.findMany).toHaveBeenCalledExactlyOnceWith({ where: {} });
+    expect(prisma).toHaveBeenCalled();
+    expect(regularMocks.deliverable.findMany).toHaveBeenCalledExactlyOnceWith(
+      expectedEmptyFilteredCall
+    );
     expect(transactionMocks.deliverable.findMany).not.toHaveBeenCalled();
   });
 
   it("should use a transaction if it is passed, even if not filtering", async () => {
-    await getManyDeliverables({}, mockTransaction);
+    await getManyDeliverables({}, { tx: mockTransaction });
+    expect(prisma).not.toHaveBeenCalled();
     expect(regularMocks.deliverable.findMany).not.toHaveBeenCalled();
-    expect(transactionMocks.deliverable.findMany).toHaveBeenCalledExactlyOnceWith({ where: {} });
+    expect(transactionMocks.deliverable.findMany).toHaveBeenCalledExactlyOnceWith(
+      expectedEmptyFilteredCall
+    );
   });
 
   it("should get the deliverables directly from the database directly if no transaction is given", async () => {
     await getManyDeliverables({ demonstrationId: testDemonstrationId });
-    expect(regularMocks.deliverable.findMany).toHaveBeenCalledExactlyOnceWith(expectedCall);
+    expect(prisma).toHaveBeenCalled();
+    expect(regularMocks.deliverable.findMany).toHaveBeenCalledExactlyOnceWith(expectedFilteredCall);
     expect(transactionMocks.deliverable.findMany).not.toHaveBeenCalled();
   });
 
   it("should get the deliverables via a transaction if one is given", async () => {
-    await getManyDeliverables({ demonstrationId: testDemonstrationId }, mockTransaction);
+    await getManyDeliverables({ demonstrationId: testDemonstrationId }, { tx: mockTransaction });
+    expect(prisma).not.toHaveBeenCalled();
     expect(regularMocks.deliverable.findMany).not.toHaveBeenCalled();
-    expect(transactionMocks.deliverable.findMany).toHaveBeenCalledExactlyOnceWith(expectedCall);
+    expect(transactionMocks.deliverable.findMany).toHaveBeenCalledExactlyOnceWith(
+      expectedFilteredCall
+    );
+  });
+
+  it("should not filter out deleted records if passed the right option", async () => {
+    await getManyDeliverables(
+      { demonstrationId: testDemonstrationId },
+      { includeDeleted: true, tx: mockTransaction }
+    );
+    expect(prisma).not.toHaveBeenCalled();
+    expect(regularMocks.deliverable.findMany).not.toHaveBeenCalled();
+    expect(transactionMocks.deliverable.findMany).toHaveBeenCalledExactlyOnceWith(
+      expectedUnfilteredCall
+    );
   });
 });

--- a/server/src/model/deliverable/queries/getManyDeliverables.ts
+++ b/server/src/model/deliverable/queries/getManyDeliverables.ts
@@ -1,13 +1,24 @@
 import { Prisma, Deliverable as PrismaDeliverable } from "@prisma/client";
 import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { DELETED_DELIVERABLE_STATUS } from "../../../constants";
 
 export async function getManyDeliverables(
   filter: Prisma.DeliverableWhereInput = {},
-  tx?: PrismaTransactionClient
+  options: {
+    includeDeleted?: boolean;
+    tx?: PrismaTransactionClient;
+  } = {}
 ): Promise<PrismaDeliverable[]> {
-  const prismaClient = tx ?? prisma();
+  const prismaClient = options.tx ?? prisma();
+  let finalFilter = filter;
+  if (!options.includeDeleted) {
+    finalFilter = {
+      ...filter,
+      NOT: { statusId: DELETED_DELIVERABLE_STATUS },
+    };
+  }
   const deliverables = await prismaClient.deliverable.findMany({
-    where: { ...filter },
+    where: { ...finalFilter },
   });
   return deliverables;
 }

--- a/server/src/model/deliverable/requestDeliverableExtension.test.ts
+++ b/server/src/model/deliverable/requestDeliverableExtension.test.ts
@@ -1,5 +1,5 @@
 // Vitest and other helpers
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DeepPartial } from "../../testUtilities";
 
 // Types
@@ -71,7 +71,6 @@ describe("requestDeliverableExtension", () => {
       easternTZDate: new TZDate(2026, 9, 12, 23, 59, 59, 999, "America/New_York"),
     },
   };
-  const mockNow = new Date(2026, 3, 27, 10, 4, 19, 232);
 
   // Mock transaction
   const mockTransaction: any = "Test!";
@@ -81,16 +80,10 @@ describe("requestDeliverableExtension", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.useFakeTimers();
-    vi.setSystemTime(mockNow);
     vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
     vi.mocked(getDeliverable).mockResolvedValue(mockDeliverable as PrismaDeliverable);
     vi.mocked(parseRequestDeliverableExtensionInput).mockReturnValue(mockParsedInput);
     mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
   it("should check that the user is allowed to do this operation", async () => {
@@ -196,7 +189,6 @@ describe("requestDeliverableExtension", () => {
       {
         deliverableId: testDeliverableId,
         actionType: "Requested Extension",
-        actionTime: mockNow,
         oldStatus: mockDeliverable.statusId,
         newStatus: mockDeliverable.statusId,
         note: mockParsedInput.details,

--- a/server/src/model/deliverable/requestDeliverableExtension.test.ts
+++ b/server/src/model/deliverable/requestDeliverableExtension.test.ts
@@ -146,7 +146,7 @@ describe("requestDeliverableExtension", () => {
     );
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
   });
 

--- a/server/src/model/deliverable/requestDeliverableExtension.ts
+++ b/server/src/model/deliverable/requestDeliverableExtension.ts
@@ -23,7 +23,7 @@ export async function requestDeliverableExtension(
   const parsedInput = parseRequestDeliverableExtensionInput(input);
 
   return await prisma().$transaction(async (tx) => {
-    const deliverable = await getDeliverable({ id: deliverableId }, tx);
+    const deliverable = await getDeliverable({ id: deliverableId }, { tx: tx });
     await validateRequestDeliverableExtensionInput(deliverable, parsedInput, tx);
 
     // Add the extension before the action record; this ensures triggers capture the information

--- a/server/src/model/deliverable/requestDeliverableExtension.ts
+++ b/server/src/model/deliverable/requestDeliverableExtension.ts
@@ -41,7 +41,6 @@ export async function requestDeliverableExtension(
       {
         deliverableId: deliverableId,
         actionType: "Requested Extension",
-        actionTime: new Date(),
         oldStatus: deliverable.statusId as DeliverableStatus,
         newStatus: deliverable.statusId as DeliverableStatus,
         note: input.details,

--- a/server/src/model/deliverable/requestDeliverableResubmission.test.ts
+++ b/server/src/model/deliverable/requestDeliverableResubmission.test.ts
@@ -1,5 +1,5 @@
 // Vitest and other helpers
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TZDate } from "@date-fns/tz";
 import { DeepPartial } from "../../testUtilities";
 
@@ -71,7 +71,6 @@ describe("requestDeliverableResubmission", () => {
       easternTZDate: new TZDate(2026, 10, 13, 4, 59, 59, 999, "America/New_York"),
     },
   };
-  const mockNow = new Date(2026, 3, 27, 10, 4, 19, 232);
 
   // Mock transaction
   const mockTransaction: any = "Test!";
@@ -81,17 +80,11 @@ describe("requestDeliverableResubmission", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.useFakeTimers();
-    vi.setSystemTime(mockNow);
     vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
     vi.mocked(parseRequestDeliverableResubmissionInput).mockReturnValue(mockParsedInput);
     vi.mocked(getDeliverable).mockResolvedValue(mockUnrequestedDeliverable as PrismaDeliverable);
     vi.mocked(editDeliverable).mockResolvedValue(mockRequestedDeliverable as PrismaDeliverable);
     mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
   it("should check that the user is allowed to do this operation", async () => {
@@ -193,7 +186,6 @@ describe("requestDeliverableResubmission", () => {
       {
         deliverableId: testDeliverableId,
         actionType: "Requested Resubmission",
-        actionTime: mockNow,
         oldStatus: mockUnrequestedDeliverable.statusId,
         newStatus: mockRequestedDeliverable.statusId,
         note: mockParsedInput.details,

--- a/server/src/model/deliverable/requestDeliverableResubmission.test.ts
+++ b/server/src/model/deliverable/requestDeliverableResubmission.test.ts
@@ -147,7 +147,7 @@ describe("requestDeliverableResubmission", () => {
     );
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
   });
 

--- a/server/src/model/deliverable/requestDeliverableResubmission.ts
+++ b/server/src/model/deliverable/requestDeliverableResubmission.ts
@@ -40,7 +40,6 @@ export async function requestDeliverableResubmission(
       {
         deliverableId: deliverableId,
         actionType: "Requested Resubmission",
-        actionTime: new Date(),
         oldStatus: unrequestedDeliverable.statusId as DeliverableStatus,
         newStatus: requestedDeliverable.statusId as DeliverableStatus,
         note: input.details,

--- a/server/src/model/deliverable/requestDeliverableResubmission.ts
+++ b/server/src/model/deliverable/requestDeliverableResubmission.ts
@@ -23,7 +23,7 @@ export async function requestDeliverableResubmission(
   const parsedInput = parseRequestDeliverableResubmissionInput(input);
 
   return await prisma().$transaction(async (tx) => {
-    const unrequestedDeliverable = await getDeliverable({ id: deliverableId }, tx);
+    const unrequestedDeliverable = await getDeliverable({ id: deliverableId }, { tx: tx });
     validateRequestDeliverableResubmissionInput(unrequestedDeliverable, parsedInput);
 
     const requestedDeliverable = await editDeliverable(

--- a/server/src/model/deliverable/startDeliverableReview.test.ts
+++ b/server/src/model/deliverable/startDeliverableReview.test.ts
@@ -94,7 +94,7 @@ describe("startDeliverableReview", () => {
     await startDeliverableReview(testDeliverableId, testUserContext as GraphQLContext);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
   });
 

--- a/server/src/model/deliverable/startDeliverableReview.ts
+++ b/server/src/model/deliverable/startDeliverableReview.ts
@@ -33,7 +33,6 @@ export async function startDeliverableReview(
       {
         deliverableId: deliverableId,
         actionType: "Started Review",
-        actionTime: new Date(),
         oldStatus: unstartedDeliverable.statusId as DeliverableStatus,
         newStatus: startedDeliverable.statusId as DeliverableStatus,
         oldDueDate: unstartedDeliverable.dueDate,

--- a/server/src/model/deliverable/startDeliverableReview.ts
+++ b/server/src/model/deliverable/startDeliverableReview.ts
@@ -19,7 +19,7 @@ export async function startDeliverableReview(
     "demos-cms-user",
   ]);
   return await prisma().$transaction(async (tx) => {
-    const unstartedDeliverable = await getDeliverable({ id: deliverableId }, tx);
+    const unstartedDeliverable = await getDeliverable({ id: deliverableId }, { tx: tx });
     validateStartDeliverableReviewInput(unstartedDeliverable);
 
     const startedDeliverable = await editDeliverable(

--- a/server/src/model/deliverable/submitDeliverable.test.ts
+++ b/server/src/model/deliverable/submitDeliverable.test.ts
@@ -1,5 +1,5 @@
 // Vitest and other helpers
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DeepPartial } from "../../testUtilities";
 
 // Types
@@ -48,7 +48,6 @@ describe("submitDeliverable", () => {
     statusId: "Submitted",
     dueDate: new Date(2026, 9, 13, 4, 59, 59, 999),
   };
-  const mockNow = new Date(2026, 3, 27, 10, 4, 19, 232);
 
   // Mock transaction
   const mockTransaction: any = "Test!";
@@ -58,16 +57,10 @@ describe("submitDeliverable", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.useFakeTimers();
-    vi.setSystemTime(mockNow);
     vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
     vi.mocked(getDeliverable).mockResolvedValue(mockUnsubmittedDeliverable as PrismaDeliverable);
     vi.mocked(editDeliverable).mockResolvedValue(mockSubmittedDeliverable as PrismaDeliverable);
     mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
   it("should get the deliverable before making changes", async () => {
@@ -101,7 +94,6 @@ describe("submitDeliverable", () => {
       {
         deliverableId: testDeliverableId,
         actionType: "Submitted Deliverable",
-        actionTime: mockNow,
         oldStatus: mockUnsubmittedDeliverable.statusId,
         newStatus: mockSubmittedDeliverable.statusId,
         oldDueDate: mockUnsubmittedDeliverable.dueDate,

--- a/server/src/model/deliverable/submitDeliverable.test.ts
+++ b/server/src/model/deliverable/submitDeliverable.test.ts
@@ -67,7 +67,7 @@ describe("submitDeliverable", () => {
     await submitDeliverable(testDeliverableId, testContext as GraphQLContext);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
   });
 

--- a/server/src/model/deliverable/submitDeliverable.ts
+++ b/server/src/model/deliverable/submitDeliverable.ts
@@ -10,7 +10,7 @@ export async function submitDeliverable(
   context: GraphQLContext
 ): Promise<PrismaDeliverable> {
   return await prisma().$transaction(async (tx) => {
-    const unsubmittedDeliverable = await getDeliverable({ id: deliverableId }, tx);
+    const unsubmittedDeliverable = await getDeliverable({ id: deliverableId }, { tx: tx });
     await validateSubmitDeliverableInput(unsubmittedDeliverable, tx);
 
     const submittedDeliverable = await editDeliverable(

--- a/server/src/model/deliverable/submitDeliverable.ts
+++ b/server/src/model/deliverable/submitDeliverable.ts
@@ -24,7 +24,6 @@ export async function submitDeliverable(
       {
         deliverableId: deliverableId,
         actionType: "Submitted Deliverable",
-        actionTime: new Date(),
         oldStatus: unsubmittedDeliverable.statusId as DeliverableStatus,
         newStatus: submittedDeliverable.statusId as DeliverableStatus,
         oldDueDate: unsubmittedDeliverable.dueDate,

--- a/server/src/model/deliverable/updateDeliverable.test.ts
+++ b/server/src/model/deliverable/updateDeliverable.test.ts
@@ -125,7 +125,7 @@ describe("updateDeliverable", () => {
     );
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
   });
 
@@ -177,7 +177,7 @@ describe("updateDeliverable", () => {
     expect(editDeliverable).not.toHaveBeenCalled();
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
   });
 

--- a/server/src/model/deliverable/updateDeliverable.ts
+++ b/server/src/model/deliverable/updateDeliverable.ts
@@ -38,7 +38,7 @@ export async function updateDeliverable(
     await updateDeliverableDemonstrationTypes(deliverableId, parsedInput, tx);
     await manuallyUpdateDeliverableDueDate(deliverableId, parsedInput, context, tx);
 
-    return await getDeliverable({ id: deliverableId }, tx);
+    return await getDeliverable({ id: deliverableId }, { tx: tx });
   });
   return updatedDeliverable;
 }

--- a/server/src/model/deliverable/updateDeliverableDemonstrationTypes.test.ts
+++ b/server/src/model/deliverable/updateDeliverableDemonstrationTypes.test.ts
@@ -99,7 +99,7 @@ describe("updateDeliverableDemonstrationTypes", () => {
     await updateDeliverableDemonstrationTypes(testDeliverableId, testInput, mockTransaction);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
     expect(selectManyDeliverableDemonstrationTypes).toHaveBeenCalledExactlyOnceWith(
       { deliverableId: testDeliverableId },
@@ -124,7 +124,7 @@ describe("updateDeliverableDemonstrationTypes", () => {
     await updateDeliverableDemonstrationTypes(testDeliverableId, testInput, mockTransaction);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
     expect(selectManyDeliverableDemonstrationTypes).toHaveBeenCalledExactlyOnceWith(
       { deliverableId: testDeliverableId },
@@ -142,7 +142,7 @@ describe("updateDeliverableDemonstrationTypes", () => {
     await updateDeliverableDemonstrationTypes(testDeliverableId, testInput, mockTransaction);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
     expect(selectManyDeliverableDemonstrationTypes).toHaveBeenCalledExactlyOnceWith(
       { deliverableId: testDeliverableId },
@@ -167,7 +167,7 @@ describe("updateDeliverableDemonstrationTypes", () => {
     await updateDeliverableDemonstrationTypes(testDeliverableId, testInput, mockTransaction);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
     expect(selectManyDeliverableDemonstrationTypes).toHaveBeenCalledExactlyOnceWith(
       { deliverableId: testDeliverableId },

--- a/server/src/model/deliverable/updateDeliverableDemonstrationTypes.ts
+++ b/server/src/model/deliverable/updateDeliverableDemonstrationTypes.ts
@@ -16,7 +16,7 @@ export async function updateDeliverableDemonstrationTypes(
   }
 
   // Need to get the demonstration ID for inserts
-  const currentDeliverable = await getDeliverable({ id: deliverableId }, tx);
+  const currentDeliverable = await getDeliverable({ id: deliverableId }, { tx: tx });
 
   // Can turn these into a set because DB guarantees uniqueness
   const oldDemonstrationTypes: Set<TagName> = new Set(

--- a/server/src/model/deliverable/validateDeliverableInputs.test.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.test.ts
@@ -28,6 +28,7 @@ import {
   validateApproveDeliverableExtensionInput,
   validateCompleteDeliverableInput,
   validateCreateDeliverableInput,
+  validateDeleteDeliverableInput,
   validateDenyDeliverableExtensionInput,
   validateRequestDeliverableExtensionInput,
   validateRequestDeliverableResubmissionInput,
@@ -54,6 +55,8 @@ vi.mock(".", () => ({
   checkDeliverableExtensionHasStatus: vi.fn(),
   checkDeliverableHasAtLeastOneDocument: vi.fn(),
   checkDeliverableHasNoActiveExtension: vi.fn(),
+  checkDeliverableHasNoComments: vi.fn(),
+  checkDeliverableHasNoDocuments: vi.fn(),
   checkDeliverableHasStatus: vi.fn(),
   checkDemonstrationStatus: vi.fn(),
   checkDueDateInFuture: vi.fn(),
@@ -71,6 +74,8 @@ import {
   checkDeliverableExtensionHasStatus,
   checkDeliverableHasAtLeastOneDocument,
   checkDeliverableHasNoActiveExtension,
+  checkDeliverableHasNoComments,
+  checkDeliverableHasNoDocuments,
   checkDeliverableHasStatus,
   checkDemonstrationStatus,
   checkDueDateInFuture,
@@ -1418,6 +1423,131 @@ describe("validateDeliverableInputs", () => {
         expect(error.extensions.originalMessages).toStrictEqual([
           "The deliverable status check failed!",
           "The deliverable extension status check failed!",
+        ]);
+      }
+    });
+  });
+
+  describe("validateDeleteDeliverableInput", () => {
+    const testDeliverable: Partial<PrismaDeliverable> = {
+      id: "40aaed7d-b0ad-47e0-aaa0-c2433db20cb7",
+    };
+
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it("should not throw if none of the rules are violated", async () => {
+      // Note: don't need to set returns to undefined, as this is what vi.fn() does already
+      await expect(
+        validateDeleteDeliverableInput(testDeliverable as PrismaDeliverable, mockTransaction)
+      ).resolves.toBeUndefined();
+    });
+
+    it("should call the check functions", async () => {
+      await validateDeleteDeliverableInput(testDeliverable as PrismaDeliverable, mockTransaction);
+      expect(checkDeliverableHasStatus).toHaveBeenCalledExactlyOnceWith(testDeliverable, [
+        "Upcoming",
+        "Past Due",
+      ]);
+      expect(checkDeliverableHasNoDocuments).toHaveBeenCalledExactlyOnceWith(
+        testDeliverable,
+        mockTransaction
+      );
+      expect(checkDeliverableHasNoComments).toHaveBeenCalledExactlyOnceWith(
+        testDeliverable,
+        mockTransaction
+      );
+    });
+
+    it("should throw if the deliverable status check fails", async () => {
+      vi.mocked(checkDeliverableHasStatus).mockReturnValue(
+        "The deliverable status check has failed!"
+      );
+
+      try {
+        await validateDeleteDeliverableInput(testDeliverable as PrismaDeliverable, mockTransaction);
+        throw new Error("Expected validateDeleteDeliverableInput to throw, but it did not.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for deleteDeliverable have failed."
+        );
+        expect(error.extensions.code).toBe("DELETE_DELIVERABLE_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable status check has failed!",
+        ]);
+      }
+    });
+
+    it("should throw if the no documents check fails", async () => {
+      vi.mocked(checkDeliverableHasNoDocuments).mockResolvedValue(
+        "The check for no documents has failed!"
+      );
+
+      try {
+        await validateDeleteDeliverableInput(testDeliverable as PrismaDeliverable, mockTransaction);
+        throw new Error("Expected validateDeleteDeliverableInput to throw, but it did not.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for deleteDeliverable have failed."
+        );
+        expect(error.extensions.code).toBe("DELETE_DELIVERABLE_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The check for no documents has failed!",
+        ]);
+      }
+    });
+
+    it("should throw if the no comments check fails", async () => {
+      vi.mocked(checkDeliverableHasNoComments).mockResolvedValue(
+        "The check for no comments has failed!"
+      );
+
+      try {
+        await validateDeleteDeliverableInput(testDeliverable as PrismaDeliverable, mockTransaction);
+        throw new Error("Expected validateDeleteDeliverableInput to throw, but it did not.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for deleteDeliverable have failed."
+        );
+        expect(error.extensions.code).toBe("DELETE_DELIVERABLE_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The check for no comments has failed!",
+        ]);
+      }
+    });
+
+    it("should combine all errors into one bject", async () => {
+      vi.mocked(checkDeliverableHasStatus).mockReturnValue(
+        "The deliverable status check has failed!"
+      );
+      vi.mocked(checkDeliverableHasNoDocuments).mockResolvedValue(
+        "The check for no documents has failed!"
+      );
+      vi.mocked(checkDeliverableHasNoComments).mockResolvedValue(
+        "The check for no comments has failed!"
+      );
+
+      try {
+        await validateDeleteDeliverableInput(testDeliverable as PrismaDeliverable, mockTransaction);
+        throw new Error("Expected validateDeleteDeliverableInput to throw, but it did not.");
+      } catch (e) {
+        expect(e).toBeInstanceOf(GraphQLError);
+        const error = e as GraphQLError;
+        expect(error.message).toBe(
+          "One or more validation checks for deleteDeliverable have failed."
+        );
+        expect(error.extensions.code).toBe("DELETE_DELIVERABLE_VALIDATION_FAILED");
+        expect(error.extensions.originalMessages).toStrictEqual([
+          "The deliverable status check has failed!",
+          "The check for no documents has failed!",
+          "The check for no comments has failed!",
         ]);
       }
     });

--- a/server/src/model/deliverable/validateDeliverableInputs.test.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.test.ts
@@ -394,7 +394,7 @@ describe("validateDeliverableInputs", () => {
 
       expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
         { id: mockDeliverable.id },
-        mockTransaction
+        { tx: mockTransaction }
       );
     });
 
@@ -449,7 +449,7 @@ describe("validateDeliverableInputs", () => {
       await validateUpdateDeliverableInput(mockDeliverable.id!, testInput, mockTransaction);
       expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
         { id: mockDeliverable.id! },
-        mockTransaction
+        { tx: mockTransaction }
       );
       expect(getDemonstrationTypeAssignments).toHaveBeenCalledExactlyOnceWith(
         { demonstrationId: mockDeliverable.demonstrationId },

--- a/server/src/model/deliverable/validateDeliverableInputs.test.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.test.ts
@@ -1523,7 +1523,7 @@ describe("validateDeliverableInputs", () => {
       }
     });
 
-    it("should combine all errors into one bject", async () => {
+    it("should combine all errors into one object", async () => {
       vi.mocked(checkDeliverableHasStatus).mockReturnValue(
         "The deliverable status check has failed!"
       );

--- a/server/src/model/deliverable/validateDeliverableInputs.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.ts
@@ -99,7 +99,7 @@ export async function validateUpdateDeliverableInput(
   input: ParsedUpdateDeliverableInput,
   tx: PrismaTransactionClient
 ): Promise<void> {
-  const deliverable = await getDeliverable({ id: deliverableId }, tx);
+  const deliverable = await getDeliverable({ id: deliverableId }, { tx: tx });
   const errors: (string | undefined)[] = [];
 
   // Updates can be performed on all active deliverables

--- a/server/src/model/deliverable/validateDeliverableInputs.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.ts
@@ -2,6 +2,8 @@ import {
   checkDeliverableExtensionHasStatus,
   checkDeliverableHasAtLeastOneDocument,
   checkDeliverableHasNoActiveExtension,
+  checkDeliverableHasNoComments,
+  checkDeliverableHasNoDocuments,
   checkDeliverableHasStatus,
   checkDemonstrationStatus,
   checkDueDateInFuture,
@@ -238,4 +240,19 @@ export function validateDenyDeliverableExtensionInput(
     "denyDeliverableExtension",
     "DENY_DELIVERABLE_EXTENSION_VALIDATION_FAILED"
   );
+}
+
+export async function validateDeleteDeliverableInput(
+  deliverable: PrismaDeliverable,
+  tx: PrismaTransactionClient
+): Promise<void> {
+  const errors: (string | undefined)[] = [];
+
+  errors.push(
+    // Extensions may be processed for any active deliverable
+    checkDeliverableHasStatus(deliverable, ["Upcoming", "Past Due"]),
+    await checkDeliverableHasNoDocuments(deliverable, tx),
+    await checkDeliverableHasNoComments(deliverable, tx)
+  );
+  cleanErrorsAndThrow(errors, "deleteDeliverable", "DELETE_DELIVERABLE_VALIDATION_FAILED");
 }

--- a/server/src/model/deliverableAction/queries/insertDeliverableAction.test.ts
+++ b/server/src/model/deliverableAction/queries/insertDeliverableAction.test.ts
@@ -20,7 +20,6 @@ describe("insertDeliverableAction", () => {
   const testInput: InsertDeliverableActionInput = {
     deliverableId: "c25385d4-d5e3-4e27-aaf3-7dfa87f677d3",
     actionType: "Created Deliverable Slot",
-    actionTime: new Date(2025, 6, 11, 12, 1, 53, 299),
     oldStatus: "Upcoming",
     newStatus: "Upcoming",
     oldDueDate: new Date(2025, 8, 13, 0, 0, 0, 0),

--- a/server/src/model/deliverableAction/queries/insertDeliverableAction.ts
+++ b/server/src/model/deliverableAction/queries/insertDeliverableAction.ts
@@ -5,7 +5,6 @@ import { DeliverableActionType, DeliverableStatus } from "../../../types";
 export type InsertDeliverableActionInput = {
   deliverableId: string;
   actionType: DeliverableActionType;
-  actionTime: Date;
   oldStatus: DeliverableStatus;
   newStatus: DeliverableStatus;
   oldDueDate: Date;

--- a/server/src/model/deliverableDemonstrationType/queries/insertDeliverableDemonstrationTypes.test.ts
+++ b/server/src/model/deliverableDemonstrationType/queries/insertDeliverableDemonstrationTypes.test.ts
@@ -86,7 +86,7 @@ describe("insertDeliverableDemonstrationTypes", () => {
     expect(transactionMocks.deliverableDemonstrationType.createMany).not.toHaveBeenCalled();
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: regularTestInput.deliverableId },
-      mockPrismaClient
+      { tx: mockPrismaClient }
     );
   });
 
@@ -98,7 +98,7 @@ describe("insertDeliverableDemonstrationTypes", () => {
     ).toHaveBeenCalledExactlyOnceWith(expectedRegularCall);
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: regularTestInput.deliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
   });
 
@@ -108,7 +108,7 @@ describe("insertDeliverableDemonstrationTypes", () => {
     expect(transactionMocks.deliverableDemonstrationType.createMany).not.toHaveBeenCalled();
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: emptyTestInput.deliverableId },
-      mockTransaction
+      { tx: mockTransaction }
     );
   });
 });

--- a/server/src/model/deliverableDemonstrationType/queries/insertDeliverableDemonstrationTypes.ts
+++ b/server/src/model/deliverableDemonstrationType/queries/insertDeliverableDemonstrationTypes.ts
@@ -18,5 +18,5 @@ export async function insertDeliverableDemonstrationTypes(
       data: createManyPayload,
     });
   }
-  return await getDeliverable({ id: input.deliverableId }, prismaClient);
+  return await getDeliverable({ id: input.deliverableId }, { tx: prismaClient });
 }

--- a/server/src/model/deliverableDemonstrationType/setDeliverableDemonstrationTypes.test.ts
+++ b/server/src/model/deliverableDemonstrationType/setDeliverableDemonstrationTypes.test.ts
@@ -59,7 +59,7 @@ describe("setDeliverableDemonstrationTypes", () => {
       {
         id: testInput.deliverableId,
       },
-      mockTransaction
+      { tx: mockTransaction }
     );
   });
 
@@ -80,7 +80,7 @@ describe("setDeliverableDemonstrationTypes", () => {
       {
         id: testInput.deliverableId,
       },
-      mockPrismaClient
+      { tx: mockPrismaClient }
     );
   });
 });

--- a/server/src/model/deliverableDemonstrationType/setDeliverableDemonstrationTypes.ts
+++ b/server/src/model/deliverableDemonstrationType/setDeliverableDemonstrationTypes.ts
@@ -23,5 +23,5 @@ export async function setDeliverableDemonstrationTypes(
     prismaClient
   );
   await insertDeliverableDemonstrationTypes(input, prismaClient);
-  return getDeliverable({ id: input.deliverableId }, prismaClient);
+  return getDeliverable({ id: input.deliverableId }, { tx: prismaClient });
 }


### PR DESCRIPTION
This PR adds support to delete deliverables via the `deleteDeliverable` API mutator.

The ability to soft-delete deliverables adds a new kind of issue we're not used to having usually, namely, the ability to run a query and get back a record that "shouldn't" exist. Normally, we just use `findUniqueOrThrow` and then the application will just throw if given an ID that does not exist. However, in the case of a soft-delete, if you default to hiding that at a different point in the query chain, it means you can get odd inconsistent scenarios (for instance, trying to delete a deliverable that has already been deleted will fail because the `statusId` is in a disallowed state, not because the deliverable doesn't exist).

Now, there's really only one place where this filtering matters, and that is in how we handle querying inside the `resolveDeliverable` function, because this needs to gracefully return `null` so that we can allow for `documents` to have a null deliverable, for instance. In other words, _most of the time_ we want to exclude the deleted deliverables, but it can occasionally be helpful to gather them. I decided to modify `getDeliverable` and `getManyDeliverables` to take an optional argument to include deleted records, so that we can, when needed, get the deleted ones, but otherwise, it functions mostly like it did before.

I also noticed that I was passing an entirely extraneous argument to the `insertDeliverableAction` function, the action time. It was always taking the system time when doing that insert, but I was still passing it along - probably a remnant of how I had been doing things before. I removed this, which allowed removing a bunch of test code that never mattered to begin with dealing with system timers.

On top of all this, I just implemented the regular checking, namely looking for public and private comments and for documents, and preventing deletion of a deliverable in those cases.

End result is a lot of small file changes, but hopefully not too much to review because most of it is just the test or call changes for small edits to a function signature.