### PR TITLE
DEMOS-1540: Complete Deliverable Review

### DIFF
--- a/client/src/components/dialog/DialogContext.tsx
+++ b/client/src/components/dialog/DialogContext.tsx
@@ -38,6 +38,10 @@ import { WorkflowApplicationType } from "components/application";
 import { AddDeliverableSlotDemonstration } from "./deliverable/AddDeliverableSlotDialog";
 import type { DeliverableTableRow } from "components/table/tables/DeliverableTable";
 import { RequestResubmissionDeliverableDialog, RequestResubmissionDeliverableDialogDeliverable } from "./deliverable/RequestResubmissionDeliverableDialog";
+import {
+  CompleteReviewDeliverableDialog,
+  CompleteReviewDeliverableDialogDeliverable,
+} from "./deliverable/CompleteReviewDeliverableDialog";
 
 type DialogContextType = {
   content: React.ReactNode | null;
@@ -265,6 +269,17 @@ export const useDialog = () => {
     );
   };
 
+  const showCompleteReviewDeliverableDialog = (
+    deliverable: CompleteReviewDeliverableDialogDeliverable
+  ) => {
+    context.showDialog(
+      <CompleteReviewDeliverableDialog
+        onClose={context.hideDialog}
+        deliverable={deliverable}
+      />
+    );
+  };
+
   const showEditDeliverableDialog = (
     deliverable: DeliverableTableRow,
     onSave?: (input: EditDeliverableInput, reasonForChange?: string) => Promise<void> | void
@@ -321,5 +336,6 @@ export const useDialog = () => {
     showEditDeliverableDialog,
     showRequestExtensionDeliverableDialog,
     showRequestResubmissionDeliverableDialog,
+    showCompleteReviewDeliverableDialog,
   };
 };

--- a/client/src/components/dialog/deliverable/CompleteReviewDeliverableDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/CompleteReviewDeliverableDialog.test.tsx
@@ -1,0 +1,228 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  COMPLETE_REVIEW_DIALOG_TITLE,
+  COMPLETE_REVIEW_ELIGIBLE_STATUSES,
+  COMPLETE_REVIEW_STATUS_FIELD_NAME,
+  COMPLETE_REVIEW_SUBMIT_BUTTON_NAME,
+  CompleteReviewDeliverableDialog,
+  CompleteReviewDeliverableDialogDeliverable,
+  INITIAL_FORM_DATA,
+  canCompleteReview,
+  formHasChanges,
+  formIsValid,
+} from "./CompleteReviewDeliverableDialog";
+
+import { DIALOG_CANCEL_BUTTON_NAME } from "components/dialog/BaseDialog";
+import { TestProvider } from "test-utils/TestProvider";
+import { DialogProvider } from "../DialogContext";
+import { DELIVERABLE_DETAILS_QUERY } from "pages/deliverables/DeliverableDetailsManagementPage";
+import { DELIVERABLE_REVIEW_COMPLETED_MESSAGE } from "util/messages";
+
+const mockShowSuccess = vi.fn();
+const mockShowError = vi.fn();
+const mockMutation = vi.fn();
+
+vi.mock("components/toast", () => ({
+  useToast: () => ({
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+  }),
+}));
+
+vi.mock("@apollo/client", async () => {
+  const actual = await vi.importActual("@apollo/client");
+
+  return {
+    ...actual,
+    useMutation: () => [mockMutation],
+  };
+});
+
+const TEST_DELIVERABLE: CompleteReviewDeliverableDialogDeliverable = {
+  id: "deliverable-1",
+};
+
+const setup = (overrides?: Partial<CompleteReviewDeliverableDialogDeliverable>) => {
+  const onClose = vi.fn();
+
+  render(
+    <TestProvider>
+      <DialogProvider>
+        <CompleteReviewDeliverableDialog
+          deliverable={{ ...TEST_DELIVERABLE, ...overrides }}
+          onClose={onClose}
+        />
+      </DialogProvider>
+    </TestProvider>
+  );
+
+  return { onClose };
+};
+
+describe("CompleteReviewDeliverableDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutation.mockResolvedValue({});
+  });
+
+  it("renders with the correct title", () => {
+    setup();
+    expect(screen.getByText(COMPLETE_REVIEW_DIALOG_TITLE)).toBeInTheDocument();
+  });
+
+  it("renders the required Status field", () => {
+    setup();
+    expect(screen.getByTestId(COMPLETE_REVIEW_STATUS_FIELD_NAME)).toBeRequired();
+  });
+
+  it("renders all three final status options", () => {
+    setup();
+    expect(
+      screen.getByTestId(`${COMPLETE_REVIEW_STATUS_FIELD_NAME}-option-Accepted`)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${COMPLETE_REVIEW_STATUS_FIELD_NAME}-option-Approved`)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${COMPLETE_REVIEW_STATUS_FIELD_NAME}-option-Received and Filed`)
+    ).toBeInTheDocument();
+  });
+
+  it("renders both Submit and Cancel buttons", () => {
+    setup();
+    expect(screen.getByTestId(COMPLETE_REVIEW_SUBMIT_BUTTON_NAME)).toBeInTheDocument();
+    expect(screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME)).toBeInTheDocument();
+  });
+
+  it("disables Submit until a status is selected", async () => {
+    const user = userEvent.setup();
+    setup();
+    const submit = screen.getByTestId(COMPLETE_REVIEW_SUBMIT_BUTTON_NAME);
+
+    expect(submit).toBeDisabled();
+
+    await user.selectOptions(
+      screen.getByTestId(COMPLETE_REVIEW_STATUS_FIELD_NAME),
+      "Approved"
+    );
+
+    await waitFor(() => expect(submit).not.toBeDisabled());
+  });
+
+  it("submits the mutation, shows a success toast, and closes the dialog", async () => {
+    const user = userEvent.setup();
+    const { onClose } = setup();
+
+    await user.selectOptions(
+      screen.getByTestId(COMPLETE_REVIEW_STATUS_FIELD_NAME),
+      "Accepted"
+    );
+
+    await user.click(screen.getByTestId(COMPLETE_REVIEW_SUBMIT_BUTTON_NAME));
+
+    await waitFor(() => expect(mockMutation).toHaveBeenCalledTimes(1));
+
+    expect(mockMutation).toHaveBeenCalledWith({
+      variables: {
+        id: "deliverable-1",
+        finalStatus: "Accepted",
+      },
+      refetchQueries: [
+        { query: DELIVERABLE_DETAILS_QUERY, variables: { id: "deliverable-1" } },
+      ],
+      awaitRefetchQueries: true,
+    });
+
+    expect(mockShowSuccess).toHaveBeenCalledWith(DELIVERABLE_REVIEW_COMPLETED_MESSAGE);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error toast when the mutation fails", async () => {
+    const user = userEvent.setup();
+    mockMutation.mockRejectedValueOnce(new Error("boom"));
+
+    const { onClose } = setup();
+
+    await user.selectOptions(
+      screen.getByTestId(COMPLETE_REVIEW_STATUS_FIELD_NAME),
+      "Approved"
+    );
+    await user.click(screen.getByTestId(COMPLETE_REVIEW_SUBMIT_BUTTON_NAME));
+
+    await waitFor(() =>
+      expect(mockShowError).toHaveBeenCalledWith("Unable to complete deliverable review.")
+    );
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("opens the cancellation confirmation when closing with a selection", async () => {
+    const user = userEvent.setup();
+    const { onClose } = setup();
+
+    await user.selectOptions(
+      screen.getByTestId(COMPLETE_REVIEW_STATUS_FIELD_NAME),
+      "Received and Filed"
+    );
+    await user.click(screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME));
+
+    expect(await screen.findByText("Are you sure?")).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes without confirmation when there are no changes", async () => {
+    const user = userEvent.setup();
+    const { onClose } = setup();
+
+    await user.click(screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("canCompleteReview", () => {
+  const noExtensions: { status: "Requested" | "Approved" | "Denied" }[] = [];
+  const openExtensions = [{ status: "Requested" as const }];
+  const resolvedExtensions = [{ status: "Approved" as const }];
+
+  it("returns true for Under CMS Review with no open extensions", () => {
+    expect(canCompleteReview("Under CMS Review", noExtensions)).toBe(true);
+    expect(canCompleteReview("Under CMS Review", resolvedExtensions)).toBe(true);
+    expect(COMPLETE_REVIEW_ELIGIBLE_STATUSES.has("Under CMS Review")).toBe(true);
+  });
+
+  it("returns false when an extension is still Requested", () => {
+    expect(canCompleteReview("Under CMS Review", openExtensions)).toBe(false);
+  });
+
+  it.each(
+    ["Upcoming", "Past Due", "Submitted", "Accepted", "Approved", "Received and Filed"] as const
+  )("returns false for %s", (status) => {
+    expect(canCompleteReview(status, noExtensions)).toBe(false);
+  });
+});
+
+describe("formIsValid / formHasChanges", () => {
+  it("INITIAL_FORM_DATA has empty status", () => {
+    expect(INITIAL_FORM_DATA).toEqual({ finalStatus: "" });
+  });
+
+  it("formHasChanges returns false for the initial state", () => {
+    expect(formHasChanges(INITIAL_FORM_DATA)).toBe(false);
+  });
+
+  it("formHasChanges returns true once a status is chosen", () => {
+    expect(formHasChanges({ finalStatus: "Approved" })).toBe(true);
+  });
+
+  it("formIsValid requires a final status", () => {
+    expect(formIsValid({ finalStatus: "" })).toBe(false);
+    expect(formIsValid({ finalStatus: "Accepted" })).toBe(true);
+    expect(formIsValid({ finalStatus: "Approved" })).toBe(true);
+    expect(formIsValid({ finalStatus: "Received and Filed" })).toBe(true);
+  });
+});

--- a/client/src/components/dialog/deliverable/CompleteReviewDeliverableDialog.tsx
+++ b/client/src/components/dialog/deliverable/CompleteReviewDeliverableDialog.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from "react";
+import { gql, useMutation } from "@apollo/client";
+
+import { Button } from "components/button";
+import { BaseDialog } from "components/dialog/BaseDialog";
+import { Select, Option } from "components/input/select/Select";
+import { useToast } from "components/toast";
+
+import {
+  DeliverableExtensionStatus,
+  DeliverableStatus,
+  FinalDeliverableStatus,
+} from "demos-server";
+import { DELIVERABLE_REVIEW_COMPLETED_MESSAGE } from "util/messages";
+
+import { DELIVERABLE_DETAILS_QUERY } from "pages/deliverables/DeliverableDetailsManagementPage";
+import { hasOpenExtensionRequest } from "./RequestExtensionDeliverableDialog";
+
+export const COMPLETE_REVIEW_DIALOG_TITLE = "Complete Review";
+export const COMPLETE_REVIEW_DIALOG_NAME = "complete-review-dialog";
+
+export const COMPLETE_REVIEW_STATUS_FIELD_NAME = "complete-review-status";
+export const COMPLETE_REVIEW_SUBMIT_BUTTON_NAME = "button-complete-review-submit";
+
+export const COMPLETE_REVIEW_ELIGIBLE_STATUSES: ReadonlySet<DeliverableStatus> = new Set([
+  "Under CMS Review",
+]);
+
+export const canCompleteReview = (
+  status: DeliverableStatus,
+  extensions: { status: DeliverableExtensionStatus }[]
+): boolean =>
+  COMPLETE_REVIEW_ELIGIBLE_STATUSES.has(status) && !hasOpenExtensionRequest(extensions);
+
+const COMPLETE_DELIVERABLE_REVIEW_MUTATION = gql`
+  mutation CompleteDeliverable($id: ID!, $finalStatus: FinalDeliverableStatus!) {
+    completeDeliverable(id: $id, finalStatus: $finalStatus) {
+      id
+      status
+    }
+  }
+`;
+
+export const FINAL_STATUS_OPTIONS: Option[] = [
+  { label: "Accepted", value: "Accepted" },
+  { label: "Approved", value: "Approved" },
+  { label: "Received and Filed", value: "Received and Filed" },
+];
+
+export interface CompleteReviewDeliverableDialogDeliverable {
+  id: string;
+}
+
+export interface CompleteReviewFormData {
+  finalStatus: FinalDeliverableStatus | "";
+}
+
+export const INITIAL_FORM_DATA: CompleteReviewFormData = {
+  finalStatus: "",
+};
+
+export const formIsValid = (form: CompleteReviewFormData): boolean =>
+  form.finalStatus !== "";
+
+export const formHasChanges = (form: CompleteReviewFormData): boolean =>
+  form.finalStatus !== "";
+
+export interface CompleteReviewDeliverableDialogProps {
+  onClose: () => void;
+  deliverable: CompleteReviewDeliverableDialogDeliverable;
+}
+
+export const CompleteReviewDeliverableDialog: React.FC<
+  CompleteReviewDeliverableDialogProps
+> = ({ onClose, deliverable }) => {
+  const { showSuccess, showError } = useToast();
+
+  const [completeReviewTrigger] = useMutation(COMPLETE_DELIVERABLE_REVIEW_MUTATION);
+
+  const [formData, setFormData] = useState<CompleteReviewFormData>(INITIAL_FORM_DATA);
+
+  const isValidForm = formIsValid(formData);
+  const hasChanges = formHasChanges(formData);
+
+  const handleSubmit = async () => {
+    if (!isValidForm || formData.finalStatus === "") return;
+
+    try {
+      await completeReviewTrigger({
+        variables: {
+          id: deliverable.id,
+          finalStatus: formData.finalStatus,
+        },
+        refetchQueries: [
+          { query: DELIVERABLE_DETAILS_QUERY, variables: { id: deliverable.id } },
+        ],
+        awaitRefetchQueries: true,
+      });
+
+      showSuccess(DELIVERABLE_REVIEW_COMPLETED_MESSAGE);
+      onClose();
+    } catch (error) {
+      console.error(error);
+      showError("Unable to complete deliverable review.");
+    }
+  };
+
+  return (
+    <BaseDialog
+      name={COMPLETE_REVIEW_DIALOG_NAME}
+      title={COMPLETE_REVIEW_DIALOG_TITLE}
+      onClose={onClose}
+      dialogHasChanges={hasChanges}
+      actionButton={
+        <Button
+          name={COMPLETE_REVIEW_SUBMIT_BUTTON_NAME}
+          onClick={handleSubmit}
+          disabled={!isValidForm}
+        >
+          Submit
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-sm">
+        <Select
+          id={COMPLETE_REVIEW_STATUS_FIELD_NAME}
+          label="Status"
+          isRequired
+          options={FINAL_STATUS_OPTIONS}
+          value={formData.finalStatus}
+          onSelect={(value) =>
+            setFormData({ finalStatus: value as FinalDeliverableStatus | "" })
+          }
+        />
+      </div>
+    </BaseDialog>
+  );
+};

--- a/client/src/components/dialog/deliverable/index.ts
+++ b/client/src/components/dialog/deliverable/index.ts
@@ -8,8 +8,4 @@ export {
   canRequestExtension,
   REQUEST_EXTENSION_DIALOG_TITLE,
 } from "./RequestExtensionDeliverableDialog";
-export {
-  CompleteReviewDeliverableDialog,
-  canCompleteReview,
-  COMPLETE_REVIEW_DIALOG_TITLE,
-} from "./CompleteReviewDeliverableDialog";
+export { canCompleteReview } from "./CompleteReviewDeliverableDialog";

--- a/client/src/components/dialog/deliverable/index.ts
+++ b/client/src/components/dialog/deliverable/index.ts
@@ -8,3 +8,8 @@ export {
   canRequestExtension,
   REQUEST_EXTENSION_DIALOG_TITLE,
 } from "./RequestExtensionDeliverableDialog";
+export {
+  CompleteReviewDeliverableDialog,
+  canCompleteReview,
+  COMPLETE_REVIEW_DIALOG_TITLE,
+} from "./CompleteReviewDeliverableDialog";

--- a/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
+++ b/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
@@ -8,7 +8,9 @@ import { HistoryTab, type DeliverableHistoryRow } from "./HistoryTab";
 import { StateFilesTab } from "./StateFilesTab";
 import { Button } from "components/button/Button";
 import { useDialog } from "components/dialog/DialogContext";
-import { DeliverableStatus } from "demos-server";
+import { canCompleteReview } from "components/dialog/deliverable";
+import { getCurrentUser } from "components/user/UserContext";
+import { DeliverableStatus, PersonType } from "demos-server";
 
 export const FILE_AND_HISTORY_TABS_NAME = "file-and-history-tabs";
 export const FILE_AND_HISTORY_ACTIONS_NAME = "file-and-history-actions";
@@ -18,6 +20,11 @@ export const RESUBMISSION_DISABLED_STATUSES: ReadonlySet<DeliverableStatus> =
 
 export const isResubmissionDisabled = (status: DeliverableStatus): boolean =>
   RESUBMISSION_DISABLED_STATUSES.has(status);
+
+const COMPLETE_REVIEW_PERSON_TYPES: ReadonlySet<PersonType> = new Set([
+  "demos-admin",
+  "demos-cms-user",
+]);
 
 const TABS = {
   STATE_FILES: "state_files",
@@ -35,13 +42,25 @@ export const FileAndHistoryTabs: React.FC<{
   const stateFiles = deliverable.stateDocuments;
   const cmsFiles = deliverable.cmsDocuments;
 
-  const { showRequestResubmissionDeliverableDialog } = useDialog();
+  const { showRequestResubmissionDeliverableDialog, showCompleteReviewDeliverableDialog } =
+    useDialog();
+  const { currentUser } = getCurrentUser();
+  const userPersonType = currentUser?.person.personType;
+  const isCompleteReviewAllowedForUser =
+    !!userPersonType && COMPLETE_REVIEW_PERSON_TYPES.has(userPersonType);
+  const isCompleteReviewDisabled =
+    !isCompleteReviewAllowedForUser ||
+    !canCompleteReview(deliverable.status, deliverable.extensionRequests);
 
   const handleRequestResubmission = () => {
     showRequestResubmissionDeliverableDialog({
       id: deliverable.id,
       dueDate: deliverable.dueDate,
     });
+  };
+
+  const handleCompleteReview = () => {
+    showCompleteReviewDeliverableDialog({ id: deliverable.id });
   };
 
   return (
@@ -75,8 +94,8 @@ export const FileAndHistoryTabs: React.FC<{
           Submit Deliverable
         </Button>
         <Button
-          disabled={true}
-          onClick={() => {}}
+          disabled={isCompleteReviewDisabled}
+          onClick={handleCompleteReview}
           size="large"
           name="button-actions-complete-review"
         >

--- a/client/src/util/messages.ts
+++ b/client/src/util/messages.ts
@@ -24,3 +24,4 @@ export const getPhaseCompletedMessage = (phaseName: PhaseName) => {
 export const DELIVERABLE_SLOTS_CREATED_MESSAGE = "Deliverable Slot(s) - have been added";
 export const DELIVERABLE_UPDATED_MESSAGE = "Changes have been saved to the deliverable";
 export const DELIVERABLE_EXTENSION_REQUESTED_MESSAGE = "Extension Request - has been Submitted";
+export const DELIVERABLE_REVIEW_COMPLETED_MESSAGE = "Deliverable Review - has been Completed";


### PR DESCRIPTION
# DEMOS-1540: Complete Deliverable Review

## Summary

CMS/Admin users can now complete a deliverable's review from the deliverable detail page. Selecting one of the three final statuses (Accepted, Approved, Received and Filed) calls the existing `completeDeliverable` mutation, refetches the deliverable, shows a success toast, and locks the deliverable from further edits via existing status-based gates.

## Changes

- **`components/dialog/deliverable/CompleteReviewDeliverableDialog.tsx`** (new) — Modal with required Status select; co-located `completeDeliverable($id, $finalStatus: FinalDeliverableStatus!)` mutation; exports `canCompleteReview(status, extensionRequests)` (true only for `Under CMS Review` with no `Requested` extension).
- **`components/dialog/DialogContext.tsx`** — Registered `showCompleteReviewDeliverableDialog`.
- **`components/dialog/deliverable/index.ts`** — Exported the new dialog + helper.
- **`pages/deliverables/sections/FileAndHistoryTabs.tsx`** — Wired the previously-disabled Complete Review button. Disabled for state users; enabled for CMS/admin only when `canCompleteReview` returns true.
- **`util/messages.ts`** — Added `DELIVERABLE_REVIEW_COMPLETED_MESSAGE`.

## QA steps

1. Open a deliverable in `Under CMS Review` (locally: Start Review on a Submitted deliverable, or hand-bump one via SQL).
2. Confirm `Complete Review` is enabled for CMS/admin and disabled for state users.
3. Click it; modal opens with required Status dropdown (Accepted / Approved / Received and Filed).
4. Submit is disabled until a status is picked; Cancel after picking prompts confirmation.
5. Submitting closes the modal, fires a success toast, deliverable status updates, and edit / delete / extension / resubmission affordances disable as the status moves to a final state.
6. Comments remain available.


https://github.com/user-attachments/assets/0ada7243-f25b-426a-b066-a3b47f771753

