### PR TITLE
DEMOS-1938 remove extra nav links

### DIFF
--- a/client/src/components/header/QuickLinks.test.tsx
+++ b/client/src/components/header/QuickLinks.test.tsx
@@ -31,8 +31,6 @@ describe("QuickLinks", () => {
   it("renders all quick links for an admin user", () => {
     setup();
     expect(screen.getByRole("link", { name: /Admin/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Notifications/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Help/i })).toBeInTheDocument();
   });
 
   it("does not render the Admin link for a non-admin user", () => {

--- a/client/src/components/header/QuickLinks.tsx
+++ b/client/src/components/header/QuickLinks.tsx
@@ -1,4 +1,4 @@
-import { HelpIcon, NotifyIcon, SettingsIcon } from "components/icons";
+import { SettingsIcon } from "components/icons";
 import { getCurrentUser } from "components/user/UserContext";
 import React from "react";
 import { Link, useLocation } from "react-router-dom";
@@ -30,16 +30,6 @@ export const QuickLinks: React.FC = () => {
           <span>Admin</span>
         </Link>
       )}
-
-      <a href="#" className={STYLES.link}>
-        <NotifyIcon className={STYLES.icon} />
-        <span>Notifications</span>
-      </a>
-
-      <a href="#" className={STYLES.link}>
-        <HelpIcon className={STYLES.icon} />
-        <span>Help</span>
-      </a>
     </div>
   );
 };

--- a/client/src/layout/SideNav.tsx
+++ b/client/src/layout/SideNav.tsx
@@ -3,17 +3,14 @@ import React from "react";
 import { DebugOnly } from "components/debug/DebugOnly";
 import {
   ActionsIcon,
-  AnalyticsIcon,
   CommentIcon,
   CompareIcon,
   DateIcon,
   FavoriteIcon,
   FileIcon,
   FolderIcon,
-  ListIcon,
   MenuCollapseLeftIcon,
   MenuCollapseRightIcon,
-  ScaleIcon,
   StackIcon,
 } from "components/icons";
 import { Link, useLocation } from "react-router-dom";
@@ -30,10 +27,7 @@ const SIDE_NAV_STYLES = "h-full bg-white transition-all duration-300 flex flex-c
 const navLinks: NavLink[] = [
   { label: "Demonstrations", href: "/demonstrations", icon: <CompareIcon /> },
   { label: "Deliverables", href: "/deliverables", icon: <FileIcon />},
-  { label: "Tasks", href: "#2", icon: <ListIcon /> },
-  { label: "Dashboards", href: "#3", icon: <AnalyticsIcon /> },
   { label: "Reports", href: "/reports", icon: <FolderIcon /> },
-  { label: "Budget", href: "#5", icon: <ScaleIcon /> },
 ];
 
 const debugNavLinks: NavLink[] = [


### PR DESCRIPTION
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/17bab3ee-7ea1-4226-8de7-98b3d5a4d898" />

Simply removes unnecessary nav links