### PR TITLE
DEMOS-1919 remove select column from demos table

### DIFF
--- a/client/src/components/table/columns/DemonstrationColumns.tsx
+++ b/client/src/components/table/columns/DemonstrationColumns.tsx
@@ -5,7 +5,6 @@ import { ChevronDownIcon, ChevronRightIcon } from "components/icons";
 import React from "react";
 import { DemonstrationTableRow } from "../tables/DemonstrationTable";
 import { Person } from "demos-server";
-import { createSelectColumnDef } from "./selectColumn";
 import { APPLICATION_STATUS, STATES_AND_TERRITORIES } from "demos-server-constants";
 import { ApplicationStatusBadge } from "components/badge/ApplicationStatusBadge";
 import type { ApplicationStatus } from "demos-server";
@@ -17,7 +16,6 @@ export function DemonstrationColumns(projectOfficerOptions: Pick<Person, "fullNa
   const columnHelper = createColumnHelper<DemonstrationTableRow>();
 
   return [
-    createSelectColumnDef(columnHelper),
     columnHelper.accessor("state.id", {
       id: "stateId",
       header: "State/Territory",

--- a/client/src/components/table/tables/DemonstrationTable.test.tsx
+++ b/client/src/components/table/tables/DemonstrationTable.test.tsx
@@ -252,8 +252,8 @@ describe("Demonstrations", () => {
       const rowData = demoRows.map((row) => {
         const cells = within(row).getAllByRole("cell");
         // Assuming state is in column 1 and title is in column 2 (after select column)
-        const stateCell = cells[1];
-        const titleCell = cells[2];
+        const stateCell = cells[0];
+        const titleCell = cells[1];
         return {
           state: stateCell.textContent,
           title: titleCell.textContent,
@@ -271,7 +271,7 @@ describe("Demonstrations", () => {
 
     it("renders table columns correctly", () => {
       const headers = screen.getAllByRole("columnheader");
-      expect(headers).toHaveLength(8);
+      expect(headers).toHaveLength(7);
       expect(screen.getByRole("columnheader", { name: "Title Sort" })).toBeInTheDocument();
       expect(
         screen.getByRole("columnheader", { name: "State/Territory Sort" })


### PR DESCRIPTION
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/609c36d5-b19f-45be-9008-eb3b51a56dbf" />

Removes the select column from the demonstrations table