### PR TITLE
DEMOS-2025-fix-cms-owner-edit-on-deliverable

### DIFF
--- a/server/src/model/deliverable/queries/editDeliverable.test.ts
+++ b/server/src/model/deliverable/queries/editDeliverable.test.ts
@@ -13,6 +13,7 @@ vi.mock("../../../prismaClient", () => ({
 }));
 
 import { prisma } from "../../../prismaClient";
+import { PersonType } from "../../../types";
 
 describe("editDeliverable", () => {
   const regularMocks = {
@@ -78,5 +79,29 @@ describe("editDeliverable", () => {
     await editDeliverable(testDeliverableId, testInput, mockTransaction);
     expect(regularMocks.deliverable.update).not.toHaveBeenCalled();
     expect(transactionMocks.deliverable.update).toHaveBeenCalledExactlyOnceWith(expectedCall);
+  });
+
+  it("should flatten the user change if it is provided", async () => {
+    const testPersonType: PersonType = "demos-admin";
+    const testInput = {
+      ...baseTestInput,
+      cmsOwner: {
+        cmsOwnerUserId: "487d8f98-8543-41bf-9d15-640c3ed5466c",
+        cmsOwnerPersonTypeId: testPersonType,
+      },
+    };
+    const expectedCall = {
+      where: {
+        id: testDeliverableId,
+      },
+      data: {
+        name: testInput.name,
+        cmsOwnerUserId: testInput.cmsOwner.cmsOwnerUserId,
+        cmsOwnerPersonTypeId: testInput.cmsOwner.cmsOwnerPersonTypeId,
+      },
+    };
+    await editDeliverable(testDeliverableId, testInput);
+    expect(regularMocks.deliverable.update).toHaveBeenCalledExactlyOnceWith(expectedCall);
+    expect(transactionMocks.deliverable.update).not.toHaveBeenCalled();
   });
 });

--- a/server/src/model/deliverable/queries/editDeliverable.ts
+++ b/server/src/model/deliverable/queries/editDeliverable.ts
@@ -1,11 +1,14 @@
 import { Deliverable as PrismaDeliverable } from "@prisma/client";
 import { prisma, PrismaTransactionClient } from "../../../prismaClient";
-import { DeliverableStatus, NonEmptyString } from "../../../types";
+import { DeliverableStatus, NonEmptyString, PersonType } from "../../../types";
 
 export type EditDeliverableInput = {
   name?: NonEmptyString;
   statusId?: DeliverableStatus;
-  cmsOwnerUserId?: string;
+  cmsOwner?: {
+    cmsOwnerUserId: string;
+    cmsOwnerPersonTypeId: PersonType;
+  };
   dueDate?: Date;
 };
 
@@ -14,11 +17,12 @@ export async function editDeliverable(
   input: EditDeliverableInput,
   tx?: PrismaTransactionClient
 ): Promise<PrismaDeliverable> {
+  const { cmsOwner, ...basicInput } = input;
   const prismaClient = tx ?? prisma();
   return await prismaClient.deliverable.update({
     where: {
       id: deliverableId,
     },
-    data: { ...input },
+    data: { ...basicInput, ...cmsOwner },
   });
 }

--- a/server/src/model/deliverable/updateDeliverable.test.ts
+++ b/server/src/model/deliverable/updateDeliverable.test.ts
@@ -4,9 +4,10 @@ import { TZDate } from "@date-fns/tz";
 import { DeepPartial } from "../../testUtilities";
 
 // Types
-import { UpdateDeliverableInput } from "../../types";
+import { PersonType, UpdateDeliverableInput } from "../../types";
 import { EditDeliverableInput, ParsedUpdateDeliverableInput } from ".";
 import { GraphQLContext } from "../../auth";
+import { User as PrismaUser } from "@prisma/client";
 
 // Functions under test
 import { updateDeliverable } from "./updateDeliverable";
@@ -30,6 +31,10 @@ vi.mock("../../errors/checkOptionalNotNullFields", () => ({
   checkOptionalNotNullFields: vi.fn(),
 }));
 
+vi.mock("../user/queries", () => ({
+  getUser: vi.fn(),
+}));
+
 import { prisma } from "../../prismaClient";
 import {
   editDeliverable,
@@ -41,24 +46,33 @@ import {
   validateUserPersonTypeAllowed,
 } from ".";
 import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
+import { getUser } from "../user/queries";
 
 describe("updateDeliverable", () => {
   // Test inputs
   const testDeliverableId = "2563ded3-b5c5-4d89-9ee4-0a9bc072e89e";
   const testName = "Test Input 1";
   const testCmsOwnerUserId = "7643eef9-dc5e-4640-bc1f-b0a660034386";
-  const testInput: UpdateDeliverableInput = {
-    name: testName,
-  };
+  const testCmsOwnerPersonTypeId: PersonType = "demos-admin";
   const testContext: DeepPartial<GraphQLContext> = {
     user: {
       id: "57f92f14-7c5e-4c78-a774-5a54d7e9c2e7",
     },
   };
 
-  // Mock parsed input
-  const mockParseInputResult: ParsedUpdateDeliverableInput = {
-    name: testInput.name,
+  // Basic test input and parsed result with only a name
+  // Inputs will be changed when needed for tests
+  const basicTestInput: UpdateDeliverableInput = {
+    name: testName,
+  };
+  const mockBasicParseInputResult: ParsedUpdateDeliverableInput = {
+    name: testName,
+  };
+
+  // Basic mocked user for getUser for when this is used
+  const mockUser: Partial<PrismaUser> = {
+    id: testCmsOwnerUserId,
+    personTypeId: testCmsOwnerPersonTypeId,
   };
 
   // Mock transaction
@@ -70,12 +84,13 @@ describe("updateDeliverable", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
-    vi.mocked(parseUpdateDeliverableInput).mockReturnValue(mockParseInputResult);
+    vi.mocked(parseUpdateDeliverableInput).mockReturnValue(mockBasicParseInputResult);
+    vi.mocked(getUser).mockResolvedValue(mockUser as PrismaUser);
     mockPrismaClient.$transaction.mockImplementation((callback) => callback(mockTransaction));
   });
 
   it("should check that the user is allowed to do this operation", async () => {
-    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
+    await updateDeliverable(testDeliverableId, basicTestInput, testContext as GraphQLContext);
     expect(validateUserPersonTypeAllowed).toHaveBeenCalledExactlyOnceWith(
       testContext,
       "updateDeliverable",
@@ -87,7 +102,7 @@ describe("updateDeliverable", () => {
     vi.mocked(validateUserPersonTypeAllowed).mockThrow("I'm throwing!");
 
     try {
-      await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
+      await updateDeliverable(testDeliverableId, basicTestInput, testContext as GraphQLContext);
       throw new Error("Expected updateDeliverable to throw, but it did not.");
     } catch (e) {
       expect(prisma).not.toHaveBeenCalled();
@@ -95,32 +110,32 @@ describe("updateDeliverable", () => {
   });
 
   it("should check for non-null in all the fields", async () => {
-    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
+    await updateDeliverable(testDeliverableId, basicTestInput, testContext as GraphQLContext);
     expect(checkOptionalNotNullFields).toHaveBeenCalledExactlyOnceWith(
       ["name", "cmsOwnerUserId", "dueDate", "demonstrationTypes"],
-      testInput
+      basicTestInput
     );
   });
 
   it("should parse the input", async () => {
-    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
-    expect(parseUpdateDeliverableInput).toHaveBeenCalledExactlyOnceWith(testInput);
+    await updateDeliverable(testDeliverableId, basicTestInput, testContext as GraphQLContext);
+    expect(parseUpdateDeliverableInput).toHaveBeenCalledExactlyOnceWith(basicTestInput);
   });
 
   it("should call the validation function with a transaction", async () => {
-    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
+    await updateDeliverable(testDeliverableId, basicTestInput, testContext as GraphQLContext);
     expect(validateUpdateDeliverableInput).toHaveBeenCalledExactlyOnceWith(
       testDeliverableId,
-      mockParseInputResult,
+      mockBasicParseInputResult,
       mockTransaction
     );
   });
 
   it("should edit the deliverable and then fetch the final version within a transaction", async () => {
-    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
+    await updateDeliverable(testDeliverableId, basicTestInput, testContext as GraphQLContext);
     expect(editDeliverable).toHaveBeenCalledExactlyOnceWith(
       testDeliverableId,
-      { name: mockParseInputResult.name },
+      { name: mockBasicParseInputResult.name },
       mockTransaction
     );
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
@@ -129,18 +144,49 @@ describe("updateDeliverable", () => {
     );
   });
 
+  it("should get the user record if a user ID is provided", async () => {
+    const testInput: UpdateDeliverableInput = {
+      ...basicTestInput,
+      cmsOwnerUserId: testCmsOwnerUserId,
+    };
+    const mockParseInputResult: ParsedUpdateDeliverableInput = {
+      ...mockBasicParseInputResult,
+      cmsOwnerUserId: testInput.cmsOwnerUserId,
+    };
+    vi.mocked(parseUpdateDeliverableInput).mockReturnValue(mockParseInputResult);
+
+    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
+    expect(getUser).toHaveBeenCalledExactlyOnceWith({ id: testCmsOwnerUserId }, mockTransaction);
+  });
+
+  it("should not get the user record if a user ID is not provided", async () => {
+    await updateDeliverable(testDeliverableId, basicTestInput, testContext as GraphQLContext);
+    expect(getUser).not.toHaveBeenCalled();
+  });
+
   const editDeliverableInputTests: [string, ParsedUpdateDeliverableInput, EditDeliverableInput][] =
     [
       ["name only", { name: testName }, { name: testName }],
       [
         "cmsOwnerUserId only",
         { cmsOwnerUserId: testCmsOwnerUserId },
-        { cmsOwnerUserId: testCmsOwnerUserId },
+        {
+          cmsOwner: {
+            cmsOwnerUserId: testCmsOwnerUserId,
+            cmsOwnerPersonTypeId: testCmsOwnerPersonTypeId,
+          },
+        },
       ],
       [
         "name + cmsOwnerUserId",
         { name: testName, cmsOwnerUserId: testCmsOwnerUserId },
-        { name: testName, cmsOwnerUserId: testCmsOwnerUserId },
+        {
+          name: testName,
+          cmsOwner: {
+            cmsOwnerUserId: testCmsOwnerUserId,
+            cmsOwnerPersonTypeId: testCmsOwnerPersonTypeId,
+          },
+        },
       ],
     ];
   it.each(editDeliverableInputTests)(
@@ -150,7 +196,7 @@ describe("updateDeliverable", () => {
       // That is why this mock is necessary, and needs to change for each set of parameters
       vi.mocked(parseUpdateDeliverableInput).mockReturnValue(mockParseInputResult);
 
-      await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
+      await updateDeliverable(testDeliverableId, basicTestInput, testContext as GraphQLContext);
       expect(editDeliverable).toHaveBeenCalledWith(
         testDeliverableId,
         expectedEditInput,
@@ -173,7 +219,7 @@ describe("updateDeliverable", () => {
     };
     vi.mocked(parseUpdateDeliverableInput).mockReturnValue(mockParseInputResult);
 
-    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
+    await updateDeliverable(testDeliverableId, basicTestInput, testContext as GraphQLContext);
     expect(editDeliverable).not.toHaveBeenCalled();
     expect(getDeliverable).toHaveBeenCalledExactlyOnceWith(
       { id: testDeliverableId },
@@ -182,15 +228,15 @@ describe("updateDeliverable", () => {
   });
 
   it("should always call the demonstration type and due date update functions", async () => {
-    await updateDeliverable(testDeliverableId, testInput, testContext as GraphQLContext);
+    await updateDeliverable(testDeliverableId, basicTestInput, testContext as GraphQLContext);
     expect(updateDeliverableDemonstrationTypes).toHaveBeenCalledExactlyOnceWith(
       testDeliverableId,
-      mockParseInputResult,
+      mockBasicParseInputResult,
       mockTransaction
     );
     expect(manuallyUpdateDeliverableDueDate).toHaveBeenCalledExactlyOnceWith(
       testDeliverableId,
-      mockParseInputResult,
+      mockBasicParseInputResult,
       testContext,
       mockTransaction
     );

--- a/server/src/model/deliverable/updateDeliverable.ts
+++ b/server/src/model/deliverable/updateDeliverable.ts
@@ -1,5 +1,5 @@
 import { Deliverable as PrismaDeliverable } from "@prisma/client";
-import { UpdateDeliverableInput } from "../../types";
+import { PersonType, UpdateDeliverableInput } from "../../types";
 import { GraphQLContext } from "../../auth";
 import {
   editDeliverable,
@@ -13,6 +13,7 @@ import {
 } from ".";
 import { prisma } from "../../prismaClient";
 import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
+import { getUser } from "../user/queries";
 
 export async function updateDeliverable(
   deliverableId: string,
@@ -27,9 +28,18 @@ export async function updateDeliverable(
     await validateUpdateDeliverableInput(deliverableId, parsedInput, tx);
 
     // Directly edit name and CMS owner
+    // Cast below enforced by database
     const editInput: EditDeliverableInput = {};
-    if (parsedInput.name) editInput.name = parsedInput.name;
-    if (parsedInput.cmsOwnerUserId) editInput.cmsOwnerUserId = parsedInput.cmsOwnerUserId;
+    if (parsedInput.name) {
+      editInput.name = parsedInput.name;
+    }
+    if (parsedInput.cmsOwnerUserId) {
+      const cmsOwner = await getUser({ id: parsedInput.cmsOwnerUserId }, tx);
+      editInput.cmsOwner = {
+        cmsOwnerUserId: cmsOwner.id,
+        cmsOwnerPersonTypeId: cmsOwner.personTypeId as PersonType,
+      };
+    }
     if (Object.keys(editInput).length > 0) {
       await editDeliverable(deliverableId, editInput, tx);
     }


### PR DESCRIPTION
This is a small PR which fixes a bug identified by @PatyshagulGurbangeldiyeva in the `updateDeliverable` mutator. Before, I was only changing the user ID of the CMS owner. However, if the new user was a different person type than the old user, this caused a foreign key error because you have to update both fields at the same time. This PR fixes that by properly updating both the user and the person type.