### PR TITLE
DEMOS-1788 Deliverables > History tab cleanup

### DIFF
--- a/client/src/mock-data/deliverableMocks.ts
+++ b/client/src/mock-data/deliverableMocks.ts
@@ -78,12 +78,15 @@ export const MOCK_DELIVERABLE_1: DeliverableDetailsManagementDeliverable = {
       actionType: "Created Deliverable Slot",
       actionTimestamp: new Date("2026-03-20T10:00:00Z"),
       userFullName: "System",
+      details: "",
     },
     {
       id: "action-1",
       actionType: "Requested Resubmission",
       actionTimestamp: new Date("2026-03-21T10:00:00Z"),
-      userFullName: "Mock CMS User",
+      userFullName: "Mock CMS User (CMS User)",
+      details:
+        "Old Due Date: 03/15/2026\nNew Due Date: 04/15/2026\nReason Details: Please resubmit with corrected figures.",
     },
   ],
   extensionRequests: [],

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -85,6 +85,7 @@ export const DELIVERABLE_DETAILS_QUERY = gql`
         actionType
         actionTimestamp
         userFullName
+        details
       }
       extensionRequests {
         id
@@ -105,7 +106,7 @@ export type DeliverableDetailsManagementDeliverable = Pick<
   cmsDocuments: DeliverableFileRow[];
   deliverableActions: Pick<
     DeliverableAction,
-    "id" | "actionType" | "actionTimestamp" | "userFullName"
+    "id" | "actionType" | "actionTimestamp" | "userFullName" | "details"
   >[];
   extensionRequests: Pick<DeliverableExtension, "id" | "status" | "createdAt">[];
 };

--- a/client/src/pages/deliverables/sections/FileAndHistoryTabs.test.tsx
+++ b/client/src/pages/deliverables/sections/FileAndHistoryTabs.test.tsx
@@ -59,13 +59,27 @@ describe("FileAndHistoryTabs", () => {
     expect(screen.getByTestId(CMS_FILES_TAB_NAME)).toBeInTheDocument();
   });
 
-  it("switches to the History tab on click", async () => {
+  it("switches to the History tab on click and renders rows from deliverable actions", async () => {
     const user = userEvent.setup();
     setup();
 
     await user.click(screen.getByTestId("button-history"));
 
-    expect(screen.getByTestId(HISTORY_TAB_NAME)).toBeInTheDocument();
+    const historyTab = screen.getByTestId(HISTORY_TAB_NAME);
+    expect(historyTab).toBeInTheDocument();
+    expect(within(historyTab).getByText("Created Deliverable Slot")).toBeInTheDocument();
+    expect(within(historyTab).getByText("Requested Resubmission")).toBeInTheDocument();
+    expect(within(historyTab).getByText("Mock CMS User (CMS User)")).toBeInTheDocument();
+    expect(within(historyTab).getByText(/Old Due Date: 03\/15\/2026/)).toBeInTheDocument();
+  });
+
+  it("shows the empty-state message in History when the deliverable has no actions", async () => {
+    const user = userEvent.setup();
+    setup({ deliverableActions: [] });
+
+    await user.click(screen.getByTestId("button-history"));
+
+    expect(screen.getByText(/No history available\./i)).toBeInTheDocument();
   });
 
   it("renders the Submit Deliverable button in the State Files tab when files exist", () => {

--- a/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
+++ b/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 
 import { HorizontalSectionTabs, Tab } from "layout/Tabs";
 
@@ -49,10 +49,7 @@ export const FileAndHistoryTabs: React.FC<{
 }> = ({ deliverable }) => {
   const stateFiles = deliverable.stateDocuments;
   const cmsFiles = deliverable.cmsDocuments;
-  const historyRows = useMemo<DeliverableHistoryRow[]>(
-    () => deliverable.deliverableActions.map(toHistoryRow),
-    [deliverable.deliverableActions]
-  );
+  const historyRows: DeliverableHistoryRow[] = deliverable.deliverableActions.map(toHistoryRow);
 
   const { showRequestResubmissionDeliverableDialog, showCompleteReviewDeliverableDialog } =
     useDialog();

--- a/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
+++ b/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 
 import { HorizontalSectionTabs, Tab } from "layout/Tabs";
 
@@ -11,6 +11,16 @@ import { useDialog } from "components/dialog/DialogContext";
 import { canCompleteReview } from "components/dialog/deliverable";
 import { getCurrentUser } from "components/user/UserContext";
 import { DeliverableStatus, PersonType } from "demos-server";
+
+type DeliverableActionRow = DeliverableDetailsManagementDeliverable["deliverableActions"][number];
+
+const toHistoryRow = (action: DeliverableActionRow): DeliverableHistoryRow => ({
+  id: action.id,
+  event: action.actionType,
+  date: new Date(action.actionTimestamp),
+  user: action.userFullName,
+  details: action.details,
+});
 
 export const FILE_AND_HISTORY_TABS_NAME = "file-and-history-tabs";
 export const FILE_AND_HISTORY_ACTIONS_NAME = "file-and-history-actions";
@@ -34,13 +44,15 @@ const TABS = {
 
 const buildTabLabel = (label: string, count: number) => (count > 0 ? `${label} (${count})` : label);
 
-const EMPTY_HISTORY: DeliverableHistoryRow[] = [];
-
 export const FileAndHistoryTabs: React.FC<{
   deliverable: DeliverableDetailsManagementDeliverable;
 }> = ({ deliverable }) => {
   const stateFiles = deliverable.stateDocuments;
   const cmsFiles = deliverable.cmsDocuments;
+  const historyRows = useMemo<DeliverableHistoryRow[]>(
+    () => deliverable.deliverableActions.map(toHistoryRow),
+    [deliverable.deliverableActions]
+  );
 
   const { showRequestResubmissionDeliverableDialog, showCompleteReviewDeliverableDialog } =
     useDialog();
@@ -73,7 +85,7 @@ export const FileAndHistoryTabs: React.FC<{
           <CmsFilesTab files={cmsFiles} />
         </Tab>
         <Tab label="History" value={TABS.HISTORY}>
-          <HistoryTab rows={EMPTY_HISTORY} />
+          <HistoryTab rows={historyRows} />
         </Tab>
       </HorizontalSectionTabs>
       <div data-testid={FILE_AND_HISTORY_ACTIONS_NAME} className="flex justify-end mt-2 gap-2">

--- a/client/src/pages/deliverables/sections/HistoryTab.test.tsx
+++ b/client/src/pages/deliverables/sections/HistoryTab.test.tsx
@@ -9,17 +9,18 @@ import { HISTORY_TAB_NAME, HistoryTab, type DeliverableHistoryRow } from "./Hist
 const MOCK_ROWS: DeliverableHistoryRow[] = [
   {
     id: "hist-1",
-    event: "Submitted",
+    event: "Submitted Deliverable",
     date: new Date("2026-04-01"),
-    user: "Leslie Carlson",
-    details: "Sorry",
+    user: "Leslie Carlson (State User)",
+    details: "",
   },
   {
     id: "hist-2",
-    event: "Resubmission Request",
+    event: "Requested Resubmission",
     date: new Date("2026-04-01"),
-    user: "Tess Davenport",
-    details: "-",
+    user: "Tess Davenport (CMS User)",
+    details:
+      "Old Due Date: 03/15/2026\nNew Due Date: 04/15/2026\nReason Details: Needs correction.",
   },
 ];
 
@@ -45,10 +46,32 @@ describe("HistoryTab", () => {
       </TestProvider>
     );
 
-    expect(screen.getByText("Submitted")).toBeInTheDocument();
-    expect(screen.getByText("Resubmission Request")).toBeInTheDocument();
-    expect(screen.getByText("Leslie Carlson")).toBeInTheDocument();
-    expect(screen.getByText("Tess Davenport")).toBeInTheDocument();
+    expect(screen.getByText("Submitted Deliverable")).toBeInTheDocument();
+    expect(screen.getByText("Requested Resubmission")).toBeInTheDocument();
+    expect(screen.getByText("Leslie Carlson (State User)")).toBeInTheDocument();
+    expect(screen.getByText("Tess Davenport (CMS User)")).toBeInTheDocument();
+  });
+
+  it("formats action timestamps in MM/DD/YYYY", () => {
+    render(
+      <TestProvider>
+        <HistoryTab rows={MOCK_ROWS} />
+      </TestProvider>
+    );
+
+    expect(screen.getAllByText("04/01/2026").length).toBeGreaterThan(0);
+  });
+
+  it("preserves newlines in the details column for multi-line entries", () => {
+    render(
+      <TestProvider>
+        <HistoryTab rows={MOCK_ROWS} />
+      </TestProvider>
+    );
+
+    const detailsText = screen.getByText(/Old Due Date: 03\/15\/2026/);
+    expect(detailsText).toBeInTheDocument();
+    expect(detailsText.closest("div")?.className).toContain("whitespace-pre-line");
   });
 
   it("renders an empty-state message when there are no rows", () => {

--- a/client/src/pages/deliverables/sections/HistoryTab.tsx
+++ b/client/src/pages/deliverables/sections/HistoryTab.tsx
@@ -1,12 +1,10 @@
 import React from "react";
-import { createColumnHelper } from "@tanstack/react-table";
+import { CellContext, createColumnHelper } from "@tanstack/react-table";
 
-import { ColumnFilter } from "components/table/ColumnFilter";
-import { KeywordSearch, highlightCell } from "components/table/KeywordSearch";
+import { highlightCell } from "components/table/KeywordSearch";
 import { PaginationControls } from "components/table/PaginationControls";
 import { Table } from "components/table/Table";
 import { createDateColumnDef } from "components/table/columns/dateColumn";
-import { createSelectColumnDef } from "components/table/columns/selectColumn";
 
 export const HISTORY_TAB_NAME = "history-tab";
 
@@ -20,10 +18,14 @@ export type DeliverableHistoryRow = {
 
 const INITIAL_TABLE_STATE = { sorting: [{ id: "date", desc: true }] };
 
+// Details may include embedded "\n" (e.g. extension request reasons); preserve those line breaks.
+function detailsCell(context: CellContext<DeliverableHistoryRow, string>) {
+  return <div className="whitespace-pre-line">{highlightCell(context)}</div>;
+}
+
 function makeHistoryColumns() {
   const columnHelper = createColumnHelper<DeliverableHistoryRow>();
   return [
-    createSelectColumnDef(columnHelper),
     columnHelper.accessor("event", {
       header: "Event",
       cell: highlightCell,
@@ -37,7 +39,7 @@ function makeHistoryColumns() {
     }),
     columnHelper.accessor("details", {
       header: "Details",
-      cell: highlightCell,
+      cell: detailsCell,
       enableColumnFilter: false,
     }),
   ];
@@ -49,12 +51,10 @@ export const HistoryTab: React.FC<{ rows: DeliverableHistoryRow[] }> = ({ rows }
       <Table<DeliverableHistoryRow>
         data={rows}
         columns={makeHistoryColumns()}
-        keywordSearch={(table) => <KeywordSearch table={table} />}
-        columnFilter={(table) => <ColumnFilter table={table} />}
         pagination={(table) => <PaginationControls table={table} />}
         initialState={INITIAL_TABLE_STATE}
         emptyRowsMessage="No history available."
-        noResultsFoundMessage="No results were returned. Adjust your search and filter criteria."
+        hideSearchAndActions
       />
     </div>
   );


### PR DESCRIPTION
# Deliverables > History tab cleanup

## Summary

History rows are immutable and ordered chronologically by default, so the row-selection checkbox column, keyword search, and Filter By dropdown are no longer needed. Removed those and tightened the layout above the table.

## Changes

All in [pages/deliverables/sections/HistoryTab.tsx](src/pages/deliverables/sections/HistoryTab.tsx):

- Dropped the checkbox column (`createSelectColumnDef`) — no bulk-action affordance for history rows.
- Stopped passing the `keywordSearch` and `columnFilter` slots to the shared `Table`.
- Added `hideSearchAndActions` to the `Table` to remove the empty `mb-[24px]` wrapper that the shared component otherwise reserves for the search/filter row.
- Removed `noResultsFoundMessage` (only fired when a search/filter narrowed results to zero; both are gone). `emptyRowsMessage="No history available."` still covers the empty case.
- Removed now-unused imports: `ColumnFilter`, `KeywordSearch`, `createSelectColumnDef`.

The chronological sort (`{ sorting: [{ id: "date", desc: true }] }`) and pagination are unchanged.

## Impact

State Files and CMS Files tabs are unaffected — they use `DeliverableFileTable`, not the shared `Table`, and `hideSearchAndActions` is a per-instance prop.

<img width="1920" height="1317" alt="image" src="https://github.com/user-attachments/assets/5812a34d-9175-496a-a7dc-b42e54fb2a6a" />

