### PR TITLE
DEMOS-2068 add validation for Signature Level on application creation

### DIFF
--- a/server/src/model/amendment/amendmentResolvers.ts
+++ b/server/src/model/amendment/amendmentResolvers.ts
@@ -5,6 +5,7 @@ import {
   ApplicationType,
   CreateAmendmentInput,
   PhaseName,
+  SignatureLevel,
   UiPathResultStatus,
   UpdateAmendmentInput,
 } from "../../types";
@@ -24,11 +25,17 @@ const amendmentApplicationType: ApplicationType = "Amendment";
 const conceptPhaseName: PhaseName = "Concept";
 const newApplicationStatusId: ApplicationStatus = "Pre-Submission";
 
+const VALID_INITIAL_AMENDMENT_SIGNATURE_LEVELS = ["OA", "OCD"] as SignatureLevel[];
+
 export async function __createAmendment(
   parent: unknown,
   { input }: { input: CreateAmendmentInput }
 ): Promise<PrismaAmendment> {
   return await prisma().$transaction(async (tx) => {
+    if (input.signatureLevel && !VALID_INITIAL_AMENDMENT_SIGNATURE_LEVELS.includes(input.signatureLevel)) {
+      throw new Error(`Invalid signature level: ${input.signatureLevel}`);
+    }
+
     const application = await tx.application.create({
       data: {
         applicationTypeId: amendmentApplicationType,

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -7,6 +7,7 @@ import {
   GrantLevel,
   PhaseName,
   Role,
+  SignatureLevel,
   UiPathResultStatus,
   UpdateDemonstrationInput,
 } from "../../types";
@@ -38,6 +39,8 @@ const conceptPhaseName: PhaseName = "Concept";
 const newApplicationStatusId: ApplicationStatus = "Pre-Submission";
 const demonstrationApplicationType: ApplicationType = "Demonstration";
 
+const VALID_INTIAL_DEMONSTRATION_SIGNATURE_LEVELS = ["OA"] as SignatureLevel[];
+
 export async function __createDemonstration(
   parent: unknown,
   { input }: { input: CreateDemonstrationInput }
@@ -45,6 +48,10 @@ export async function __createDemonstration(
   let newApplicationId: string;
   try {
     newApplicationId = await prisma().$transaction(async (tx) => {
+      if (input.signatureLevel && !VALID_INTIAL_DEMONSTRATION_SIGNATURE_LEVELS.includes(input.signatureLevel)) {
+        throw new Error(`Invalid signature level: ${input.signatureLevel}`);
+      }
+
       const application = await tx.application.create({
         data: {
           applicationTypeId: demonstrationApplicationType,

--- a/server/src/model/extension/extensionResolvers.ts
+++ b/server/src/model/extension/extensionResolvers.ts
@@ -5,6 +5,7 @@ import {
   ApplicationType,
   CreateExtensionInput,
   PhaseName,
+  SignatureLevel,
   UiPathResultStatus,
   UpdateExtensionInput,
 } from "../../types";
@@ -24,11 +25,17 @@ const extensionApplicationType: ApplicationType = "Extension";
 const conceptPhaseName: PhaseName = "Concept";
 const newApplicationStatusId: ApplicationStatus = "Pre-Submission";
 
+const VALID_INITIAL_EXTENSION_SIGNATURE_LEVELS = ["OA", "OCD"] as SignatureLevel[];
+
 export async function __createExtension(
   parent: unknown,
   { input }: { input: CreateExtensionInput }
 ): Promise<PrismaExtension> {
   return await prisma().$transaction(async (tx) => {
+    if (input.signatureLevel && !VALID_INITIAL_EXTENSION_SIGNATURE_LEVELS.includes(input.signatureLevel)) {
+      throw new Error(`Invalid signature level: ${input.signatureLevel}`);
+    }
+
     const application = await tx.application.create({
       data: {
         applicationTypeId: extensionApplicationType,


### PR DESCRIPTION
Validates input for Singature Level when application is created.
For demonstrations, only OA is accepted.
For amendments/extensions, only OA or OCD is accepted.