### PR TITLE
DEMOS-1572 — CMS/Admin: Review Extension Requests

### DIFF
--- a/client/src/components/dialog/DialogContext.tsx
+++ b/client/src/components/dialog/DialogContext.tsx
@@ -45,6 +45,10 @@ import {
   CompleteReviewDeliverableDialog,
   CompleteReviewDeliverableDialogDeliverable,
 } from "./deliverable/CompleteReviewDeliverableDialog";
+import {
+  ReviewExtensionDeliverableDialog,
+  ReviewExtensionDeliverableDialogDeliverable,
+} from "./deliverable/ReviewExtensionDeliverableDialog";
 
 type DialogContextType = {
   content: React.ReactNode | null;
@@ -280,6 +284,14 @@ export const useDialog = () => {
     );
   };
 
+  const showReviewExtensionDeliverableDialog = (
+    deliverable: ReviewExtensionDeliverableDialogDeliverable
+  ) => {
+    context.showDialog(
+      <ReviewExtensionDeliverableDialog onClose={context.hideDialog} deliverable={deliverable} />
+    );
+  };
+
   const showEditDeliverableDialog = (
     deliverable: DeliverableTableRow,
     onSave?: (input: EditDeliverableInput, reasonForChange?: string) => Promise<void> | void
@@ -337,5 +349,6 @@ export const useDialog = () => {
     showRequestExtensionDeliverableDialog,
     showRequestResubmissionDeliverableDialog,
     showCompleteReviewDeliverableDialog,
+    showReviewExtensionDeliverableDialog,
   };
 };

--- a/client/src/components/dialog/deliverable/ReviewExtensionDeliverableDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/ReviewExtensionDeliverableDialog.test.tsx
@@ -1,0 +1,352 @@
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import {
+  INITIAL_FORM_DATA,
+  REVIEW_EXTENSION_DETAILS_FIELD_NAME,
+  REVIEW_EXTENSION_DIALOG_TITLE,
+  REVIEW_EXTENSION_EXPIRED_NOTICE_NAME,
+  REVIEW_EXTENSION_NEW_DATE_FIELD_NAME,
+  REVIEW_EXTENSION_STATUS_FIELD_NAME,
+  REVIEW_EXTENSION_SUBMIT_BUTTON_NAME,
+  ReviewExtensionDeliverableDialog,
+  ReviewExtensionDeliverableDialogDeliverable,
+  STATE_REQUESTED_DATE_EXPIRED_MESSAGE,
+  formHasChanges,
+  formIsValid,
+  getNewDateValidationMessage,
+  isStateRequestedDateExpired,
+} from "./ReviewExtensionDeliverableDialog";
+import { DIALOG_CANCEL_BUTTON_NAME } from "components/dialog/BaseDialog";
+import { TestProvider } from "test-utils/TestProvider";
+import { DELIVERABLE_DETAILS_QUERY } from "pages/deliverables/DeliverableDetailsManagementPage";
+import { DELIVERABLE_EXTENSION_REVIEW_SUBMITTED_MESSAGE } from "util/messages";
+
+const mockShowSuccess = vi.fn();
+const mockShowError = vi.fn();
+const mockApproveMutation = vi.fn();
+const mockDenyMutation = vi.fn();
+
+vi.mock("components/toast", () => ({
+  useToast: () => ({
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+  }),
+}));
+
+vi.mock("@apollo/client", async () => {
+  const actual = await vi.importActual("@apollo/client");
+  return {
+    ...actual,
+    useMutation: vi.fn((document: { definitions: { name?: { value: string } }[] }) => {
+      const opName = document.definitions[0]?.name?.value ?? "";
+      if (opName === "ApproveDeliverableExtension") return [mockApproveMutation];
+      if (opName === "DenyDeliverableExtension") return [mockDenyMutation];
+      return [vi.fn()];
+    }),
+  };
+});
+
+const FUTURE_REQUESTED_DATE = new Date("2099-04-02");
+const PAST_REQUESTED_DATE = new Date("2020-01-02");
+
+const buildDeliverable = (
+  overrides?: Partial<ReviewExtensionDeliverableDialogDeliverable["extensionRequest"]>
+): ReviewExtensionDeliverableDialogDeliverable => ({
+  id: "deliverable-1",
+  extensionRequest: {
+    id: "extension-1",
+    reasonCode: "Technical Difficulties",
+    reasonDetails: "Our state is experiencing a delay in data collection.",
+    initialDueDateAtRequest: new Date("2099-03-17"),
+    originalDateRequested: FUTURE_REQUESTED_DATE,
+    ...overrides,
+  },
+});
+
+const setup = (
+  overrides?: Partial<ReviewExtensionDeliverableDialogDeliverable["extensionRequest"]>
+) => {
+  const onClose = vi.fn();
+  const deliverable = buildDeliverable(overrides);
+  render(
+    <TestProvider>
+      <ReviewExtensionDeliverableDialog deliverable={deliverable} onClose={onClose} />
+    </TestProvider>
+  );
+  return { onClose, deliverable };
+};
+
+describe("ReviewExtensionDeliverableDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApproveMutation.mockResolvedValue({});
+    mockDenyMutation.mockResolvedValue({});
+  });
+
+  it("renders the dialog title", () => {
+    setup();
+    expect(screen.getByText(REVIEW_EXTENSION_DIALOG_TITLE)).toBeInTheDocument();
+  });
+
+  it("renders the extension request details", () => {
+    setup();
+    expect(screen.getByText("Technical Difficulties")).toBeInTheDocument();
+    expect(
+      screen.getByText("Our state is experiencing a delay in data collection.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders Submit and Cancel buttons", () => {
+    setup();
+    expect(screen.getByTestId(REVIEW_EXTENSION_SUBMIT_BUTTON_NAME)).toBeInTheDocument();
+    expect(screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME)).toBeInTheDocument();
+  });
+
+  it("disables Submit until a decision is selected", () => {
+    setup();
+    expect(screen.getByTestId(REVIEW_EXTENSION_SUBMIT_BUTTON_NAME)).toBeDisabled();
+  });
+
+  it("does not show the expired notice when the requested date is in the future", () => {
+    setup();
+    expect(screen.queryByTestId(REVIEW_EXTENSION_EXPIRED_NOTICE_NAME)).not.toBeInTheDocument();
+  });
+
+  it("shows the expired notice when the requested date has passed", () => {
+    setup({ originalDateRequested: PAST_REQUESTED_DATE });
+    expect(screen.getByTestId(REVIEW_EXTENSION_EXPIRED_NOTICE_NAME)).toHaveTextContent(
+      STATE_REQUESTED_DATE_EXPIRED_MESSAGE
+    );
+  });
+
+  it("blocks submission when 'Approved' is selected but the requested date is expired", async () => {
+    const user = userEvent.setup();
+    setup({ originalDateRequested: PAST_REQUESTED_DATE });
+    await user.selectOptions(
+      screen.getByTestId(REVIEW_EXTENSION_STATUS_FIELD_NAME),
+      "Approved"
+    );
+    expect(screen.getByTestId(REVIEW_EXTENSION_SUBMIT_BUTTON_NAME)).toBeDisabled();
+  });
+
+  it("submits an approval without a new date", async () => {
+    const user = userEvent.setup();
+    const { onClose } = setup();
+    await user.selectOptions(
+      screen.getByTestId(REVIEW_EXTENSION_STATUS_FIELD_NAME),
+      "Approved"
+    );
+    await user.click(screen.getByTestId(REVIEW_EXTENSION_SUBMIT_BUTTON_NAME));
+
+    await waitFor(() => expect(mockApproveMutation).toHaveBeenCalledTimes(1));
+    expect(mockApproveMutation).toHaveBeenCalledWith({
+      variables: {
+        deliverableId: "deliverable-1",
+        input: { deliverableExtensionId: "extension-1" },
+      },
+      refetchQueries: [
+        { query: DELIVERABLE_DETAILS_QUERY, variables: { id: "deliverable-1" } },
+      ],
+      awaitRefetchQueries: true,
+    });
+    expect(mockShowSuccess).toHaveBeenCalledWith(DELIVERABLE_EXTENSION_REVIEW_SUBMITTED_MESSAGE);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires a New Date when 'Approve With New Date' is selected", async () => {
+    const user = userEvent.setup();
+    setup();
+    await user.selectOptions(
+      screen.getByTestId(REVIEW_EXTENSION_STATUS_FIELD_NAME),
+      "Approve With New Date"
+    );
+    expect(screen.getByTestId(REVIEW_EXTENSION_SUBMIT_BUTTON_NAME)).toBeDisabled();
+    expect(screen.getByTestId(REVIEW_EXTENSION_NEW_DATE_FIELD_NAME)).toBeInTheDocument();
+  });
+
+  it("submits 'Approve With New Date' with a future date", async () => {
+    const user = userEvent.setup();
+    const { onClose } = setup();
+    await user.selectOptions(
+      screen.getByTestId(REVIEW_EXTENSION_STATUS_FIELD_NAME),
+      "Approve With New Date"
+    );
+    fireEvent.change(screen.getByTestId(REVIEW_EXTENSION_NEW_DATE_FIELD_NAME), {
+      target: { value: "2099-03-25" },
+    });
+    await user.click(screen.getByTestId(REVIEW_EXTENSION_SUBMIT_BUTTON_NAME));
+
+    await waitFor(() => expect(mockApproveMutation).toHaveBeenCalledTimes(1));
+    expect(mockApproveMutation).toHaveBeenCalledWith({
+      variables: {
+        deliverableId: "deliverable-1",
+        input: { deliverableExtensionId: "extension-1", newDueDate: "2099-03-25" },
+      },
+      refetchQueries: [
+        { query: DELIVERABLE_DETAILS_QUERY, variables: { id: "deliverable-1" } },
+      ],
+      awaitRefetchQueries: true,
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires denial details when 'Denied' is selected", async () => {
+    const user = userEvent.setup();
+    setup();
+    await user.selectOptions(
+      screen.getByTestId(REVIEW_EXTENSION_STATUS_FIELD_NAME),
+      "Denied"
+    );
+    expect(screen.getByTestId(REVIEW_EXTENSION_SUBMIT_BUTTON_NAME)).toBeDisabled();
+    expect(screen.getByTestId(REVIEW_EXTENSION_DETAILS_FIELD_NAME)).toBeRequired();
+  });
+
+  it("submits a denial with details", async () => {
+    const user = userEvent.setup();
+    const { onClose } = setup();
+    await user.selectOptions(
+      screen.getByTestId(REVIEW_EXTENSION_STATUS_FIELD_NAME),
+      "Denied"
+    );
+    await user.type(
+      screen.getByTestId(REVIEW_EXTENSION_DETAILS_FIELD_NAME),
+      "  Here is a reason.  "
+    );
+    await user.click(screen.getByTestId(REVIEW_EXTENSION_SUBMIT_BUTTON_NAME));
+
+    await waitFor(() => expect(mockDenyMutation).toHaveBeenCalledTimes(1));
+    expect(mockDenyMutation).toHaveBeenCalledWith({
+      variables: {
+        deliverableId: "deliverable-1",
+        input: { deliverableExtensionId: "extension-1", details: "Here is a reason." },
+      },
+      refetchQueries: [
+        { query: DELIVERABLE_DETAILS_QUERY, variables: { id: "deliverable-1" } },
+      ],
+      awaitRefetchQueries: true,
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error toast when the approval mutation fails", async () => {
+    const user = userEvent.setup();
+    mockApproveMutation.mockRejectedValueOnce(new Error("boom"));
+    const { onClose } = setup();
+    await user.selectOptions(
+      screen.getByTestId(REVIEW_EXTENSION_STATUS_FIELD_NAME),
+      "Approved"
+    );
+    await user.click(screen.getByTestId(REVIEW_EXTENSION_SUBMIT_BUTTON_NAME));
+
+    await waitFor(() =>
+      expect(mockShowError).toHaveBeenCalledWith("Unable to submit extension review.")
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("prompts the cancellation confirmation when closing with unsaved changes", async () => {
+    const user = userEvent.setup();
+    const { onClose } = setup();
+    await user.selectOptions(
+      screen.getByTestId(REVIEW_EXTENSION_STATUS_FIELD_NAME),
+      "Denied"
+    );
+    await user.click(screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME));
+
+    expect(await screen.findByText("Are you sure?")).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes without confirmation when there are no unsaved changes", async () => {
+    const user = userEvent.setup();
+    const { onClose } = setup();
+    await user.click(screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("isStateRequestedDateExpired", () => {
+  it("returns true when the requested date is in the past", () => {
+    expect(isStateRequestedDateExpired(new Date("2020-01-01"))).toBe(true);
+  });
+
+  it("returns false when the requested date is in the future", () => {
+    expect(isStateRequestedDateExpired(new Date("2099-01-01"))).toBe(false);
+  });
+});
+
+describe("getNewDateValidationMessage", () => {
+  it("returns empty for an empty value", () => {
+    expect(getNewDateValidationMessage("")).toBe("");
+  });
+
+  it("flags dates not after today", () => {
+    expect(getNewDateValidationMessage("2020-01-01")).toBe("New Date must be after today.");
+  });
+
+  it("accepts a future date", () => {
+    expect(getNewDateValidationMessage("2099-01-01")).toBe("");
+  });
+});
+
+describe("formIsValid / formHasChanges", () => {
+  it("INITIAL_FORM_DATA has empty fields", () => {
+    expect(INITIAL_FORM_DATA).toEqual({ decision: "", newDate: "", denialDetails: "" });
+  });
+
+  it("formHasChanges returns false when initial", () => {
+    expect(formHasChanges(INITIAL_FORM_DATA)).toBe(false);
+  });
+
+  it("formHasChanges returns true when any field has been touched", () => {
+    expect(formHasChanges({ ...INITIAL_FORM_DATA, decision: "Denied" })).toBe(true);
+    expect(formHasChanges({ ...INITIAL_FORM_DATA, newDate: "2099-01-01" })).toBe(true);
+    expect(formHasChanges({ ...INITIAL_FORM_DATA, denialDetails: "x" })).toBe(true);
+  });
+
+  it("formIsValid requires a decision", () => {
+    expect(formIsValid(INITIAL_FORM_DATA, false)).toBe(false);
+  });
+
+  it("formIsValid rejects 'Approved' when expired", () => {
+    expect(
+      formIsValid({ decision: "Approved", newDate: "", denialDetails: "" }, true)
+    ).toBe(false);
+    expect(
+      formIsValid({ decision: "Approved", newDate: "", denialDetails: "" }, false)
+    ).toBe(true);
+  });
+
+  it("formIsValid requires a valid future date for 'Approve With New Date'", () => {
+    expect(
+      formIsValid(
+        { decision: "Approve With New Date", newDate: "", denialDetails: "" },
+        false
+      )
+    ).toBe(false);
+    expect(
+      formIsValid(
+        { decision: "Approve With New Date", newDate: "2020-01-01", denialDetails: "" },
+        false
+      )
+    ).toBe(false);
+    expect(
+      formIsValid(
+        { decision: "Approve With New Date", newDate: "2099-01-01", denialDetails: "" },
+        false
+      )
+    ).toBe(true);
+  });
+
+  it("formIsValid requires non-empty details for 'Denied'", () => {
+    expect(
+      formIsValid({ decision: "Denied", newDate: "", denialDetails: "   " }, false)
+    ).toBe(false);
+    expect(
+      formIsValid({ decision: "Denied", newDate: "", denialDetails: "reason" }, false)
+    ).toBe(true);
+  });
+});

--- a/client/src/components/dialog/deliverable/ReviewExtensionDeliverableDialog.tsx
+++ b/client/src/components/dialog/deliverable/ReviewExtensionDeliverableDialog.tsx
@@ -1,0 +1,279 @@
+import React, { useState } from "react";
+import { gql, useMutation } from "@apollo/client";
+import { isAfter, isValid, parseISO, startOfToday } from "date-fns";
+
+import { Button } from "components/button";
+import { BaseDialog } from "components/dialog/BaseDialog";
+import { DatePicker } from "components/input/date/DatePicker";
+import { Select, Option } from "components/input/select/Select";
+import { Textarea } from "components/input/Textarea";
+import { Notice } from "components/notice/Notice";
+import { useToast } from "components/toast";
+import { DeliverableExtensionReasonCode } from "demos-server";
+import { DELIVERABLE_DETAILS_QUERY } from "pages/deliverables/DeliverableDetailsManagementPage";
+import { formatDate, formatDateForServer } from "util/formatDate";
+import { DELIVERABLE_EXTENSION_REVIEW_SUBMITTED_MESSAGE } from "util/messages";
+
+export const APPROVE_DELIVERABLE_EXTENSION_MUTATION = gql`
+  mutation ApproveDeliverableExtension(
+    $deliverableId: ID!
+    $input: ApproveDeliverableExtensionInput!
+  ) {
+    approveDeliverableExtension(deliverableId: $deliverableId, input: $input) {
+      id
+      status
+      dueDate
+    }
+  }
+`;
+
+export const DENY_DELIVERABLE_EXTENSION_MUTATION = gql`
+  mutation DenyDeliverableExtension(
+    $deliverableId: ID!
+    $input: DenyDeliverableExtensionInput!
+  ) {
+    denyDeliverableExtension(deliverableId: $deliverableId, input: $input) {
+      id
+      status
+      dueDate
+    }
+  }
+`;
+
+export const REVIEW_EXTENSION_DIALOG_TITLE = "Review Extension Request";
+export const REVIEW_EXTENSION_DIALOG_NAME = "review-extension-dialog";
+export const REVIEW_EXTENSION_STATUS_FIELD_NAME = "review-extension-status";
+export const REVIEW_EXTENSION_NEW_DATE_FIELD_NAME = "review-extension-new-date";
+export const REVIEW_EXTENSION_DETAILS_FIELD_NAME = "review-extension-details";
+export const REVIEW_EXTENSION_SUBMIT_BUTTON_NAME = "button-review-extension-submit";
+export const REVIEW_EXTENSION_EXPIRED_NOTICE_NAME = "review-extension-expired-notice";
+
+export const STATE_REQUESTED_DATE_EXPIRED_MESSAGE =
+  "State Requested Date has expired and cannot be approved as is";
+
+export type ReviewExtensionDecision = "Approved" | "Approve With New Date" | "Denied";
+
+export const REVIEW_EXTENSION_OPTIONS: Option[] = [
+  { label: "Approved", value: "Approved" },
+  { label: "Approve With New Date", value: "Approve With New Date" },
+  { label: "Denied", value: "Denied" },
+];
+
+export const isStateRequestedDateExpired = (originalDateRequested: Date): boolean =>
+  !isAfter(originalDateRequested, startOfToday());
+
+export const getNewDateValidationMessage = (newDate: string): string => {
+  if (newDate === "") return "";
+  const parsed = parseISO(newDate);
+  if (!isValid(parsed)) return "Enter a valid date.";
+  if (!isAfter(parsed, startOfToday())) {
+    return "New Date must be after today.";
+  }
+  return "";
+};
+
+export interface ReviewExtensionDeliverableDialogDeliverable {
+  id: string;
+  extensionRequest: {
+    id: string;
+    reasonCode: DeliverableExtensionReasonCode;
+    reasonDetails: string;
+    initialDueDateAtRequest: Date;
+    originalDateRequested: Date;
+  };
+}
+
+export interface ReviewExtensionFormData {
+  decision: ReviewExtensionDecision | "";
+  newDate: string;
+  denialDetails: string;
+}
+
+export const INITIAL_FORM_DATA: ReviewExtensionFormData = {
+  decision: "",
+  newDate: "",
+  denialDetails: "",
+};
+
+export const formHasChanges = (form: ReviewExtensionFormData): boolean =>
+  form.decision !== "" || form.newDate.length > 0 || form.denialDetails.trim().length > 0;
+
+export const formIsValid = (
+  form: ReviewExtensionFormData,
+  stateRequestedDateExpired: boolean
+): boolean => {
+  if (form.decision === "") return false;
+  if (form.decision === "Approved") {
+    return !stateRequestedDateExpired;
+  }
+  if (form.decision === "Approve With New Date") {
+    return form.newDate.length > 0 && getNewDateValidationMessage(form.newDate) === "";
+  }
+  return form.denialDetails.trim().length > 0;
+};
+
+const Field: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="flex flex-col gap-xs">
+    <span className="text-[14px] font-bold text-text-font">{label}</span>
+    <span className="text-[14px] text-text-font">{value}</span>
+  </div>
+);
+
+export interface ReviewExtensionDeliverableDialogProps {
+  onClose: () => void;
+  deliverable: ReviewExtensionDeliverableDialogDeliverable;
+}
+
+export const ReviewExtensionDeliverableDialog: React.FC<
+  ReviewExtensionDeliverableDialogProps
+> = ({ onClose, deliverable }) => {
+  const { showSuccess, showError } = useToast();
+
+  const [formData, setFormData] = useState<ReviewExtensionFormData>(INITIAL_FORM_DATA);
+  const [attemptedSubmit, setAttemptedSubmit] = useState(false);
+
+  const [approveExtensionTrigger] = useMutation(APPROVE_DELIVERABLE_EXTENSION_MUTATION);
+  const [denyExtensionTrigger] = useMutation(DENY_DELIVERABLE_EXTENSION_MUTATION);
+
+  const { extensionRequest } = deliverable;
+  const expired = isStateRequestedDateExpired(extensionRequest.originalDateRequested);
+  const newDateError = getNewDateValidationMessage(formData.newDate);
+  const isValidForm = formIsValid(formData, expired);
+  const hasChanges = formHasChanges(formData);
+
+  const requestedDateDisplay = expired
+    ? `${formatDate(extensionRequest.originalDateRequested)} (Expired)`
+    : formatDate(extensionRequest.originalDateRequested);
+
+  const handleSubmit = async () => {
+    setAttemptedSubmit(true);
+    if (!isValidForm) return;
+
+    const refetchQueries = [
+      { query: DELIVERABLE_DETAILS_QUERY, variables: { id: deliverable.id } },
+    ];
+
+    try {
+      if (formData.decision === "Denied") {
+        await denyExtensionTrigger({
+          variables: {
+            deliverableId: deliverable.id,
+            input: {
+              deliverableExtensionId: extensionRequest.id,
+              details: formData.denialDetails.trim(),
+            },
+          },
+          refetchQueries,
+          awaitRefetchQueries: true,
+        });
+      } else {
+        const input: { deliverableExtensionId: string; newDueDate?: string } = {
+          deliverableExtensionId: extensionRequest.id,
+        };
+        if (formData.decision === "Approve With New Date") {
+          input.newDueDate = formatDateForServer(parseISO(formData.newDate));
+        }
+        await approveExtensionTrigger({
+          variables: { deliverableId: deliverable.id, input },
+          refetchQueries,
+          awaitRefetchQueries: true,
+        });
+      }
+
+      showSuccess(DELIVERABLE_EXTENSION_REVIEW_SUBMITTED_MESSAGE);
+      onClose();
+    } catch (error) {
+      console.error(error);
+      showError("Unable to submit extension review.");
+    }
+  };
+
+  return (
+    <BaseDialog
+      name={REVIEW_EXTENSION_DIALOG_NAME}
+      title={REVIEW_EXTENSION_DIALOG_TITLE}
+      onClose={onClose}
+      dialogHasChanges={hasChanges}
+      actionButton={
+        <Button
+          name={REVIEW_EXTENSION_SUBMIT_BUTTON_NAME}
+          onClick={handleSubmit}
+          disabled={!isValidForm}
+        >
+          Submit
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-sm">
+        <div className="bg-surface-secondary p-sm rounded grid grid-cols-2 gap-sm">
+          <Field
+            label="Initial Due Date"
+            value={formatDate(extensionRequest.initialDueDateAtRequest)}
+          />
+          <Field label="State Requested New Date" value={requestedDateDisplay} />
+          <div className="col-span-2">
+            <Field label="Requested Reason" value={extensionRequest.reasonCode} />
+          </div>
+          <div className="col-span-2">
+            <Field label="Requested Details" value={extensionRequest.reasonDetails} />
+          </div>
+        </div>
+
+        {expired && (
+          <div data-testid={REVIEW_EXTENSION_EXPIRED_NOTICE_NAME}>
+            <Notice title={STATE_REQUESTED_DATE_EXPIRED_MESSAGE} variant="error" />
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 gap-sm items-start">
+          <Select
+            id={REVIEW_EXTENSION_STATUS_FIELD_NAME}
+            label="Request Status"
+            isRequired
+            options={REVIEW_EXTENSION_OPTIONS}
+            value={formData.decision}
+            onSelect={(value) =>
+              setFormData((prev) => ({
+                ...prev,
+                decision: value as ReviewExtensionDecision | "",
+                newDate: value === "Approve With New Date" ? prev.newDate : "",
+                denialDetails: value === "Denied" ? prev.denialDetails : "",
+              }))
+            }
+            validationMessage={
+              attemptedSubmit && formData.decision === "" ? "Request Status is required." : ""
+            }
+          />
+          {formData.decision === "Approve With New Date" && (
+            <DatePicker
+              name={REVIEW_EXTENSION_NEW_DATE_FIELD_NAME}
+              label="New Date"
+              isRequired
+              value={formData.newDate}
+              onChange={(newDate) => setFormData((prev) => ({ ...prev, newDate }))}
+              getValidationMessage={() =>
+                attemptedSubmit && formData.newDate === ""
+                  ? "New Date is required."
+                  : newDateError
+              }
+            />
+          )}
+        </div>
+
+        {formData.decision === "Denied" && (
+          <Textarea
+            name={REVIEW_EXTENSION_DETAILS_FIELD_NAME}
+            label="Details"
+            isRequired
+            value={formData.denialDetails}
+            placeholder="Enter"
+            onChange={(value) => setFormData((prev) => ({ ...prev, denialDetails: value }))}
+            getValidationMessage={(value) =>
+              attemptedSubmit && value.trim() === "" ? "Details is required." : ""
+            }
+          />
+        )}
+      </div>
+    </BaseDialog>
+  );
+};

--- a/client/src/components/dialog/deliverable/index.ts
+++ b/client/src/components/dialog/deliverable/index.ts
@@ -8,4 +8,8 @@ export {
   canRequestExtension,
   REQUEST_EXTENSION_DIALOG_TITLE,
 } from "./RequestExtensionDeliverableDialog";
+export {
+  ReviewExtensionDeliverableDialog,
+  REVIEW_EXTENSION_DIALOG_TITLE,
+} from "./ReviewExtensionDeliverableDialog";
 export { canCompleteReview } from "./CompleteReviewDeliverableDialog";

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
@@ -210,12 +210,14 @@ describe("DeliverableDetailsManagementPage", () => {
 
     render(
       <TestProvider mocks={[notFoundMock]} routerEntries={["/deliverables/1"]}>
-        <Routes>
-          <Route
-            path="/deliverables/:deliverableId"
-            element={<DeliverableDetailsManagementPage />}
-          />
-        </Routes>
+        <DialogProvider>
+          <Routes>
+            <Route
+              path="/deliverables/:deliverableId"
+              element={<DeliverableDetailsManagementPage />}
+            />
+          </Routes>
+        </DialogProvider>
       </TestProvider>
     );
 
@@ -230,12 +232,14 @@ describe("DeliverableDetailsManagementPage", () => {
 
     render(
       <TestProvider mocks={[errorMock]} routerEntries={["/deliverables/1"]}>
-        <Routes>
-          <Route
-            path="/deliverables/:deliverableId"
-            element={<DeliverableDetailsManagementPage />}
-          />
-        </Routes>
+        <DialogProvider>
+          <Routes>
+            <Route
+              path="/deliverables/:deliverableId"
+              element={<DeliverableDetailsManagementPage />}
+            />
+          </Routes>
+        </DialogProvider>
       </TestProvider>
     );
 

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -215,33 +215,29 @@ export const DeliverableDetailsManagementPage: React.FC<{
       )[0]?.userFullName ?? "State User";
 
   const pendingExtensionRequest =
-    [...data.deliverable.extensionRequests]
-      .filter((extension) => extension.status === "Requested")
-      .sort(
-        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-      )[0] ?? null;
+    data.deliverable.extensionRequests.find((e) => e.status === "Requested") ?? null;
 
+  const requestExtensionActions = data.deliverable.deliverableActions.filter(
+    (a) => a.actionType === "Requested Extension"
+  );
   const extensionRequesterName =
-    [...data.deliverable.deliverableActions]
-      .filter((action) => action.actionType === "Requested Extension")
-      .sort(
-        (a, b) =>
-          new Date(b.actionTimestamp).getTime() - new Date(a.actionTimestamp).getTime()
-      )[0]?.userFullName ?? "State User";
+    requestExtensionActions[requestExtensionActions.length - 1]?.userFullName ?? "State User";
 
   const canReviewExtension =
     EXTENSION_REVIEWER_PERSON_TYPES.has(userPersonType) && pendingExtensionRequest !== null;
 
   const handleReviewExtensionRequest = () => {
     if (!pendingExtensionRequest) return;
+    const { id, reasonCode, reasonDetails, initialDueDateAtRequest, originalDateRequested } =
+      pendingExtensionRequest;
     showReviewExtensionDeliverableDialog({
       id: data.deliverable.id,
       extensionRequest: {
-        id: pendingExtensionRequest.id,
-        reasonCode: pendingExtensionRequest.reasonCode,
-        reasonDetails: pendingExtensionRequest.reasonDetails,
-        initialDueDateAtRequest: pendingExtensionRequest.initialDueDateAtRequest,
-        originalDateRequested: pendingExtensionRequest.originalDateRequested,
+        id,
+        reasonCode,
+        reasonDetails,
+        initialDueDateAtRequest,
+        originalDateRequested,
       },
     });
   };

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -12,8 +12,10 @@ import { Loading } from "components/loading/Loading";
 import { useToast } from "components/toast";
 import { getCurrentUser } from "components/user/UserContext";
 import { DELIVERABLE_REVIEW_STARTED_MESSAGE } from "util/messages";
+import { useDialog } from "components/dialog/DialogContext";
 import { CommentBox } from "./sections/comment_box";
 import { DeliverableInfoFields } from "./sections/DeliverableInfoFields";
+import { ExtensionRequestedNotice } from "./sections/ExtensionRequestedNotice";
 import { FileAndHistoryTabs } from "./sections/FileAndHistoryTabs";
 import { PendingReviewNotice } from "./sections/PendingReviewNotice";
 import { DeliverableButtons } from "./sections/DeliverableButtons";
@@ -30,6 +32,11 @@ export const START_DELIVERABLE_REVIEW_MUTATION = gql`
 `;
 
 const REVIEW_STARTER_PERSON_TYPES: ReadonlySet<PersonType> = new Set([
+  "demos-admin",
+  "demos-cms-user",
+]);
+
+const EXTENSION_REVIEWER_PERSON_TYPES: ReadonlySet<PersonType> = new Set([
   "demos-admin",
   "demos-cms-user",
 ]);
@@ -90,6 +97,10 @@ export const DELIVERABLE_DETAILS_QUERY = gql`
       extensionRequests {
         id
         status
+        reasonCode
+        reasonDetails
+        initialDueDateAtRequest
+        originalDateRequested
         createdAt
       }
     }
@@ -108,7 +119,16 @@ export type DeliverableDetailsManagementDeliverable = Pick<
     DeliverableAction,
     "id" | "actionType" | "actionTimestamp" | "userFullName" | "details"
   >[];
-  extensionRequests: Pick<DeliverableExtension, "id" | "status" | "createdAt">[];
+  extensionRequests: Pick<
+    DeliverableExtension,
+    | "id"
+    | "status"
+    | "reasonCode"
+    | "reasonDetails"
+    | "initialDueDateAtRequest"
+    | "originalDateRequested"
+    | "createdAt"
+  >[];
 };
 
 export const DeliverableDetailsManagementPage: React.FC<{
@@ -117,6 +137,7 @@ export const DeliverableDetailsManagementPage: React.FC<{
 }> = ({ deliverableId, onBack }) => {
   const { currentUser } = getCurrentUser();
   const { showSuccess, showError } = useToast();
+  const { showReviewExtensionDeliverableDialog } = useDialog();
   const navigate = useNavigate();
   const { deliverableId: routeDeliverableId } = useParams<{ deliverableId?: string }>();
   const resolvedDeliverableId = deliverableId ?? routeDeliverableId;
@@ -193,6 +214,38 @@ export const DeliverableDetailsManagementPage: React.FC<{
           new Date(b.actionTimestamp).getTime() - new Date(a.actionTimestamp).getTime()
       )[0]?.userFullName ?? "State User";
 
+  const pendingExtensionRequest =
+    [...data.deliverable.extensionRequests]
+      .filter((extension) => extension.status === "Requested")
+      .sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      )[0] ?? null;
+
+  const extensionRequesterName =
+    [...data.deliverable.deliverableActions]
+      .filter((action) => action.actionType === "Requested Extension")
+      .sort(
+        (a, b) =>
+          new Date(b.actionTimestamp).getTime() - new Date(a.actionTimestamp).getTime()
+      )[0]?.userFullName ?? "State User";
+
+  const canReviewExtension =
+    EXTENSION_REVIEWER_PERSON_TYPES.has(userPersonType) && pendingExtensionRequest !== null;
+
+  const handleReviewExtensionRequest = () => {
+    if (!pendingExtensionRequest) return;
+    showReviewExtensionDeliverableDialog({
+      id: data.deliverable.id,
+      extensionRequest: {
+        id: pendingExtensionRequest.id,
+        reasonCode: pendingExtensionRequest.reasonCode,
+        reasonDetails: pendingExtensionRequest.reasonDetails,
+        initialDueDateAtRequest: pendingExtensionRequest.initialDueDateAtRequest,
+        originalDateRequested: pendingExtensionRequest.originalDateRequested,
+      },
+    });
+  };
+
   return (
     <div className="shadow-md bg-white p-[16px] h-full flex flex-col">
       <h1 className="text-[20px] font-bold mb-[24px] text-brand uppercase border-b pb-[8px]">
@@ -222,6 +275,12 @@ export const DeliverableDetailsManagementPage: React.FC<{
             submitterName={submitterName}
             onStartReview={handleStartReview}
             isSubmitting={startReviewLoading}
+          />
+        ) : null}
+        {canReviewExtension ? (
+          <ExtensionRequestedNotice
+            requesterName={extensionRequesterName}
+            onReviewRequest={handleReviewExtensionRequest}
           />
         ) : null}
         <div className="flex w-full gap-2 flex-1">

--- a/client/src/pages/deliverables/sections/DeliverableButtons.test.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableButtons.test.tsx
@@ -113,7 +113,15 @@ describe("DeliverableButtons", () => {
       buildDeliverable({
         status: "Upcoming",
         extensionRequests: [
-          { id: "ext-1", status: "Requested", createdAt: new Date("2026-04-01") },
+          {
+            id: "ext-1",
+            status: "Requested",
+            reasonCode: "Other",
+            reasonDetails: "details",
+            initialDueDateAtRequest: new Date("2026-03-01"),
+            originalDateRequested: new Date("2026-04-15"),
+            createdAt: new Date("2026-04-01"),
+          },
         ],
       })
     );

--- a/client/src/pages/deliverables/sections/DeliverableInfoFields.test.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableInfoFields.test.tsx
@@ -45,8 +45,24 @@ describe("DeliverableInfoFields", () => {
     const deliverable = {
       ...MOCK_DELIVERABLE_1,
       extensionRequests: [
-        { id: "ext-old", status: "Approved" as const, createdAt: new Date("2026-01-01") },
-        { id: "ext-new", status: "Requested" as const, createdAt: new Date("2026-03-01") },
+        {
+          id: "ext-old",
+          status: "Approved" as const,
+          reasonCode: "Other" as const,
+          reasonDetails: "details" as const,
+          initialDueDateAtRequest: new Date("2025-12-01"),
+          originalDateRequested: new Date("2026-01-15"),
+          createdAt: new Date("2026-01-01"),
+        },
+        {
+          id: "ext-new",
+          status: "Requested" as const,
+          reasonCode: "Other" as const,
+          reasonDetails: "details" as const,
+          initialDueDateAtRequest: new Date("2026-02-01"),
+          originalDateRequested: new Date("2026-04-15"),
+          createdAt: new Date("2026-03-01"),
+        },
       ],
     };
     render(

--- a/client/src/pages/deliverables/sections/ExtensionRequestedNotice.test.tsx
+++ b/client/src/pages/deliverables/sections/ExtensionRequestedNotice.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  EXTENSION_REQUESTED_NOTICE_NAME,
+  ExtensionRequestedNotice,
+  REVIEW_EXTENSION_REQUEST_BUTTON_NAME,
+} from "./ExtensionRequestedNotice";
+
+describe("ExtensionRequestedNotice", () => {
+  it("renders the title and requester message", () => {
+    render(
+      <ExtensionRequestedNotice requesterName="Florida State User" onReviewRequest={vi.fn()} />
+    );
+
+    expect(screen.getByTestId(EXTENSION_REQUESTED_NOTICE_NAME)).toBeInTheDocument();
+    expect(screen.getByText("Extension Requested")).toBeInTheDocument();
+    expect(
+      screen.getByText("Florida State User has requested an extension on this deliverable.")
+    ).toBeInTheDocument();
+  });
+
+  it("invokes onReviewRequest when the button is clicked", async () => {
+    const user = userEvent.setup();
+    const onReviewRequest = vi.fn();
+    render(
+      <ExtensionRequestedNotice requesterName="Florida State User" onReviewRequest={onReviewRequest} />
+    );
+
+    await user.click(screen.getByTestId(REVIEW_EXTENSION_REQUEST_BUTTON_NAME));
+
+    expect(onReviewRequest).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/pages/deliverables/sections/ExtensionRequestedNotice.tsx
+++ b/client/src/pages/deliverables/sections/ExtensionRequestedNotice.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Button } from "components/button";
+import { WarningIcon } from "components/icons";
+
+export const REVIEW_EXTENSION_REQUEST_BUTTON_NAME = "button-review-extension-request";
+export const EXTENSION_REQUESTED_NOTICE_NAME = "extension-requested-notice";
+
+export const ExtensionRequestedNotice: React.FC<{
+  requesterName: string;
+  onReviewRequest: () => void;
+}> = ({ requesterName, onReviewRequest }) => {
+  return (
+    <div
+      className="flex items-center gap-2 border border-border-alert border-l-[6px] rounded-sm bg-white px-1 py-1"
+      data-testid={EXTENSION_REQUESTED_NOTICE_NAME}
+    >
+      <span className="shrink-0" aria-hidden="true">
+        <WarningIcon width="28" height="28" />
+      </span>
+      <div className="flex-1 leading-2">
+        <p className="text-[15px] font-bold text-text-font">Extension Requested</p>
+        <p className="text-sm text-text-font">
+          {requesterName} has requested an extension on this deliverable.
+        </p>
+      </div>
+      <Button
+        type="button"
+        size="small"
+        name={REVIEW_EXTENSION_REQUEST_BUTTON_NAME}
+        onClick={onReviewRequest}
+      >
+        Review Request
+      </Button>
+    </div>
+  );
+};

--- a/client/src/util/messages.ts
+++ b/client/src/util/messages.ts
@@ -24,5 +24,7 @@ export const getPhaseCompletedMessage = (phaseName: PhaseName) => {
 export const DELIVERABLE_SLOTS_CREATED_MESSAGE = "Deliverable Slot(s) - have been added";
 export const DELIVERABLE_UPDATED_MESSAGE = "Changes have been saved to the deliverable";
 export const DELIVERABLE_EXTENSION_REQUESTED_MESSAGE = "Extension Request - has been Submitted";
+export const DELIVERABLE_EXTENSION_REVIEW_SUBMITTED_MESSAGE =
+  "Extension Review has been submitted successfully.";
 export const DELIVERABLE_REVIEW_COMPLETED_MESSAGE = "Deliverable Review - has been Completed";
 export const DELIVERABLE_REVIEW_STARTED_MESSAGE = "Deliverable - Review process has Begun";


### PR DESCRIPTION
# DEMOS-1572 — CMS/Admin: Review Extension Requests

CMS and Admin users can now Approve, Approve with New Date, or Deny extension
requests submitted by State users via a banner + modal on the deliverable
detail page. State users do not see the banner.

### Role guard

As a State user, the banner does **not** appear.


<img width="1920" height="1074" alt="image" src="https://github.com/user-attachments/assets/0665c47e-22dc-4677-a591-95a530a748bf" />
<img width="1919" height="906" alt="image" src="https://github.com/user-attachments/assets/d2651268-de32-470b-874f-cc2f6ad2ee91" />
<img width="1917" height="880" alt="image" src="https://github.com/user-attachments/assets/dd166f6d-d849-4395-81db-b4a615d584a4" />
<img width="1915" height="877" alt="image" src="https://github.com/user-attachments/assets/93bd8c0a-e3b5-4446-b222-f8995754a749" />
