### PR TITLE
DEMOS-2110: removed deleted status from table filters

### DIFF
--- a/client/src/components/table/columns/DeliverableColumns.tsx
+++ b/client/src/components/table/columns/DeliverableColumns.tsx
@@ -62,7 +62,9 @@ export function DeliverableColumns({
       filterConfig: {
         filterType: "select",
         // Extension Requested options not ready yet.
-        options: DELIVERABLE_STATUSES.map((status) => ({ label: status, value: status })),
+        options: DELIVERABLE_STATUSES
+          .filter((status) => status !== "Deleted")
+          .map((status) => ({ label: status, value: status })),
       },
     },
   });

--- a/client/src/components/table/tables/DemonstrationDeliverableTable.tsx
+++ b/client/src/components/table/tables/DemonstrationDeliverableTable.tsx
@@ -75,7 +75,9 @@ export const DemonstrationDeliverableTable: React.FC<{
       meta: {
         filterConfig: {
           filterType: "select",
-          options: DELIVERABLE_STATUSES.map((status) => ({ label: status, value: status })),
+          options: DELIVERABLE_STATUSES
+            .filter((status) => status !== "Deleted")
+            .map((status) => ({ label: status, value: status })),
         },
       },
     }),


### PR DESCRIPTION
Remove deleted status from deliverable statuses in the filters. 

This will be the end statuses, but for now we can just nuke the delete. 
<img width="884" height="536" alt="image" src="https://github.com/user-attachments/assets/b29eb852-1f29-454f-b157-53a76de8cb83" />

<img width="1976" height="627" alt="Screenshot 2026-05-13 at 16 21 45" src="https://github.com/user-attachments/assets/9db1ea08-2e46-4e18-88ae-b39046131d9e" />
