### PR TITLE
DEMOS-1540 — Finalized deliverables: lock edit/delete/file/submit actions

### DIFF
--- a/client/src/components/table/tables/DeliverableActionButtons.tsx
+++ b/client/src/components/table/tables/DeliverableActionButtons.tsx
@@ -20,8 +20,11 @@ export const DeliverableActionButtons: React.FC<{
 
   const selectedIsEditable =
     singleSelectedDeliverable === null || isDeliverableEditable(singleSelectedDeliverable.status);
+  const allSelectedAreDeletable = selectedRows.every((row) =>
+    isDeliverableEditable(row.original.status)
+  );
   const editEnabled = selectedCount === 1 && selectedIsEditable;
-  const deleteEnabled = selectedCount >= 1;
+  const deleteEnabled = selectedCount >= 1 && allSelectedAreDeletable;
 
   const baseEditTooltip = selectionTooltip({
     action: "Edit",
@@ -32,12 +35,16 @@ export const DeliverableActionButtons: React.FC<{
   const editTooltip =
     selectedCount === 1 && !selectedIsEditable ? "Select a Deliverable to Edit" : baseEditTooltip;
 
-  const deleteTooltip = selectionTooltip({
+  const baseDeleteTooltip = selectionTooltip({
     action: "Delete",
     nounSingular: "Deliverable",
     selectedCount,
     rule: { kind: "atLeast", count: 1 },
   });
+  const deleteTooltip =
+    selectedCount >= 1 && !allSelectedAreDeletable
+      ? "Finalized Deliverables cannot be deleted"
+      : baseDeleteTooltip;
 
   return (
     <div className="flex gap-1 ml-4">

--- a/client/src/components/table/tables/DeliverableTable.test.tsx
+++ b/client/src/components/table/tables/DeliverableTable.test.tsx
@@ -326,6 +326,42 @@ describe("DeliverableTable demos-state-user view mode", () => {
   });
 });
 
+describe("DeliverableTable Remove gating with finalized rows", () => {
+  const FINALIZED_ROWS: DeliverableTableRow[] = [
+    { ...MOCK_DELIVERABLE_TABLE_ROW, id: "active", status: "Upcoming" },
+    { ...MOCK_DELIVERABLE_TABLE_ROW, id: "approved", status: "Approved" },
+    { ...MOCK_DELIVERABLE_TABLE_ROW, id: "accepted", status: "Accepted" },
+  ];
+
+  it("disables Remove when the only selected row is finalized", async () => {
+    render(<DeliverableTable deliverables={FINALIZED_ROWS} viewMode="demos-cms-user" />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("select-row-approved"));
+
+    expect(screen.getByTestId("remove-deliverable")).toBeDisabled();
+  });
+
+  it("disables Remove when any of multiple selected rows is finalized", async () => {
+    render(<DeliverableTable deliverables={FINALIZED_ROWS} viewMode="demos-cms-user" />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("select-row-active"));
+    await user.click(screen.getByTestId("select-row-accepted"));
+
+    expect(screen.getByTestId("remove-deliverable")).toBeDisabled();
+  });
+
+  it("enables Remove when every selected row is not finalized", async () => {
+    render(<DeliverableTable deliverables={FINALIZED_ROWS} viewMode="demos-cms-user" />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId("select-row-active"));
+
+    expect(screen.getByTestId("remove-deliverable")).not.toBeDisabled();
+  });
+});
+
 describe("DeliverableTable default sorting behavior", () => {
   it("reapplies default sort order when the table data is reloaded", async () => {
     const base = MOCK_DELIVERABLE_TABLE_ROWS[0] as DeliverableTableRow;

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
@@ -7,6 +7,7 @@ import {
   DeliverableDetailsManagementPage,
   DELIVERABLE_DETAILS_QUERY,
   START_DELIVERABLE_REVIEW_MUTATION,
+  type DeliverableDetailsManagementDeliverable,
 } from "./DeliverableDetailsManagementPage";
 import { MOCK_DELIVERABLE_1 } from "mock-data/deliverableMocks";
 import { TestProvider } from "test-utils/TestProvider";
@@ -47,6 +48,7 @@ const buildSubmittedDeliverableMock = (overrides?: { submitterName?: string }) =
       actionType: "Submitted Deliverable" as const,
       actionTimestamp: new Date("2026-04-01T10:00:00Z"),
       userFullName: overrides?.submitterName ?? "Jane State",
+      details: "",
     },
   ],
 });
@@ -59,7 +61,7 @@ const buildCurrentUser = (
 });
 
 const renderWithDeliverable = (
-  deliverable: ReturnType<typeof buildSubmittedDeliverableMock>,
+  deliverable: DeliverableDetailsManagementDeliverable,
   personType: CurrentUser["person"]["personType"] = "demos-cms-user",
   extraMocks: import("@apollo/client/testing").MockedResponse[] = []
 ) =>
@@ -200,6 +202,22 @@ describe("DeliverableDetailsManagementPage", () => {
     await waitFor(() =>
       expect(screen.queryByTestId(DELIVERABLE_REVIEW_NOTICE_NAME)).not.toBeInTheDocument()
     );
+  });
+
+  it("disables the header Edit and Delete buttons when the deliverable is finalized", async () => {
+    const deliverable = { ...MOCK_DELIVERABLE_1, status: "Approved" as const };
+    renderWithDeliverable(deliverable);
+
+    expect(await screen.findByTestId("edit-deliverable-button")).toBeDisabled();
+    expect(screen.getByTestId("delete-deliverable-button")).toBeDisabled();
+  });
+
+  it("keeps the header Edit and Delete buttons enabled for an editable deliverable", async () => {
+    const deliverable = { ...MOCK_DELIVERABLE_1, status: "Upcoming" as const };
+    renderWithDeliverable(deliverable);
+
+    expect(await screen.findByTestId("edit-deliverable-button")).not.toBeDisabled();
+    expect(screen.getByTestId("delete-deliverable-button")).not.toBeDisabled();
   });
 
   it("shows not found state", async () => {

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -12,6 +12,7 @@ import { Loading } from "components/loading/Loading";
 import { useToast } from "components/toast";
 import { getCurrentUser } from "components/user/UserContext";
 import { DELIVERABLE_REVIEW_STARTED_MESSAGE } from "util/messages";
+import { isDeliverableEditable } from "components/dialog/deliverable";
 import { CommentBox } from "./sections/comment_box";
 import { DeliverableInfoFields } from "./sections/DeliverableInfoFields";
 import { FileAndHistoryTabs } from "./sections/FileAndHistoryTabs";
@@ -184,6 +185,7 @@ export const DeliverableDetailsManagementPage: React.FC<{
   const canStartReview =
     REVIEW_STARTER_PERSON_TYPES.has(userPersonType) &&
     data.deliverable.status === "Submitted";
+  const isFinalized = !isDeliverableEditable(data.deliverable.status);
 
   const submitterName =
     [...data.deliverable.deliverableActions]
@@ -215,6 +217,8 @@ export const DeliverableDetailsManagementPage: React.FC<{
           <EditAndDeleteButtonGroup
             onDelete={handleDeleteDeliverable}
             onEdit={handleEditDeliverable}
+            deleteDisabled={isFinalized}
+            editDisabled={isFinalized}
           />
         </div>
         {canStartReview ? (

--- a/client/src/pages/deliverables/sections/CmsFilesTab.test.tsx
+++ b/client/src/pages/deliverables/sections/CmsFilesTab.test.tsx
@@ -120,4 +120,30 @@ describe("CmsFilesTab", () => {
     expect(openSpy).toHaveBeenCalledWith("/document/cms-a", "_blank");
     openSpy.mockRestore();
   });
+
+  describe("when disabled", () => {
+    it("disables the Add File(s) button", () => {
+      renderTab({ disabled: true });
+
+      expect(screen.getByTestId(CMS_FILES_ADD_BUTTON_NAME)).toBeDisabled();
+    });
+
+    it("keeps Edit disabled even when a row is selected", async () => {
+      const user = userEvent.setup();
+      renderTab({ disabled: true });
+
+      await user.click(screen.getByTestId("select-row-cms-a"));
+
+      expect(screen.getByTestId(CMS_FILES_EDIT_BUTTON_NAME)).toBeDisabled();
+    });
+
+    it("keeps Delete disabled even when a row is selected", async () => {
+      const user = userEvent.setup();
+      renderTab({ disabled: true });
+
+      await user.click(screen.getByTestId("select-row-cms-a"));
+
+      expect(screen.getByTestId(CMS_FILES_DELETE_BUTTON_NAME)).toBeDisabled();
+    });
+  });
 });

--- a/client/src/pages/deliverables/sections/CmsFilesTab.tsx
+++ b/client/src/pages/deliverables/sections/CmsFilesTab.tsx
@@ -16,9 +16,16 @@ export type CmsFilesTabProps = {
   onAdd?: () => void;
   onEdit?: (file: DeliverableFileRow) => void;
   onDelete?: (fileIds: string[]) => void;
+  disabled?: boolean;
 };
 
-export const CmsFilesTab: React.FC<CmsFilesTabProps> = ({ files, onAdd, onEdit, onDelete }) => {
+export const CmsFilesTab: React.FC<CmsFilesTabProps> = ({
+  files,
+  onAdd,
+  onEdit,
+  onDelete,
+  disabled = false,
+}) => {
   const columns = makeCmsFileColumns();
 
   return (
@@ -36,6 +43,7 @@ export const CmsFilesTab: React.FC<CmsFilesTabProps> = ({ files, onAdd, onEdit, 
       onAdd={onAdd}
       onEdit={onEdit}
       onDelete={onDelete}
+      disabled={disabled}
     />
   );
 };

--- a/client/src/pages/deliverables/sections/DeliverableFileTable.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableFileTable.tsx
@@ -28,6 +28,7 @@ export type DeliverableFileTableProps = {
   onEdit?: (file: DeliverableFileRow) => void;
   onDelete?: (fileIds: string[]) => void;
   footer?: React.ReactNode;
+  disabled?: boolean;
 };
 
 export const DeliverableFileTable: React.FC<DeliverableFileTableProps> = ({
@@ -45,11 +46,12 @@ export const DeliverableFileTable: React.FC<DeliverableFileTableProps> = ({
   onEdit,
   onDelete,
   footer,
+  disabled = false,
 }) => (
   <div data-testid={testId} className="flex flex-col gap-1">
     <div className="flex justify-between items-center">
       <span className="text-[20px] font-bold uppercase text-brand">{title}</span>
-      <SecondaryButton name={addButtonName} onClick={onAdd}>
+      <SecondaryButton name={addButtonName} onClick={onAdd} disabled={disabled}>
         Add File(s)
       </SecondaryButton>
     </div>
@@ -85,7 +87,7 @@ export const DeliverableFileTable: React.FC<DeliverableFileTableProps> = ({
               name={editButtonName}
               ariaLabel={editAriaLabel}
               tooltip={editTooltip}
-              disabled={selectedCount !== 1}
+              disabled={disabled || selectedCount !== 1}
               onClick={() => onEdit?.(selectedRows[0])}
             >
               <EditIcon />
@@ -94,7 +96,7 @@ export const DeliverableFileTable: React.FC<DeliverableFileTableProps> = ({
               name={deleteButtonName}
               ariaLabel={deleteAriaLabel}
               tooltip={deleteTooltip}
-              disabled={selectedCount < 1}
+              disabled={disabled || selectedCount < 1}
               onClick={() => onDelete?.(selectedRows.map((row) => row.id))}
             >
               <DeleteIcon />

--- a/client/src/pages/deliverables/sections/EditAndDeleteButtonGroup.test.tsx
+++ b/client/src/pages/deliverables/sections/EditAndDeleteButtonGroup.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { EditAndDeleteButtonGroup } from "./EditAndDeleteButtonGroup";
+
+const renderGroup = (
+  overrides: Partial<React.ComponentProps<typeof EditAndDeleteButtonGroup>> = {}
+) => {
+  const onEdit = vi.fn();
+  const onDelete = vi.fn();
+  render(<EditAndDeleteButtonGroup onEdit={onEdit} onDelete={onDelete} {...overrides} />);
+  return { onEdit, onDelete };
+};
+
+describe("EditAndDeleteButtonGroup", () => {
+  it("invokes onEdit and onDelete when enabled", async () => {
+    const user = userEvent.setup();
+    const { onEdit, onDelete } = renderGroup();
+
+    await user.click(screen.getByTestId("edit-deliverable-button"));
+    await user.click(screen.getByTestId("delete-deliverable-button"));
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Edit when editDisabled is true", async () => {
+    const user = userEvent.setup();
+    const { onEdit } = renderGroup({ editDisabled: true });
+
+    const editButton = screen.getByTestId("edit-deliverable-button");
+    expect(editButton).toBeDisabled();
+
+    await user.click(editButton);
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+
+  it("disables Delete when deleteDisabled is true", async () => {
+    const user = userEvent.setup();
+    const { onDelete } = renderGroup({ deleteDisabled: true });
+
+    const deleteButton = screen.getByTestId("delete-deliverable-button");
+    expect(deleteButton).toBeDisabled();
+
+    await user.click(deleteButton);
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/pages/deliverables/sections/EditAndDeleteButtonGroup.tsx
+++ b/client/src/pages/deliverables/sections/EditAndDeleteButtonGroup.tsx
@@ -6,12 +6,16 @@ type EditAndDeleteButtonGroupProps = {
   onDelete: () => void;
   onEdit: () => void;
   defaultExpanded?: boolean;
+  deleteDisabled?: boolean;
+  editDisabled?: boolean;
 };
 
 export const EditAndDeleteButtonGroup: React.FC<EditAndDeleteButtonGroupProps> = ({
   onDelete,
   onEdit,
   defaultExpanded = true,
+  deleteDisabled = false,
+  editDisabled = false,
 }) => {
   const [showButtons, setShowButtons] = useState(defaultExpanded);
 
@@ -28,7 +32,8 @@ export const EditAndDeleteButtonGroup: React.FC<EditAndDeleteButtonGroupProps> =
             name="Delete deliverable"
             data-testid="delete-deliverable-button"
             onClick={onDelete}
-            className="inline-flex items-center justify-center text-[#CD2026] hover:opacity-80"
+            disabled={deleteDisabled}
+            className="inline-flex items-center justify-center text-[#CD2026] hover:opacity-80 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:opacity-40"
           >
             <DeleteIcon fill="currentColor" width="18" height="18" />
           </button>
@@ -37,7 +42,8 @@ export const EditAndDeleteButtonGroup: React.FC<EditAndDeleteButtonGroupProps> =
             name="Edit deliverable"
             data-testid="edit-deliverable-button"
             onClick={onEdit}
-            className="inline-flex items-center justify-center text-action hover:opacity-80"
+            disabled={editDisabled}
+            className="inline-flex items-center justify-center text-action hover:opacity-80 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:opacity-40"
           >
             <EditIcon width="18" height="18" />
           </button>

--- a/client/src/pages/deliverables/sections/FileAndHistoryTabs.test.tsx
+++ b/client/src/pages/deliverables/sections/FileAndHistoryTabs.test.tsx
@@ -7,8 +7,12 @@ import { MOCK_DELIVERABLE_1 } from "mock-data/deliverableMocks";
 import { TestProvider } from "test-utils/TestProvider";
 
 import { FileAndHistoryTabs } from "./FileAndHistoryTabs";
-import { STATE_FILES_TAB_NAME } from "./StateFilesTab";
-import { CMS_FILES_TAB_NAME } from "./CmsFilesTab";
+import {
+  STATE_FILES_ADD_BUTTON_NAME,
+  STATE_FILES_SUBMIT_BUTTON_NAME,
+  STATE_FILES_TAB_NAME,
+} from "./StateFilesTab";
+import { CMS_FILES_ADD_BUTTON_NAME, CMS_FILES_TAB_NAME } from "./CmsFilesTab";
 import { HISTORY_TAB_NAME } from "./HistoryTab";
 
 const mockShowRequestResubmissionDeliverableDialog = vi.fn();
@@ -175,6 +179,33 @@ describe("FileAndHistoryTabs", () => {
       expect(
         screen.getByTestId("button-actions-complete-review")
       ).toBeDisabled();
+    });
+  });
+
+  describe("when the deliverable is finalized", () => {
+    it.each(["Accepted", "Approved", "Received and Filed"] as const)(
+      "disables the State Files Add and Submit Deliverable buttons for status %s",
+      (status) => {
+        setup({ status });
+
+        expect(screen.getByTestId(STATE_FILES_ADD_BUTTON_NAME)).toBeDisabled();
+        expect(screen.getByTestId(STATE_FILES_SUBMIT_BUTTON_NAME)).toBeDisabled();
+      }
+    );
+
+    it("disables the CMS Files Add button when status is Approved", async () => {
+      const user = userEvent.setup();
+      setup({ status: "Approved" });
+
+      await user.click(screen.getByTestId("button-cms_files"));
+
+      expect(screen.getByTestId(CMS_FILES_ADD_BUTTON_NAME)).toBeDisabled();
+    });
+
+    it("keeps the State Files Add button enabled when status is Submitted", () => {
+      setup({ status: "Submitted" });
+
+      expect(screen.getByTestId(STATE_FILES_ADD_BUTTON_NAME)).not.toBeDisabled();
     });
   });
 });

--- a/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
+++ b/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
@@ -8,7 +8,7 @@ import { HistoryTab, type DeliverableHistoryRow } from "./HistoryTab";
 import { StateFilesTab } from "./StateFilesTab";
 import { Button } from "components/button/Button";
 import { useDialog } from "components/dialog/DialogContext";
-import { canCompleteReview } from "components/dialog/deliverable";
+import { canCompleteReview, isDeliverableEditable } from "components/dialog/deliverable";
 import { getCurrentUser } from "components/user/UserContext";
 import { DeliverableStatus, PersonType } from "demos-server";
 
@@ -50,6 +50,7 @@ export const FileAndHistoryTabs: React.FC<{
   const stateFiles = deliverable.stateDocuments;
   const cmsFiles = deliverable.cmsDocuments;
   const historyRows: DeliverableHistoryRow[] = deliverable.deliverableActions.map(toHistoryRow);
+  const isFinalized = !isDeliverableEditable(deliverable.status);
 
   const { showRequestResubmissionDeliverableDialog, showCompleteReviewDeliverableDialog } =
     useDialog();
@@ -76,10 +77,10 @@ export const FileAndHistoryTabs: React.FC<{
     <div data-testid={FILE_AND_HISTORY_TABS_NAME}>
       <HorizontalSectionTabs defaultValue={TABS.STATE_FILES} variant="bordered">
         <Tab label={buildTabLabel("State Files", stateFiles.length)} value={TABS.STATE_FILES}>
-          <StateFilesTab files={stateFiles} />
+          <StateFilesTab files={stateFiles} disabled={isFinalized} />
         </Tab>
         <Tab label={buildTabLabel("CMS Files", cmsFiles.length)} value={TABS.CMS_FILES}>
-          <CmsFilesTab files={cmsFiles} />
+          <CmsFilesTab files={cmsFiles} disabled={isFinalized} />
         </Tab>
         <Tab label="History" value={TABS.HISTORY}>
           <HistoryTab rows={historyRows} />

--- a/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
+++ b/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
@@ -159,4 +159,36 @@ describe("StateFilesTab", () => {
       expect(onSubmit).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("when disabled", () => {
+    it("disables the Add File(s) button", () => {
+      renderTab({ disabled: true });
+
+      expect(screen.getByTestId(STATE_FILES_ADD_BUTTON_NAME)).toBeDisabled();
+    });
+
+    it("disables the Submit Deliverable button", () => {
+      renderTab({ disabled: true });
+
+      expect(screen.getByTestId(STATE_FILES_SUBMIT_BUTTON_NAME)).toBeDisabled();
+    });
+
+    it("keeps Edit disabled even when a row is selected", async () => {
+      const user = userEvent.setup();
+      renderTab({ disabled: true });
+
+      await user.click(screen.getByTestId("select-row-file-a"));
+
+      expect(screen.getByTestId(STATE_FILES_EDIT_BUTTON_NAME)).toBeDisabled();
+    });
+
+    it("keeps Delete disabled even when rows are selected", async () => {
+      const user = userEvent.setup();
+      renderTab({ disabled: true });
+
+      await user.click(screen.getByTestId("select-row-file-a"));
+
+      expect(screen.getByTestId(STATE_FILES_DELETE_BUTTON_NAME)).toBeDisabled();
+    });
+  });
 });

--- a/client/src/pages/deliverables/sections/StateFilesTab.tsx
+++ b/client/src/pages/deliverables/sections/StateFilesTab.tsx
@@ -21,6 +21,7 @@ export type StateFilesTabProps = {
   onEdit?: (file: DeliverableFileRow) => void;
   onDelete?: (fileIds: string[]) => void;
   onSubmit?: () => void;
+  disabled?: boolean;
 };
 
 export const StateFilesTab: React.FC<StateFilesTabProps> = ({
@@ -29,6 +30,7 @@ export const StateFilesTab: React.FC<StateFilesTabProps> = ({
   onEdit,
   onDelete,
   onSubmit,
+  disabled = false,
 }) => {
   const columns = makeStateFileColumns();
   const hasFiles = files.length > 0;
@@ -48,10 +50,15 @@ export const StateFilesTab: React.FC<StateFilesTabProps> = ({
       onAdd={onAdd}
       onEdit={onEdit}
       onDelete={onDelete}
+      disabled={disabled}
       footer={
         hasFiles && (
           <div className="flex justify-end">
-            <SecondaryButton name={STATE_FILES_SUBMIT_BUTTON_NAME} onClick={onSubmit}>
+            <SecondaryButton
+              name={STATE_FILES_SUBMIT_BUTTON_NAME}
+              onClick={onSubmit}
+              disabled={disabled}
+            >
               Submit Deliverable
             </SecondaryButton>
           </div>


### PR DESCRIPTION
Several gates from the spec weren't enforced once a deliverable reached a final status (`Accepted`, `Approved`, `Received and Filed`). Comments remain addable; everything else is disabled. Reused the existing `isDeliverableEditable` predicate rather than introducing a new one.

## Changes

- **`pages/deliverables/sections/EditAndDeleteButtonGroup.tsx`** — added optional `editDisabled` / `deleteDisabled` props; native `disabled` + `disabled:opacity-40 disabled:cursor-not-allowed` styling.
- **`pages/deliverables/DeliverableDetailsManagementPage.tsx`** — computes `isFinalized = !isDeliverableEditable(status)` and passes it to the header Edit/Delete buttons.
- **`pages/deliverables/sections/FileAndHistoryTabs.tsx`** — derives `isFinalized` from the deliverable's status and forwards `disabled` to `StateFilesTab` and `CmsFilesTab` (Request Re-submission and Complete Review were already gated).
- **`pages/deliverables/sections/StateFilesTab.tsx` / `CmsFilesTab.tsx`** — accept `disabled`, forward to `DeliverableFileTable`. State Files also disables the footer **Submit Deliverable** button.
- **`pages/deliverables/sections/DeliverableFileTable.tsx`** — new `disabled` prop force-disables Add File(s) and the row Edit/Delete circle buttons regardless of selection.
- **`components/table/tables/DeliverableActionButtons.tsx`** — list-page Delete now requires every selected row to satisfy `isDeliverableEditable`; tooltip explains why when blocked.

## Notes

- Comments (Public/Private) and the ellipsis menu are intentionally untouched — comments must remain addable on finalized deliverables.
- Resolved a merge conflict in `DeliverableDetailsManagementPage.tsx` by keeping both the new `isDeliverableEditable` import (this PR) and the `useDialog` import (origin's review-extension wiring).


<img width="1739" height="744" alt="image" src="https://github.com/user-attachments/assets/7080921e-6df7-4319-8521-908d6afda483" />
<img width="1745" height="750" alt="image" src="https://github.com/user-attachments/assets/dac8e6e3-90d5-49a7-a006-0fb78e1c50b8" />
<img width="1914" height="696" alt="image" src="https://github.com/user-attachments/assets/978dcb31-5bd7-46e5-a071-a999a612e4b2" />
