### PR TITLE
DEMOS 2068 and DEMOS 1940 - Signature Level Validations

### DIFF
--- a/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.tsx
+++ b/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.tsx
@@ -309,7 +309,6 @@ export const ApprovalSummaryPhase = ({
           ? formatDateForServer(parseFormDateString(formData.expirationDate))
           : null,
         sdgDivision: formData.sdgDivision,
-        signatureLevel: formData.signatureLevel,
         stateId: formData.stateId,
         projectOfficerUserId: formData.projectOfficerId,
       };
@@ -327,7 +326,6 @@ export const ApprovalSummaryPhase = ({
       effectiveDate: formData.effectiveDate
         ? formatDateForServer(parseFormDateString(formData.effectiveDate))
         : null,
-      signatureLevel: formData.signatureLevel,
     };
     if (formData.applicationType === "amendment") {
       return await updateAmendmentTrigger({

--- a/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
+++ b/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
@@ -14,6 +14,9 @@ import { formatDate } from "util/formatDate";
 const LABEL_CLASSES = tw`text-text-font font-bold text-sm tracking-wide h-[14px] flex items-center`;
 const VALUE_CLASSES = tw`text-text-font text-base leading-relaxed h-[40px] flex items-start mt-1`;
 
+export const DEMONSTRATION_SIGNATURE_LEVELS: SignatureLevel[] = ["OA"];
+export const MODIFICATION_SIGNATURE_LEVELS: SignatureLevel[] = ["OA", "OCD"];
+
 export type BaseFormData = {
   name: string;
   description?: string;
@@ -327,8 +330,8 @@ export const ApplicationDetailsSection = ({
               initialValue={sectionFormData.signatureLevel}
               allowedSignatureLevels={
                 sectionFormData.applicationType === "demonstration"
-                  ? ["OA"]
-                  : ["OA", "OCD"]
+                  ? DEMONSTRATION_SIGNATURE_LEVELS
+                  : MODIFICATION_SIGNATURE_LEVELS
               }
               onSelect={(signatureLevel) =>
                 setSectionFormData({ ...sectionFormData, signatureLevel })

--- a/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
+++ b/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
@@ -325,6 +325,11 @@ export const ApplicationDetailsSection = ({
             <SelectSignatureLevel
               key={`sig-${sectionFormData.signatureLevel || "empty"}`}
               initialValue={sectionFormData.signatureLevel}
+              allowedSignatureLevels={
+                sectionFormData.applicationType === "demonstration"
+                  ? ["OA"]
+                  : ["OA", "OCD"]
+              }
               onSelect={(signatureLevel) =>
                 setSectionFormData({ ...sectionFormData, signatureLevel })
               }

--- a/client/src/components/dialog/demonstration/CreateDemonstrationDialog.test.tsx
+++ b/client/src/components/dialog/demonstration/CreateDemonstrationDialog.test.tsx
@@ -11,7 +11,7 @@ import {
   CREATE_DEMONSTRATION_MUTATION,
 } from "./CreateDemonstrationDialog";
 import { DIALOG_CANCEL_BUTTON_NAME } from "components/dialog/BaseDialog";
-import { DEMONSTRATION_DIALOG_DESCRIPTION_NAME } from "./DemonstrationDialog";
+import { DEFAULT_DEMONSTRATION_SIGNATURE_LEVEL, DEMONSTRATION_DIALOG_DESCRIPTION_NAME } from "./DemonstrationDialog";
 
 const DEFAULT_PROPS = {
   onClose: vi.fn(),
@@ -49,7 +49,6 @@ describe("CreateDemonstrationDialog", () => {
           stateId: "AL",
           projectOfficerUserId: "test-officer-id",
           sdgDivision: "Division of System Reform Demonstrations",
-          signatureLevel: "OA",
         },
       },
     },
@@ -124,6 +123,14 @@ describe("CreateDemonstrationDialog", () => {
 
     // Note: Actual selection of project officer would require more complex interaction
     // This test verifies the fields render correctly
+  });
+  it("renders signature level select disabled and with the default value", () => {
+    render(getCreateDemonstrationDialog());
+
+    const signatureLevelSelect = screen.getByLabelText(/Signature Level/i);
+    expect(signatureLevelSelect).toBeInTheDocument();
+    expect(signatureLevelSelect).toBeDisabled();
+    expect(signatureLevelSelect).toHaveValue(DEFAULT_DEMONSTRATION_SIGNATURE_LEVEL);
   });
 
   it("calls onSubmit with correct data when form is submitted", async () => {

--- a/client/src/components/dialog/demonstration/CreateDemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/CreateDemonstrationDialog.tsx
@@ -43,7 +43,6 @@ export const CreateDemonstrationDialog: React.FC<{
     stateId: demonstration.stateId,
     projectOfficerUserId: demonstration.projectOfficerId,
     sdgDivision: demonstration.sdgDivision,
-    signatureLevel: demonstration.signatureLevel,
   });
 
   const onSubmit = async (demonstration: DemonstrationDialogFields) => {

--- a/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
@@ -8,7 +8,7 @@ import { SelectSignatureLevel } from "components/input/select/SelectSignatureLev
 import { SelectUSAStates } from "components/input/select/SelectUSAStates";
 import { SelectUsers } from "components/input/select/SelectUsers";
 import { TextInput } from "components/input/TextInput";
-import { Demonstration } from "demos-server";
+import { Demonstration, SignatureLevel } from "demos-server";
 import { DatePicker } from "components/input/date/DatePicker";
 import { EXPIRATION_DATE_ERROR_MESSAGE } from "util/messages";
 import { SubmitButton } from "components/button/SubmitButton";
@@ -16,6 +16,7 @@ import { HintIcon } from "components/icons/Input/HintIcon";
 import { isBefore } from "date-fns";
 
 export const DEMONSTRATION_DIALOG_DESCRIPTION_NAME = "textarea-demonstration-description";
+export const DEFAULT_DEMONSTRATION_SIGNATURE_LEVEL = "OA" as SignatureLevel;
 
 export type DemonstrationDialogMode = "create" | "edit";
 
@@ -270,8 +271,12 @@ export const DemonstrationDialog: React.FC<{
             onSelect={(sdgDivision) => handleChange({ ...activeDemonstration, sdgDivision })}
           />
           <SelectSignatureLevel
-            initialValue={activeDemonstration.signatureLevel}
-            onSelect={(signatureLevel) => handleChange({ ...activeDemonstration, signatureLevel })}
+            initialValue={DEFAULT_DEMONSTRATION_SIGNATURE_LEVEL}
+            allowedSignatureLevels={["OA"]}
+            isDisabled
+            onSelect={(signatureLevel) =>
+              handleChange({ ...activeDemonstration, signatureLevel })
+            }
           />
         </div>
 

--- a/client/src/components/dialog/demonstration/EditDemonstrationDialog.test.tsx
+++ b/client/src/components/dialog/demonstration/EditDemonstrationDialog.test.tsx
@@ -88,7 +88,6 @@ describe("EditDemonstrationDialog", () => {
           description: "A test demonstration.",
           stateId: "AL",
           sdgDivision: "Division of System Reform Demonstrations",
-          signatureLevel: "OA",
         },
       },
     },

--- a/client/src/components/dialog/modification/ModificationForm.tsx
+++ b/client/src/components/dialog/modification/ModificationForm.tsx
@@ -127,6 +127,7 @@ export const ModificationForm: React.FC<{
       />
       <div className="w-1/2">
         <SelectSignatureLevel
+          allowedSignatureLevels={["OA", "OCD"]}
           onSelect={(signatureLevel) =>
             setModificationFormDataField({
               signatureLevel: signatureLevel,

--- a/client/src/components/input/select/SelectSignatureLevel.test.tsx
+++ b/client/src/components/input/select/SelectSignatureLevel.test.tsx
@@ -23,4 +23,24 @@ describe("SelectSignatureLevel", () => {
     expect(select).toHaveValue(SIGNATURE_LEVEL[0]);
     expect(onSelect).toHaveBeenCalledWith(SIGNATURE_LEVEL[0]);
   });
+
+  it("renders only allowed signature level options", () => {
+    render(
+      <SelectSignatureLevel
+        onSelect={onSelect}
+        allowedSignatureLevels={["OA", "OCD"]}
+      />
+    );
+    const select = screen.getByLabelText("Signature Level");
+    fireEvent.mouseDown(select);
+    expect(
+      screen.getByText("OA - Office of the Administrator")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("OCD - Office of the Center Director")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("OGD - Office of the Group Director")
+    ).not.toBeInTheDocument();
+  });
 });

--- a/client/src/components/input/select/SelectSignatureLevel.tsx
+++ b/client/src/components/input/select/SelectSignatureLevel.tsx
@@ -11,30 +11,33 @@ const labelMap: Record<SignatureLevel, string> = {
   OGD: "OGD - Office of the Group Director",
 };
 
-const options: Option[] = SIGNATURE_LEVEL.map((level) => ({
-  value: level,
-  label: labelMap[level] || level,
-}));
+type SelectSignatureLevelProps = {
+  onSelect: (value: SignatureLevel | undefined) => void;
+  initialValue?: SignatureLevel;
+  isDisabled?: boolean;
+  isRequired?: boolean;
+  allowedSignatureLevels?: readonly SignatureLevel[];
+};
 
 export const SelectSignatureLevel = ({
   onSelect,
   initialValue,
   isDisabled = false,
   isRequired = false,
-}: {
-  onSelect: (value: SignatureLevel | undefined) => void;
-  initialValue?: SignatureLevel;
-  isDisabled?: boolean;
-  isRequired?: boolean;
-}) => {
-  const [signatureLevel, setSignatureLevel] = React.useState<SignatureLevel | undefined>(
-    initialValue
-  );
+  allowedSignatureLevels = SIGNATURE_LEVEL,
+}: SelectSignatureLevelProps) => {
+  const [signatureLevel, setSignatureLevel] = React.useState<
+    SignatureLevel | undefined
+  >(initialValue);
 
-  // Sync internal state when initialValue changes
   React.useEffect(() => {
     setSignatureLevel(initialValue);
   }, [initialValue]);
+
+  const options: Option[] = allowedSignatureLevels.map((level) => ({
+    value: level,
+    label: labelMap[level] || level,
+  }));
 
   return (
     <Select
@@ -42,7 +45,9 @@ export const SelectSignatureLevel = ({
       options={options}
       placeholder="Select Signature Level"
       onSelect={(value) => {
-        const selectedValue = value === "" ? undefined : (value as SignatureLevel);
+        const selectedValue =
+          value === "" ? undefined : (value as SignatureLevel);
+
         setSignatureLevel(selectedValue);
         onSelect(selectedValue);
       }}

--- a/server/src/model/amendment/amendmentResolvers.test.ts
+++ b/server/src/model/amendment/amendmentResolvers.test.ts
@@ -335,6 +335,44 @@ describe("amendmentResolvers", () => {
       expect(transactionMocks.application.create).toHaveBeenCalledExactlyOnceWith(expectedCalls[0]);
       expect(transactionMocks.amendment.create).toHaveBeenCalledExactlyOnceWith(expectedCalls[1]);
     });
+
+    it.each(["OA", "OCD"] as const)(
+      "allows valid signature level %s during creation",
+      async (signatureLevel) => {
+        transactionMocks.application.create.mockResolvedValueOnce({
+          id: testAmendmentId,
+          applicationTypeId: testAmendmentTypeId,
+        });
+
+        await __createAmendment(undefined, {
+          input: {
+            demonstrationId: testDemonstrationId,
+            name: testAmendmentName,
+            description: testAmendmentDescription,
+            signatureLevel,
+          },
+        });
+
+        expect(transactionMocks.application.create).toHaveBeenCalledOnce();
+        expect(transactionMocks.amendment.create).toHaveBeenCalledOnce();
+      }
+    );
+
+    it("rejects invalid signature levels during creation", async () => {
+      await expect(
+        __createAmendment(undefined, {
+          input: {
+            demonstrationId: testDemonstrationId,
+            name: testAmendmentName,
+            description: testAmendmentDescription,
+            signatureLevel: "INVALID" as SignatureLevel,
+          },
+        })
+      ).rejects.toThrowError("Invalid signature level for amendment.");
+
+      expect(transactionMocks.application.create).not.toHaveBeenCalled();
+      expect(transactionMocks.amendment.create).not.toHaveBeenCalled();
+    });
   });
 
   describe("__updateAmendment", () => {

--- a/server/src/model/amendment/amendmentResolvers.ts
+++ b/server/src/model/amendment/amendmentResolvers.ts
@@ -5,6 +5,7 @@ import {
   ApplicationType,
   CreateAmendmentInput,
   PhaseName,
+  SignatureLevel,
   UiPathResultStatus,
   UpdateAmendmentInput,
 } from "../../types";
@@ -24,11 +25,17 @@ const amendmentApplicationType: ApplicationType = "Amendment";
 const conceptPhaseName: PhaseName = "Concept";
 const newApplicationStatusId: ApplicationStatus = "Pre-Submission";
 
+const VALID_AMENDMENT_SIGNATURE_LEVELS: readonly SignatureLevel[] = ["OA", "OCD"];
+
 export async function __createAmendment(
   parent: unknown,
   { input }: { input: CreateAmendmentInput }
 ): Promise<PrismaAmendment> {
   return await prisma().$transaction(async (tx) => {
+    if (input.signatureLevel && !VALID_AMENDMENT_SIGNATURE_LEVELS.includes(input.signatureLevel)) {
+      throw new Error(`Invalid signature level for amendment.`);
+    }
+
     const application = await tx.application.create({
       data: {
         applicationTypeId: amendmentApplicationType,
@@ -54,6 +61,10 @@ export async function __updateAmendment(
   parent: unknown,
   { id, input }: { id: string; input: UpdateAmendmentInput }
 ): Promise<PrismaAmendment> {
+  if (input.signatureLevel && !VALID_AMENDMENT_SIGNATURE_LEVELS.includes(input.signatureLevel)) {
+    throw new Error(`Invalid signature level for amendment.`);
+  }
+
   const { effectiveDate } = parseAndValidateEffectiveAndExpirationDates(input);
   checkOptionalNotNullFields(["demonstrationId", "name", "status"], input);
   try {

--- a/server/src/model/demonstration/demonstrationResolvers.test.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.test.ts
@@ -219,7 +219,7 @@ describe("demonstrationResolvers", () => {
     demonstrationName: "The Demonstration",
     demonstrationDescription: "A description of a demonstration",
     sdgDivisionId: "Division of Eligibility and Coverage Demonstrations",
-    signatureLevelId: "OCD",
+    signatureLevelId: "OA",
     personTypeId: "demos-cms-user",
     newApplicationStatusId: "Pre-Submission",
     newApplicationPhaseId: "Concept",
@@ -563,7 +563,6 @@ describe("demonstrationResolvers", () => {
           stateId: testValues.stateId,
           description: testValues.demonstrationDescription,
           sdgDivision: testValues.sdgDivisionId,
-          signatureLevel: testValues.signatureLevelId,
         },
       };
 
@@ -580,8 +579,8 @@ describe("demonstrationResolvers", () => {
             name: testValues.demonstrationName,
             description: testValues.demonstrationDescription,
             sdgDivisionId: testValues.sdgDivisionId,
-            signatureLevelId: testValues.signatureLevelId,
             statusId: testValues.newApplicationStatusId,
+            signatureLevelId: testValues.signatureLevelId,
             stateId: testValues.stateId,
             currentPhaseId: testValues.newApplicationPhaseId,
           },
@@ -644,7 +643,6 @@ describe("demonstrationResolvers", () => {
           stateId: testValues.stateId,
           description: testValues.demonstrationDescription,
           sdgDivision: testValues.sdgDivisionId,
-          signatureLevel: testValues.signatureLevelId,
         },
       };
 

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -7,6 +7,7 @@ import {
   GrantLevel,
   PhaseName,
   Role,
+  SignatureLevel,
   UiPathResultStatus,
   UpdateDemonstrationInput,
 } from "../../types";
@@ -38,6 +39,8 @@ const conceptPhaseName: PhaseName = "Concept";
 const newApplicationStatusId: ApplicationStatus = "Pre-Submission";
 const demonstrationApplicationType: ApplicationType = "Demonstration";
 
+const DEFAULT_SIGNATURE_LEVEL: SignatureLevel = "OA";
+
 export async function __createDemonstration(
   parent: unknown,
   { input }: { input: CreateDemonstrationInput }
@@ -58,7 +61,7 @@ export async function __createDemonstration(
           name: input.name,
           description: input.description,
           sdgDivisionId: input.sdgDivision,
-          signatureLevelId: input.signatureLevel,
+          signatureLevelId: DEFAULT_SIGNATURE_LEVEL,
           statusId: newApplicationStatusId,
           stateId: input.stateId,
           currentPhaseId: conceptPhaseName,
@@ -117,7 +120,6 @@ export async function __updateDemonstration(
           effectiveDate: effectiveDate,
           expirationDate: expirationDate,
           sdgDivisionId: input.sdgDivision,
-          signatureLevelId: input.signatureLevel,
           statusId: input.status,
           stateId: input.stateId,
         },

--- a/server/src/model/demonstration/demonstrationSchema.ts
+++ b/server/src/model/demonstration/demonstrationSchema.ts
@@ -53,7 +53,6 @@ export const demonstrationSchema = gql`
     projectOfficerUserId: String!
     description: String
     sdgDivision: SdgDivision
-    signatureLevel: SignatureLevel
   }
 
   input UpdateDemonstrationInput {
@@ -62,7 +61,6 @@ export const demonstrationSchema = gql`
     effectiveDate: DateTimeOrLocalDate
     expirationDate: DateTimeOrLocalDate
     sdgDivision: SdgDivision
-    signatureLevel: SignatureLevel
     status: ApplicationStatus
     stateId: ID
     projectOfficerUserId: String
@@ -112,7 +110,6 @@ export interface CreateDemonstrationInput {
   stateId: string;
   description?: string;
   sdgDivision?: SdgDivision;
-  signatureLevel?: SignatureLevel;
 }
 
 export interface UpdateDemonstrationInput {
@@ -121,7 +118,6 @@ export interface UpdateDemonstrationInput {
   effectiveDate?: DateTimeOrLocalDate | null;
   expirationDate?: DateTimeOrLocalDate | null;
   sdgDivision?: SdgDivision;
-  signatureLevel?: SignatureLevel;
   status?: ApplicationStatus;
   stateId?: string;
   projectOfficerUserId?: string;

--- a/server/src/model/extension/extensionResolvers.test.ts
+++ b/server/src/model/extension/extensionResolvers.test.ts
@@ -343,6 +343,44 @@ describe("extensionResolvers", () => {
       expect(transactionMocks.application.create).toHaveBeenCalledExactlyOnceWith(expectedCalls[0]);
       expect(transactionMocks.extension.create).toHaveBeenCalledExactlyOnceWith(expectedCalls[1]);
     });
+
+    it.each(["OA", "OCD"] as const)(
+      "allows valid signature level %s during creation",
+      async (signatureLevel) => {
+        transactionMocks.application.create.mockResolvedValueOnce({
+          id: testExtensionId,
+          applicationTypeId: testExtensionTypeId,
+        });
+
+        await __createExtension(undefined, {
+          input: {
+            demonstrationId: testDemonstrationId,
+            name: testExtensionName,
+            description: testExtensionDescription,
+            signatureLevel,
+          },
+        });
+
+        expect(transactionMocks.application.create).toHaveBeenCalledOnce();
+        expect(transactionMocks.extension.create).toHaveBeenCalledOnce();
+      }
+    );
+
+    it("rejects invalid signature levels during creation", async () => {
+      await expect(
+        __createExtension(undefined, {
+          input: {
+            demonstrationId: testDemonstrationId,
+            name: testExtensionName,
+            description: testExtensionDescription,
+            signatureLevel: "INVALID" as SignatureLevel,
+          },
+        })
+      ).rejects.toThrowError("Invalid signature level for extension.");
+
+      expect(transactionMocks.application.create).not.toHaveBeenCalled();
+      expect(transactionMocks.extension.create).not.toHaveBeenCalled();
+    });
   });
 
   describe("__updateExtension", () => {

--- a/server/src/model/extension/extensionResolvers.ts
+++ b/server/src/model/extension/extensionResolvers.ts
@@ -5,6 +5,7 @@ import {
   ApplicationType,
   CreateExtensionInput,
   PhaseName,
+  SignatureLevel,
   UiPathResultStatus,
   UpdateExtensionInput,
 } from "../../types";
@@ -23,11 +24,16 @@ import { getManyApplicationTagSuggestions } from "../applicationTagSuggestion";
 const extensionApplicationType: ApplicationType = "Extension";
 const conceptPhaseName: PhaseName = "Concept";
 const newApplicationStatusId: ApplicationStatus = "Pre-Submission";
+const VALID_EXTENSION_SIGNATURE_LEVELS: readonly SignatureLevel[] = ["OA", "OCD"];
 
 export async function __createExtension(
   parent: unknown,
   { input }: { input: CreateExtensionInput }
 ): Promise<PrismaExtension> {
+  if (input.signatureLevel && !VALID_EXTENSION_SIGNATURE_LEVELS.includes(input.signatureLevel)) {
+    throw new Error(`Invalid signature level for extension.`);
+  }
+
   return await prisma().$transaction(async (tx) => {
     const application = await tx.application.create({
       data: {
@@ -54,6 +60,10 @@ export async function __updateExtension(
   parent: unknown,
   { id, input }: { id: string; input: UpdateExtensionInput }
 ): Promise<PrismaExtension> {
+  if (input.signatureLevel && !VALID_EXTENSION_SIGNATURE_LEVELS.includes(input.signatureLevel)) {
+    throw new Error(`Invalid signature level for extension.`);
+  }
+
   const { effectiveDate } = parseAndValidateEffectiveAndExpirationDates(input);
   checkOptionalNotNullFields(["demonstrationId", "name", "status"], input);
   try {

--- a/server/src/seeder.ts
+++ b/server/src/seeder.ts
@@ -817,7 +817,6 @@ async function seedDatabase() {
       name: demoName,
       description: faker.lorem.sentence(),
       sdgDivision: sampleFromArray([...SDG_DIVISIONS, undefined], 1)[0],
-      signatureLevel: sampleFromArray([...SIGNATURE_LEVEL, undefined], 1)[0],
       stateId: stateSelection.stateId,
       projectOfficerUserId: person.id,
     };


### PR DESCRIPTION
I've included both the FE and BE ticket in this PR to avoid a weird state where errors could occur.

Demonstrations now only accept OA as Sig Level. This value cannot be modified and the select option renders as disabled.
Modifications accept OA and OCD only. It can be modified.

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/d7cbc14a-e467-42b0-ac83-c01efd0c6b49" />
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/a2b8ce28-cacf-4174-84d9-d4a85bf263fe" />
