### PR TITLE
DEMOS-1736-create-private-comment

### DIFF
--- a/server/src/model/graphql.ts
+++ b/server/src/model/graphql.ts
@@ -101,6 +101,9 @@ import { phaseResolvers } from "./phase/phaseResolvers.js";
 import { phaseStatusSchema } from "./phaseStatus/phaseStatusSchema.js";
 import { phaseStatusResolvers } from "./phaseStatus/phaseStatusResolvers.js";
 
+import { privateCommentSchema } from "./privateComment/privateCommentSchema";
+import { privateCommentResolvers } from "./privateComment/privateCommentResolvers";
+
 import { publicCommentSchema } from "./publicComment/publicCommentSchema";
 import { publicCommentResolvers } from "./publicComment/publicCommentResolvers";
 
@@ -170,8 +173,8 @@ export const typeDefs = [
   demonstrationRoleAssignmentSchema,
   demonstrationSchema,
   demonstrationTypeTagAssignmentSchema,
-  documentSchema,
   documentPendingUploadSchema,
+  documentSchema,
   documentTypeSchema,
   eventSchema,
   eventTypeSchema,
@@ -182,6 +185,7 @@ export const typeDefs = [
   personTypeSchema,
   phaseSchema,
   phaseStatusSchema,
+  privateCommentSchema,
   publicCommentSchema,
   roleSchema,
   sdgDivisionSchema,
@@ -219,8 +223,8 @@ export const resolvers = [
   demonstrationResolvers,
   demonstrationRoleAssigmentResolvers,
   demonstrationTypeTagAssignmentResolvers,
-  documentResolvers,
   documentPendingUploadResolvers,
+  documentResolvers,
   documentTypeResolvers,
   eventResolvers,
   eventTypeResolvers,
@@ -231,6 +235,7 @@ export const resolvers = [
   personTypeResolvers,
   phaseResolvers,
   phaseStatusResolvers,
+  privateCommentResolvers,
   publicCommentResolvers,
   roleResolvers,
   sdgDivisionResolvers,

--- a/server/src/model/privateComment/createPrivateComment.test.ts
+++ b/server/src/model/privateComment/createPrivateComment.test.ts
@@ -6,7 +6,7 @@ import { DeepPartial } from "../../testUtilities";
 import { GraphQLContext } from "../../auth";
 
 // Functions under test
-import { createPublicComment } from "./createPublicComment";
+import { createPrivateComment } from "./createPrivateComment";
 
 // Mock imports
 vi.mock("../../prismaClient", () => ({
@@ -14,24 +14,24 @@ vi.mock("../../prismaClient", () => ({
 }));
 
 vi.mock(".", () => ({
-  validateUserPermittedToMakePublicComment: vi.fn(),
+  validateUserPermittedToMakePrivateComment: vi.fn(),
 }));
 
 vi.mock("./queries", () => ({
-  insertPublicComment: vi.fn(),
+  insertPrivateComment: vi.fn(),
 }));
 
 import { prisma } from "../../prismaClient";
-import { validateUserPermittedToMakePublicComment } from ".";
-import { insertPublicComment } from "./queries";
+import { validateUserPermittedToMakePrivateComment } from ".";
+import { insertPrivateComment } from "./queries";
 
-describe("createPublicComment", () => {
+describe("createPrivateComment", () => {
   // Test inputs
-  const testDeliverableId = "e1b4a166-9a23-480c-9ac8-d5361414dfd0";
+  const testDeliverableId = "7dad9b78-9c38-4bca-8985-f292edb4d12d";
   const testComment = "Free insulin is a good policy proposal!";
   const testContext: DeepPartial<GraphQLContext> = {
     user: {
-      id: "03728c69-1676-4cb5-8b31-c98b24cbda76",
+      id: "f41d7a0b-49d7-4f9e-b079-2e97a21c294d",
       personTypeId: "demos-cms-user",
     },
   };
@@ -49,25 +49,22 @@ describe("createPublicComment", () => {
   });
 
   it("should create a transaction whenever it is called", async () => {
-    await createPublicComment(testDeliverableId, testComment, testContext as GraphQLContext);
+    await createPrivateComment(testDeliverableId, testComment, testContext as GraphQLContext);
     expect(prisma).toHaveBeenCalledOnce();
   });
 
   it("should call the validator to verify the inputs", async () => {
-    await createPublicComment(testDeliverableId, testComment, testContext as GraphQLContext);
-    expect(validateUserPermittedToMakePublicComment).toHaveBeenCalledExactlyOnceWith(
-      testDeliverableId,
-      testContext,
-      mockTransaction
-    );
+    await createPrivateComment(testDeliverableId, testComment, testContext as GraphQLContext);
+    expect(validateUserPermittedToMakePrivateComment).toHaveBeenCalledExactlyOnceWith(testContext);
   });
 
   it("should insert the comment", async () => {
-    await createPublicComment(testDeliverableId, testComment, testContext as GraphQLContext);
-    expect(insertPublicComment).toHaveBeenCalledExactlyOnceWith(
+    await createPrivateComment(testDeliverableId, testComment, testContext as GraphQLContext);
+    expect(insertPrivateComment).toHaveBeenCalledExactlyOnceWith(
       {
         deliverableId: testDeliverableId,
         authorUserId: testContext.user!.id,
+        authorPersonTypeId: testContext.user!.personTypeId,
         content: testComment,
       },
       mockTransaction

--- a/server/src/model/privateComment/createPrivateComment.ts
+++ b/server/src/model/privateComment/createPrivateComment.ts
@@ -1,0 +1,25 @@
+import { PrivateComment as PrismaPrivateComment } from "@prisma/client";
+import { NonEmptyString } from "../../types";
+import { GraphQLContext } from "../../auth";
+import { prisma } from "../../prismaClient";
+import { validateUserPermittedToMakePrivateComment } from ".";
+import { insertPrivateComment } from "./queries";
+
+export async function createPrivateComment(
+  deliverableId: string,
+  comment: NonEmptyString,
+  context: GraphQLContext
+): Promise<PrismaPrivateComment> {
+  return await prisma().$transaction(async (tx) => {
+    validateUserPermittedToMakePrivateComment(context);
+    return await insertPrivateComment(
+      {
+        deliverableId: deliverableId,
+        authorUserId: context.user.id,
+        authorPersonTypeId: context.user.personTypeId,
+        content: comment,
+      },
+      tx
+    );
+  });
+}

--- a/server/src/model/privateComment/index.ts
+++ b/server/src/model/privateComment/index.ts
@@ -1,0 +1,5 @@
+// Functions
+export { createPrivateComment } from "./createPrivateComment";
+export { validateUserPermittedToMakePrivateComment } from "./validateUserPermittedToMakePrivateComment";
+
+// Types & Constants

--- a/server/src/model/privateComment/privateComment.prisma
+++ b/server/src/model/privateComment/privateComment.prisma
@@ -1,5 +1,5 @@
 model PrivateComment {
-  id                 String   @db.Uuid
+  id                 String   @default(uuid()) @db.Uuid
   deliverableId      String   @map("deliverable_id") @db.Uuid
   authorUserId       String   @map("author_user_id") @db.Uuid
   authorPersonTypeId String   @map("author_person_type_id")

--- a/server/src/model/privateComment/privateCommentResolvers.test.ts
+++ b/server/src/model/privateComment/privateCommentResolvers.test.ts
@@ -1,0 +1,49 @@
+// Vitest and other helpers
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DeepPartial } from "../../testUtilities";
+
+// Types
+import { GraphQLContext } from "../../auth";
+
+// Functions under test
+import { privateCommentResolvers } from "./privateCommentResolvers";
+
+// Mock imports
+vi.mock(".", () => ({
+  createPrivateComment: vi.fn(),
+}));
+
+import { createPrivateComment } from ".";
+
+describe("privateCommentResolvers", () => {
+  const testDeliverableId = "e0709359-8016-4106-9490-844ac9a0e6ea";
+  const testComment = "Free insulin is a good policy proposal!";
+  const testContext: DeepPartial<GraphQLContext> = {
+    user: {
+      id: "eb43833e-a8de-438c-a06a-4837c2f90373",
+    },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("Mutation.createPrivateComment", () => {
+    it("should call the createPrivateComment function", async () => {
+      await privateCommentResolvers.Mutation.createPrivateComment(
+        undefined,
+        {
+          deliverableId: testDeliverableId,
+          comment: testComment,
+        },
+        testContext as GraphQLContext
+      );
+
+      expect(createPrivateComment).toHaveBeenCalledExactlyOnceWith(
+        testDeliverableId,
+        testComment,
+        testContext
+      );
+    });
+  });
+});

--- a/server/src/model/privateComment/privateCommentResolvers.ts
+++ b/server/src/model/privateComment/privateCommentResolvers.ts
@@ -1,0 +1,15 @@
+import { NonEmptyString } from "../../types";
+import { GraphQLContext } from "../../auth";
+import { createPrivateComment } from ".";
+
+export const privateCommentResolvers = {
+  Mutation: {
+    createPrivateComment: async (
+      parent: unknown,
+      args: { deliverableId: string; comment: NonEmptyString },
+      context: GraphQLContext
+    ) => {
+      return await createPrivateComment(args.deliverableId, args.comment, context);
+    },
+  },
+};

--- a/server/src/model/privateComment/privateCommentSchema.ts
+++ b/server/src/model/privateComment/privateCommentSchema.ts
@@ -1,0 +1,7 @@
+import { gql } from "graphql-tag";
+
+export const privateCommentSchema = gql`
+  type Mutation {
+    createPrivateComment(deliverableId: ID!, comment: NonEmptyString!): DeliverableComment!
+  }
+`;

--- a/server/src/model/privateComment/queries/index.ts
+++ b/server/src/model/privateComment/queries/index.ts
@@ -1,1 +1,4 @@
+export { insertPrivateComment } from "./insertPrivateComment";
 export { selectManyPrivateComments } from "./selectManyPrivateComments";
+
+export type { AllowedPrivateCommenters, InsertPrivateCommentInput } from "./insertPrivateComment";

--- a/server/src/model/privateComment/queries/insertPrivateComment.test.ts
+++ b/server/src/model/privateComment/queries/insertPrivateComment.test.ts
@@ -1,0 +1,72 @@
+// Vitest and other helpers
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Types
+import { AllowedPrivateCommenters, InsertPrivateCommentInput } from ".";
+
+// Functions under test
+import { insertPrivateComment } from "./insertPrivateComment";
+
+// Mock imports
+vi.mock("../../../prismaClient", () => ({
+  prisma: vi.fn(),
+}));
+
+import { prisma } from "../../../prismaClient";
+
+describe("insertPrivateComment", () => {
+  // Test inputs
+  const testInput: InsertPrivateCommentInput = {
+    deliverableId: "316cad98-643a-4c47-bd41-199625de6964",
+    authorUserId: "1578fa6e-db49-4359-a9aa-d10dc066ff5f",
+    authorPersonTypeId: "demos-admin" satisfies AllowedPrivateCommenters,
+    content: "We can probably be more aggresive about the free insulin program",
+  };
+
+  // Mock return values
+  const regularMocks = {
+    privateComment: {
+      create: vi.fn(),
+    },
+  };
+  const mockPrismaClient = {
+    privateComment: {
+      create: regularMocks.privateComment.create,
+    },
+  };
+
+  const transactionMocks = {
+    privateComment: {
+      create: vi.fn(),
+    },
+  };
+  const mockTransaction = {
+    privateComment: {
+      create: transactionMocks.privateComment.create,
+    },
+  } as any;
+
+  // Expected call
+  const expectedCall = {
+    data: testInput,
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
+  });
+
+  it("should insert using a new client if no transaction is given", async () => {
+    await insertPrivateComment(testInput);
+    expect(prisma).toHaveBeenCalledOnce();
+    expect(regularMocks.privateComment.create).toHaveBeenCalledExactlyOnceWith(expectedCall);
+    expect(transactionMocks.privateComment.create).not.toHaveBeenCalled();
+  });
+
+  it("should insert using an existing client if provided", async () => {
+    await insertPrivateComment(testInput, mockTransaction);
+    expect(prisma).not.toHaveBeenCalled();
+    expect(regularMocks.privateComment.create).not.toHaveBeenCalled();
+    expect(transactionMocks.privateComment.create).toHaveBeenCalledExactlyOnceWith(expectedCall);
+  });
+});

--- a/server/src/model/privateComment/queries/insertPrivateComment.ts
+++ b/server/src/model/privateComment/queries/insertPrivateComment.ts
@@ -1,0 +1,27 @@
+import { PrivateComment as PrismaPrivateComment } from "@prisma/client";
+import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { UserType, NonEmptyString } from "../../../types";
+
+export type AllowedPrivateCommenters = Extract<UserType, "demos-admin" | "demos-cms-user">;
+
+export type InsertPrivateCommentInput = {
+  deliverableId: string;
+  authorUserId: string;
+  authorPersonTypeId: AllowedPrivateCommenters;
+  content: NonEmptyString;
+};
+
+export async function insertPrivateComment(
+  input: InsertPrivateCommentInput,
+  tx?: PrismaTransactionClient
+): Promise<PrismaPrivateComment> {
+  const prismaClient = tx ?? prisma();
+  return await prismaClient.privateComment.create({
+    data: {
+      deliverableId: input.deliverableId,
+      authorUserId: input.authorUserId,
+      authorPersonTypeId: input.authorPersonTypeId,
+      content: input.content,
+    },
+  });
+}

--- a/server/src/model/privateComment/validateUserPermittedToMakePrivateComment.test.ts
+++ b/server/src/model/privateComment/validateUserPermittedToMakePrivateComment.test.ts
@@ -1,0 +1,56 @@
+// Vitest and other helpers
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DeepPartial } from "../../testUtilities";
+
+// Types
+import { GraphQLContext } from "../../auth";
+
+// Functions under test
+import { validateUserPermittedToMakePrivateComment } from "./validateUserPermittedToMakePrivateComment";
+
+// Mock imports
+
+describe("validateUserPermittedToMakePrivateComment", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should not throw if the user is an admin or a CMS user", () => {
+    const testContext1: DeepPartial<GraphQLContext> = {
+      user: {
+        id: "1c55aaeb-b81d-43d3-bdec-0a31061fc45a",
+        personTypeId: "demos-cms-user",
+      },
+    };
+    const testContext2: DeepPartial<GraphQLContext> = {
+      user: {
+        id: "1c55aaeb-b81d-43d3-bdec-0a31061fc45a",
+        personTypeId: "demos-admin",
+      },
+    };
+
+    validateUserPermittedToMakePrivateComment(testContext1 as GraphQLContext);
+    validateUserPermittedToMakePrivateComment(testContext2 as GraphQLContext);
+  });
+
+  it("should throw if the user is a state user", () => {
+    const testContext: DeepPartial<GraphQLContext> = {
+      user: {
+        id: "1c55aaeb-b81d-43d3-bdec-0a31061fc45a",
+        personTypeId: "demos-state-user",
+      },
+    };
+
+    try {
+      validateUserPermittedToMakePrivateComment(testContext as GraphQLContext);
+      throw new Error(
+        "Expected validateUserPermittedToMakePrivateComment to throw, but it did not."
+      );
+    } catch (e) {
+      const error = e as Error;
+      expect(error.message).toBe(
+        `The user with ID ${testContext.user!.id} is not permitted to create a private comment; incorrect user type.`
+      );
+    }
+  });
+});

--- a/server/src/model/privateComment/validateUserPermittedToMakePrivateComment.test.ts
+++ b/server/src/model/privateComment/validateUserPermittedToMakePrivateComment.test.ts
@@ -29,8 +29,12 @@ describe("validateUserPermittedToMakePrivateComment", () => {
       },
     };
 
-    validateUserPermittedToMakePrivateComment(testContext1 as GraphQLContext);
-    validateUserPermittedToMakePrivateComment(testContext2 as GraphQLContext);
+    expect(
+      validateUserPermittedToMakePrivateComment(testContext1 as GraphQLContext)
+    ).toBeUndefined();
+    expect(
+      validateUserPermittedToMakePrivateComment(testContext2 as GraphQLContext)
+    ).toBeUndefined();
   });
 
   it("should throw if the user is a state user", () => {

--- a/server/src/model/privateComment/validateUserPermittedToMakePrivateComment.ts
+++ b/server/src/model/privateComment/validateUserPermittedToMakePrivateComment.ts
@@ -1,0 +1,17 @@
+import { GraphQLContext } from "../../auth";
+import { UserType } from "../../types";
+import { AllowedPrivateCommenters } from "./queries";
+
+export function validateUserPermittedToMakePrivateComment(
+  context: GraphQLContext
+): asserts context is GraphQLContext & { user: { personTypeId: AllowedPrivateCommenters } } {
+  const allowedPrivateCommenters: UserType[] = [
+    "demos-admin",
+    "demos-cms-user",
+  ] satisfies AllowedPrivateCommenters[];
+  if (!allowedPrivateCommenters.includes(context.user.personTypeId)) {
+    throw new Error(
+      `The user with ID ${context.user.id} is not permitted to create a private comment; incorrect user type.`
+    );
+  }
+}

--- a/server/src/model/publicComment/createPublicComment.ts
+++ b/server/src/model/publicComment/createPublicComment.ts
@@ -2,7 +2,7 @@ import { PublicComment as PrismaPublicComment } from "@prisma/client";
 import { NonEmptyString } from "../../types";
 import { GraphQLContext } from "../../auth";
 import { prisma } from "../../prismaClient";
-import { validateUserPermittedToMakePublicComment } from "./validateUserPermittedToMakePublicComment";
+import { validateUserPermittedToMakePublicComment } from ".";
 import { insertPublicComment } from "./queries";
 
 export async function createPublicComment(

--- a/server/src/model/publicComment/queries/insertPublicComment.test.ts
+++ b/server/src/model/publicComment/queries/insertPublicComment.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Types
-import { InsertPublicCommentInput } from "./insertPublicComment";
+import { InsertPublicCommentInput } from ".";
 
 // Functions under test
 import { insertPublicComment } from "./insertPublicComment";


### PR DESCRIPTION
This PR implements the `createPrivateComment` mutator which allows private comments to be added to a deliverable. A lot of the implementation is very similar to creating public comments, and the validation is actually simpler because we can just use the user type (for now anyway).