### PR TITLE
DEMOS-2067 implement logic for combined status column

### DIFF
--- a/client/src/components/table/columns/DeliverableColumns.tsx
+++ b/client/src/components/table/columns/DeliverableColumns.tsx
@@ -8,7 +8,7 @@ import type { Option } from "components/input/select/Select";
 
 import { SecondaryButton } from "../../button/SecondaryButton";
 import { highlightCell } from "../KeywordSearch";
-import type { DeliverableTableRow } from "../tables/DeliverableTable";
+import type { FormattedDeliverableTableRow } from "../tables/DeliverableTable";
 
 type DeliverableColumnsProps = {
   viewMode: UserType;
@@ -21,7 +21,7 @@ export function DeliverableColumns({
   demonstrationNameOptions,
   cmsOwnerOptions,
 }: DeliverableColumnsProps) {
-  const columnHelper = createColumnHelper<DeliverableTableRow>();
+  const columnHelper = createColumnHelper<FormattedDeliverableTableRow>();
 
   const demonstrationNameColumn = columnHelper.accessor("demonstration.name", {
     header: "Demonstration Name",
@@ -54,7 +54,7 @@ export function DeliverableColumns({
 
   const dueDateColumn = createDateColumnDef(columnHelper, "dueDate", "Due Date");
   const submissionDateColumn = createDateColumnDef(columnHelper, "submissionDate", "Submission Date");
-  const statusColumn = columnHelper.accessor("status", {
+  const statusColumn = columnHelper.accessor("combinedStatus", {
     header: "Status",
     cell: highlightCell,
     filterFn: "arrIncludesSome",

--- a/client/src/components/table/tables/DeliverableActionButtons.tsx
+++ b/client/src/components/table/tables/DeliverableActionButtons.tsx
@@ -8,10 +8,10 @@ import { DeleteIcon } from "components/icons/Action/DeleteIcon";
 import { EditIcon } from "components/icons/Navigation/EditIcon";
 
 import { selectionTooltip } from "./actionTooltips";
-import type { DeliverableTableRow } from "./DeliverableTable";
+import type { FormattedDeliverableTableRow } from "./DeliverableTable";
 
 export const DeliverableActionButtons: React.FC<{
-  table: TanstackTable<DeliverableTableRow>;
+  table: TanstackTable<FormattedDeliverableTableRow>;
 }> = ({ table }) => {
   const { showEditDeliverableDialog } = useDialog();
   const selectedRows = table.getSelectedRowModel().rows;

--- a/client/src/components/table/tables/DeliverableTable.test.tsx
+++ b/client/src/components/table/tables/DeliverableTable.test.tsx
@@ -161,17 +161,139 @@ describe("DeliverableTable", () => {
     });
   });
 
-  it("renders status values as-is", () => {
+  it("renders finalized statuses as-is", () => {
     expect(
       formatDeliverableStatus({
-        status: "Upcoming",
+        status: "Accepted",
+        deliverableActions: [],
+        extensionRequests: [],
       })
-    ).toBe("Upcoming");
+    ).toBe("Accepted");
+
     expect(
       formatDeliverableStatus({
         status: "Approved",
+        deliverableActions: [],
+        extensionRequests: [
+          {
+            id: "1",
+            status: "Requested",
+          },
+        ],
       })
     ).toBe("Approved");
+
+    expect(
+      formatDeliverableStatus({
+        status: "Received and Filed",
+        deliverableActions: [
+          {
+            id: "1",
+            actionType: "Requested Resubmission",
+          },
+        ],
+        extensionRequests: [
+          {
+            id: "1",
+            status: "Requested",
+          },
+        ],
+      })
+    ).toBe("Received and Filed");
+  });
+
+  it("renders base status when there are no resubmissions or open extension requests", () => {
+    expect(
+      formatDeliverableStatus({
+        status: "Submitted",
+        deliverableActions: [],
+        extensionRequests: [],
+      })
+    ).toBe("Submitted");
+  });
+
+  it("renders extension requested suffix when an extension request is open", () => {
+    expect(
+      formatDeliverableStatus({
+        status: "Submitted",
+        deliverableActions: [],
+        extensionRequests: [
+          {
+            id: "1",
+            status: "Requested",
+          },
+        ],
+      })
+    ).toBe("Submitted - Extension Requested");
+  });
+
+  it("renders resubmission count when resubmissions have been requested", () => {
+    expect(
+      formatDeliverableStatus({
+        status: "Submitted",
+        deliverableActions: [
+          {
+            id: "1",
+            actionType: "Requested Resubmission",
+          },
+          {
+            id: "2",
+            actionType: "Requested Resubmission",
+          },
+        ],
+        extensionRequests: [],
+      })
+    ).toBe("Submitted (2)");
+  });
+
+  it("renders both resubmission count and extension requested suffix", () => {
+    expect(
+      formatDeliverableStatus({
+        status: "Under CMS Review",
+        deliverableActions: [
+          {
+            id: "1",
+            actionType: "Requested Resubmission",
+          },
+        ],
+        extensionRequests: [
+          {
+            id: "1",
+            status: "Requested",
+          },
+        ],
+      })
+    ).toBe("Under CMS Review (1) - Extension Requested");
+  });
+
+  it("ignores non-requested extension request statuses", () => {
+    expect(
+      formatDeliverableStatus({
+        status: "Submitted",
+        deliverableActions: [],
+        extensionRequests: [
+          {
+            id: "1",
+            status: "Approved",
+          },
+        ],
+      })
+    ).toBe("Submitted");
+  });
+
+  it("ignores non-resubmission deliverable actions", () => {
+    expect(
+      formatDeliverableStatus({
+        status: "Submitted",
+        deliverableActions: [
+          {
+            id: "1",
+            actionType: "Created Deliverable Slot",
+          },
+        ],
+        extensionRequests: [],
+      })
+    ).toBe("Submitted");
   });
 
   it("renders column filter dropdown", () => {

--- a/client/src/components/table/tables/DeliverableTable.tsx
+++ b/client/src/components/table/tables/DeliverableTable.tsx
@@ -41,6 +41,12 @@ export type DeliverableTableRow = Omit<
   };
   demonstrationTypes: Tag[];
   submissionDate?: string;
+  extensionRequests: Pick<Deliverable["extensionRequests"][number], "id" | "status">[];
+  deliverableActions: Pick<Deliverable["deliverableActions"][number], "id" | "actionType">[];
+};
+
+export type FormattedDeliverableTableRow = DeliverableTableRow & {
+  combinedStatus: string;
 };
 
 export type DeliverablesQueryResult = {
@@ -91,6 +97,14 @@ export const DELIVERABLES_PAGE_QUERY = gql`
         tagName
         approvalStatus
       }
+      extensionRequests {
+        id
+        status
+      }
+      deliverableActions {
+        id
+        actionType
+      }
     }
   }
 `;
@@ -127,6 +141,14 @@ export const STATE_USER_DELIVERABLES_PAGE_QUERY = gql`
                 }
               }
               dueDate
+              extensionRequests {
+                id
+                status
+              }
+              deliverableActions {
+                id
+                actionType
+              }
             }
           }
         }
@@ -138,7 +160,41 @@ export const STATE_USER_DELIVERABLES_PAGE_QUERY = gql`
 const EMPTY_ROWS_MESSAGE = "There are no assigned Deliverables at this time";
 const NO_RESULTS_FOUND = "No deliverables match your search.";
 
-export const formatDeliverableStatus = ({ status }: Pick<Deliverable, "status">) => status;
+const FINAL_STATUSES = ["Accepted", "Approved", "Received and Filed"];
+
+export const formatDeliverableStatus = (
+  deliverable: Pick<
+    DeliverableTableRow,
+    "status" | "deliverableActions" | "extensionRequests"
+  >
+) => {
+  const { status, deliverableActions, extensionRequests } = deliverable;
+
+  // Final statuses always display as-is
+  if (FINAL_STATUSES.includes(status)) {
+    return status;
+  }
+
+  const resubmissionsRequested = deliverableActions.filter(
+    (action) => action.actionType === "Requested Resubmission"
+  ).length;
+
+  const hasOpenExtensionRequest = extensionRequests.some(
+    (request) => request.status === "Requested"
+  );
+
+  let formattedStatus = status;
+
+  if (resubmissionsRequested > 0) {
+    formattedStatus += ` (${resubmissionsRequested})`;
+  }
+
+  if (hasOpenExtensionRequest) {
+    formattedStatus += " - Extension Requested";
+  }
+
+  return formattedStatus;
+};
 
 export const DeliverableTable: React.FC<{
   deliverables: DeliverableTableRow[];
@@ -153,11 +209,11 @@ export const DeliverableTable: React.FC<{
   });
   const formattedDeliverables = sortDeliverablesByDefault(deliverables).map((deliverable) => ({
     ...deliverable,
-    status: formatDeliverableStatus(deliverable),
+    combinedStatus: formatDeliverableStatus(deliverable),
   }));
 
   type RenderDeliverableActionButtons = NonNullable<
-    TableProps<DeliverableTableRow>["actionButtons"]
+    TableProps<FormattedDeliverableTableRow>["actionButtons"]
   >;
 
   const renderActionButtons: RenderDeliverableActionButtons = (table) => (
@@ -169,7 +225,7 @@ export const DeliverableTable: React.FC<{
   return (
     <div className="flex flex-col gap-[24px]" data-view-mode={viewMode}>
       {deliverableColumns && (
-        <Table<DeliverableTableRow>
+        <Table<FormattedDeliverableTableRow>
           data={formattedDeliverables}
           columns={deliverableColumns}
           keywordSearch={(table) => <KeywordSearch table={table} />}

--- a/client/src/components/table/tables/DemonstrationDeliverableTable.test.tsx
+++ b/client/src/components/table/tables/DemonstrationDeliverableTable.test.tsx
@@ -27,6 +27,8 @@ const baseDeliverable: Omit<DeliverableTableRow, "id" | "name" | "dueDate" | "st
     },
   },
   demonstrationTypes: [],
+  extensionRequests: [],
+  deliverableActions: [],
 };
 
 describe("DemonstrationDeliverableTable", () => {
@@ -141,6 +143,7 @@ describe("DemonstrationDeliverableTable", () => {
       name: "Editable Item",
       dueDate: new Date("2026-01-01"),
       status: "Upcoming" as const,
+      combinedStatus: "Upcoming",
       ...baseDeliverable,
     };
 

--- a/client/src/components/table/tables/DemonstrationDeliverableTable.tsx
+++ b/client/src/components/table/tables/DemonstrationDeliverableTable.tsx
@@ -4,7 +4,7 @@ import type { UserType } from "demos-server";
 import { DELIVERABLE_STATUSES, DELIVERABLE_TYPES } from "demos-server-constants";
 import { SecondaryButton } from "components/button";
 
-import type { DeliverableTableRow } from "./DeliverableTable";
+import type { DeliverableTableRow, FormattedDeliverableTableRow } from "./DeliverableTable";
 import { Table, type TableProps } from "components/table/Table";
 import { createDateColumnDef } from "components/table/columns/dateColumn";
 import { highlightCell, KeywordSearch } from "components/table/KeywordSearch";
@@ -32,7 +32,7 @@ export const DemonstrationDeliverableTable: React.FC<{
   noResultsFoundMessage = DEFAULT_NO_SEARCH_RESULTS_MESSAGE,
   onViewDeliverable,
 }) => {
-  const columnHelper = createColumnHelper<DeliverableTableRow>();
+  const columnHelper = createColumnHelper<FormattedDeliverableTableRow>();
   const { cmsOwnerOptions } = getDeliverableFilterOptions(deliverables);
   const viewColumn = columnHelper.display({
     id: "view",
@@ -68,7 +68,7 @@ export const DemonstrationDeliverableTable: React.FC<{
     }),
     createDateColumnDef(columnHelper, "dueDate", "Due Date"),
     createDateColumnDef(columnHelper, "submissionDate", "Submission Date"),
-    columnHelper.accessor("status", {
+    columnHelper.accessor("combinedStatus", {
       header: "Status",
       cell: highlightCell,
       filterFn: "arrIncludesSome",
@@ -101,7 +101,7 @@ export const DemonstrationDeliverableTable: React.FC<{
   ];
   const resolvedColumns = viewMode === "demos-state-user" ? columns : columnsWithCmsFields;
   type DemonstrationDeliverableActionButtons = NonNullable<
-    TableProps<DeliverableTableRow>["actionButtons"]
+    TableProps<FormattedDeliverableTableRow>["actionButtons"]
   >;
   const renderActionButtons: DemonstrationDeliverableActionButtons = (table) => (
     <DeliverableActionButtons table={table} />
@@ -110,11 +110,11 @@ export const DemonstrationDeliverableTable: React.FC<{
 
   const formattedDeliverables = sortDeliverablesByDefault(deliverables).map((deliverable) => ({
     ...deliverable,
-    status: formatDeliverableStatus(deliverable),
+    combinedStatus: formatDeliverableStatus(deliverable),
   }));
 
   return (
-    <Table<DeliverableTableRow>
+    <Table<FormattedDeliverableTableRow>
       data={formattedDeliverables}
       columns={resolvedColumns}
       keywordSearch={(table) => <KeywordSearch table={table} />}

--- a/client/src/mock-data/deliverableMocks.ts
+++ b/client/src/mock-data/deliverableMocks.ts
@@ -31,6 +31,8 @@ export const MOCK_DELIVERABLE_TABLE_ROW: DeliverableTableRow = {
   dueDate: new Date("2024-07-01"),
   status: "Upcoming",
   demonstrationTypes: [],
+  deliverableActions: [],
+  extensionRequests: [],
 };
 
 export const MOCK_DELIVERABLE_1: DeliverableDetailsManagementDeliverable = {


### PR DESCRIPTION
Implements logic for the "Combined Status Column"

Display <Status> when status is Accepted, Approved, or Received and Filed

For all other statuses (Upcoming, Past Due, Submitted or Under CMS Review):
- Display <Status> when there is no extension requested or extension is approved, rejected or withdrawn AND the resubmission requested count is 0
- Display <Status - Extension Requested> when an extension request is open AND the resubmission requested count is 0
- Display <Status (#)> when there is no extension requested or extension is approved, rejected or withdrawn AND the resubmission requested count > 0, where # represents the resubmission requested count
- Display <Status (#) - Extension Requested> when an extension request is open AND the resubmission requested count > 0, where # represents the resubmission requested count

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/c65c9335-f8b2-4dd9-986b-0c26636a53e3" />
