### PR TITLE
DEMOS-2108 — Request Extension button & Current Files toggle UI fixes

### DIFF
--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
@@ -14,7 +14,7 @@ import { TestProvider } from "test-utils/TestProvider";
 import { COMMENT_BOX_NAME } from "./sections/comment_box";
 import { DELIVERABLE_INFO_FIELDS_NAME,   BACK_TO_DELIVERABLES_BUTTON_NAME} from "./sections/DeliverableInfoFields";
 import { FILE_AND_HISTORY_TABS_NAME } from "./sections/FileAndHistoryTabs";
-// import { DELIVERABLE_BUTTONS_NAME } from "./sections/DeliverableButtons";
+import { REQUEST_EXTENSION_BUTTON_NAME } from "./sections/DeliverableButtons";
 import { DialogProvider } from "components/dialog/DialogContext";
 import {
   DELIVERABLE_REVIEW_NOTICE_NAME,
@@ -218,6 +218,22 @@ describe("DeliverableDetailsManagementPage", () => {
 
     expect(await screen.findByTestId("edit-deliverable-button")).not.toBeDisabled();
     expect(screen.getByTestId("delete-deliverable-button")).not.toBeDisabled();
+  });
+
+  it("shows only the Request Extension button for state users", async () => {
+    renderWithDeliverable(MOCK_DELIVERABLE_1, "demos-state-user");
+
+    expect(await screen.findByTestId(REQUEST_EXTENSION_BUTTON_NAME)).toBeInTheDocument();
+    expect(screen.queryByTestId("edit-deliverable-button")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("delete-deliverable-button")).not.toBeInTheDocument();
+  });
+
+  it("shows Request Extension alongside Edit and Delete for admin users", async () => {
+    renderWithDeliverable(MOCK_DELIVERABLE_1, "demos-admin");
+
+    expect(await screen.findByTestId(REQUEST_EXTENSION_BUTTON_NAME)).toBeInTheDocument();
+    expect(screen.getByTestId("edit-deliverable-button")).toBeInTheDocument();
+    expect(screen.getByTestId("delete-deliverable-button")).toBeInTheDocument();
   });
 
   it("shows not found state", async () => {

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -42,6 +42,12 @@ const EXTENSION_REVIEWER_PERSON_TYPES: ReadonlySet<PersonType> = new Set([
   "demos-cms-user",
 ]);
 
+// State users only get the Request Extension action; edit/delete is hidden for them.
+const EDIT_DELETE_PERSON_TYPES: ReadonlySet<PersonType> = new Set([
+  "demos-admin",
+  "demos-cms-user",
+]);
+
 export const GET_DELIVERABLE_DETAILS_QUERY_NAME = "GetDeliverableDetails";
 export const DELIVERABLE_DETAILS_QUERY = gql`
   query ${GET_DELIVERABLE_DETAILS_QUERY_NAME}($id: ID!) {
@@ -227,6 +233,7 @@ export const DeliverableDetailsManagementPage: React.FC<{
 
   const canReviewExtension =
     EXTENSION_REVIEWER_PERSON_TYPES.has(userPersonType) && pendingExtensionRequest !== null;
+  const canEditDelete = EDIT_DELETE_PERSON_TYPES.has(userPersonType);
 
   const handleReviewExtensionRequest = () => {
     if (!pendingExtensionRequest) return;
@@ -259,16 +266,17 @@ export const DeliverableDetailsManagementPage: React.FC<{
             showAdditionalDetailsToggle
             onToggleAdditionalDetails={handleToggleAdditionalDetails}
           />
-          {/* I'm sure these go somewhere but they arent in my spec sheet. Uncomment at your leisure */}
-          <DeliverableButtons
-            deliverable={data.deliverable}
-          />
-          <EditAndDeleteButtonGroup
-            onDelete={handleDeleteDeliverable}
-            onEdit={handleEditDeliverable}
-            deleteDisabled={isFinalized}
-            editDisabled={isFinalized}
-          />
+          <div className="flex items-start gap-2">
+            <DeliverableButtons deliverable={data.deliverable} />
+            {canEditDelete ? (
+              <EditAndDeleteButtonGroup
+                onDelete={handleDeleteDeliverable}
+                onEdit={handleEditDeliverable}
+                deleteDisabled={isFinalized}
+                editDisabled={isFinalized}
+              />
+            ) : null}
+          </div>
         </div>
         {canStartReview ? (
           <PendingReviewNotice

--- a/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
+++ b/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
@@ -158,6 +158,16 @@ describe("StateFilesTab", () => {
       await user.click(submitButton);
       expect(onSubmit).toHaveBeenCalledTimes(1);
     });
+
+    it("renders the Current toggle with horizontal sizing", () => {
+      renderTab();
+
+      const toggle = screen.getByTestId("toggle-current-file-a");
+      // Width must exceed height so the switch renders horizontally, not as a
+      // vertical sliver. Guards against the spacing-scale regression (w-9/h-5).
+      expect(toggle).toHaveClass("w-[36px]", "h-[20px]");
+      expect(toggle).not.toHaveClass("w-9", "h-5");
+    });
   });
 
   describe("when disabled", () => {

--- a/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
+++ b/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
@@ -159,14 +159,16 @@ describe("StateFilesTab", () => {
       expect(onSubmit).toHaveBeenCalledTimes(1);
     });
 
-    it("renders the Current toggle with horizontal sizing", () => {
+    it("renders the Current toggle as the shared styled switch", () => {
       renderTab();
 
-      const toggle = screen.getByTestId("toggle-current-file-a");
-      // Width must exceed height so the switch renders horizontally, not as a
-      // vertical sliver. Guards against the spacing-scale regression (w-9/h-5).
-      expect(toggle).toHaveClass("w-[36px]", "h-[20px]");
-      expect(toggle).not.toHaveClass("w-9", "h-5");
+      // react-switch renders a role="switch" element with fixed px sizing, so
+      // it's immune to the custom Tailwind spacing theme that previously made
+      // the hand-rolled toggle render as a vertical sliver.
+      const toggle = screen.getByRole("switch", {
+        name: /toggle current file file-a/i,
+      });
+      expect(toggle).toBeInTheDocument();
     });
   });
 

--- a/client/src/pages/deliverables/sections/fileColumns.tsx
+++ b/client/src/pages/deliverables/sections/fileColumns.tsx
@@ -89,6 +89,9 @@ export function makeCmsFileColumns() {
   ];
 }
 
+// Sizing uses explicit px instead of the spacing scale: this project's custom
+// Tailwind theme remaps `--spacing-*`, so `h-5`/`w-9`/`h-4` resolve to large,
+// mismatched values that render the switch as a tall vertical sliver.
 const CurrentToggle: React.FC<{ fileId: string }> = ({ fileId }) => (
   <button
     type="button"
@@ -96,8 +99,8 @@ const CurrentToggle: React.FC<{ fileId: string }> = ({ fileId }) => (
     aria-checked={false}
     aria-label={`Toggle current file ${fileId}`}
     data-testid={`toggle-current-${fileId}`}
-    className="relative inline-flex h-5 w-9 items-center rounded-full bg-border-fields focus:outline-none focus:ring-2 focus:ring-action-focus"
+    className="relative inline-flex h-[20px] w-[36px] shrink-0 items-center rounded-full bg-border-fields focus:outline-none focus:ring-2 focus:ring-action-focus"
   >
-    <span className="inline-block h-4 w-4 translate-x-1 transform rounded-full bg-white" />
+    <span className="inline-block h-[16px] w-[16px] translate-x-[2px] transform rounded-full bg-white" />
   </button>
 );

--- a/client/src/pages/deliverables/sections/fileColumns.tsx
+++ b/client/src/pages/deliverables/sections/fileColumns.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { createColumnHelper } from "@tanstack/react-table";
+import Switch from "react-switch";
 
 import { DOCUMENT_TYPES } from "demos-server-constants";
 import { SecondaryButton } from "components/button";
@@ -89,18 +90,24 @@ export function makeCmsFileColumns() {
   ];
 }
 
-// Sizing uses explicit px instead of the spacing scale: this project's custom
-// Tailwind theme remaps `--spacing-*`, so `h-5`/`w-9`/`h-4` resolve to large,
-// mismatched values that render the switch as a tall vertical sliver.
+// Uses the shared `react-switch` styling (matching ContactColumns) so the
+// toggle renders consistently and isn't affected by the custom Tailwind
+// spacing theme.
 const CurrentToggle: React.FC<{ fileId: string }> = ({ fileId }) => (
-  <button
-    type="button"
-    role="switch"
-    aria-checked={false}
-    aria-label={`Toggle current file ${fileId}`}
-    data-testid={`toggle-current-${fileId}`}
-    className="relative inline-flex h-[20px] w-[36px] shrink-0 items-center rounded-full bg-border-fields focus:outline-none focus:ring-2 focus:ring-action-focus"
-  >
-    <span className="inline-block h-[16px] w-[16px] translate-x-[2px] transform rounded-full bg-white" />
-  </button>
+  <div className="inline-flex items-center justify-center">
+    <Switch
+      checked={false}
+      onChange={() => {}}
+      aria-label={`Toggle current file ${fileId}`}
+      onColor="#6B7280"
+      offColor="#E5E7EB"
+      checkedIcon={false}
+      uncheckedIcon={false}
+      height={18}
+      width={40}
+      handleDiameter={24}
+      boxShadow="0 2px 8px rgba(0, 0, 0, 0.6)"
+      activeBoxShadow="0 0 2px 3px #3bf"
+    />
+  </div>
 );


### PR DESCRIPTION
**Request Extension button placement / role gating**
`DeliverableDetailsManagementPage.tsx`
- Grouped `Request Extension` + edit/delete into one right-aligned cluster (was scattered by `justify-between`), matching the mockup.
- Added `EDIT_DELETE_PERSON_TYPES` (admin + cms) and gated the edit/delete group on it. State users now see **only** Request Extension; admin sees both in the same section.
- Removed stale "uncomment at your leisure" comment.

**Current Files toggle rendering vertically**
`fileColumns.tsx`
- `CurrentToggle` used stock-Tailwind sizes (`h-5 w-9`), but this project's custom Tailwind v4 spacing theme remaps `--spacing-*`, so it rendered as a tall vertical sliver.
- Replaced the hand-rolled toggle with the shared `react-switch` `<Switch>` (same styling as `ContactColumns.tsx`); fixed px sizing is immune to the spacing theme.

_Note: the Figma italic text was a Figma-only issue — `SecondaryButton` is not italic, no change needed._


<img width="1920" height="883" alt="image" src="https://github.com/user-attachments/assets/94aea87d-e2a3-4d37-bea4-1285c6532674" />
