### PR TITLE
DEMOS-2020-add-login-info-to-user-object

### DIFF
--- a/server/src/model/user/userResolvers.test.ts
+++ b/server/src/model/user/userResolvers.test.ts
@@ -1,17 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { User as PrismaUser } from "@prisma/client";
-import type { GraphQLContext } from "../../auth";
-import { userResolvers } from "./userResolvers";
-
-// Mock imports
-import { getManyDocuments } from "../document";
-import { getUser } from "./userData";
-import { getPerson } from "../person";
-import {
-  selectManySystemRoleAssignments,
-  SystemRoleAssignmentQueryResult,
-} from "../systemRoleAssignment";
 import { DeepPartial } from "../../testUtilities";
+
+import { User as PrismaUser } from "@prisma/client";
+import type { SystemRoleAssignmentQueryResult } from "../systemRoleAssignment";
+import type { GraphQLContext } from "../../auth";
+
+import { userResolvers } from "./userResolvers";
 
 vi.mock("../../prismaClient", () => ({
   prisma: vi.fn(),
@@ -32,6 +26,16 @@ vi.mock("./userData", () => ({
 vi.mock("../person", () => ({
   getPerson: vi.fn(),
 }));
+
+vi.mock("../userSession/queries", () => ({
+  selectLastLoginForUser: vi.fn(),
+}));
+
+import { selectManySystemRoleAssignments } from "../systemRoleAssignment";
+import { getManyDocuments } from "../document";
+import { getUser } from "./userData";
+import { getPerson } from "../person";
+import { selectLastLoginForUser } from "../userSession/queries";
 
 describe("userResolvers", () => {
   const testUserId = "abc123";
@@ -147,6 +151,16 @@ describe("userResolvers", () => {
         personId: "abc123",
       });
       expect(result).toStrictEqual(["permission-1", "permission-2", "permission-3"]);
+    });
+  });
+
+  describe("User.lastLogin", () => {
+    it("delegates to selectLastLoginForUser", async () => {
+      const testUser = {
+        id: "abc123",
+      } as PrismaUser;
+      await userResolvers.User.lastLogin(testUser);
+      expect(selectLastLoginForUser).toHaveBeenCalledExactlyOnceWith(testUser.id);
     });
   });
 });

--- a/server/src/model/user/userResolvers.ts
+++ b/server/src/model/user/userResolvers.ts
@@ -7,6 +7,7 @@ import { getUser } from "./userData";
 import { getPerson } from "../person";
 import { Permission, Role } from "../../types";
 import { selectManySystemRoleAssignments } from "../systemRoleAssignment";
+import { selectLastLoginForUser } from "../userSession/queries";
 
 export const userResolvers = {
   Query: {
@@ -32,6 +33,9 @@ export const userResolvers = {
         });
       });
       return Array.from(permissions);
+    },
+    lastLogin: async (parent: PrismaUser): Promise<Date | null> => {
+      return await selectLastLoginForUser(parent.id);
     },
   },
 };

--- a/server/src/model/user/userSchema.ts
+++ b/server/src/model/user/userSchema.ts
@@ -11,6 +11,7 @@ export const userSchema = gql`
     ownedDeliverables: [Deliverable!]!
     systemRoles: [SystemRole!]!
     permissions: [Permission!]!
+    lastLogin: DateTime
     createdAt: DateTime!
     updatedAt: DateTime!
   }
@@ -29,6 +30,7 @@ export interface User {
   ownedDeliverables: Deliverable[];
   systemRoles: SystemRole[];
   permissions: Permission[];
+  lastLogin: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/server/src/model/userSession/queries/index.ts
+++ b/server/src/model/userSession/queries/index.ts
@@ -1,1 +1,2 @@
+export { selectLastLoginForUser } from "./selectLastLoginForUser";
 export { upsertUserSession } from "./upsertUserSession";

--- a/server/src/model/userSession/queries/selectLastLoginForUser.test.ts
+++ b/server/src/model/userSession/queries/selectLastLoginForUser.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { selectLastLoginForUser } from "./selectLastLoginForUser";
+
+vi.mock("../../../prismaClient", () => ({
+  prisma: vi.fn(),
+}));
+
+import { prisma } from "../../../prismaClient";
+
+describe("selectLastLoginForUser", () => {
+  const testUserId = "9a85bee6-9cb1-4714-af5d-ecc50ca3ff64";
+
+  const mockLastLogin = new Date(2025, 11, 3, 1, 15, 22, 909);
+  const regularMocks = {
+    userSession: {
+      aggregate: vi.fn(),
+    },
+  };
+  const mockPrismaClient = {
+    userSession: {
+      aggregate: regularMocks.userSession.aggregate,
+    },
+  };
+  const transactionMocks = {
+    userSession: {
+      aggregate: vi.fn(),
+    },
+  };
+  const mockTransaction = {
+    userSession: {
+      aggregate: transactionMocks.userSession.aggregate,
+    },
+  };
+
+  const expectedCall = {
+    _max: {
+      authTime: true,
+    },
+    where: {
+      userId: testUserId,
+    },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(prisma).mockReturnValue(mockPrismaClient as any);
+  });
+
+  it("should find the most recent login using a new client if no transaction is given", async () => {
+    vi.mocked(regularMocks.userSession.aggregate).mockReturnValue({
+      _max: {
+        authTime: mockLastLogin,
+      },
+    });
+    await selectLastLoginForUser(testUserId);
+    expect(prisma).toHaveBeenCalledOnce();
+    expect(regularMocks.userSession.aggregate).toHaveBeenCalledExactlyOnceWith(expectedCall);
+    expect(transactionMocks.userSession.aggregate).not.toHaveBeenCalled();
+  });
+
+  it("should find the most recent login using a transaction if one is given", async () => {
+    vi.mocked(transactionMocks.userSession.aggregate).mockReturnValue({
+      _max: {
+        authTime: mockLastLogin,
+      },
+    });
+    await selectLastLoginForUser(testUserId, mockTransaction as any);
+    expect(prisma).not.toHaveBeenCalledOnce();
+    expect(regularMocks.userSession.aggregate).not.toHaveBeenCalled();
+    expect(transactionMocks.userSession.aggregate).toHaveBeenCalledExactlyOnceWith(expectedCall);
+  });
+
+  it("should return null if the aggregate is null", async () => {
+    vi.mocked(regularMocks.userSession.aggregate).mockReturnValue({
+      _max: {
+        authTime: null,
+      },
+    });
+    const result = await selectLastLoginForUser(testUserId);
+    expect(result).toBeNull();
+    expect(prisma).toHaveBeenCalledOnce();
+    expect(regularMocks.userSession.aggregate).toHaveBeenCalledExactlyOnceWith(expectedCall);
+    expect(transactionMocks.userSession.aggregate).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/model/userSession/queries/selectLastLoginForUser.ts
+++ b/server/src/model/userSession/queries/selectLastLoginForUser.ts
@@ -1,0 +1,17 @@
+import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+
+export async function selectLastLoginForUser(
+  userId: string,
+  tx?: PrismaTransactionClient
+): Promise<Date | null> {
+  const prismaClient = tx ?? prisma();
+  const result = await prismaClient.userSession.aggregate({
+    _max: {
+      authTime: true,
+    },
+    where: {
+      userId: userId,
+    },
+  });
+  return result._max.authTime;
+}


### PR DESCRIPTION
This just adds the last login field to the `User` object, which right now is only queried directly via `currentUser`. It technically is nullable even though in practice it's not possible to have a user get created without there being at least one session (because of how the creation happens coming from IDM).