### PR TITLE
DEMOS-1911-nightly-cron-past-due

### DIFF
--- a/server/src/sql/cron_schedules.sql
+++ b/server/src/sql/cron_schedules.sql
@@ -15,7 +15,7 @@ BEGIN
 END
 $$;
 
--- update_federal_comment_phase_status
+-- nightly-update-federal-comment-phase-status
 -- Scheduled to run at 00:05 Eastern
 -- Time is in UTC, so during EDT will run at 23:05 and then 00:05
 -- During EST, will run at 00:05 and then 01:05
@@ -23,4 +23,12 @@ SELECT cron.schedule(
     'nightly-update-federal-comment-phase-status',
     '5 4,5 * * *',
     'CALL demos_app.update_federal_comment_phase_status();'
+);
+
+-- nightly-mark-deliverables-past-due
+-- Scheduled to run at 00:10 Eastern, same setup as above
+SELECT cron.schedule(
+    'nightly-mark-deliverables-past-due',
+    '10 4,5 * * *',
+    'CALL demos_app.mark_deliverables_as_past_due();'
 );

--- a/server/src/sql/functions.sql
+++ b/server/src/sql/functions.sql
@@ -1326,3 +1326,58 @@ CREATE TRIGGER check_that_main_record_deleted_from_document
 BEFORE DELETE ON demos_app.budget_neutrality_workbook
 FOR EACH ROW
 EXECUTE FUNCTION demos_app.check_that_main_record_deleted_from_document();
+
+-- mark_deliverables_as_past_due
+CREATE PROCEDURE demos_app.mark_deliverables_as_past_due()
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    WITH past_due_deliverables AS (
+        UPDATE
+            demos_app.deliverable
+        SET
+            status_id = 'Past Due',
+            updated_at = CURRENT_TIMESTAMP
+        WHERE
+            status_id = 'Upcoming'
+            AND due_date < CURRENT_TIMESTAMP
+        RETURNING
+            id, due_date
+    )
+    INSERT INTO
+        demos_app.deliverable_action (
+            id,
+            action_timestamp,
+            deliverable_id,
+            action_type_id,
+            old_status_id,
+            new_status_id,
+            note,
+            due_date_change_allowed,
+            should_have_note,
+            should_have_user_id,
+            extension_id_optional,
+            old_due_date,
+            new_due_date,
+            user_id
+        )
+    SELECT
+        gen_random_uuid(),
+        CURRENT_TIMESTAMP,
+        pdd.id,
+        'Marked as Past Due',
+        'Upcoming',
+        'Past Due',
+        NULL,
+        FALSE,
+        FALSE,
+        FALSE,
+        TRUE,
+        pdd.due_date,
+        pdd.due_date,
+        NULL
+    FROM
+        past_due_deliverables AS pdd;
+
+END;
+$$;


### PR DESCRIPTION
This turned out to be a fair bit simpler than I was afraid, mostly because this logic is simpler than the previous iteration of this (dealing with the federal comment period). I set the cronjob to run at 00:10 nightly; because the times are UTC, it will run at 11:10PM and 12:10AM sometimes, and 12:10AM and 1:10AM other times. The process is fast and there's no downside in running it multiple times, so there's no risk here.

The SQL is very straightforward and all runs in a single query, meaning we don't have to worry about transaction control. It uses `UPDATE RETURNING` to make the change to `deliverable` and then inserts into `deliverable_action` with a SELECT from that.