### PR TITLE
DEMOS-2159: Update pipelines to handle errors during deploy

### DIFF
--- a/pipelines/Jenkinsfile.cdk
+++ b/pipelines/Jenkinsfile.cdk
@@ -12,12 +12,18 @@ pipeline {
     buildDiscarder(retentionPolicy(env.BRANCH_NAME))
   }
 
+  parameters {
+    booleanParam(name: 'HANDLE_ERRORS', defaultValue: false, description: 'Allow build to continue when errors occur')
+  }
+
   stages {
     stage('CDK - Snyk') {
       steps {
         script {
-          if (hasChange('deployment')) {
-            snykScan('deployment')
+          handleError(params.HANDLE_ERRORS) {
+            if (hasChange('deployment')) {
+              snykScan('deployment')
+            }
           }
         }
       }
@@ -26,13 +32,15 @@ pipeline {
     stage('CDK - Lint') {
       steps {
         script {
-          if (hasChange('deployment')) {
-            dirCon('deployment', 'node') {
-              sh '''
-            npm ci
-            npm run lint
-            npm run tsc:ci
-            '''
+          handleError(params.HANDLE_ERRORS) {
+            if (hasChange('deployment')) {
+              dirCon('deployment', 'node') {
+                sh '''
+              npm ci
+              npm run lint
+              npm run tsc:ci
+              '''
+              }
             }
           }
         }
@@ -42,19 +50,21 @@ pipeline {
     stage('CDK - Test') {
       steps {
         script {
-          if (hasChange('deployment')) {
-            dirCon('deployment', 'node') {
-              sh '''
-            mkdir ../client/dist
-            mkdir ../server/build
-            touch ../server/build/server.cjs
+          handleError(params.HANDLE_ERRORS) {
+            if (hasChange('deployment')) {
+              dirCon('deployment', 'node') {
+                sh '''
+              mkdir ../client/dist
+              mkdir ../server/build
+              touch ../server/build/server.cjs
 
-            # These are needed for the built-in CDK bundling
-            apk add bash
-            npm i -g esbuild
+              # These are needed for the built-in CDK bundling
+              apk add bash
+              npm i -g esbuild
 
-            npm run test:ci
-            '''
+              npm run test:ci
+              '''
+              }
             }
           }
         }
@@ -64,8 +74,10 @@ pipeline {
     stage('CDK - Snyk Code Scan') {
       steps {
         script {
-          if (hasChange('deployment')) {
-            snykCodeScan('deployment')
+          handleError(true) {
+            if (hasChange('deployment')) {
+              snykCodeScan('deployment')
+            }
           }
         }
       }
@@ -74,18 +86,20 @@ pipeline {
     stage('CDK - Synth') {
       steps {
         script {
-          if (hasChange('deployment')) {
-            assumeRole(accountNumber: env.DEMOS_AWS_NONPROD_ACCOUNT_NUMBER)
-            dirCon('shared_library', 'node') {
-              sh '''
-            npm ci
-            npm run build
-            '''
-            }
-            dirCon('deployment', 'node') {
-              sh '''
-            npm run synth:dev
-            '''
+          handleError(params.HANDLE_ERRORS) {
+            if (hasChange('deployment')) {
+              assumeRole(accountNumber: env.DEMOS_AWS_NONPROD_ACCOUNT_NUMBER)
+              dirCon('shared_library', 'node') {
+                sh '''
+              npm ci
+              npm run build
+              '''
+              }
+              dirCon('deployment', 'node') {
+                sh '''
+              npm run synth:dev
+              '''
+              }
             }
           }
         }
@@ -94,11 +108,13 @@ pipeline {
     stage('CDK - Checkov') {
       steps {
         script {
-          if (hasChange('deployment')) {
-            dirCon('deployment', 'checkov') {
-              sh '''
-            checkov -d cdk.out --config-file .checkov.yml
-            '''
+          handleError(params.HANDLE_ERRORS) {
+            if (hasChange('deployment')) {
+              dirCon('deployment', 'checkov') {
+                sh '''
+              checkov -d cdk.out --config-file .checkov.yml
+              '''
+              }
             }
           }
         }
@@ -111,6 +127,9 @@ pipeline {
       slackPipelineFail('CDK')
     }
     always {
+      script {
+        handleError.setFailureDescription()
+      }
       cleanWs(deleteDirs: true)
     }
   }

--- a/pipelines/Jenkinsfile.client
+++ b/pipelines/Jenkinsfile.client
@@ -6,19 +6,24 @@ pipeline {
       yaml kubeBlock(containerNames:['node', 'snyk'], opts: [
         NODE_CPU_REQUEST: '4000m',
         NODE_CPU_LIMIT: '8000m'
-      ])
-    }
+    ])
   }
+}
 
-  options {
-    disableConcurrentBuilds(abortPrevious: true)
-    buildDiscarder(retentionPolicy(env.BRANCH_NAME))
-  }
+options {
+  disableConcurrentBuilds(abortPrevious: true)
+  buildDiscarder(retentionPolicy(env.BRANCH_NAME))
+}
 
-  stages {
-    stage('Build Shared Library') {
-      steps {
-        script {
+parameters {
+  booleanParam(name: 'HANDLE_ERRORS', defaultValue: false, description: 'Allow build to continue when errors occur')
+}
+
+stages {
+  stage('Build Shared Library') {
+    steps {
+      script {
+        handleError(params.HANDLE_ERRORS) {
           if (fileExists('shared_library')) {
             dirCon('shared_library', 'node') {
               sh '''
@@ -30,28 +35,32 @@ pipeline {
         }
       }
     }
-    stage('Client - Snyk') {
-      steps {
-        script {
+  }
+  stage('Client - Snyk') {
+    steps {
+      script {
+        handleError(params.HANDLE_ERRORS) {
           if (hasChange(changePaths)) {
             snykScan('client')
           }
         }
       }
     }
+  }
 
-    stage('Client - Lint') {
-      steps {
-        script {
+  stage('Client - Lint') {
+    steps {
+      script {
+        handleError(params.HANDLE_ERRORS) {
           if (hasChange(changePaths)) {
             dirCon('client', 'node') {
               sh '''
               # Ensure shared_library is installed and built before installing client deps
               if [ -d ../shared_library ]; then
-                cd ../shared_library
-                npm ci
-                npm run build || true
-                cd -
+              cd ../shared_library
+              npm ci
+              npm run build || true
+              cd -
               fi
 
               npm ci
@@ -64,38 +73,46 @@ pipeline {
         }
       }
     }
+  }
 
-    stage('Client - Unit Test') {
-      steps {
-        script {
+  stage('Client - Unit Test') {
+    steps {
+      script {
+        handleError(params.HANDLE_ERRORS) {
           if (hasChange(changePaths)) {
             dirCon('client', 'node') {
               sh '''
-                npm run coverage:ci
-                '''
+              npm run coverage:ci
+              '''
             }
           }
         }
       }
     }
+  }
 
-    stage('Client - Code Scan') {
-          steps {
-            script {
-              if (hasChange('client')) {
+  stage('Client - Code Scan') {
+    steps {
+      script {
+        handleError(params.HANDLE_ERRORS) {
+          if (hasChange('client')) {
             snykCodeScan('client')
-              }
-            }
           }
+        }
+      }
     }
   }
+}
 
-  post {
-    failure {
-      slackPipelineFail('Client')
-    }
-    always {
-      cleanWs(deleteDirs: true)
-    }
+post {
+  failure {
+    slackPipelineFail('Client')
   }
+  always {
+    script {
+      handleError.setFailureDescription()
+    }
+    cleanWs(deleteDirs: true)
+  }
+}
 }

--- a/pipelines/Jenkinsfile.deploy
+++ b/pipelines/Jenkinsfile.deploy
@@ -1,6 +1,8 @@
+def advisoryFailures = []
+
 pipeline {
   agent {
-    kubernetes { 
+    kubernetes {
       yaml kubeBlock(containerNames:["node", "aws-cli"])
     }
   }
@@ -13,7 +15,7 @@ pipeline {
   environment {
     NO_COLOR = 1
   }
-  
+
   stages {
     stage('Set env from branch') {
       steps {
@@ -53,13 +55,11 @@ pipeline {
               parallel(
                 'Build Client': {
                   dirCon('deployment','node') {
-                      sh "npx tsx demosctl/index build:client ${env.STAGE}"
-                      
-                      
+                    sh "npx tsx demosctl/index build:client ${env.STAGE}"
                   }
                 }, 'Build Server': {
                   dirCon('deployment', 'node') {
-                      sh "npx tsx demosctl/index build:server ${env.STAGE}"
+                    sh "npx tsx demosctl/index build:server ${env.STAGE}"
                   }
                 }
               )
@@ -68,22 +68,42 @@ pipeline {
         }
         stage('Test Client') {
           steps {
-            build(job: "Client/$BRANCH_NAME", propagate: true, wait: true)
+            script {
+              def clientBuild = build(job: "Client/$BRANCH_NAME", propagate: false, wait: true, parameters: [booleanParam(name: 'HANDLE_ERRORS', value: true)])
+              if (clientBuild.description) {
+                advisoryFailures.addAll(clientBuild.description.split(/\|/))
+              }
+            }
           }
         }
         stage('Test Server') {
           steps {
-            build(job: "Server/$BRANCH_NAME", propagate: true, wait: true)
+            script {
+              def serverBuild = build(job: "Server/$BRANCH_NAME", propagate: false, wait: true, parameters: [booleanParam(name: 'HANDLE_ERRORS', value: true)])
+              if (serverBuild.description) {
+                advisoryFailures.addAll(serverBuild.description.split(/\|/))
+              }
+            }
           }
         }
         stage('Test CDK') {
           steps {
-            build(job: "CDK/$BRANCH_NAME", propagate: true, wait: true)
+            script {
+              def cdkBuild = build(job: "CDK/$BRANCH_NAME", propagate: false, wait: true, parameters: [booleanParam(name: 'HANDLE_ERRORS', value: true)])
+              if (cdkBuild.description) {
+                advisoryFailures.addAll(cdkBuild.description.split(/\|/))
+              }
+            }
           }
         }
         stage('Test Lambdas') {
           steps {
-            build(job: "Lambdas/$BRANCH_NAME", propagate: true, wait: true)
+            script {
+              def lambdasBuild = build(job: "Lambdas/$BRANCH_NAME", propagate: false, wait: true, parameters: [booleanParam(name: 'HANDLE_ERRORS', value: true)])
+              if (lambdasBuild.description) {
+                advisoryFailures.addAll(lambdasBuild.description.split(/\|/))
+              }
+            }
           }
         }
       }
@@ -110,28 +130,36 @@ pipeline {
 
     stage('Deploy') {
       steps {
-          script {
-            dirCon('deployment','node') {
-              sh """
-              export UI_COMMIT_HASH=${env.GIT_COMMIT}
-              export API_COMMIT_HASH=${env.GIT_COMMIT}
-              npx tsx demosctl/index deploy:all ${env.STAGE}
-              """
-            }
+        script {
+          dirCon('deployment','node') {
+            sh """
+            export UI_COMMIT_HASH=${env.GIT_COMMIT}
+            export API_COMMIT_HASH=${env.GIT_COMMIT}
+            npx tsx demosctl/index deploy:all ${env.STAGE}
+            """
           }
+        }
       }
     }
   }
 
-    post {
-      success {
-        slackSend(color: "good", message: "${env.STAGE.toUpperCase()} Deployment succeeded!\n\nJenkins Build: <${env.BUILD_URL}|${env.BUILD_NUMBER}>\nCommit Hash: ${env.GIT_COMMIT}")
+  post {
+    success {
+      script {
+        if (advisoryFailures) {
+          def advisoryText = advisoryFailures.findAll { it }.collect { "- ${it}" }.join("\n")
+          slackSend(color: "warning", message: "${env.STAGE.toUpperCase()} Deployment completed with check failures\n\nAdvisory failures:\n${advisoryText}\n\nJenkins Build: <${env.BUILD_URL}|${env.BUILD_NUMBER}>\nCommit Hash: <${env.GIT_URL.replaceFirst(/\.git$/, '')}/commit/${env.GIT_COMMIT}|${env.GIT_COMMIT}>")
+
+        } else {
+          slackSend(color: "good", message: "${env.STAGE.toUpperCase()} Deployment succeeded!\n\nJenkins Build: <${env.BUILD_URL}|${env.BUILD_NUMBER}>\nCommit Hash: <${env.GIT_URL.replaceFirst(/\.git$/, '')}/commit/${env.GIT_COMMIT}|${env.GIT_COMMIT}>")
+        }
       }
-      failure {
-        slackSend(color: "danger", message: "${env.STAGE.toUpperCase()} Deployment failed:\n\nJenkins Build: <${env.BUILD_URL}|${env.BUILD_NUMBER}>\nCommit Hash: ${env.GIT_COMMIT}")
-      }
+    }
+    failure {
+      slackSend(color: "danger", message: "${env.STAGE.toUpperCase()} Deployment failed:\n\nJenkins Build: <${env.BUILD_URL}|${env.BUILD_NUMBER}>\nCommit Hash: ${env.GIT_COMMIT}")
+    }
     always {
       cleanWs(deleteDirs: true)
     }
-    }
+  }
 }

--- a/pipelines/Jenkinsfile.lambdas
+++ b/pipelines/Jenkinsfile.lambdas
@@ -4,31 +4,36 @@ pipeline {
       yaml kubeBlock(containerNames:['node', 'snyk'], opts: [
         NODE_IMAGE: 'artifactory.cloud.cms.gov/docker/node:24-alpine'
     ])
-    }
   }
+}
 
-  options {
-    disableConcurrentBuilds(abortPrevious: true)
-    buildDiscarder(retentionPolicy(env.BRANCH_NAME))
-  }
+options {
+  disableConcurrentBuilds(abortPrevious: true)
+  buildDiscarder(retentionPolicy(env.BRANCH_NAME))
+}
 
-  stages {
-    stage('Prep Shared Library') {
-      steps {
-        script {
-          dirCon('shared_library', 'node') {
-            sh '''
-              npm ci
-              npm run build || true
-            '''
-          }
+parameters {
+  booleanParam(name: 'HANDLE_ERRORS', defaultValue: false, description: 'Allow build to continue when errors occur')
+}
+
+stages {
+  stage('Prep Shared Library') {
+    steps {
+      script {
+        dirCon('shared_library', 'node') {
+          sh '''
+          npm ci
+          npm run build || true
+          '''
         }
       }
     }
+  }
 
-    stage('Lambdas - Snyk - All') {
-      steps {
-        script {
+  stage('Lambdas - Snyk - All') {
+    steps {
+      script {
+        handleError(params.HANDLE_ERRORS) {
           if (hasChange('lambdas')) {
             snykScan('lambdas/authorizer')
             snykScan('lambdas/dbRoleManagement')
@@ -41,110 +46,124 @@ pipeline {
         }
       }
     }
+  }
 
-    stage('Lambdas - Test - All') {
-      failFast true
-      parallel {
-        stage('Unit Test - Authorizer') {
-          steps {
-            script {
+  stage('Lambdas - Test - All') {
+    failFast true
+    parallel {
+      stage('Unit Test - Authorizer') {
+        steps {
+          script {
+            handleError(params.HANDLE_ERRORS) {
               if (hasChange('lambdas')) {
                 dirCon('lambdas/authorizer', 'node') {
                   sh '''
-                npm ci
-                npm run lint
-                npm run test
-                '''
+                  npm ci
+                  npm run lint
+                  npm run test
+                  '''
                 }
               }
             }
           }
         }
-        stage('Unit Test - DB Role Management') {
-          steps {
-            script {
+      }
+      stage('Lambdas - Unit Test - DB Role Management') {
+        steps {
+          script {
+            handleError(params.HANDLE_ERRORS) {
               if (hasChange('lambdas')) {
                 dirCon('lambdas/dbRoleManagement', 'node') {
                   sh '''
-                npm ci
-                npm run lint
-                npm run test
-                '''
+                  npm ci
+                  npm run lint
+                  npm run test
+                  '''
                 }
               }
             }
           }
         }
-        stage('Unit Test - File Process') {
-          steps {
-            script {
+      }
+      stage('Lambdas - Unit Test - File Process') {
+        steps {
+          script {
+            handleError(params.HANDLE_ERRORS) {
               if (hasChange('lambdas')) {
                 dirCon('lambdas/fileprocess', 'node') {
                   sh '''
-                npm ci
-                npm run lint
-                npm run test
-                '''
+                  npm ci
+                  npm run lint
+                  npm run test
+                  '''
                 }
               }
             }
           }
         }
-        stage('Unit Test - UI Path') {
-          steps {
-            script {
+      }
+      stage('Lambdas - Unit Test - UI Path') {
+        steps {
+          script {
+            handleError(params.HANDLE_ERRORS) {
               if (hasChange('lambdas')) {
                 dirCon('lambdas/UIPath', 'node') {
                   sh '''
-                npm ci
-                npm run lint
-                npm run test
-                '''
+                  npm ci
+                  npm run lint
+                  npm run test
+                  '''
                 }
               }
             }
           }
         }
-        stage('Unit Test - Delete Infected File') {
-          steps {
-            script {
+      }
+      stage('Lambdas - Unit Test - Delete Infected File') {
+        steps {
+          script {
+            handleError(params.HANDLE_ERRORS) {
               if (hasChange('lambdas')) {
                 dirCon('lambdas/deleteinfectedfile', 'node') {
                   sh '''
-                npm ci
-                npm run lint
-                npm run test
-                '''
+                  npm ci
+                  npm run lint
+                  npm run test
+                  '''
                 }
               }
             }
           }
         }
-        stage('Unit Test - Emailer') {
-          steps {
-            script {
+      }
+      stage('Lambdas - Unit Test - Emailer') {
+        steps {
+          script {
+            handleError(params.HANDLE_ERRORS) {
               if (hasChange('lambdas')) {
                 dirCon('lambdas/emailer', 'node') {
                   sh '''
-                npm ci
-                npm run lint
-                npm run test
-                '''
+                  npm ci
+                  npm run lint
+                  npm run test
+                  '''
                 }
               }
             }
           }
         }
-        stage('Unit Test - budgetNeutrality') {
-          steps {
-            script {
+      }
+      stage('Lambdas - Unit Test - budgetNeutrality') {
+        steps {
+          script {
+            handleError(params.HANDLE_ERRORS) {
               if (hasChange('lambdas')) {
                 dirCon('lambdas/budgetNeutrality', 'node') {
                   sh '''
-                npm ci
-                npm run lint
-                npm run test
-                '''
+                  npm ci
+                  npm run lint
+                  npm run test
+                  '''
                 }
               }
             }
@@ -152,10 +171,12 @@ pipeline {
         }
       }
     }
+  }
 
-    stage('Lambdas - Code Scan') {
-      steps {
-        script {
+  stage('Lambdas - Lambdas - Code Scan') {
+    steps {
+      script {
+        handleError(params.HANDLE_ERRORS) {
           if (hasChange('lambdas')) {
             snykCodeScan('lambdas', [allProjects: true])
           }
@@ -163,13 +184,17 @@ pipeline {
       }
     }
   }
+}
 
-  post {
-    failure {
-      slackPipelineFail('Lambdas')
-    }
-    always {
-      cleanWs(deleteDirs: true)
-    }
+post {
+  failure {
+    slackPipelineFail('Lambdas')
   }
+  always {
+    script {
+      handleError.setFailureDescription()
+    }
+    cleanWs(deleteDirs: true)
+  }
+}
 }

--- a/pipelines/Jenkinsfile.server
+++ b/pipelines/Jenkinsfile.server
@@ -3,19 +3,24 @@ pipeline {
     kubernetes {
       yaml kubeBlock(containerNames:['node', 'snyk', 'aws-cli'], opts: [
         NODE_IMAGE: 'artifactory.cloud.cms.gov/docker/node:24-alpine'
-      ])
-    }
+    ])
   }
+}
 
-  options {
-    disableConcurrentBuilds(abortPrevious: true)
-    buildDiscarder(retentionPolicy(env.BRANCH_NAME))
-  }
+options {
+  disableConcurrentBuilds(abortPrevious: true)
+  buildDiscarder(retentionPolicy(env.BRANCH_NAME))
+}
 
-  stages {
-    stage('Build Shared Library') {
-      steps {
-        script {
+parameters {
+  booleanParam(name: 'HANDLE_ERRORS', defaultValue: false, description: 'Allow build to continue when errors occur')
+}
+
+stages {
+  stage('Build Shared Library') {
+    steps {
+      script {
+        handleError(params.HANDLE_ERRORS) {
           if (fileExists('shared_library')) {
             dirCon('shared_library', 'node') {
               sh '''
@@ -27,28 +32,32 @@ pipeline {
         }
       }
     }
-    stage('Server - Snyk') {
-      steps {
-        script {
+  }
+  stage('Server - Snyk') {
+    steps {
+      script {
+        handleError(params.HANDLE_ERRORS) {
           if (hasChange('server')) {
             snykScan('server')
           }
         }
       }
     }
+  }
 
-    stage('Server - Lint') {
-      steps {
-        script {
+  stage('Server - Lint') {
+    steps {
+      script {
+        handleError(params.HANDLE_ERRORS) {
           if (hasChange('server')) {
             dirCon('server', 'node') {
               sh '''
               # Ensure shared_library is installed and built before installing server deps
               if [ -d ../shared_library ]; then
-                cd ../shared_library
-                npm ci
-                npm run build || true
-                cd -
+              cd ../shared_library
+              npm ci
+              npm run build || true
+              cd -
               fi
 
               npm ci
@@ -62,12 +71,14 @@ pipeline {
         }
       }
     }
+  }
 
-    stage('Server - Concurrent Steps') {
-      parallel {
-        stage('Server - Unit Test') {
-          steps {
-            script {
+  stage('Server - Concurrent Steps') {
+    parallel {
+      stage('Server - Unit Test') {
+        steps {
+          script {
+            handleError(params.HANDLE_ERRORS) {
               if (hasChange('server')) {
                 dirCon('server', 'node') {
                   sh '''
@@ -78,46 +89,50 @@ pipeline {
             }
           }
         }
+      }
 
-        stage('Server - Code Scan') {
-          steps {
-            script {
+      stage('Server - Code Scan') {
+        steps {
+          script {
+            handleError(params.HANDLE_ERRORS) {
               if (hasChange('server')) {
                 snykCodeScan('server')
               }
             }
           }
         }
+      }
 
-        stage('Server - Validate Migrations') {
-          when {
-            expression {
-              if (!env.CHANGE_TARGET) {
-                return false
-              }
-              def diff = sh(
-                script: "git diff --name-only origin/${env.CHANGE_TARGET}...HEAD",
-                returnStdout: true
-              ).trim()
-              return diff.split('\n').any { it.startsWith('server/src/model/migrations/') }
+      stage('Server - Validate Migrations') {
+        when {
+          expression {
+            if (!env.CHANGE_TARGET) {
+              return false
             }
+            def diff = sh(
+              script: "git diff --name-only origin/${env.CHANGE_TARGET}...HEAD",
+              returnStdout: true
+            ).trim()
+            return diff.split('\n').any { it.startsWith('server/src/model/migrations/') }
           }
-          steps {
-            assumeRole(accountNumber: env.DEMOS_AWS_NONPROD_ACCOUNT_NUMBER)
-            script {
+        }
+        steps {
+          assumeRole(accountNumber: env.DEMOS_AWS_NONPROD_ACCOUNT_NUMBER)
+          script {
+            handleError(params.HANDLE_ERRORS) {
               dirCon('deployment', 'node') {
                 sh """
-                  # Build shared_library first so the linked package is ready for migration tests
-                  if [ -d ../shared_library ]; then
-                    cd ../shared_library
-                    npm ci
-                    npm run build || true
-                    cd -
-                  fi
+                # Build shared_library first so the linked package is ready for migration tests
+                if [ -d ../shared_library ]; then
+                cd ../shared_library
+                npm ci
+                npm run build || true
+                cd -
+                fi
 
-                  npm ci
-                  export IS_TEST_MIGRATION="true"
-                  npx tsx demosctl/index test-migration dev "temp_${env.CHANGE_ID}_${currentBuild.startTimeInMillis}"
+                npm ci
+                export IS_TEST_MIGRATION="true"
+                npx tsx demosctl/index test-migration dev "temp_${env.CHANGE_ID}_${currentBuild.startTimeInMillis}"
                 """
               }
             }
@@ -126,12 +141,16 @@ pipeline {
       }
     }
   }
-  post {
-    failure {
-      slackPipelineFail('Server')
-    }
-    always {
-      cleanWs(deleteDirs: true)
-    }
+}
+post {
+  failure {
+    slackPipelineFail('Server')
   }
+  always {
+    script {
+      handleError.setFailureDescription()
+    }
+    cleanWs(deleteDirs: true)
+  }
+}
 }

--- a/pipelines/Jenkinsfile.test-deploy
+++ b/pipelines/Jenkinsfile.test-deploy
@@ -1,6 +1,6 @@
 pipeline {
   agent {
-    kubernetes { 
+    kubernetes {
       yaml kubeBlock(containerNames:["node", "aws-cli"])
     }
   }
@@ -28,17 +28,33 @@ pipeline {
 
       steps {
         script {
-          // The GIT_COMMIT env set by Jenkins isn't accurate for this type of
-          // pipeline, so it needs to be parsed
-          env.MAIN_COMMIT_HASH = sh(script: "git rev-parse HEAD", returnStdout: true).trim()
+          container('node') {
+            // The GIT_COMMIT env set by Jenkins isn't accurate for this type of
+            // pipeline, so it needs to be parsed
+            env.MAIN_COMMIT_HASH = sh(script: "git rev-parse HEAD", returnStdout: true).trim()
 
-          def mainStatus = sh( script: """
-            curl -s https://api.github.com/repos/Enterprise-CMCS/demos/commits/${env.MAIN_COMMIT_HASH}/status  | grep "state" | head -n1 | sed -E 's/.*"state": "(.*)".*/\\1/'
-          """, returnStdout: true).trim()
+            sh 'apk add --no-cache curl jq'
 
+            def mainStatus = sh( script:'''
+            required_contexts='ci/cloudbees/stage/Run Migrations|ci/cloudbees/stage/Deploy'
 
-          if (mainStatus != "success") {
-            error("Main branch is not in a successful state: ${mainStatus}")
+            curl -fsSL "https://api.github.com/repos/Enterprise-CMCS/demos/commits/$MAIN_COMMIT_HASH/status" \
+            | jq -r --arg contexts "$required_contexts" '
+            ($contexts | split("|") | map(select(length > 0))) as $required
+            | [ .statuses[] | {context, state} ] as $statuses
+            | $required[]
+            | . as $ctx
+            | ($statuses | map(select(.context == $ctx)) | first) as $status
+            | if $status == null then "\\($ctx)=missing"
+            elif $status.state != "success" then "\\($ctx)=\\($status.state)"
+            else empty
+            end
+            '
+            ''', returnStdout: true).trim()
+
+            if (mainStatus) {
+              error("Main branch is not in a successful state:\n${mainStatus}")
+            }
           }
         }
       }
@@ -72,13 +88,12 @@ pipeline {
           parallel(
             'Build Client': {
               dirCon('deployment','node') {
-                  sh "npx tsx demosctl/index build:client ${env.STAGE}"
-                  
-                  
+                sh "npx tsx demosctl/index build:client ${env.STAGE}"
+
               }
             }, 'Build Server': {
               dirCon('deployment', 'node') {
-                  sh "npx tsx demosctl/index build:server ${env.STAGE}"
+                sh "npx tsx demosctl/index build:server ${env.STAGE}"
               }
             }
           )
@@ -106,25 +121,25 @@ pipeline {
 
     stage('Deploy') {
       steps {
-          script {
-            dirCon('deployment','node') {
-              sh """
-              export UI_COMMIT_HASH=${env.MAIN_COMMIT_HASH}
-              export API_COMMIT_HASH=${env.MAIN_COMMIT_HASH}
-              npx tsx demosctl/index deploy:all ${env.STAGE}
-              """
-            }
+        script {
+          dirCon('deployment','node') {
+            sh """
+            export UI_COMMIT_HASH=${env.MAIN_COMMIT_HASH}
+            export API_COMMIT_HASH=${env.MAIN_COMMIT_HASH}
+            npx tsx demosctl/index deploy:all ${env.STAGE}
+            """
           }
+        }
       }
     }
   }
 
-    post {
-      success {
-        slackSend(color: "good", message: "${env.STAGE.toUpperCase()} Deployment succeeded!\n\nJenkins Build: <${env.BUILD_URL}|${env.BUILD_NUMBER}>\nCommit Hash: <${env.GIT_URL}/commit/${env.MAIN_COMMIT_HASH}|${env.MAIN_COMMIT_HASH}>")
-      }
-      failure {
-        slackSend(color: "danger", message: "${env.STAGE.toUpperCase()} Deployment failed:\n\nJenkins Build: <${env.BUILD_URL}|${env.BUILD_NUMBER}>\nCommit Hash: <${env.GIT_URL}/commit/${env.MAIN_COMMIT_HASH}|${env.MAIN_COMMIT_HASH}>")
-      }
+  post {
+    success {
+      slackSend(color: "good", message: "${env.STAGE.toUpperCase()} Deployment succeeded!\n\nJenkins Build: <${env.BUILD_URL}|${env.BUILD_NUMBER}>\nCommit Hash: <${env.GIT_URL}/commit/${env.MAIN_COMMIT_HASH}|${env.MAIN_COMMIT_HASH}>")
     }
+    failure {
+      slackSend(color: "danger", message: "${env.STAGE.toUpperCase()} Deployment failed:\n\nJenkins Build: <${env.BUILD_URL}|${env.BUILD_NUMBER}>\nCommit Hash: <${env.GIT_URL}/commit/${env.MAIN_COMMIT_HASH}|${env.MAIN_COMMIT_HASH}>")
+    }
+  }
 }


### PR DESCRIPTION
## Overview

Currently, when a PR is merged, changes are deployed to DEV. During a DEV deployment, every package is scanned and tested. If any of the individual package pipelines fail, the deployment stops. This means that if a new finding comes up between deployments, the finding will prevent deployment regardless of if its related to the changes that were made.

The pipeline should assume that if code is merged to `main`, it has already passed quality checks and should be deployed. We still want to be aware/notified about issues, but issues shouldn't block the work of unrelated changes, especially if the issue itself already exists in deployed code.

## Change Details

This change updates all of the main pipelines to make use of the `handleError` library function to conditionally ignore errors during deployment.

if `handleError(true)` is wrapping the executed code, if the code fails, the error will be reported, but will not exit the pipeilne. 

The deployment will still continue regardless of these failures. If there are failures, the slack notification will list out the failures and the individual builds will be set to an unstable status.