### PR TITLE
DEMOS-1991: remove unused imports/vars

### DIFF
--- a/server/eslint.config.js
+++ b/server/eslint.config.js
@@ -25,7 +25,6 @@ const eslintConfig = tseslint.config(
     files: ["**/*.{ts,tsx}"],
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-unused-vars": "off",
       "no-useless-escape": "off",
     },
   }

--- a/server/src/adapters/s3/LocalS3Adapter.ts
+++ b/server/src/adapters/s3/LocalS3Adapter.ts
@@ -1,6 +1,4 @@
-import { randomUUID } from "node:crypto";
 import { prisma, PrismaTransactionClient } from "../../prismaClient";
-import { log } from "../../log";
 import { S3Adapter } from "../";
 import { Prisma, DocumentPendingUpload as PrismaDocumentPendingUpload } from "@prisma/client";
 

--- a/server/src/dateUtilities.test.ts
+++ b/server/src/dateUtilities.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { LocalDate } from "./types.js";
 import {
   EasternTZDate,

--- a/server/src/errors/checkOptionalNotNullFields.test.ts
+++ b/server/src/errors/checkOptionalNotNullFields.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { checkOptionalNotNullFields } from "./checkOptionalNotNullFields";
 
 describe("checkOptionalNotNullFields", () => {

--- a/server/src/local-server.test.ts
+++ b/server/src/local-server.test.ts
@@ -9,11 +9,11 @@ const ApolloServerMock = class {
   }
 };
 
-const startStandaloneServerMock = vi.fn(async (_server: any, _opts: any) => ({
+const startStandaloneServerMock = vi.fn(async () => ({
   url: "http://localhost:4000",
 }));
 
-const ApolloArmorMock = vi.fn(function (this: any, cfg: any) {
+const ApolloArmorMock = vi.fn(function (this: any) {
   this.protect = () => ({ plugins: [], validationRules: [] });
 });
 const validateClaimsMock = vi.fn();
@@ -52,7 +52,7 @@ describe("local-server startup", () => {
 
   it("initializes ApolloArmor with GraphQLArmorConfig and starts the server", async () => {
     // Import module after mocks are active
-    const mod = await import("./local-server");
+    await import("./local-server");
 
     // ApolloArmor should have been constructed with the sentinel config
     expect(ApolloArmorMock).toHaveBeenCalled();

--- a/server/src/log.test.ts
+++ b/server/src/log.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import * as log from './log'
 import { Writable } from "node:stream";

--- a/server/src/model/amendment/amendmentResolvers.test.ts
+++ b/server/src/model/amendment/amendmentResolvers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, expectTypeOf } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   __createAmendment,
   __updateAmendment,
@@ -180,8 +180,6 @@ describe("amendmentResolvers", () => {
     it("delegates to `applicationPhaseData/queries.selectManyApplicationPhases`", async () => {
       await amendmentResolvers.Amendment.phases(
         { id: "amendmentId" } as PrismaAmendment,
-        {},
-        mockContext
       );
       expect(selectManyApplicationPhases).toHaveBeenCalledExactlyOnceWith({
         applicationId: "amendmentId",

--- a/server/src/model/amendment/amendmentResolvers.ts
+++ b/server/src/model/amendment/amendmentResolvers.ts
@@ -105,7 +105,7 @@ export const amendmentResolvers = {
       getManyDocuments({ applicationId: parent.id }, context.user),
     currentPhaseName: (parent: PrismaAmendment) => parent.currentPhaseId,
     status: (parent: PrismaAmendment) => parent.statusId,
-    phases: (parent: PrismaAmendment, args: unknown, context: GraphQLContext) =>
+    phases: (parent: PrismaAmendment) =>
       selectManyApplicationPhases({ applicationId: parent.id }),
     clearanceLevel: (parent: PrismaAmendment) => parent.clearanceLevelId,
     tags: async (parent: PrismaAmendment) =>

--- a/server/src/model/amendment/queries/selectAmendment.test.ts
+++ b/server/src/model/amendment/queries/selectAmendment.test.ts
@@ -1,6 +1,6 @@
 import { Amendment as PrismaAmendment } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectAmendment } from "./selectAmendment";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/amendment/queries/selectManyAmendments.test.ts
+++ b/server/src/model/amendment/queries/selectManyAmendments.test.ts
@@ -1,6 +1,6 @@
 import { Amendment as PrismaAmendment } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyAmendments } from "./selectManyAmendments";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/application/applicationResolvers.test.ts
+++ b/server/src/model/application/applicationResolvers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { resolveApplicationType, PrismaApplication } from ".";
-import { ApplicationStatus, ApplicationType, PhaseName } from "../../types";
+import { ApplicationType } from "../../types";
 
 vi.mock("../../prismaClient.js", () => ({
   prisma: vi.fn(),

--- a/server/src/model/application/queries/getManyApplications.test.ts
+++ b/server/src/model/application/queries/getManyApplications.test.ts
@@ -31,8 +31,6 @@ describe("getManyApplications", () => {
     },
   };
   const testDemonstrationApplicationTypeId: ApplicationType = "Demonstration";
-  const testAmendmentApplicationTypeId: ApplicationType = "Amendment";
-  const testExtensionApplicationTypeId: ApplicationType = "Extension";
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -71,7 +69,7 @@ describe("getManyApplications", () => {
         extension: true,
       },
     };
-    const result = await getManyApplications(testDemonstrationApplicationTypeId, mockTransaction);
+    await getManyApplications(testDemonstrationApplicationTypeId, mockTransaction);
 
     expect(transactionMocks.application.findMany).toHaveBeenCalledExactlyOnceWith(expectedCall);
   });
@@ -80,16 +78,6 @@ describe("getManyApplications", () => {
     mockPrismaClient.application.findMany.mockResolvedValue([
       { applicationId: "abc", demonstration: { id: "abc", value: "Just some test" } },
     ]);
-    const expectedCall = {
-      where: {
-        applicationTypeId: testDemonstrationApplicationTypeId,
-      },
-      include: {
-        demonstration: true,
-        amendment: true,
-        extension: true,
-      },
-    };
     const result = await getManyApplications(testDemonstrationApplicationTypeId);
     expect(result).toEqual([{ id: "abc", value: "Just some test" }]);
   });
@@ -98,16 +86,6 @@ describe("getManyApplications", () => {
     mockPrismaClient.application.findMany.mockResolvedValue([
       { applicationId: "abc", amendment: { id: "abc", value: "Just some test" } },
     ]);
-    const expectedCall = {
-      where: {
-        applicationTypeId: testDemonstrationApplicationTypeId,
-      },
-      include: {
-        demonstration: true,
-        amendment: true,
-        extension: true,
-      },
-    };
     const result = await getManyApplications(testDemonstrationApplicationTypeId);
     expect(result).toEqual([{ id: "abc", value: "Just some test" }]);
   });
@@ -116,16 +94,6 @@ describe("getManyApplications", () => {
     mockPrismaClient.application.findMany.mockResolvedValue([
       { applicationId: "abc", extension: { id: "abc", value: "Just some test" } },
     ]);
-    const expectedCall = {
-      where: {
-        applicationTypeId: testDemonstrationApplicationTypeId,
-      },
-      include: {
-        demonstration: true,
-        amendment: true,
-        extension: true,
-      },
-    };
     const result = await getManyApplications(testDemonstrationApplicationTypeId);
     expect(result).toEqual([{ id: "abc", value: "Just some test" }]);
   });

--- a/server/src/model/applicationDate/queries/deleteApplicationDates.test.ts
+++ b/server/src/model/applicationDate/queries/deleteApplicationDates.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { deleteApplicationDates } from "./deleteApplicationDates.js";
 import { ParsedSetApplicationDatesInput } from "..";
-import { EasternTZDate } from "../../../dateUtilities.js";
-import { TZDate } from "@date-fns/tz";
 
 describe("deleteApplicationDates", () => {
   const transactionMocks = {

--- a/server/src/model/applicationDate/queries/selectApplicationDate.test.ts
+++ b/server/src/model/applicationDate/queries/selectApplicationDate.test.ts
@@ -1,6 +1,6 @@
 import { ApplicationDate as PrismaApplicationDate } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectApplicationDate } from "./selectApplicationDate";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/applicationDate/queries/selectManyApplicationDates.test.ts
+++ b/server/src/model/applicationDate/queries/selectManyApplicationDates.test.ts
@@ -1,6 +1,6 @@
 import { ApplicationDate as PrismaApplicationDate } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyApplicationDates } from "./selectManyApplicationDates";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/applicationDate/validateAllowedDateChangeForApplication.test.ts
+++ b/server/src/model/applicationDate/validateAllowedDateChangeForApplication.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { ApplicationStatus, SetApplicationDatesInput, LocalDate } from "../../types";
+import { SetApplicationDatesInput, LocalDate } from "../../types";
 import { validateAllowedDateChangeForApplication } from "./validateAllowedDateChangeForApplication";
 
 // Mock imports

--- a/server/src/model/applicationDate/validateInputDates.test.ts
+++ b/server/src/model/applicationDate/validateInputDates.test.ts
@@ -46,7 +46,7 @@ describe("validateInputDates", () => {
       let isGreaterThanChecksCorrect = true;
       let isGreaterThanOrEqualChecksCorrect = true;
       let isOffsetChecksCorrect = true;
-      for (const [_, validationChecks] of Object.entries(result)) {
+      for (const [, validationChecks] of Object.entries(result)) {
         if (!["Start of Day", "End of Day"].includes(validationChecks.expectedTimestamp)) {
           isExpectedTimestampCorrect = false;
         }

--- a/server/src/model/applicationNote/applicationNoteResolvers.test.ts
+++ b/server/src/model/applicationNote/applicationNoteResolvers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { __setApplicationNotes, applicationNoteResolvers } from "./applicationNoteResolvers";
-import { Prisma, ApplicationNote as PrismaApplicationNote } from "@prisma/client";
+import { ApplicationNote as PrismaApplicationNote } from "@prisma/client";
 import { prisma } from "../../prismaClient";
 import { handlePrismaError } from "../../errors/handlePrismaError";
 import { getApplication } from "../application";

--- a/server/src/model/applicationNote/parseSetApplicationNotesInput.test.ts
+++ b/server/src/model/applicationNote/parseSetApplicationNotesInput.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { parseSetApplicationNotesInput } from ".";
 import { SetApplicationNotesInput } from "../../types";
 

--- a/server/src/model/applicationNote/queries/selectApplicationNote.test.ts
+++ b/server/src/model/applicationNote/queries/selectApplicationNote.test.ts
@@ -1,6 +1,6 @@
 import { ApplicationNote as PrismaApplicationNote } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectApplicationNote } from "./selectApplicationNote";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/applicationNote/queries/selectManyApplicationNotes.test.ts
+++ b/server/src/model/applicationNote/queries/selectManyApplicationNotes.test.ts
@@ -1,6 +1,6 @@
 import { ApplicationNote as PrismaApplicationNote } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyApplicationNotes } from "./selectManyApplicationNotes";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/applicationNote/validateAllowedNoteChangeByPhase.test.ts
+++ b/server/src/model/applicationNote/validateAllowedNoteChangeByPhase.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { validateAllowedNoteChangeByPhase } from "./validateAllowedNoteChangeByPhase";
 import { SetApplicationNotesInput } from "../../types";
-import { PrismaTransactionClient } from "../../prismaClient";
 import { getFinishedApplicationPhaseIds } from "../applicationPhase";
 import { getPhaseNoteTypes } from "../phaseNoteType";
 

--- a/server/src/model/applicationPhase/completePhase.test.ts
+++ b/server/src/model/applicationPhase/completePhase.test.ts
@@ -7,9 +7,8 @@ import { prisma } from "../../prismaClient.js";
 import { handlePrismaError } from "../../errors/handlePrismaError.js";
 import { validateAndUpdateDates } from "../applicationDate";
 import { validatePhaseCompletion, updatePhaseStatus, setPhaseToStarted } from ".";
-import { EasternNow, EasternTZDate, getEasternNow } from "../../dateUtilities.js";
+import { EasternNow, getEasternNow } from "../../dateUtilities.js";
 import { TZDate } from "@date-fns/tz";
-import { getApplication } from "../application";
 
 vi.mock("../../prismaClient.js", () => ({
   prisma: vi.fn(),

--- a/server/src/model/applicationPhase/queries/getFinishedApplicationPhaseIds.test.ts
+++ b/server/src/model/applicationPhase/queries/getFinishedApplicationPhaseIds.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getFinishedApplicationPhaseIds } from "./getFinishedApplicationPhaseIds";
-import { PhaseName, PhaseStatus } from "../../../types";
+import { PhaseName } from "../../../types";
 
 describe("getCompletedApplicationPhaseIds", () => {
   const transactionMocks = {

--- a/server/src/model/applicationPhase/queries/selectApplicationPhase.test.ts
+++ b/server/src/model/applicationPhase/queries/selectApplicationPhase.test.ts
@@ -1,6 +1,6 @@
 import { ApplicationPhase as PrismaApplicationPhase } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectApplicationPhase } from "./selectApplicationPhase";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/applicationPhase/queries/selectManyApplicationPhases.test.ts
+++ b/server/src/model/applicationPhase/queries/selectManyApplicationPhases.test.ts
@@ -1,6 +1,6 @@
 import { ApplicationPhase as PrismaApplicationPhase } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyApplicationPhases } from "./selectManyApplicationPhases";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/applicationPhase/skipConceptPhase.test.ts
+++ b/server/src/model/applicationPhase/skipConceptPhase.test.ts
@@ -12,8 +12,7 @@ import {
   setPhaseToStarted,
   updatePhaseStatus,
 } from ".";
-import { EasternNow, EasternTZDate, getEasternNow } from "../../dateUtilities.js";
-import { getApplication } from "../application";
+import { EasternNow, getEasternNow } from "../../dateUtilities.js";
 
 vi.mock("../../prismaClient.js", () => ({
   prisma: vi.fn(),

--- a/server/src/model/applicationTagAssignment/queries/deleteAllApplicationTags.test.ts
+++ b/server/src/model/applicationTagAssignment/queries/deleteAllApplicationTags.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { deleteAllApplicationTags } from "./deleteAllApplicationTags";
-import { SetApplicationTagsInput } from "../../../types";
 
 describe("deleteAllApplicationTags", () => {
   const transactionMocks = {

--- a/server/src/model/applicationTagAssignment/queries/insertApplicationTags.test.ts
+++ b/server/src/model/applicationTagAssignment/queries/insertApplicationTags.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { insertApplicationTags } from "./insertApplicationTags";
-import { SetApplicationTagsInput } from "../../../types";
 
 describe("insertApplicationTags", () => {
   const transactionMocks = {

--- a/server/src/model/applicationTagAssignment/queries/selectApplicationTagAssignment.test.ts
+++ b/server/src/model/applicationTagAssignment/queries/selectApplicationTagAssignment.test.ts
@@ -1,6 +1,6 @@
 import { ApplicationTagAssignment as PrismaApplicationTagAssignment } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectApplicationTagAssignment } from "./selectApplicationTagAssignment";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/applicationTagAssignment/queries/selectManyApplicationTagAssignments.test.ts
+++ b/server/src/model/applicationTagAssignment/queries/selectManyApplicationTagAssignments.test.ts
@@ -1,6 +1,6 @@
 import { Prisma, ApplicationTagAssignment as PrismaApplicationTagAssignment } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyApplicationTagAssignments } from "./selectManyApplicationTagAssignments";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/applicationTagSuggestion/queries/selectApplicationTagSuggestion.test.ts
+++ b/server/src/model/applicationTagSuggestion/queries/selectApplicationTagSuggestion.test.ts
@@ -1,6 +1,6 @@
 import { ApplicationTagSuggestion as PrismaApplicationTagSuggestion } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectApplicationTagSuggestion } from "./selectApplicationTagSuggestion";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/applicationTagSuggestion/queries/selectManyApplicationTagSuggestions.test.ts
+++ b/server/src/model/applicationTagSuggestion/queries/selectManyApplicationTagSuggestions.test.ts
@@ -1,6 +1,6 @@
 import { Prisma, ApplicationTagSuggestion as PrismaApplicationTagSuggestion } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyApplicationTagSuggestions } from "./selectManyApplicationTagSuggestions";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/deliverable/approveDeliverableExtension.test.ts
+++ b/server/src/model/deliverable/approveDeliverableExtension.test.ts
@@ -138,7 +138,7 @@ describe("approveDeliverableExtension", () => {
         testContext as GraphQLContext
       );
       throw new Error("Expected approveDeliverableExtension to throw, but it did not.");
-    } catch (e) {
+    } catch {
       expect(prisma).not.toHaveBeenCalled();
     }
   });
@@ -153,7 +153,7 @@ describe("approveDeliverableExtension", () => {
         testContext as GraphQLContext
       );
       throw new Error("Expected approveDeliverableExtension to throw, but it did not.");
-    } catch (e) {
+    } catch {
       expect(prisma).not.toHaveBeenCalled();
     }
   });

--- a/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
+++ b/server/src/model/deliverable/checkDeliverableInputFunctions.test.ts
@@ -17,7 +17,6 @@ import {
   DemonstrationTypeTagAssignment as PrismaDemonstrationTypeTagAssignment,
   Document as PrismaDocument,
   PrivateComment as PrismaPrivateComment,
-  PublicComment as PrismaPublicComment,
   User as PrismaUser,
 } from "@prisma/client";
 

--- a/server/src/model/deliverable/completeDeliverable.test.ts
+++ b/server/src/model/deliverable/completeDeliverable.test.ts
@@ -87,7 +87,7 @@ describe("completeDeliverable", () => {
     try {
       await completeDeliverable(testDeliverableId, "Approved", testContext as GraphQLContext);
       throw new Error("Expected completeDeliverable to throw, but it did not.");
-    } catch (e) {
+    } catch {
       expect(prisma).not.toHaveBeenCalled();
     }
   });

--- a/server/src/model/deliverable/createDeliverable.test.ts
+++ b/server/src/model/deliverable/createDeliverable.test.ts
@@ -102,7 +102,7 @@ describe("createDeliverable", () => {
     try {
       await createDeliverable(testInput, testContext as GraphQLContext);
       throw new Error("Expected createDeliverable to throw, but it did not.");
-    } catch (e) {
+    } catch {
       expect(prisma).not.toHaveBeenCalled();
     }
   });

--- a/server/src/model/deliverable/deleteDeliverable.test.ts
+++ b/server/src/model/deliverable/deleteDeliverable.test.ts
@@ -79,7 +79,7 @@ describe("deleteDeliverable", () => {
     try {
       await deleteDeliverable(testDeliverableId, testContext as GraphQLContext);
       throw new Error("Expected deleteDeliverable to throw, but it did not.");
-    } catch (e) {
+    } catch {
       expect(prisma).not.toHaveBeenCalled();
     }
   });

--- a/server/src/model/deliverable/deliverableResolvers.test.ts
+++ b/server/src/model/deliverable/deliverableResolvers.test.ts
@@ -57,6 +57,10 @@ vi.mock(".", () => ({
   updateDeliverable: vi.fn(),
 }));
 
+vi.mock("../thing", () => ({
+  resolveThing: vi.fn(),
+}));
+
 vi.mock("../application", () => ({
   getApplication: vi.fn(),
 }));
@@ -733,16 +737,8 @@ describe("deliverableResolvers", () => {
 
     describe("Deliverable.privateComments", () => {
       it("should query the private comments of the parent deliverable", async () => {
-        const testContext: DeepPartial<GraphQLContext> = {
-          user: {
-            id: "27cb9043-0016-44ca-a361-dd047bfa5993",
-            personTypeId: "demos-cms-user",
-          },
-        };
         await deliverableResolvers.Deliverable.privateComments(
-          testDeliverable as PrismaDeliverable,
-          undefined,
-          testContext as GraphQLContext
+          testDeliverable as PrismaDeliverable
         );
         expect(selectManyPrivateComments).toHaveBeenCalledExactlyOnceWith({
           deliverableId: testDeliverableId,

--- a/server/src/model/deliverable/deliverableResolvers.ts
+++ b/server/src/model/deliverable/deliverableResolvers.ts
@@ -37,7 +37,6 @@ import {
   DeliverableType,
   DenyDeliverableExtensionInput,
   FinalDeliverableStatus,
-  PersonType,
   RequestDeliverableExtensionInput,
   RequestDeliverableResubmissionInput,
   UpdateDeliverableInput,
@@ -196,8 +195,7 @@ export const deliverableResolvers = {
     deliverableType: resolveDeliverableType,
     demonstration: resolveDemonstration,
     status: resolveDeliverableStatus,
-    cmsOwner: (parent: PrismaDeliverable) =>
-      selectUserOrThrow({ id: parent.cmsOwnerUserId }),
+    cmsOwner: (parent: PrismaDeliverable) => selectUserOrThrow({ id: parent.cmsOwnerUserId }),
     dueDateType: resolveDeliverableDueDateType,
     demonstrationTypes: async (parent: PrismaDeliverable) =>
       (await selectManyDeliverableDemonstrationTypes({ deliverableId: parent.id })).map(
@@ -242,11 +240,7 @@ export const deliverableResolvers = {
     publicComments: async (parent: PrismaDeliverable): Promise<PrismaPublicComment[]> => {
       return await selectManyPublicComments({ deliverableId: parent.id });
     },
-    privateComments: async (
-      parent: PrismaDeliverable,
-      args: unknown,
-      context: GraphQLContext
-    ): Promise<PrismaPrivateComment[]> => {
+    privateComments: async (parent: PrismaDeliverable): Promise<PrismaPrivateComment[]> => {
       return await selectManyPrivateComments({ deliverableId: parent.id });
     },
   },

--- a/server/src/model/deliverable/denyDeliverableExtension.test.ts
+++ b/server/src/model/deliverable/denyDeliverableExtension.test.ts
@@ -102,7 +102,7 @@ describe("denyDeliverableExtension", () => {
     try {
       await denyDeliverableExtension(testDeliverableId, testInput, testContext as GraphQLContext);
       throw new Error("Expected denyDeliverableExtension to throw, but it did not.");
-    } catch (e) {
+    } catch {
       expect(prisma).not.toHaveBeenCalled();
     }
   });

--- a/server/src/model/deliverable/parseDeliverableInputs.test.ts
+++ b/server/src/model/deliverable/parseDeliverableInputs.test.ts
@@ -149,9 +149,6 @@ describe("parseDeliverableInputs", () => {
       const testInput = {
         ...baseTestInput,
       };
-      const expectedResult: ParsedUpdateDeliverableInput = {
-        name: testInput.name,
-      };
 
       parseUpdateDeliverableInput(testInput);
       expect(parseDateTimeOrLocalDateToEasternTZDate).not.toHaveBeenCalled();

--- a/server/src/model/deliverable/queries/selectDeliverableOrThrow.test.ts
+++ b/server/src/model/deliverable/queries/selectDeliverableOrThrow.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { selectDeliverable } from "./selectDeliverable";
 
 // Mock imports

--- a/server/src/model/deliverable/queries/selectManyDeliverables.test.ts
+++ b/server/src/model/deliverable/queries/selectManyDeliverables.test.ts
@@ -37,9 +37,6 @@ describe("selectManyDeliverables", () => {
   const expectedFilteredCall = {
     where: { demonstrationId: testDemonstrationId, NOT: { statusId: DELETED_DELIVERABLE_STATUS } },
   };
-  const expectedUnfilteredCall = {
-    where: { demonstrationId: testDemonstrationId },
-  };
 
   beforeEach(() => {
     vi.resetAllMocks();

--- a/server/src/model/deliverable/requestDeliverableExtension.test.ts
+++ b/server/src/model/deliverable/requestDeliverableExtension.test.ts
@@ -105,7 +105,7 @@ describe("requestDeliverableExtension", () => {
         testContext as GraphQLContext
       );
       throw new Error("Expected requestDeliverableExtension to throw, but it did not.");
-    } catch (e) {
+    } catch {
       expect(prisma).not.toHaveBeenCalled();
     }
   });
@@ -125,7 +125,7 @@ describe("requestDeliverableExtension", () => {
         testContext as GraphQLContext
       );
       throw new Error("Expected requestDeliverableExtension to throw, but it did not.");
-    } catch (e) {
+    } catch {
       expect(prisma).not.toHaveBeenCalled();
     }
   });

--- a/server/src/model/deliverable/requestDeliverableResubmission.test.ts
+++ b/server/src/model/deliverable/requestDeliverableResubmission.test.ts
@@ -110,7 +110,7 @@ describe("requestDeliverableResubmission", () => {
         testContext as GraphQLContext
       );
       throw new Error("Expected requestDeliverableResubmission to throw, but it did not.");
-    } catch (e) {
+    } catch {
       expect(prisma).not.toHaveBeenCalled();
     }
   });
@@ -134,7 +134,7 @@ describe("requestDeliverableResubmission", () => {
         testContext as GraphQLContext
       );
       throw new Error("Expected requestDeliverableResubmission to throw, but it did not.");
-    } catch (e) {
+    } catch {
       expect(prisma).not.toHaveBeenCalled();
     }
   });

--- a/server/src/model/deliverable/startDeliverableReview.test.ts
+++ b/server/src/model/deliverable/startDeliverableReview.test.ts
@@ -87,7 +87,7 @@ describe("startDeliverableReview", () => {
     try {
       await startDeliverableReview(testDeliverableId, testContext as GraphQLContext);
       throw new Error("Expected startDeliverableReview to throw, but it did not.");
-    } catch (e) {
+    } catch {
       expect(prisma).not.toHaveBeenCalled();
     }
   });

--- a/server/src/model/deliverable/updateDeliverable.test.ts
+++ b/server/src/model/deliverable/updateDeliverable.test.ts
@@ -104,7 +104,7 @@ describe("updateDeliverable", () => {
     try {
       await updateDeliverable(testDeliverableId, basicTestInput, testContext as GraphQLContext);
       throw new Error("Expected updateDeliverable to throw, but it did not.");
-    } catch (e) {
+    } catch {
       expect(prisma).not.toHaveBeenCalled();
     }
   });

--- a/server/src/model/deliverable/updateDeliverable.ts
+++ b/server/src/model/deliverable/updateDeliverable.ts
@@ -13,7 +13,7 @@ import {
 } from ".";
 import { prisma } from "../../prismaClient";
 import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
-import { selectUser, selectUserOrThrow } from "../user/queries";
+import { selectUserOrThrow } from "../user/queries";
 
 export async function updateDeliverable(
   deliverableId: string,

--- a/server/src/model/deliverable/validateDeliverableInputs.ts
+++ b/server/src/model/deliverable/validateDeliverableInputs.ts
@@ -20,7 +20,7 @@ import {
 } from ".";
 import { PrismaTransactionClient } from "../../prismaClient";
 import { getApplication } from "../application";
-import { selectUser, selectUserOrThrow } from "../user/queries";
+import { selectUserOrThrow } from "../user/queries";
 import { getDemonstrationTypeAssignments } from "../demonstrationTypeTagAssignment";
 import { GraphQLError } from "graphql";
 import {

--- a/server/src/model/deliverableDemonstrationType/queries/selectDeliverableDemonstrationType.test.ts
+++ b/server/src/model/deliverableDemonstrationType/queries/selectDeliverableDemonstrationType.test.ts
@@ -1,9 +1,5 @@
-import {
-  Deliverable,
-  DemonstrationTypeTagAssignment as PrismaDemonstrationTypeTagAssignment,
-} from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma,  } from "../../../prismaClient";
 import { selectDeliverableDemonstrationType } from "./selectDeliverableDemonstrationType";
 import { DeliverableDemonstrationTypeQueryResult } from ".";
 

--- a/server/src/model/deliverableDemonstrationType/queries/selectManyDeliverableDemonstrationTypes.test.ts
+++ b/server/src/model/deliverableDemonstrationType/queries/selectManyDeliverableDemonstrationTypes.test.ts
@@ -1,9 +1,8 @@
 import {
-  DeliverableDemonstrationType as PrismaDeliverableDemonstrationType,
   Prisma,
 } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyDeliverableDemonstrationTypes } from "./selectManyDeliverableDemonstrationTypes";
 import { DeliverableDemonstrationTypeQueryResult } from ".";
 

--- a/server/src/model/deliverableExtension/deliverableExtensionResolvers.test.ts
+++ b/server/src/model/deliverableExtension/deliverableExtensionResolvers.test.ts
@@ -1,6 +1,5 @@
 // Vitest and other helpers
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { DeepPartial } from "../../testUtilities";
 
 // Types
 import {

--- a/server/src/model/demonstration/demonstrationResolvers.test.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.test.ts
@@ -3,7 +3,6 @@ import {
   __createDemonstration,
   __updateDemonstration,
   deleteDemonstration,
-  __resolveDemonstrationPrimaryProjectOfficer,
   demonstrationResolvers,
 } from "./demonstrationResolvers";
 import {
@@ -300,8 +299,6 @@ describe("demonstrationResolvers", () => {
     it("delegates to `applicationPhaseData/queries.selectManyApplicationPhases`", async () => {
       await demonstrationResolvers.Demonstration.phases(
         { id: "demonstrationId" } as PrismaDemonstration,
-        {},
-        mockContext
       );
       expect(selectManyApplicationPhases).toHaveBeenCalledExactlyOnceWith({
         applicationId: "demonstrationId",

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -248,7 +248,7 @@ export const demonstrationResolvers = {
     roles: (parent: PrismaDemonstration) =>
       selectManyDemonstrationRoleAssignments({ demonstrationId: parent.id }),
     status: (parent: PrismaDemonstration) => parent.statusId,
-    phases: (parent: PrismaDemonstration, args: unknown, context: GraphQLContext) =>
+    phases: (parent: PrismaDemonstration) =>
       selectManyApplicationPhases({ applicationId: parent.id }),
     primaryProjectOfficer: resolvePrimaryProjectOfficer,
     clearanceLevel: (parent: PrismaDemonstration) => parent.clearanceLevelId,

--- a/server/src/model/demonstration/determineDemonstrationTypeStatus.test.ts
+++ b/server/src/model/demonstration/determineDemonstrationTypeStatus.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, beforeEach, vi, expect } from "vitest";
 import { determineDemonstrationTypeStatus } from "./determineDemonstrationTypeStatus";
-import { DemonstrationTypeStatus } from "../../types";
 
 describe("determineDemonstrationTypeStatus", () => {
   beforeEach(() => {

--- a/server/src/model/demonstration/queries/selectDemonstration.test.ts
+++ b/server/src/model/demonstration/queries/selectDemonstration.test.ts
@@ -1,6 +1,6 @@
 import { Demonstration as PrismaDemonstration } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectDemonstration } from "./selectDemonstration";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/demonstration/queries/selectManyDemonstrations.test.ts
+++ b/server/src/model/demonstration/queries/selectManyDemonstrations.test.ts
@@ -1,6 +1,6 @@
 import { Demonstration as PrismaDemonstration } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyDemonstrations } from "./selectManyDemonstrations";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/demonstrationRoleAssignment/queries/selectDemonstrationRoleAssignment.test.ts
+++ b/server/src/model/demonstrationRoleAssignment/queries/selectDemonstrationRoleAssignment.test.ts
@@ -1,6 +1,6 @@
 import { DemonstrationRoleAssignment as PrismaDemonstrationRoleAssignment } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectDemonstrationRoleAssignment } from "./selectDemonstrationRoleAssignment";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/demonstrationRoleAssignment/queries/selectDemonstrationRoleAssignmentOrThrow.test.ts
+++ b/server/src/model/demonstrationRoleAssignment/queries/selectDemonstrationRoleAssignmentOrThrow.test.ts
@@ -1,8 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { selectDemonstrationRoleAssignment } from "./selectDemonstrationRoleAssignment";
 
 // Mock imports
-import { DemonstrationRoleAssignment as PrismaDemonstrationRoleAssignment } from "@prisma/client";
 import { selectDemonstrationRoleAssignmentOrThrow } from "./selectDemonstrationRoleAssignmentOrThrow";
 import { DemonstrationRoleAssignmentQueryResult } from ".";
 

--- a/server/src/model/demonstrationRoleAssignment/queries/selectManyDemonstrationRoleAssignments.test.ts
+++ b/server/src/model/demonstrationRoleAssignment/queries/selectManyDemonstrationRoleAssignments.test.ts
@@ -4,7 +4,7 @@ import {
   DemonstrationRoleAssignment as PrismaDemonstrationRoleAssignment,
 } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyDemonstrationRoleAssignments } from "./selectManyDemonstrationRoleAssignments";
 import { type DemonstrationRoleAssignmentQueryResult } from ".";
 

--- a/server/src/model/demonstrationTypeTagAssignment/queries/selectDemonstrationTypeTagAssignment.test.ts
+++ b/server/src/model/demonstrationTypeTagAssignment/queries/selectDemonstrationTypeTagAssignment.test.ts
@@ -1,6 +1,6 @@
 import { DemonstrationTypeTagAssignment as PrismaDemonstrationTypeTagAssignment } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectDemonstrationTypeTagAssignment } from "./selectDemonstrationTypeTagAssignment";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/demonstrationTypeTagAssignment/queries/selectManyDemonstrationTypeTagAssignments.test.ts
+++ b/server/src/model/demonstrationTypeTagAssignment/queries/selectManyDemonstrationTypeTagAssignments.test.ts
@@ -3,7 +3,7 @@ import {
   DemonstrationTypeTagAssignment as PrismaDemonstrationTypeTagAssignment,
 } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyDemonstrationTypeTagAssignments } from "./selectManyDemonstrationTypeTagAssignments";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/document/documentResolvers.test.ts
+++ b/server/src/model/document/documentResolvers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { Document as PrismaDocument, User as PrismaUser } from "@prisma/client";
+import { Document as PrismaDocument } from "@prisma/client";
 import { GraphQLContext } from "../../auth";
 import { UpdateDocumentInput, DocumentType, PhaseName } from "../../types";
 import { prisma } from "../../prismaClient";
@@ -100,15 +100,6 @@ describe("documentResolvers", () => {
     deliverableIsCmsAttachedFile: null,
     deliverableSubmissionActionId: null,
     deliverableSubmissionActionTypeId: null,
-  };
-
-  const mockUser: PrismaUser = {
-    id: testUserId,
-    createdAt: new Date("2025-01-01T00:00:00.000Z"),
-    updatedAt: new Date("2025-01-01T00:00:00.000Z"),
-    personTypeId: "demos-cms-user",
-    cognitoSubject: "cognito-subject-123",
-    username: "testuser",
   };
 
   const mockApplication = {

--- a/server/src/model/document/queries/selectDocument.test.ts
+++ b/server/src/model/document/queries/selectDocument.test.ts
@@ -1,6 +1,6 @@
 import { Document as PrismaDocument } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectDocument } from "./selectDocument";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/document/queries/selectManyDocuments.test.ts
+++ b/server/src/model/document/queries/selectManyDocuments.test.ts
@@ -1,6 +1,6 @@
 import { Document as PrismaDocument } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyDocuments } from "./selectManyDocuments";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/documentPendingUpload/documentPendingUploadResolvers.test.ts
+++ b/server/src/model/documentPendingUpload/documentPendingUploadResolvers.test.ts
@@ -6,10 +6,8 @@ import {
   UploadDocumentToPhaseInput,
 } from "./documentPendingUploadSchema";
 import { GraphQLContext } from "../../auth";
-import { Deliverable as PrismaDeliverable } from "@prisma/client";
 import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
 import { getS3Adapter } from "../../adapters";
-import { selectDeliverableOrThrow } from "../deliverable";
 import { updateAssociatedPhase } from "./updateAssociatedPhase";
 import { handleUploadDocumentToDeliverable } from "./handleUploadDocumentToDeliverable";
 

--- a/server/src/model/documentPendingUpload/documentPendingUploadResolvers.ts
+++ b/server/src/model/documentPendingUpload/documentPendingUploadResolvers.ts
@@ -13,7 +13,7 @@ import type {
 import { getS3Adapter } from "../../adapters";
 import { getApplication, PrismaApplication } from "../application";
 import { selectUserOrThrow } from "../user/queries";
-import { selectDeliverableOrThrow, resolveDeliverable } from "../deliverable";
+import { resolveDeliverable } from "../deliverable";
 import { updateAssociatedPhase } from "./updateAssociatedPhase";
 import { handleUploadDocumentToDeliverable } from "./handleUploadDocumentToDeliverable";
 
@@ -69,13 +69,13 @@ export const documentPendingUploadResolvers = {
         handlePrismaError(error);
       }
     },
-    uploadDocumentToDeliverableCMSFiles: async (
+    uploadDocumentToDeliverableCMSFiles: (
       parent: unknown,
       { input }: { input: UploadDocumentToDeliverableInput },
       context: GraphQLContext
     ): Promise<PrismaDocumentPendingUpload> =>
       handleUploadDocumentToDeliverable(input, context.user.id, true),
-    uploadDocumentToDeliverableStateFiles: async (
+    uploadDocumentToDeliverableStateFiles: (
       parent: unknown,
       { input }: { input: UploadDocumentToDeliverableInput },
       context: GraphQLContext
@@ -84,8 +84,7 @@ export const documentPendingUploadResolvers = {
   },
 
   DocumentPendingUpload: {
-    owner: (parent: PrismaDocumentPendingUpload) =>
-      selectUserOrThrow({ id: parent.ownerUserId }),
+    owner: (parent: PrismaDocumentPendingUpload) => selectUserOrThrow({ id: parent.ownerUserId }),
     documentType: (parent: PrismaDocumentPendingUpload) => parent.documentTypeId as DocumentType,
     presignedUploadUrl: async (parent: PrismaDocumentPendingUpload) =>
       await getS3Adapter().getPresignedUploadUrl(parent.id),

--- a/server/src/model/extension/extensionResolvers.test.ts
+++ b/server/src/model/extension/extensionResolvers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, expectTypeOf } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   __createExtension,
   __updateExtension,
@@ -175,11 +175,7 @@ describe("extensionResolvers", () => {
 
   describe("Extension.phases", () => {
     it("delegates to `applicationPhaseData/queries.selectManyApplicationPhases`", async () => {
-      await extensionResolvers.Extension.phases(
-        { id: "extensionId" } as PrismaExtension,
-        {},
-        mockContext
-      );
+      await extensionResolvers.Extension.phases({ id: "extensionId" } as PrismaExtension);
       expect(selectManyApplicationPhases).toHaveBeenCalledExactlyOnceWith({
         applicationId: "extensionId",
       });
@@ -233,17 +229,13 @@ describe("extensionResolvers", () => {
         },
       ] as PrismaApplicationTagSuggestion[]);
 
-      const result = await extensionResolvers.Extension.suggestedApplicationTags(
-        mockExtension,
-      );
-      expect(selectManyApplicationTagSuggestions).toHaveBeenCalledExactlyOnceWith(
-        {
-          applicationId: "abc123",
-          statusId: {
-            in: ["Pending"],
-          },
+      const result = await extensionResolvers.Extension.suggestedApplicationTags(mockExtension);
+      expect(selectManyApplicationTagSuggestions).toHaveBeenCalledExactlyOnceWith({
+        applicationId: "abc123",
+        statusId: {
+          in: ["Pending"],
         },
-      );
+      });
       expect(result).toEqual(["Suggestion1", "Suggestion2"]);
     });
   });

--- a/server/src/model/extension/extensionResolvers.ts
+++ b/server/src/model/extension/extensionResolvers.ts
@@ -105,7 +105,7 @@ export const extensionResolvers = {
       getManyDocuments({ applicationId: parent.id }, context.user),
     currentPhaseName: (parent: PrismaExtension) => parent.currentPhaseId,
     status: (parent: PrismaExtension) => parent.statusId,
-    phases: (parent: PrismaExtension, args: unknown, context: GraphQLContext) =>
+    phases: (parent: PrismaExtension) =>
       selectManyApplicationPhases({ applicationId: parent.id }),
     clearanceLevel: (parent: PrismaExtension) => parent.clearanceLevelId,
     tags: async (parent: PrismaExtension) =>

--- a/server/src/model/extension/queries/selectExtension.test.ts
+++ b/server/src/model/extension/queries/selectExtension.test.ts
@@ -1,6 +1,6 @@
 import { Extension as PrismaExtension } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectExtension } from "./selectExtension";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/extension/queries/selectManyExtensions.test.ts
+++ b/server/src/model/extension/queries/selectManyExtensions.test.ts
@@ -1,6 +1,6 @@
 import { Extension as PrismaExtension } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyExtensions } from "./selectManyExtensions";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/person/personResolvers.test.ts
+++ b/server/src/model/person/personResolvers.test.ts
@@ -3,17 +3,11 @@ import { personResolvers } from "./personResolvers";
 import { Person as PrismaPerson } from "@prisma/client";
 
 // Mock imports
-import { ContextUser, GraphQLContext } from "../../auth";
 import { selectManyDemonstrationRoleAssignments } from "../demonstrationRoleAssignment/queries";
 
 vi.mock("../demonstrationRoleAssignment/queries", () => ({
   selectManyDemonstrationRoleAssignments: vi.fn(),
 }));
-
-const mockUser = { id: "test-user-id" } as ContextUser;
-const mockContext: GraphQLContext = {
-  user: mockUser,
-} as GraphQLContext;
 
 describe("applicationPhaseResolvers", () => {
   describe("Person.roles", () => {

--- a/server/src/model/person/personResolvers.ts
+++ b/server/src/model/person/personResolvers.ts
@@ -1,7 +1,6 @@
 import { Person as PrismaPerson } from "@prisma/client";
 
 import { prisma } from "../../prismaClient";
-import { GraphQLContext } from "../../auth";
 import { selectManyDemonstrationRoleAssignments } from "../demonstrationRoleAssignment/queries";
 import { getManyStates } from "../state";
 import { selectManyPeople, selectPersonOrThrow } from "./queries";

--- a/server/src/model/person/queries/selectManyPeople.test.ts
+++ b/server/src/model/person/queries/selectManyPeople.test.ts
@@ -1,6 +1,6 @@
 import { Person as PrismaPerson } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyPeople } from "./selectManyPeople";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/person/queries/selectPerson.test.ts
+++ b/server/src/model/person/queries/selectPerson.test.ts
@@ -1,6 +1,6 @@
 import { Person as PrismaPerson } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectPerson } from "./selectPerson";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/person/queries/selectPersonOrThrow.test.ts
+++ b/server/src/model/person/queries/selectPersonOrThrow.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { selectPerson } from "./selectPerson";
 
 // Mock imports

--- a/server/src/model/state/queries/selectManyStates.test.ts
+++ b/server/src/model/state/queries/selectManyStates.test.ts
@@ -1,6 +1,6 @@
 import { State as PrismaState } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyStates } from "./selectManyStates";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/state/queries/selectState.test.ts
+++ b/server/src/model/state/queries/selectState.test.ts
@@ -1,6 +1,6 @@
 import { State as PrismaState } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectState } from "./selectState";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/systemRoleAssignment/index.ts
+++ b/server/src/model/systemRoleAssignment/index.ts
@@ -2,7 +2,6 @@ import {
   SystemRoleAssignment as PrismaSystemRoleAssignment,
   Role as PrismaRole,
   RolePermission as PrismaRolePermission,
-  Permission as PrismaPermission,
 } from "@prisma/client";
 
 export { selectManySystemRoleAssignments } from "./queries/selectManySystemRoleAssignments";

--- a/server/src/model/systemRoleAssignment/queries/selectManySystemRoleAssignments.test.ts
+++ b/server/src/model/systemRoleAssignment/queries/selectManySystemRoleAssignments.test.ts
@@ -1,6 +1,5 @@
-import { SystemRoleAssignment as PrismaSystemRoleAssignment } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManySystemRoleAssignments } from "./selectManySystemRoleAssignments";
 import { SystemRoleAssignmentQueryResult } from "..";
 import { DeepPartial } from "../../../testUtilities";

--- a/server/src/model/systemRoleAssignment/queries/selectManySystemRoleAssignments.ts
+++ b/server/src/model/systemRoleAssignment/queries/selectManySystemRoleAssignments.ts
@@ -1,4 +1,4 @@
-import { SystemRoleAssignment as PrismaSystemRoleAssignment, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { prisma, PrismaTransactionClient } from "../../../prismaClient";
 import { SystemRoleAssignmentQueryResult } from "..";
 

--- a/server/src/model/tag/tagResolvers.test.ts
+++ b/server/src/model/tag/tagResolvers.test.ts
@@ -15,14 +15,14 @@ describe("tagResolvers", () => {
 
   describe("getDemonstrationTypes", () => {
     it("should query the demonstration type tags", async () => {
-      const result = await getDemonstrationTypes();
+      await getDemonstrationTypes();
       expect(getFormattedTagsByTagType).toHaveBeenCalledExactlyOnceWith("Demonstration Type");
     });
   });
 
   describe("getApplicationTags", () => {
     it("should query the application tags", async () => {
-      const result = await getApplicationTags();
+      await getApplicationTags();
       expect(getFormattedTagsByTagType).toHaveBeenCalledExactlyOnceWith("Application");
     });
   });

--- a/server/src/model/user/queries/selectManyUsers.test.ts
+++ b/server/src/model/user/queries/selectManyUsers.test.ts
@@ -1,6 +1,6 @@
 import { User as PrismaUser } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { prisma } from "../../../prismaClient";
 import { selectManyUsers } from "./selectManyUsers";
 
 vi.mock("../../../prismaClient", () => ({

--- a/server/src/model/user/queries/selectUserOrThrow.test.ts
+++ b/server/src/model/user/queries/selectUserOrThrow.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { selectUser } from "./selectUser";
 
 // Mock imports

--- a/server/src/model/user/userResolvers.ts
+++ b/server/src/model/user/userResolvers.ts
@@ -1,4 +1,3 @@
-import { prisma } from "../../prismaClient";
 import type { GraphQLContext } from "../../auth";
 import { User as PrismaUser } from "@prisma/client";
 import { resolveManyDeliverables } from "../deliverable";

--- a/server/src/seeder.ts
+++ b/server/src/seeder.ts
@@ -6,7 +6,6 @@ import { fileURLToPath } from "node:url";
 import {
   SDG_DIVISIONS,
   PERSON_TYPES,
-  SIGNATURE_LEVEL,
   PHASE_DOCUMENT_TYPE_MAP,
   NOTE_TYPES,
   TAG_TYPES,
@@ -21,7 +20,6 @@ import {
   UpdateAmendmentInput,
   UpdateExtensionInput,
   SetApplicationDatesInput,
-  Role,
   CreateDeliverableInput,
   PersonType,
   DateTimeOrLocalDate,

--- a/server/src/server.test.ts
+++ b/server/src/server.test.ts
@@ -8,11 +8,11 @@ const ApolloServerMock = class {
   }
 };
 
-const startServerAndCreateLambdaHandlerMock = vi.fn((server: any, handler: any, opts: any) => ({
+const startServerAndCreateLambdaHandlerMock = vi.fn(() => ({
   handlerCalled: true,
 }));
 const handlersMock = { createAPIGatewayProxyEventRequestHandler: vi.fn(() => ({ handler: true })) };
-const ApolloArmorMock = vi.fn(function (this: any, cfg: any) {
+const ApolloArmorMock = vi.fn(function (this: any) {
   this.protect = () => ({ plugins: [], validationRules: [] });
 });
 const validateClaimsMock = vi.fn();


### PR DESCRIPTION
noticed i had left some unused args in some of the resolvers which should be cleaned up. Doing so cascaded the changes to test files where i found some other unused vars. So decided to just remove the exception form the linter rule and clean up all the unused vars from the backend. Thus, 88 files changed but just about all are 1-token removals. Main boon is that the linter rules now enforce it, so we can catch these in the future. 