### PR TITLE
Demos 1991 copy deliverable getx pattern to other types

### DIFF
--- a/server/src/model/amendment/amendmentData.test.ts
+++ b/server/src/model/amendment/amendmentData.test.ts
@@ -3,9 +3,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildAuthorizationFilter, ContextUser } from "../../auth";
 import { getAmendment, getManyAmendments } from "./amendmentData";
 import { selectAmendment, selectManyAmendments } from "./queries";
+import { log } from "../../log";
 
 vi.mock("../../auth", () => ({
   buildAuthorizationFilter: vi.fn(),
+}));
+
+vi.mock("../../log", () => ({
+  log: {
+    warn: vi.fn(),
+  },
 }));
 
 vi.mock("./queries", () => ({
@@ -45,17 +52,63 @@ describe("amendmentData", () => {
   });
 
   describe("getAmendment", () => {
-    it("returns null when authorization filter returns null", async () => {
+    it("throws not found error when authorization filter returns null", async () => {
       vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(null);
+      vi.mocked(selectAmendment).mockResolvedValueOnce(null);
 
-      const result = await getAmendment(where, user);
+      await expect(getAmendment(where, user)).rejects.toThrow(
+        "Requested Amendment not found or User does not have Permission to view it."
+      );
 
       expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
-      expect(selectAmendment).not.toHaveBeenCalled();
-      expect(result).toBeNull();
+      expect(selectAmendment).toHaveBeenCalledExactlyOnceWith(where, undefined);
     });
 
-    it("queries for a single amendment with the authorization filter applied", async () => {
+    it("throws not found error when amendment is not found even if auth filter is applied", async () => {
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      vi.mocked(selectAmendment).mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+
+      await expect(getAmendment(where, user)).rejects.toThrow(
+        "Requested Amendment not found or User does not have Permission to view it."
+      );
+
+      expect(buildAuthorizationFilter).toHaveBeenCalledExactlyOnceWith(user, expect.any(Function));
+
+      expect(selectAmendment).toHaveBeenNthCalledWith(
+        1,
+        {
+          AND: [where, authFilter],
+        },
+        undefined
+      );
+      expect(selectAmendment).toHaveBeenNthCalledWith(2, where, undefined);
+    });
+
+    it("logs a warning and throws not found error when amendment is found but user does not have permission to view it", async () => {
+      const amendment = { id: "amendment-1" } as PrismaAmendment;
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      vi.mocked(selectAmendment).mockResolvedValueOnce(null).mockResolvedValueOnce(amendment);
+
+      await expect(getAmendment(where, user)).rejects.toThrow(
+        "Requested Amendment not found or User does not have Permission to view it."
+      );
+
+      expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
+      expect(buildAuthorizationFilter).toHaveBeenCalledWith(user, expect.any(Function));
+      expect(selectAmendment).toHaveBeenNthCalledWith(
+        1,
+        {
+          AND: [where, authFilter],
+        },
+        undefined
+      );
+      expect(selectAmendment).toHaveBeenNthCalledWith(2, where, undefined);
+      expect(log.warn).toHaveBeenCalledExactlyOnceWith(
+        `User ${user.id} attempted to access Amendment ${amendment.id} without sufficient permissions.`
+      );
+    });
+
+    it("returns the amendment when found and user has permission to view it", async () => {
       const amendment = { id: "amendment-1" } as PrismaAmendment;
       vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
       vi.mocked(selectAmendment).mockResolvedValueOnce(amendment);
@@ -76,6 +129,8 @@ describe("amendmentData", () => {
     it("passes transaction client to selectAmendment if provided", async () => {
       const mockTransactionClient = {} as any;
       vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      const amendment = { id: "amendment-1" } as PrismaAmendment;
+      vi.mocked(selectAmendment).mockResolvedValueOnce(amendment);
 
       await getAmendment(where, user, mockTransactionClient);
       expect(buildAuthorizationFilter).toHaveBeenCalledOnce();

--- a/server/src/model/amendment/amendmentData.ts
+++ b/server/src/model/amendment/amendmentData.ts
@@ -28,7 +28,7 @@ export async function getAmendment(
   where: Prisma.AmendmentWhereInput,
   user: ContextUser,
   tx?: PrismaTransactionClient
-): Promise<PrismaAmendment | null> {
+): Promise<PrismaAmendment> {
   const authFilter = buildAuthorizationFilter<Prisma.AmendmentWhereInput>(
     user,
     getPermissionFilters

--- a/server/src/model/amendment/amendmentData.ts
+++ b/server/src/model/amendment/amendmentData.ts
@@ -3,6 +3,7 @@ import { buildAuthorizationFilter, PermissionFilters, ContextUser } from "../../
 import { selectAmendment, selectManyAmendments } from "./queries";
 import { PrismaTransactionClient } from "../../prismaClient";
 import { isAStatePointOfContactAssociatedWithDemonstration } from "../demonstration/demonstrationData";
+import { log } from "../../log";
 
 export const isAStatePointOfContactAssociatedWithAmendment = (
   userId: string
@@ -33,16 +34,27 @@ export async function getAmendment(
     getPermissionFilters
   );
 
-  if (authFilter === null) {
-    return null;
+  if (authFilter !== null) {
+    const authorizedAmendment = await selectAmendment(
+      {
+        AND: [where, authFilter],
+      },
+      tx
+    );
+
+    if (authorizedAmendment) {
+      return authorizedAmendment;
+    }
   }
 
-  return await selectAmendment(
-    {
-      AND: [where, authFilter],
-    },
-    tx
-  );
+  const amendment = await selectAmendment(where, tx);
+  if (amendment) {
+    log.warn(
+      `User ${user.id} attempted to access Amendment ${amendment.id} without sufficient permissions.`
+    );
+  }
+
+  throw new Error("Requested Amendment not found or User does not have Permission to view it.");
 }
 
 export async function getManyAmendments(

--- a/server/src/model/deliverable/deliverableData.ts
+++ b/server/src/model/deliverable/deliverableData.ts
@@ -28,12 +28,11 @@ export async function getDeliverable(
   where: Prisma.DeliverableWhereInput,
   user: ContextUser,
   tx?: PrismaTransactionClient
-): Promise<PrismaDeliverable | null> {
+): Promise<PrismaDeliverable> {
   const authFilter = buildAuthorizationFilter<Prisma.DeliverableWhereInput>(
     user,
     getPermissionFilters
   );
-
 
   if (authFilter !== null) {
     const authorizedDeliverable = await selectDeliverable(

--- a/server/src/model/deliverable/deliverableData.ts
+++ b/server/src/model/deliverable/deliverableData.ts
@@ -34,7 +34,6 @@ export async function getDeliverable(
     getPermissionFilters
   );
 
-  
 
   if (authFilter !== null) {
     const authorizedDeliverable = await selectDeliverable(

--- a/server/src/model/demonstration/demonstrationData.test.ts
+++ b/server/src/model/demonstration/demonstrationData.test.ts
@@ -3,9 +3,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildAuthorizationFilter, ContextUser } from "../../auth";
 import { getDemonstration, getManyDemonstrations } from "./demonstrationData";
 import { selectDemonstration, selectManyDemonstrations } from "./queries";
+import { log } from "../../log";
 
 vi.mock("../../auth", () => ({
   buildAuthorizationFilter: vi.fn(),
+}));
+
+vi.mock("../../log", () => ({
+  log: {
+    warn: vi.fn(),
+  },
 }));
 
 vi.mock("./queries", () => ({
@@ -43,17 +50,65 @@ describe("demonstrationData", () => {
   });
 
   describe("getDemonstration", () => {
-    it("returns null when authorization filter returns null", async () => {
+    it("throws not found error when authorization filter returns null", async () => {
       vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(null);
+      vi.mocked(selectDemonstration).mockResolvedValueOnce(null);
 
-      const result = await getDemonstration(where, user);
+      await expect(getDemonstration(where, user)).rejects.toThrow(
+        "Requested Demonstration not found or User does not have Permission to view it."
+      );
 
       expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
-      expect(selectDemonstration).not.toHaveBeenCalled();
-      expect(result).toBeNull();
+      expect(selectDemonstration).toHaveBeenCalledExactlyOnceWith(where, undefined);
     });
 
-    it("queries for a single demonstration with the authorization filter applied", async () => {
+    it("throws not found error when demonstration is not found even if auth filter is applied", async () => {
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      vi.mocked(selectDemonstration).mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+
+      await expect(getDemonstration(where, user)).rejects.toThrow(
+        "Requested Demonstration not found or User does not have Permission to view it."
+      );
+
+      expect(buildAuthorizationFilter).toHaveBeenCalledExactlyOnceWith(user, expect.any(Function));
+
+      expect(selectDemonstration).toHaveBeenNthCalledWith(
+        1,
+        {
+          AND: [where, authFilter],
+        },
+        undefined
+      );
+      expect(selectDemonstration).toHaveBeenNthCalledWith(2, where, undefined);
+    });
+
+    it("logs a warning and throws not found error when demonstration is found but user does not have permission to view it", async () => {
+      const demonstration = { id: "demonstration-1" } as PrismaDemonstration;
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      vi.mocked(selectDemonstration)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(demonstration);
+
+      await expect(getDemonstration(where, user)).rejects.toThrow(
+        "Requested Demonstration not found or User does not have Permission to view it."
+      );
+
+      expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
+      expect(buildAuthorizationFilter).toHaveBeenCalledWith(user, expect.any(Function));
+      expect(selectDemonstration).toHaveBeenNthCalledWith(
+        1,
+        {
+          AND: [where, authFilter],
+        },
+        undefined
+      );
+      expect(selectDemonstration).toHaveBeenNthCalledWith(2, where, undefined);
+      expect(log.warn).toHaveBeenCalledExactlyOnceWith(
+        `User ${user.id} attempted to access Demonstration ${demonstration.id} without sufficient permissions.`
+      );
+    });
+
+    it("returns the demonstration when found and user has permission to view it", async () => {
       const demonstration = { id: "demonstration-1" } as PrismaDemonstration;
       vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
       vi.mocked(selectDemonstration).mockResolvedValueOnce(demonstration);
@@ -74,6 +129,8 @@ describe("demonstrationData", () => {
     it("passes transaction client to selectDemonstration if provided", async () => {
       const mockTransactionClient = {} as any;
       vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      const demonstration = { id: "demonstration-1" } as PrismaDemonstration;
+      vi.mocked(selectDemonstration).mockResolvedValueOnce(demonstration);
 
       await getDemonstration(where, user, mockTransactionClient);
       expect(buildAuthorizationFilter).toHaveBeenCalledOnce();

--- a/server/src/model/demonstration/demonstrationData.ts
+++ b/server/src/model/demonstration/demonstrationData.ts
@@ -2,6 +2,7 @@ import { Prisma, Demonstration as PrismaDemonstration } from "@prisma/client";
 import { buildAuthorizationFilter, PermissionFilters, ContextUser } from "../../auth";
 import { selectDemonstration, selectManyDemonstrations } from "./queries";
 import { PrismaTransactionClient } from "../../prismaClient";
+import { log } from "../../log";
 
 export const isAStatePointOfContactAssociatedWithDemonstration = (
   userId: string
@@ -36,16 +37,27 @@ export async function getDemonstration(
     getPermissionFilters
   );
 
-  if (authFilter === null) {
-    return null;
+  if (authFilter !== null) {
+    const authorizedDemonstration = await selectDemonstration(
+      {
+        AND: [where, authFilter],
+      },
+      tx
+    );
+
+    if (authorizedDemonstration) {
+      return authorizedDemonstration;
+    }
   }
 
-  return await selectDemonstration(
-    {
-      AND: [where, authFilter],
-    },
-    tx
-  );
+  const demonstration = await selectDemonstration(where, tx);
+  if (demonstration) {
+    log.warn(
+      `User ${user.id} attempted to access Demonstration ${demonstration.id} without sufficient permissions.`
+    );
+  }
+
+  throw new Error("Requested Demonstration not found or User does not have Permission to view it.");
 }
 
 export async function getManyDemonstrations(

--- a/server/src/model/demonstration/demonstrationData.ts
+++ b/server/src/model/demonstration/demonstrationData.ts
@@ -31,7 +31,7 @@ export async function getDemonstration(
   where: Prisma.DemonstrationWhereInput,
   user: ContextUser,
   tx?: PrismaTransactionClient
-): Promise<PrismaDemonstration | null> {
+): Promise<PrismaDemonstration> {
   const authFilter = buildAuthorizationFilter<Prisma.DemonstrationWhereInput>(
     user,
     getPermissionFilters

--- a/server/src/model/document/documentData.test.ts
+++ b/server/src/model/document/documentData.test.ts
@@ -3,9 +3,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildAuthorizationFilter, ContextUser } from "../../auth";
 import { getDocument, getManyDocuments } from "./documentData";
 import { selectDocument, selectManyDocuments } from "./queries";
+import { log } from "../../log";
 
 vi.mock("../../auth", () => ({
   buildAuthorizationFilter: vi.fn(),
+}));
+
+vi.mock("../../log", () => ({
+  log: {
+    warn: vi.fn(),
+  },
 }));
 
 vi.mock("./queries", () => ({
@@ -38,17 +45,63 @@ describe("documentData", () => {
   });
 
   describe("getDocument", () => {
-    it("returns null when authorization filter returns null", async () => {
+    it("throws not found error when authorization filter returns null", async () => {
       vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(null);
+      vi.mocked(selectDocument).mockResolvedValueOnce(null);
 
-      const result = await getDocument(where, user);
+      await expect(getDocument(where, user)).rejects.toThrow(
+        "Requested Document not found or User does not have Permission to view it."
+      );
 
       expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
-      expect(selectDocument).not.toHaveBeenCalled();
-      expect(result).toBeNull();
+      expect(selectDocument).toHaveBeenCalledExactlyOnceWith(where, undefined);
     });
 
-    it("queries for a single document with the authorization filter applied", async () => {
+    it("throws not found error when document is not found even if auth filter is applied", async () => {
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      vi.mocked(selectDocument).mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+
+      await expect(getDocument(where, user)).rejects.toThrow(
+        "Requested Document not found or User does not have Permission to view it."
+      );
+
+      expect(buildAuthorizationFilter).toHaveBeenCalledExactlyOnceWith(user, expect.any(Function));
+
+      expect(selectDocument).toHaveBeenNthCalledWith(
+        1,
+        {
+          AND: [where, authFilter],
+        },
+        undefined
+      );
+      expect(selectDocument).toHaveBeenNthCalledWith(2, where, undefined);
+    });
+
+    it("logs a warning and throws not found error when document is found but user does not have permission to view it", async () => {
+      const document = { id: "document-1" } as PrismaDocument;
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      vi.mocked(selectDocument).mockResolvedValueOnce(null).mockResolvedValueOnce(document);
+
+      await expect(getDocument(where, user)).rejects.toThrow(
+        "Requested Document not found or User does not have Permission to view it."
+      );
+
+      expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
+      expect(buildAuthorizationFilter).toHaveBeenCalledWith(user, expect.any(Function));
+      expect(selectDocument).toHaveBeenNthCalledWith(
+        1,
+        {
+          AND: [where, authFilter],
+        },
+        undefined
+      );
+      expect(selectDocument).toHaveBeenNthCalledWith(2, where, undefined);
+      expect(log.warn).toHaveBeenCalledExactlyOnceWith(
+        `User ${user.id} attempted to access Document ${document.id} without sufficient permissions.`
+      );
+    });
+
+    it("returns the document when found and user has permission to view it", async () => {
       const document = { id: "document-1" } as PrismaDocument;
       vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
       vi.mocked(selectDocument).mockResolvedValueOnce(document);
@@ -69,6 +122,8 @@ describe("documentData", () => {
     it("passes transaction client to selectDocument if provided", async () => {
       const mockTransactionClient = {} as any;
       vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      const document = { id: "document-1" } as PrismaDocument;
+      vi.mocked(selectDocument).mockResolvedValueOnce(document);
 
       await getDocument(where, user, mockTransactionClient);
       expect(buildAuthorizationFilter).toHaveBeenCalledOnce();

--- a/server/src/model/document/documentData.ts
+++ b/server/src/model/document/documentData.ts
@@ -3,6 +3,7 @@ import { buildAuthorizationFilter, PermissionFilters, ContextUser } from "../../
 import { selectDocument, selectManyDocuments } from "./queries";
 import { PrismaTransactionClient } from "../../prismaClient";
 import { isAStatePointOfContactAssociatedWithApplication } from "../application/applicationData";
+import { log } from "../../log";
 
 export const isAStatePointOfContactAssociatedWithDocument = (
   userId: string
@@ -35,16 +36,27 @@ export async function getDocument(
     getPermissionFilters
   );
 
-  if (authFilter === null) {
-    return null;
+  if (authFilter !== null) {
+    const authorizedDocument = await selectDocument(
+      {
+        AND: [where, authFilter],
+      },
+      tx
+    );
+
+    if (authorizedDocument) {
+      return authorizedDocument;
+    }
   }
 
-  return await selectDocument(
-    {
-      AND: [where, authFilter],
-    },
-    tx
-  );
+  const document = await selectDocument(where, tx);
+  if (document) {
+    log.warn(
+      `User ${user.id} attempted to access Document ${document.id} without sufficient permissions.`
+    );
+  }
+
+  throw new Error("Requested Document not found or User does not have Permission to view it.");
 }
 
 export async function getManyDocuments(

--- a/server/src/model/document/documentData.ts
+++ b/server/src/model/document/documentData.ts
@@ -30,7 +30,7 @@ export async function getDocument(
   where: Prisma.DocumentWhereInput,
   user: ContextUser,
   tx?: PrismaTransactionClient
-): Promise<PrismaDocument | null> {
+): Promise<PrismaDocument> {
   const authFilter = buildAuthorizationFilter<Prisma.DocumentWhereInput>(
     user,
     getPermissionFilters

--- a/server/src/model/document/documentResolvers.test.ts
+++ b/server/src/model/document/documentResolvers.test.ts
@@ -142,7 +142,7 @@ describe("documentResolvers", () => {
   });
 
   describe("Query.documentExists", () => {
-    it("returns true when getDocument returns non-null", async () => {
+    it("returns true when getDocument returns", async () => {
       vi.mocked(getDocument).mockResolvedValue({ id: "abc123" } as PrismaDocument);
       const result = await documentResolvers.Query.documentExists(
         undefined,
@@ -153,8 +153,8 @@ describe("documentResolvers", () => {
       expect(result).toBe(true);
     });
 
-    it("returns false when getDocument returns null", async () => {
-      vi.mocked(getDocument).mockResolvedValue(null);
+    it("returns false when getDocument throws", async () => {
+      vi.mocked(getDocument).mockRejectedValue(new Error());
       const result = await documentResolvers.Query.documentExists(
         undefined,
         { documentId: "abc123" },
@@ -221,9 +221,7 @@ describe("documentResolvers", () => {
   describe("Document.owner", () => {
     it("delegates to userData/queries.selectUserOrThrow", () => {
       documentResolvers.Document.owner(mockDocument);
-      expect(selectUserOrThrow).toHaveBeenCalledExactlyOnceWith(
-        { id: mockDocument.ownerUserId },
-      );
+      expect(selectUserOrThrow).toHaveBeenCalledExactlyOnceWith({ id: mockDocument.ownerUserId });
     });
   });
 
@@ -260,16 +258,6 @@ describe("documentResolvers", () => {
       await expect(
         triggerUiPath(undefined, { documentId: testDocumentId }, mockContext)
       ).rejects.toThrow("Queue send failed");
-    });
-
-    it("throws when document does not exist", async () => {
-      vi.mocked(getDocument).mockResolvedValue(null);
-
-      await expect(triggerUiPath(undefined, { documentId: "abc123" }, mockContext)).rejects.toThrow(
-        `Document with ID abc123 does not exist.`
-      );
-      expect(getDocument).toHaveBeenCalledExactlyOnceWith({ id: "abc123" }, mockContext.user);
-      expect(enqueueUiPath).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/model/document/documentResolvers.ts
+++ b/server/src/model/document/documentResolvers.ts
@@ -108,7 +108,13 @@ export const documentResolvers = {
       parent: unknown,
       args: { documentId: string },
       context: GraphQLContext
-    ) => !!(await getDocument({ id: args.documentId }, context.user)),
+    ) => {
+      try {
+        return !!(await getDocument({ id: args.documentId }, context.user));
+      } catch {
+        return false;
+      }
+    },
   },
 
   Mutation: {
@@ -119,8 +125,7 @@ export const documentResolvers = {
   },
 
   Document: {
-    owner: (parent: PrismaDocument) =>
-      selectUserOrThrow({ id: parent.ownerUserId }),
+    owner: (parent: PrismaDocument) => selectUserOrThrow({ id: parent.ownerUserId }),
     documentType: (parent: PrismaDocument) => parent.documentTypeId as DocumentType,
     presignedDownloadUrl: async (parent: PrismaDocument) =>
       await getS3Adapter().getPresignedDownloadUrl(parent.s3Path),

--- a/server/src/model/extension/extensionData.test.ts
+++ b/server/src/model/extension/extensionData.test.ts
@@ -3,9 +3,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildAuthorizationFilter, ContextUser } from "../../auth";
 import { getExtension, getManyExtensions } from "./extensionData";
 import { selectExtension, selectManyExtensions } from "./queries";
+import { log } from "../../log";
 
 vi.mock("../../auth", () => ({
   buildAuthorizationFilter: vi.fn(),
+}));
+
+vi.mock("../../log", () => ({
+  log: {
+    warn: vi.fn(),
+  },
 }));
 
 vi.mock("./queries", () => ({
@@ -45,17 +52,63 @@ describe("extensionData", () => {
   });
 
   describe("getExtension", () => {
-    it("returns null when authorization filter returns null", async () => {
+    it("throws not found error when authorization filter returns null", async () => {
       vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(null);
+      vi.mocked(selectExtension).mockResolvedValueOnce(null);
 
-      const result = await getExtension(where, user);
+      await expect(getExtension(where, user)).rejects.toThrow(
+        "Requested Extension not found or User does not have Permission to view it."
+      );
 
       expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
-      expect(selectExtension).not.toHaveBeenCalled();
-      expect(result).toBeNull();
+      expect(selectExtension).toHaveBeenCalledExactlyOnceWith(where, undefined);
     });
 
-    it("queries for a single extension with the authorization filter applied", async () => {
+    it("throws not found error when extension is not found even if auth filter is applied", async () => {
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      vi.mocked(selectExtension).mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+
+      await expect(getExtension(where, user)).rejects.toThrow(
+        "Requested Extension not found or User does not have Permission to view it."
+      );
+
+      expect(buildAuthorizationFilter).toHaveBeenCalledExactlyOnceWith(user, expect.any(Function));
+
+      expect(selectExtension).toHaveBeenNthCalledWith(
+        1,
+        {
+          AND: [where, authFilter],
+        },
+        undefined
+      );
+      expect(selectExtension).toHaveBeenNthCalledWith(2, where, undefined);
+    });
+
+    it("logs a warning and throws not found error when extension is found but user does not have permission to view it", async () => {
+      const extension = { id: "extension-1" } as PrismaExtension;
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      vi.mocked(selectExtension).mockResolvedValueOnce(null).mockResolvedValueOnce(extension);
+
+      await expect(getExtension(where, user)).rejects.toThrow(
+        "Requested Extension not found or User does not have Permission to view it."
+      );
+
+      expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
+      expect(buildAuthorizationFilter).toHaveBeenCalledWith(user, expect.any(Function));
+      expect(selectExtension).toHaveBeenNthCalledWith(
+        1,
+        {
+          AND: [where, authFilter],
+        },
+        undefined
+      );
+      expect(selectExtension).toHaveBeenNthCalledWith(2, where, undefined);
+      expect(log.warn).toHaveBeenCalledExactlyOnceWith(
+        `User ${user.id} attempted to access Extension ${extension.id} without sufficient permissions.`
+      );
+    });
+
+    it("returns the extension when found and user has permission to view it", async () => {
       const extension = { id: "extension-1" } as PrismaExtension;
       vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
       vi.mocked(selectExtension).mockResolvedValueOnce(extension);
@@ -73,9 +126,11 @@ describe("extensionData", () => {
       expect(result).toBe(extension);
     });
 
-    it("passes transaction client to selectManyAmendments if provided", async () => {
+    it("passes transaction client to selectExtension if provided", async () => {
       const mockTransactionClient = {} as any;
       vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      const extension = { id: "extension-1" } as PrismaExtension;
+      vi.mocked(selectExtension).mockResolvedValueOnce(extension);
 
       await getExtension(where, user, mockTransactionClient);
       expect(buildAuthorizationFilter).toHaveBeenCalledOnce();

--- a/server/src/model/extension/extensionData.ts
+++ b/server/src/model/extension/extensionData.ts
@@ -28,12 +28,11 @@ export async function getExtension(
   where: Prisma.ExtensionWhereInput,
   user: ContextUser,
   tx?: PrismaTransactionClient
-): Promise<PrismaExtension | null> {
+): Promise<PrismaExtension> {
   const authFilter = buildAuthorizationFilter<Prisma.ExtensionWhereInput>(
     user,
     getPermissionFilters
   );
-
 
   if (authFilter !== null) {
     const authorizedExtension = await selectExtension(

--- a/server/src/model/extension/extensionData.ts
+++ b/server/src/model/extension/extensionData.ts
@@ -3,6 +3,7 @@ import { buildAuthorizationFilter, PermissionFilters, ContextUser } from "../../
 import { selectExtension, selectManyExtensions } from "./queries";
 import { PrismaTransactionClient } from "../../prismaClient";
 import { isAStatePointOfContactAssociatedWithDemonstration } from "../demonstration/demonstrationData";
+import { log } from "../../log";
 
 export const isAStatePointOfContactAssociatedWithExtension = (
   userId: string
@@ -33,18 +34,29 @@ export async function getExtension(
     getPermissionFilters
   );
 
-  if (authFilter === null) {
-    return null;
+
+  if (authFilter !== null) {
+    const authorizedExtension = await selectExtension(
+      {
+        AND: [where, authFilter],
+      },
+      tx
+    );
+
+    if (authorizedExtension) {
+      return authorizedExtension;
+    }
   }
 
-  return await selectExtension(
-    {
-      AND: [where, authFilter],
-    },
-    tx
-  );
-}
+  const extension = await selectExtension(where, tx);
+  if (extension) {
+    log.warn(
+      `User ${user.id} attempted to access Extension ${extension.id} without sufficient permissions.`
+    );
+  }
 
+  throw new Error("Requested Extension not found or User does not have Permission to view it.");
+}
 export async function getManyExtensions(
   where: Prisma.ExtensionWhereInput,
   user: ContextUser,


### PR DESCRIPTION
During the development of the DeliverableData's getDeliverable function, we settled on a pattern that for the "singleton" resolvers, we should protect against returning null when the gql schema expects a non-null value.  Instead, it returns an explicit error stating that the row was either not found or the user doesnt have the permission to view it, logging in the case of a permission violation.  Coincidentally, state users dont have access to the amendments, extensions, or documents queries (because of directive permissions) but nontheless would rather keep the pattern consistent between each of these types at the fetch level. 

This PR copies that pattern for the other main objects such that our 5 core object each utilize this: Deliverables (already done), demonstrations, amendments, extensions, and documents. 