### PR TITLE
DEMOS-2159: Add new library function to conditionally catch errors

### DIFF
--- a/pipelines/lib/vars/handleError.groovy
+++ b/pipelines/lib/vars/handleError.groovy
@@ -1,0 +1,29 @@
+import groovy.transform.Field
+
+@Field List<String> caughtFailures = []
+
+def call(Boolean shouldCatchError = false, Closure body) {
+  if (shouldCatchError) {
+    catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {
+      try {
+        body()
+      } catch ( Exception err) {
+        echo "Failure in ${env.STAGE_NAME}"
+        echo "Error: ${err}"
+
+        caughtFailures << env.STAGE_NAME
+
+        throw err
+      }
+    }
+  } else {
+    body()
+  }
+}
+
+def setFailureDescription() {
+  if (caughtFailures.size() > 0) {
+    def failureList = caughtFailures.join('|')
+    currentBuild.description = "${failureList}"
+  }
+}


### PR DESCRIPTION
This is part 1 of a 2-part ticket. I'm splitting this up just so that I can get the library function in to `main` and then test using it on the rest of the changes.

This function conditionally catches all errors. If "shouldCatchError" is true, and there are errors within a stage, the stage will fail, but the pipeline itself will continue. The stage name will be added to the list of caught failures to use for reporting.

This function will allow the deployment pipeline to report issues, but still deploy when new errors arise that weren't directly caused by code changes from a merged PR.