### PR TITLE
DEMOS-1785: configured start and end dates for phase 8

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -436,7 +436,10 @@ export const PHASE_START_END_DATES: PhaseStartEndDateRecord = {
     startDate: "Approval Package Start Date",
     endDate: "Approval Package Completion Date",
   },
-  "Approval Summary": {},
+  "Approval Summary": {
+    startDate: "Approval Summary Start Date",
+    endDate: "Approval Summary Completion Date",
+  },
 };
 
 export const TAG_STATUSES = ["Unapproved", "Approved"] as const;
@@ -477,7 +480,7 @@ export const PERMISSIONS = [
   "View Owned Documents",
   "View All Deliverables",
   "View Deliverables on Assigned Demonstrations",
-  
+
   // Field Level Permissions
   "Access CMS Field",
   "Access CMS Query",

--- a/server/src/model/applicationDate/createPhaseStartDate.test.ts
+++ b/server/src/model/applicationDate/createPhaseStartDate.test.ts
@@ -66,16 +66,4 @@ describe("createPhaseStartDate", () => {
       });
     });
   });
-
-  describe("when phase has no start date", () => {
-    it("should return null for phase without start date", () => {
-      // approval summary phase currently has no start date
-      const phaseId = "Approval Summary" as PhaseName;
-
-      const result = createPhaseStartDate(phaseId, mockEasternNow);
-
-      expect(result).toBeNull();
-      expect(getDayBoundaryLabel).not.toHaveBeenCalled();
-    });
-  });
 });


### PR DESCRIPTION
Thought it was curious why this wasnt working already. No _real_ code change needed, just a configuration of a const. Not sure how that was missed, but now correctly captures the start date and not just the status. 

Tried to find some context to see if this was intentional, since we had a test case for it, but from what i could find i think that was just to cover a technicallypossible codepath, but wasnt actually a requirement