### PR TITLE
Demos 1991 remove search people query

### DIFF
--- a/client/src/components/dialog/DialogContext.test.tsx
+++ b/client/src/components/dialog/DialogContext.test.tsx
@@ -424,7 +424,7 @@ const TestConsumer: React.FC = () => {
       </button>
       <button
         data-testid="open-contacts-btn"
-        onClick={() => showManageContactsDialog("demo-id", mockRoles)}
+        onClick={() => showManageContactsDialog("demo-id", "NC", mockRoles)}
       >
         Open Manage Contacts Dialog
       </button>

--- a/client/src/components/dialog/DialogContext.tsx
+++ b/client/src/components/dialog/DialogContext.tsx
@@ -108,11 +108,13 @@ export const useDialog = () => {
 
   const showManageContactsDialog = (
     demonstrationId: string,
+    stateId: string,
     existingContacts?: ExistingContactType[]
   ) => {
     context.showDialog(
       <ManageContactsDialog
         demonstrationId={demonstrationId}
+        stateId={stateId}
         existingContacts={existingContacts}
         onClose={context.hideDialog}
       />

--- a/client/src/components/dialog/ManageContactsDialog.test.tsx
+++ b/client/src/components/dialog/ManageContactsDialog.test.tsx
@@ -10,44 +10,28 @@ import { DIALOG_CANCEL_BUTTON_NAME } from "components/dialog/BaseDialog";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { ManageContactsDialog, ManageContactsDialogProps } from "./ManageContactsDialog";
-
-// GraphQL queries used in the component
-const SEARCH_PEOPLE_QUERY = gql`
-  query SearchPeople($search: String!, $demonstrationId: ID) {
-    searchPeople(search: $search, demonstrationId: $demonstrationId) {
-      id
-      firstName
-      lastName
-      email
-      personType
-    }
-  }
-`;
-
-const SET_DEMONSTRATION_ROLE_MUTATION = gql`
-  mutation SetDemonstrationRoles($input: [SetDemonstrationRoleInput!]!) {
-    setDemonstrationRoles(input: $input) {
-      role
-    }
-  }
-`;
+import {
+  ManageContactsDialog,
+  ManageContactsDialogProps,
+  SEARCH_PEOPLE_QUERY,
+  SET_DEMONSTRATION_ROLE_MUTATION,
+} from "./ManageContactsDialog";
 
 // Mock GraphQL queries/mutations - Multiple search terms
-const createSearchMock = (searchTerm: string) => ({
+const createSearchMock = () => ({
   request: {
     query: SEARCH_PEOPLE_QUERY,
-    variables: { search: searchTerm, demonstrationId: "demo-1" },
   },
   result: {
     data: {
-      searchPeople: [
+      people: [
         {
           id: "person-1",
           firstName: "John",
           lastName: "Doe",
           email: "john.doe@example.com",
           personType: "demos-cms-user",
+          states: [{ id: "NC" }],
         },
         {
           id: "person-2",
@@ -55,20 +39,15 @@ const createSearchMock = (searchTerm: string) => ({
           lastName: "Smith",
           email: "jane.smith@state.gov",
           personType: "demos-state-user",
+          states: [{ id: "SC" }, { id: "GA" }],
         },
       ],
     },
   },
+  maxUsageCount: Number.POSITIVE_INFINITY,
 });
 
-const SEARCH_PEOPLE_MOCKS = [
-  createSearchMock("jo"),
-  createSearchMock("joh"),
-  createSearchMock("john"),
-  createSearchMock("ja"),
-  createSearchMock("jan"),
-  createSearchMock("jane"),
-];
+const SEARCH_PEOPLE_MOCKS = [createSearchMock()];
 
 const SET_ROLES_MOCK = {
   request: {
@@ -93,6 +72,7 @@ const SET_ROLES_MOCK = {
 
 const defaultProps: ManageContactsDialogProps = {
   onClose: vi.fn(),
+  stateId: "NC",
   demonstrationId: "demo-1",
   existingContacts: [],
 };
@@ -450,7 +430,9 @@ describe("ManageContactsDialog", () => {
       expect(screen.getByText("John Doe")).toBeInTheDocument();
     });
 
-    const deleteButton = screen.getByRole("button", { name: "Delete Contact - Assign another Primary Project Officer to Delete" });
+    const deleteButton = screen.getByRole("button", {
+      name: "Delete Contact - Assign another Primary Project Officer to Delete",
+    });
     expect(deleteButton).toBeDisabled();
   });
 
@@ -504,17 +486,23 @@ describe("ManageContactsDialog", () => {
 
     // Primary Project Officer should be disabled
     const johnRow = screen.getByText("John Doe").closest("tr");
-    const johnDeleteButton = within(johnRow!).getByRole("button", { name: "Delete Contact - Assign another Primary Project Officer to Delete" });
+    const johnDeleteButton = within(johnRow!).getByRole("button", {
+      name: "Delete Contact - Assign another Primary Project Officer to Delete",
+    });
     expect(johnDeleteButton).toBeDisabled();
 
     // Primary State Point of Contact should be enabled (not a Project Officer)
     const janeRow = screen.getByText("Jane Smith").closest("tr");
-    const janeDeleteButton = within(janeRow!).getByRole("button", { name: "Delete Contact - Delete" });
+    const janeDeleteButton = within(janeRow!).getByRole("button", {
+      name: "Delete Contact - Delete",
+    });
     expect(janeDeleteButton).not.toBeDisabled();
 
     // Non-primary State Point of Contact should be enabled
     const bobRow = screen.getByText("Bob Wilson").closest("tr");
-    const bobDeleteButton = within(bobRow!).getByRole("button", { name: "Delete Contact - Delete" });
+    const bobDeleteButton = within(bobRow!).getByRole("button", {
+      name: "Delete Contact - Delete",
+    });
     expect(bobDeleteButton).not.toBeDisabled();
   });
 
@@ -700,9 +688,7 @@ describe("ManageContactsDialog", () => {
     });
     const searchResults1 = await screen.getByTestId("search-results-dropdown");
 
-    await user.click(
-      within(searchResults1).getByText("John Doe")
-    );
+    await user.click(within(searchResults1).getByText("John Doe"));
 
     // Assign role so search re-enables
     const firstSelect = await screen.getByTestId("contact-type-0");
@@ -715,16 +701,16 @@ describe("ManageContactsDialog", () => {
     });
     const searchResults2 = await screen.getByTestId("search-results-dropdown");
 
-    await user.click(
-      within(searchResults2).getByText("John Doe")
-    );
+    await user.click(within(searchResults2).getByText("John Doe"));
 
     // Now second row should exist
     const secondSelect = screen.getByTestId("contact-type-1");
 
     await waitFor(() => {
       expect(
-        within(secondSelect).getAllByRole("option").map(o => o.textContent)
+        within(secondSelect)
+          .getAllByRole("option")
+          .map((o) => o.textContent)
       ).not.toContain("Project Officer");
     });
   });
@@ -946,7 +932,9 @@ describe("ManageContactsDialog", () => {
 
       renderWithProviders(propsWithContacts);
 
-      const deleteButton = screen.getByRole("button", { name: "Delete Contact - Assign another Primary Project Officer to Delete" });
+      const deleteButton = screen.getByRole("button", {
+        name: "Delete Contact - Assign another Primary Project Officer to Delete",
+      });
       expect(deleteButton).toBeDisabled();
     });
 
@@ -988,14 +976,18 @@ describe("ManageContactsDialog", () => {
 
       // Find the delete button for the primary Project Officer (John Doe)
       const johnRow = screen.getByText("John Doe (Primary)").closest("tr");
-      const johnDeleteButton = within(johnRow!).getByRole("button", { name: "Delete Contact - Assign another Primary Project Officer to Delete" });
+      const johnDeleteButton = within(johnRow!).getByRole("button", {
+        name: "Delete Contact - Assign another Primary Project Officer to Delete",
+      });
 
       // Primary Project Officer delete button should ALWAYS be disabled
       expect(johnDeleteButton).toBeDisabled();
 
       // Find the delete button for the non-primary Project Officer (Jane Smith)
       const janeRow = screen.getByText("Jane Smith").closest("tr");
-      const janeDeleteButton = within(janeRow!).getByRole("button", { name: "Delete Contact - Delete" });
+      const janeDeleteButton = within(janeRow!).getByRole("button", {
+        name: "Delete Contact - Delete",
+      });
 
       // Non-primary Project Officer delete button should be enabled when there are multiple POs
       expect(janeDeleteButton).not.toBeDisabled();
@@ -1040,7 +1032,9 @@ describe("ManageContactsDialog", () => {
 
       // Find the delete button for the non-primary Project Officer (Jane Smith)
       const janeRow = screen.getByText("Jane Smith").closest("tr");
-      const deleteButton = within(janeRow!).getByRole("button", { name: "Delete Contact - Delete" });
+      const deleteButton = within(janeRow!).getByRole("button", {
+        name: "Delete Contact - Delete",
+      });
 
       // Non-primary Project Officer should be deletable
       expect(deleteButton).not.toBeDisabled();
@@ -1283,7 +1277,7 @@ describe("ManageContactsDialog", () => {
       const user = userEvent.setup();
       const mocks = SEARCH_PEOPLE_MOCKS;
 
-      renderWithProviders(defaultProps, mocks);
+      renderWithProviders({ ...defaultProps, stateId: "GA" }, mocks);
 
       const searchInput = screen.getByPlaceholderText("Search by name or email");
 

--- a/client/src/components/dialog/ManageContactsDialog.tsx
+++ b/client/src/components/dialog/ManageContactsDialog.tsx
@@ -24,19 +24,22 @@ import type { ContactRow, ContactType } from "../table/columns/ContactColumns";
 import { ContactColumns } from "../table/columns/ContactColumns";
 import { PaginationControls } from "../table/PaginationControls";
 
-const SEARCH_PEOPLE_QUERY = gql`
-  query SearchPeople($search: String!, $demonstrationId: ID) {
-    searchPeople(search: $search, demonstrationId: $demonstrationId) {
+export const SEARCH_PEOPLE_QUERY = gql`
+  query ManageContactsQuery {
+    people {
       id
       firstName
       lastName
       email
       personType
+      states {
+        id
+      }
     }
   }
 `;
 
-const SET_DEMONSTRATION_ROLE_MUTATION = gql`
+export const SET_DEMONSTRATION_ROLE_MUTATION = gql`
   mutation SetDemonstrationRoles($input: [SetDemonstrationRoleInput!]!) {
     setDemonstrationRoles(input: $input) {
       role
@@ -77,6 +80,9 @@ type PersonSearchResult = {
   lastName: string;
   email: string;
   personType: string;
+  states: {
+    id: string;
+  }[];
 };
 
 export type ExistingContactType = Pick<DemonstrationRoleAssignment, "role" | "isPrimary"> & {
@@ -87,6 +93,7 @@ export type ExistingContactType = Pick<DemonstrationRoleAssignment, "role" | "is
 export type ManageContactsDialogProps = {
   onClose: () => void;
   demonstrationId: string;
+  stateId: string;
   existingContacts?: ExistingContactType[];
 };
 
@@ -104,6 +111,7 @@ const mapExistingContacts = (arr: ManageContactsDialogProps["existingContacts"] 
 export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
   onClose,
   demonstrationId,
+  stateId,
   existingContacts = [],
 }) => {
   const contactIdCounter = useRef(0);
@@ -125,7 +133,7 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
   const [searchPeople] = useLazyQuery(SEARCH_PEOPLE_QUERY, {
     fetchPolicy: "network-only",
     onCompleted: (data) => {
-      const results = data.searchPeople || [];
+      const results = data.people || [];
       setSearchResults(results);
     },
     onError: (error) => {
@@ -182,12 +190,7 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
     if (!personId) return options;
 
     const usedRoles = selectedContacts
-      .filter(
-        (c) =>
-          c.personId === personId &&
-          c.contactType &&
-          c.id !== currentRowId
-      )
+      .filter((c) => c.personId === personId && c.contactType && c.id !== currentRowId)
       .map((c) => c.contactType);
 
     return options.filter((opt) => !usedRoles.includes(opt.value));
@@ -197,12 +200,7 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
 
   useEffect(() => {
     if (debouncedSearchTerm.length >= 2) {
-      searchPeople({
-        variables: {
-          search: debouncedSearchTerm,
-          demonstrationId: demonstrationId,
-        },
-      });
+      searchPeople();
     } else {
       setSearchResults([]);
     }
@@ -262,10 +260,7 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
 
           if (newType === "Project Officer") {
             const existingPrimaryPOs = previousContacts.filter(
-              (c) =>
-                c.contactType === "Project Officer" &&
-                c.isPrimary &&
-                c.id !== id
+              (c) => c.contactType === "Project Officer" && c.isPrimary && c.id !== id
             );
             newIsPrimary = existingPrimaryPOs.length === 0;
           }
@@ -534,7 +529,6 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
     }
   };
 
-
   const contactColumns = useMemo(
     () =>
       ContactColumns({
@@ -594,21 +588,26 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
               </div>
             )}
             {(() => {
-              let filteredResults = searchResults.filter((p) => {
-                const idmRoles = [p.personType];
+              let filteredResults = searchResults
+                .filter((person) => {
+                  return person.states.some((s) => s.id === stateId);
+                })
+                .filter((p) => {
+                  const idmRoles = [p.personType];
 
-                const allowedRoles = getFilteredContactTypeOptions(idmRoles).map((r) => r.value);
+                  const allowedRoles = getFilteredContactTypeOptions(idmRoles).map((r) => r.value);
 
-                const alreadyUsedRoles = selectedContacts
-                  .filter((c) => c.personId === p.id && c.contactType)
-                  .map((c) => c.contactType);
+                  const alreadyUsedRoles = selectedContacts
+                    .filter((c) => c.personId === p.id && c.contactType)
+                    .map((c) => c.contactType);
 
-                const remainingRoles = allowedRoles.filter((role) => !alreadyUsedRoles.includes(role));
+                  const remainingRoles = allowedRoles.filter(
+                    (role) => !alreadyUsedRoles.includes(role)
+                  );
 
-                return remainingRoles.length > 0;
-              }).filter(
-                (p, index, arr) => arr.findIndex((item) => item.id === p.id) === index
-              );
+                  return remainingRoles.length > 0;
+                })
+                .filter((p, index, arr) => arr.findIndex((item) => item.id === p.id) === index);
 
               if (searchTerm.length >= 2) {
                 const searchTermLower = searchTerm.toLowerCase();

--- a/client/src/pages/DemonstrationDetail/ContactsTab.test.tsx
+++ b/client/src/pages/DemonstrationDetail/ContactsTab.test.tsx
@@ -22,6 +22,9 @@ vi.mock("components/dialog/DialogContext", () => ({
 
 const mockDemonstration: DemonstrationTabDemonstration = {
   id: "demo-123",
+  state: {
+    id: "NC",
+  },
   name: "Contacts Test Demonstration",
   status: "Pre-Submission" as const,
   currentPhaseName: "Concept" as const,
@@ -70,6 +73,9 @@ const mockDemonstration: DemonstrationTabDemonstration = {
 
 const mockDemonstrationEmptyRoles: DemonstrationTabDemonstration = {
   id: "demo-123",
+  state: {
+    id: "NC",
+  },
   name: "Contacts Test Demonstration",
   status: "Pre-Submission" as const,
   currentPhaseName: "Concept" as const,
@@ -143,7 +149,7 @@ describe("DemonstrationTab", () => {
       }));
 
       // Verify the dialog gets the mapped contacts with personType
-      expect(showManageContactsDialog).toHaveBeenCalledWith(mockDemonstration.id, roles);
+      expect(showManageContactsDialog).toHaveBeenCalledWith(mockDemonstration.id, "NC", roles);
     });
 
     it("shows Manage Contact(s) button in contacts tab", async () => {
@@ -161,7 +167,11 @@ describe("DemonstrationTab", () => {
       const manageContactsButton = screen.getByRole("button", { name: "manage-contacts" });
       await user.click(manageContactsButton);
 
-      expect(showManageContactsDialog).toHaveBeenCalledWith(mockDemonstrationEmptyRoles.id, []);
+      expect(showManageContactsDialog).toHaveBeenCalledWith(
+        mockDemonstrationEmptyRoles.id,
+        "NC",
+        []
+      );
     });
   });
 });

--- a/client/src/pages/DemonstrationDetail/ContactsTab.tsx
+++ b/client/src/pages/DemonstrationDetail/ContactsTab.tsx
@@ -7,6 +7,7 @@ import {
   Demonstration as ServerDemonstration,
   DemonstrationRoleAssignment,
   Person,
+  State,
 } from "demos-server";
 
 import { useDialog } from "components/dialog/DialogContext";
@@ -18,6 +19,7 @@ type Role = Pick<DemonstrationRoleAssignment, "role" | "isPrimary"> & {
 };
 
 type Demonstration = Pick<ServerDemonstration, "id"> & {
+  state: Pick<State, "id">;
   roles: Role[];
 };
 
@@ -43,7 +45,9 @@ export const ContactsTab: React.FC<{ demonstration: Demonstration }> = ({ demons
           icon={<EditIcon />}
           name="manage-contacts"
           size="small"
-          onClick={() => showManageContactsDialog(demonstration.id, rolesForDialog)}
+          onClick={() =>
+            showManageContactsDialog(demonstration.id, demonstration.state.id, rolesForDialog)
+          }
         >
           Manage Contact(s)
         </IconButton>

--- a/client/src/pages/DemonstrationDetail/DemonstrationDetail.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetail.tsx
@@ -7,6 +7,7 @@ import {
   DemonstrationTypeAssignment,
   Document,
   Person,
+  State,
 } from "demos-server";
 import { useLocation, useParams } from "react-router-dom";
 import { gql, useQuery } from "@apollo/client";
@@ -46,6 +47,9 @@ export const DEMONSTRATION_DETAIL_QUERY = gql`
       currentPhaseName
       effectiveDate
       expirationDate
+      state {
+        id
+      }
       amendments {
         name
         id
@@ -133,7 +137,11 @@ export type DemonstrationDetailModification = Pick<
     owner: { person: Pick<Person, "fullName"> };
   })[];
 };
-export type DemonstrationDetail = Pick<Demonstration, "id" | "name" | "status" | "currentPhaseName" | "effectiveDate" | "expirationDate"> & {
+export type DemonstrationDetail = Pick<
+  Demonstration,
+  "id" | "name" | "status" | "currentPhaseName" | "effectiveDate" | "expirationDate"
+> & {
+  state: Pick<State, "id">;
   amendments: DemonstrationDetailModification[];
   extensions: DemonstrationDetailModification[];
   demonstrationTypes: Pick<

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.test.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.test.tsx
@@ -15,6 +15,9 @@ const mockDemonstration: DemonstrationTabDemonstration = {
   status: "Pre-Submission" as const,
   currentPhaseName: "Concept" as const,
   demonstrationTypes: [],
+  state: {
+    id: "NC",
+  },
   documents: [
     {
       id: "doc-1",

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
@@ -21,6 +21,7 @@ import {
   Document,
   Person,
   PhaseName,
+  State,
   Tag,
 } from "demos-server";
 import { Tab, VerticalTabs } from "layout/Tabs";
@@ -45,7 +46,10 @@ export type DemonstrationDetailDemonstrationType = Pick<
   | "approvalStatus"
 >;
 
-export type DemonstrationTabDemonstration = Pick<Demonstration, "id" | "name" | "status" | "effectiveDate" | "expirationDate"> & {
+export type DemonstrationTabDemonstration = Pick<
+  Demonstration,
+  "id" | "name" | "status" | "effectiveDate" | "expirationDate"
+> & {
   demonstrationTypes: DemonstrationDetailDemonstrationType[];
   documents: (Pick<Document, "id" | "name" | "description" | "documentType" | "createdAt"> & {
     owner: {
@@ -54,6 +58,7 @@ export type DemonstrationTabDemonstration = Pick<Demonstration, "id" | "name" | 
   })[];
   roles: Role[];
   currentPhaseName: PhaseName;
+  state: Pick<State, "id">;
 };
 
 const TAB = {

--- a/client/src/pages/debug/DialogSandbox.tsx
+++ b/client/src/pages/debug/DialogSandbox.tsx
@@ -180,7 +180,7 @@ export const DialogSandbox: React.FC = () => {
           </Button>
           <Button
             name="manage-contacts"
-            onClick={() => showManageContactsDialog(ID, EXISTING_CONTACTS)}
+            onClick={() => showManageContactsDialog(ID, "NC", EXISTING_CONTACTS)}
           >
             Manage Contacts
           </Button>

--- a/server/src/model/demonstrationRoleAssignment/demonstrationRoleAssignmentSchema.ts
+++ b/server/src/model/demonstrationRoleAssignment/demonstrationRoleAssignmentSchema.ts
@@ -5,7 +5,7 @@ import { Person } from "../person/personSchema";
 
 export const demonstrationRoleAssignmentSchema = gql`
   type DemonstrationRoleAssignment {
-    demonstration: Demonstration! @auth(requires: ["Access CMS Field"])
+    demonstration: Demonstration!
     person: Person!
     role: Role!
     isPrimary: Boolean!

--- a/server/src/model/person/personResolvers.ts
+++ b/server/src/model/person/personResolvers.ts
@@ -4,7 +4,6 @@ import {
   State,
 } from "@prisma/client";
 
-import { prisma } from "../../prismaClient";
 import { selectManyDemonstrationRoleAssignments } from "../demonstrationRoleAssignment/queries";
 import { selectManyPeople, selectPersonOrThrow } from "./queries";
 import { PersonType } from "../../types";

--- a/server/src/model/person/personResolvers.ts
+++ b/server/src/model/person/personResolvers.ts
@@ -15,52 +15,6 @@ export const personResolvers = {
     person: (parent: unknown, args: { id: string }): Promise<PrismaPerson> =>
       selectPersonOrThrow({ id: args.id }),
     people: (): Promise<PrismaPerson[]> => selectManyPeople({}),
-    searchPeople: async (
-      parent: unknown,
-      { search, demonstrationId }: { search: string; demonstrationId?: string }
-    ): Promise<PrismaPerson[]> => {
-      const searchConditions = [
-        { firstName: { contains: search, mode: "insensitive" as const } },
-        { lastName: { contains: search, mode: "insensitive" as const } },
-        { email: { contains: search, mode: "insensitive" as const } },
-      ];
-
-      const baseWhere = {
-        OR: searchConditions,
-      };
-
-      if (demonstrationId) {
-        const demonstration = await prisma().demonstration.findUnique({
-          where: { id: demonstrationId },
-          include: { state: true },
-        });
-
-        if (demonstration) {
-          return await prisma().person.findMany({
-            where: {
-              ...baseWhere,
-              OR: [
-                {
-                  personTypeId: { not: "demos-state-user" },
-                },
-                {
-                  personTypeId: "demos-state-user",
-                  personStates: {
-                    some: {
-                      stateId: demonstration.stateId,
-                    },
-                  },
-                },
-              ],
-            },
-          });
-        }
-      }
-
-      return await prisma().person.findMany({
-        where: baseWhere,
-      });
-    },
   },
 
   Person: {

--- a/server/src/model/person/personSchema.ts
+++ b/server/src/model/person/personSchema.ts
@@ -19,8 +19,6 @@ export const personSchema = gql`
   type Query {
     person(id: ID!): Person! @auth(requires: ["Access CMS Query"])
     people: [Person!]! @auth(requires: ["Access CMS Query"])
-    searchPeople(search: String!, demonstrationId: ID): [Person!]!
-      @auth(requires: ["Access CMS Query"])
   }
 `;
 


### PR DESCRIPTION
One of the goals of this permissions epic was to reduce the overall surface area of the API, this meant removing queries that were not in use or that could be easily refactored out. As i was examining the searchPeople query, i realized that it was incorrectly filtering, causing the search string filter to get overwritten. I examined frontend to see why this wasnt causing problems, and it was because we are implementing the filtrering behavior there as well. So i went ahead and removed this searchPeople query, implementing the only part that was missing from the filtering behavior: state association. Now the frontend just calls the people query, and handles all the filtering it needs itself. 

because of the dependence on this search behavior, there are a lot of aspects to this frontend component that are no longer needed; this whole component could probably lose over 50% of its lines.  However, with release on the horizon and the prospect of redesigning this component, its not worth refactoring now. Instead, i did the minimum amount of changes to get it working with Query.people.

Finally, i found one bug when fetching demonstration role assignments because of a permission that should not belong; so that auth directive was removed. 