### PR TITLE
DEMOS-1937— Date field fixes

### DIFF
--- a/client/src/components/application/phases/ApplicationIntakePhase.test.tsx
+++ b/client/src/components/application/phases/ApplicationIntakePhase.test.tsx
@@ -230,6 +230,7 @@ describe("ApplicationIntakePhase", () => {
       expect(submittedDateInput.value).toBe("");
 
       fireEvent.change(submittedDateInput, { target: { value: "2024-04-10" } });
+      fireEvent.blur(submittedDateInput);
 
       expect(submittedDateInput.value).toBe("2024-04-10");
 
@@ -613,6 +614,7 @@ describe("ApplicationIntakePhase", () => {
       ) as HTMLInputElement;
 
       fireEvent.change(submittedDateInput, { target: { value: "2024-03-15" } });
+      fireEvent.blur(submittedDateInput);
 
       expect(submittedDateInput.value).toBe("2024-03-15");
     });
@@ -627,6 +629,7 @@ describe("ApplicationIntakePhase", () => {
       ) as HTMLInputElement;
 
       fireEvent.change(submittedDateInput, { target: { value: "2024-03-15" } });
+      fireEvent.blur(submittedDateInput);
 
       // Completeness review due date should be 15 days later: 2024-03-30
       await waitFor(() => {

--- a/client/src/components/application/phases/CompletenessPhase.test.tsx
+++ b/client/src/components/application/phases/CompletenessPhase.test.tsx
@@ -258,6 +258,7 @@ describe("CompletenessPhase", () => {
 
       const dateInput = screen.getByTestId(STATE_DEEMED_COMPLETE_DATEPICKER_NAME);
       fireEvent.change(dateInput, { target: { value: "2026-03-15" } });
+      fireEvent.blur(dateInput);
       expect(dateInput).toHaveValue("2026-03-15");
 
       const declareIncompleteButton = screen.getByTestId(
@@ -298,6 +299,7 @@ describe("CompletenessPhase", () => {
       expect(dateInput.value).toBe("");
 
       fireEvent.change(dateInput, { target: { value: "2026-04-10" } });
+      fireEvent.blur(dateInput);
 
       expect(dateInput.value).toBe("2026-04-10");
       expect(screen.getByTestId(FEDERAL_COMMENT_START_DATEPICKER_NAME)).toHaveValue("2026-04-11");

--- a/client/src/components/application/phases/SdgPreparationPhase.test.tsx
+++ b/client/src/components/application/phases/SdgPreparationPhase.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {
@@ -238,6 +238,7 @@ describe("SdgPreparationPhase", () => {
       const expectedApprovalDateInput = screen.getByTestId("datepicker-expected-approval-date");
       await userEvent.clear(expectedApprovalDateInput);
       await userEvent.type(expectedApprovalDateInput, "2025-02-01");
+      fireEvent.blur(expectedApprovalDateInput);
 
       expect(saveButton).toBeEnabled();
     });
@@ -442,6 +443,7 @@ describe("Completed Phase Behavior", () => {
     const dateInput = screen.getByTestId("datepicker-expected-approval-date");
     await userEvent.clear(dateInput);
     await userEvent.type(dateInput, "2025-06-01");
+    fireEvent.blur(dateInput);
 
     expect(saveButton).toBeEnabled();
   });

--- a/client/src/components/application/phases/review/ReviewPhase.test.tsx
+++ b/client/src/components/application/phases/review/ReviewPhase.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { parseISO, format } from "date-fns";
 
@@ -324,6 +324,7 @@ describe("ReviewPhase Component", () => {
 
       const dateInput = screen.getByTestId("datepicker-ogc-approval-to-share-date");
       await userEvent.type(dateInput, "2025-12-25");
+      fireEvent.blur(dateInput);
 
       await waitFor(() => {
         const saveButton = screen.getByTestId("review-save-for-later");
@@ -341,6 +342,7 @@ describe("ReviewPhase Component", () => {
 
       const dateInput = screen.getByTestId("datepicker-ogc-approval-to-share-date");
       await userEvent.type(dateInput, "2025-12-25");
+      fireEvent.blur(dateInput);
 
       const saveButton = screen.getByTestId("review-save-for-later");
       await waitFor(() => {
@@ -364,6 +366,7 @@ describe("ReviewPhase Component", () => {
 
       const dateInput = screen.getByTestId("datepicker-ogc-approval-to-share-date");
       await userEvent.type(dateInput, "2025-12-25");
+      fireEvent.blur(dateInput);
 
       const saveButton = screen.getByTestId("review-save-for-later");
       await userEvent.click(saveButton);
@@ -375,6 +378,7 @@ describe("ReviewPhase Component", () => {
       // Make another change
       await userEvent.clear(dateInput);
       await userEvent.type(dateInput, "2025-12-31");
+      fireEvent.blur(dateInput);
 
       await waitFor(() => {
         expect(saveButton).toBeEnabled();

--- a/client/src/components/application/phases/review/cmsOsoraClearanceSection.test.tsx
+++ b/client/src/components/application/phases/review/cmsOsoraClearanceSection.test.tsx
@@ -57,6 +57,7 @@ describe("CmsOsoraClearanceSection", () => {
     const datepicker = screen.getByTestId("datepicker-osora-r1-comments-due-date");
 
     fireEvent.change(datepicker, { target: { value: "2025-01-01" } });
+    fireEvent.blur(datepicker);
 
     expect(mockSetSectionFormData).toHaveBeenCalledWith({
       ...defaultProps.sectionFormData,
@@ -72,6 +73,7 @@ describe("CmsOsoraClearanceSection", () => {
     const datepicker = screen.getByTestId("datepicker-submit-approval-package-to-osora");
 
     fireEvent.change(datepicker, { target: { value: "2025-01-01" } });
+    fireEvent.blur(datepicker);
 
     expect(mockSetSectionFormData).toHaveBeenCalledWith({
       ...defaultProps.sectionFormData,
@@ -99,6 +101,7 @@ describe("CmsOsoraClearanceSection", () => {
     const datepicker = screen.getByTestId("datepicker-submit-approval-package-to-osora");
 
     fireEvent.change(datepicker, { target: { value: "2025-01-01" } });
+    fireEvent.blur(datepicker);
 
     expect(mockSetSectionFormData).toHaveBeenCalledWith({
       ...propsWithClearanceEndDate.sectionFormData,

--- a/client/src/components/application/phases/review/commsClearanceSection.test.tsx
+++ b/client/src/components/application/phases/review/commsClearanceSection.test.tsx
@@ -55,6 +55,7 @@ describe("CommsClearanceSection", () => {
     const datepicker = screen.getByTestId("datepicker-package-sent-for-comms-clearance-date");
 
     fireEvent.change(datepicker, { target: { value: "2025-01-01" } });
+    fireEvent.blur(datepicker);
 
     expect(mockSetSectionFormData).toHaveBeenCalledWith({
       ...defaultProps.sectionFormData,

--- a/client/src/components/application/phases/review/ogcAndOmbSection.test.tsx
+++ b/client/src/components/application/phases/review/ogcAndOmbSection.test.tsx
@@ -57,6 +57,7 @@ describe("OgcAndOmbSection", () => {
     const datepicker = screen.getByTestId("datepicker-bn-pmt-approval-received-date");
 
     fireEvent.change(datepicker, { target: { value: "2025-01-01" } });
+    fireEvent.blur(datepicker);
 
     expect(mockSetSectionFormData).toHaveBeenCalledWith({
       ...defaultProps.sectionFormData,

--- a/client/src/components/application/phases/review/poAndOgdSection.test.tsx
+++ b/client/src/components/application/phases/review/poAndOgdSection.test.tsx
@@ -57,6 +57,7 @@ describe("PoAndOgdSection", () => {
     const datepicker = screen.getByTestId("datepicker-ogc-approval-to-share-date");
 
     fireEvent.change(datepicker, { target: { value: "2025-01-01" } });
+    fireEvent.blur(datepicker);
 
     expect(mockSetSectionFormData).toHaveBeenCalledWith({
       ...defaultProps.sectionFormData,

--- a/client/src/components/dialog/DemonstrationTypes/AddDemonstrationTypesForm.test.tsx
+++ b/client/src/components/dialog/DemonstrationTypes/AddDemonstrationTypesForm.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
@@ -117,8 +117,12 @@ describe("AddDemonstrationTypesForm", () => {
 
     await user.click(screen.getByRole("textbox"));
     await user.click(screen.getByText("Type C (Unapproved)"));
-    await user.type(screen.getByLabelText(/effective date/i), "2024-01-03");
-    await user.type(screen.getByLabelText(/expiration date/i), "2025-01-03");
+    const effectiveDate = screen.getByLabelText(/effective date/i);
+    const expirationDate = screen.getByLabelText(/expiration date/i);
+    await user.type(effectiveDate, "2024-01-03");
+    await user.type(expirationDate, "2025-01-03");
+    fireEvent.blur(effectiveDate);
+    fireEvent.blur(expirationDate);
 
     expect(addButton).toBeEnabled();
   });
@@ -129,8 +133,12 @@ describe("AddDemonstrationTypesForm", () => {
 
     await user.click(screen.getByRole("textbox"));
     await user.click(screen.getByText("Type C (Unapproved)"));
-    await user.type(screen.getByLabelText(/effective date/i), "2024-01-03");
-    await user.type(screen.getByLabelText(/expiration date/i), "2025-01-03");
+    const effectiveDate = screen.getByLabelText(/effective date/i);
+    const expirationDate = screen.getByLabelText(/expiration date/i);
+    await user.type(effectiveDate, "2024-01-03");
+    await user.type(expirationDate, "2025-01-03");
+    fireEvent.blur(effectiveDate);
+    fireEvent.blur(expirationDate);
     await user.click(screen.getByTestId("button-add-demonstration-type"));
 
     expect(mockAddDemonstrationType).toHaveBeenCalledWith({
@@ -213,8 +221,12 @@ describe("AddDemonstrationTypesForm", () => {
     await user.type(input, "Brand New Type");
     await user.click(screen.getByTestId("button-create-type"));
 
-    await user.type(screen.getByLabelText(/effective date/i), "2024-01-03");
-    await user.type(screen.getByLabelText(/expiration date/i), "2025-01-03");
+    const effectiveDate = screen.getByLabelText(/effective date/i);
+    const expirationDate = screen.getByLabelText(/expiration date/i);
+    await user.type(effectiveDate, "2024-01-03");
+    await user.type(expirationDate, "2025-01-03");
+    fireEvent.blur(effectiveDate);
+    fireEvent.blur(expirationDate);
     await user.click(screen.getByTestId("button-add-demonstration-type"));
 
     expect(mockAddDemonstrationType).toHaveBeenCalledWith({
@@ -271,8 +283,12 @@ describe("AddDemonstrationTypesForm", () => {
     await user.click(screen.getByText("Type C (Unapproved)"));
     expect(screen.getByTestId("unapproved-warning-banner")).toBeInTheDocument();
 
-    await user.type(screen.getByLabelText(/effective date/i), "2024-01-03");
-    await user.type(screen.getByLabelText(/expiration date/i), "2025-01-03");
+    const effectiveDate = screen.getByLabelText(/effective date/i);
+    const expirationDate = screen.getByLabelText(/expiration date/i);
+    await user.type(effectiveDate, "2024-01-03");
+    await user.type(expirationDate, "2025-01-03");
+    fireEvent.blur(effectiveDate);
+    fireEvent.blur(expirationDate);
     await user.click(screen.getByTestId("button-add-demonstration-type"));
 
     expect(screen.queryByTestId("unapproved-warning-banner")).not.toBeInTheDocument();

--- a/client/src/components/dialog/DemonstrationTypes/EditDemonstrationTypeDialog.test.tsx
+++ b/client/src/components/dialog/DemonstrationTypes/EditDemonstrationTypeDialog.test.tsx
@@ -84,6 +84,7 @@ describe("EditDemonstrationTypeDialog", () => {
     const effectiveDateInput = screen.getByLabelText(/Effective Date/i);
     await user.clear(effectiveDateInput);
     await user.type(effectiveDateInput, "2024-02-01");
+    fireEvent.blur(effectiveDateInput);
 
     await waitFor(() => {
       const submitButton = screen.getByTestId(SUBMIT_BUTTON_TEST_ID);
@@ -145,6 +146,7 @@ describe("EditDemonstrationTypeDialog", () => {
       const effectiveDateInput = screen.getByLabelText(/Effective Date/i);
       await user.clear(effectiveDateInput);
       await user.type(effectiveDateInput, "2024-02-01");
+      fireEvent.blur(effectiveDateInput);
 
       await waitFor(() => {
         const submitButton = screen.getByTestId(SUBMIT_BUTTON_TEST_ID);
@@ -167,6 +169,7 @@ describe("EditDemonstrationTypeDialog", () => {
 
       const expirationDateInput = screen.getByLabelText(/Expiration Date/i);
       await user.clear(expirationDateInput);
+      fireEvent.blur(expirationDateInput);
 
       await waitFor(() => {
         expect(screen.getByText("Expiration Date is required.")).toBeInTheDocument();
@@ -180,6 +183,7 @@ describe("EditDemonstrationTypeDialog", () => {
 
       const effectiveDateInput = screen.getByLabelText(/Effective Date/i);
       await user.clear(effectiveDateInput);
+      fireEvent.blur(effectiveDateInput);
 
       await waitFor(() => {
         expect(screen.getByText("Effective Date is required.")).toBeInTheDocument();
@@ -196,8 +200,10 @@ describe("EditDemonstrationTypeDialog", () => {
 
       await user.clear(effectiveDateInput);
       await user.type(effectiveDateInput, "2024-12-31");
+      fireEvent.blur(effectiveDateInput);
       await user.clear(expirationDateInput);
       await user.type(expirationDateInput, "2024-01-01");
+      fireEvent.blur(expirationDateInput);
 
       await waitFor(() => {
         expect(
@@ -217,8 +223,10 @@ describe("EditDemonstrationTypeDialog", () => {
 
         await user.clear(effectiveDateInput);
         await user.type(effectiveDateInput, "2090-01-01");
+        fireEvent.blur(effectiveDateInput);
         await user.clear(expirationDateInput);
         await user.type(expirationDateInput, "2090-12-31");
+        fireEvent.blur(expirationDateInput);
 
         await waitFor(() => {
           expect(screen.getByText("Pending")).toBeInTheDocument();
@@ -234,8 +242,10 @@ describe("EditDemonstrationTypeDialog", () => {
 
         await user.clear(effectiveDateInput);
         await user.type(effectiveDateInput, "1901-01-01");
+        fireEvent.blur(effectiveDateInput);
         await user.clear(expirationDateInput);
         await user.type(expirationDateInput, "1901-12-31");
+        fireEvent.blur(expirationDateInput);
 
         await waitFor(() => {
           expect(screen.getByText("Expired")).toBeInTheDocument();
@@ -251,8 +261,10 @@ describe("EditDemonstrationTypeDialog", () => {
 
         await user.clear(effectiveDateInput);
         await user.type(effectiveDateInput, "1901-01-01");
+        fireEvent.blur(effectiveDateInput);
         await user.clear(expirationDateInput);
         await user.type(expirationDateInput, "2090-12-31");
+        fireEvent.blur(expirationDateInput);
 
         await waitFor(() => {
           expect(screen.getByText("Active")).toBeInTheDocument();
@@ -270,8 +282,10 @@ describe("EditDemonstrationTypeDialog", () => {
 
         await user.clear(effectiveDateInput);
         await user.type(effectiveDateInput, today);
+        fireEvent.blur(effectiveDateInput);
         await user.clear(expirationDateInput);
         await user.type(expirationDateInput, "2090-12-31");
+        fireEvent.blur(expirationDateInput);
 
         await waitFor(() => {
           expect(screen.getByText("Active")).toBeInTheDocument();
@@ -286,8 +300,10 @@ describe("EditDemonstrationTypeDialog", () => {
         const today = formatDateForServer(getTodayEst());
         await user.clear(effectiveDateInput);
         await user.type(effectiveDateInput, "1901-01-01");
+        fireEvent.blur(effectiveDateInput);
         await user.clear(expirationDateInput);
         await user.type(expirationDateInput, today);
+        fireEvent.blur(expirationDateInput);
         await waitFor(() => {
           expect(screen.getByText("Active")).toBeInTheDocument();
         });
@@ -355,6 +371,7 @@ describe("EditDemonstrationTypeDialog", () => {
       const effectiveDateInput = screen.getByLabelText(/Effective Date/i);
       await user.clear(effectiveDateInput);
       await user.type(effectiveDateInput, "2024-02-01");
+      fireEvent.blur(effectiveDateInput);
 
       await waitFor(() => {
         const submitButton = screen.getByTestId(SUBMIT_BUTTON_TEST_ID);
@@ -376,6 +393,7 @@ describe("EditDemonstrationTypeDialog", () => {
       const effectiveDateInput = screen.getByLabelText(/Effective Date/i);
       await user.clear(effectiveDateInput);
       await user.type(effectiveDateInput, "2024-02-01");
+      fireEvent.blur(effectiveDateInput);
 
       await waitFor(() => {
         const submitButton = screen.getByTestId(SUBMIT_BUTTON_TEST_ID);
@@ -396,8 +414,10 @@ describe("EditDemonstrationTypeDialog", () => {
 
       await user.clear(effectiveDateInput);
       await user.type(effectiveDateInput, "2024-03-15");
+      fireEvent.blur(effectiveDateInput);
       await user.clear(expirationDateInput);
       await user.type(expirationDateInput, "2024-11-30");
+      fireEvent.blur(expirationDateInput);
 
       await waitFor(() => {
         const submitButton = screen.getByTestId(SUBMIT_BUTTON_TEST_ID);

--- a/client/src/components/dialog/deliverable/AddDeliverableSlotDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/AddDeliverableSlotDialog.test.tsx
@@ -180,6 +180,7 @@ describe("AddDeliverableSlotDialog", () => {
     fireEvent.change(screen.getByTestId(SINGLE_DELIVERABLE_DUE_DATE_NAME), {
       target: { value: "2026-06-15" },
     });
+    fireEvent.blur(screen.getByTestId(SINGLE_DELIVERABLE_DUE_DATE_NAME));
 
     await user.type(screen.getByTestId(DELIVERABLE_NAME_FIELD_ID), "Test Deliverable");
 

--- a/client/src/components/dialog/deliverable/EditDeliverableDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/EditDeliverableDialog.test.tsx
@@ -100,6 +100,7 @@ describe("EditDeliverableDialog", () => {
     fireEvent.change(screen.getByTestId(SINGLE_DELIVERABLE_DUE_DATE_NAME), {
       target: { value: "2026-07-20" },
     });
+    fireEvent.blur(screen.getByTestId(SINGLE_DELIVERABLE_DUE_DATE_NAME));
     expect(screen.getByTestId(EDIT_DELIVERABLE_REASON_FIELD_NAME)).toBeInTheDocument();
   });
 
@@ -133,6 +134,7 @@ describe("EditDeliverableDialog", () => {
     fireEvent.change(screen.getByTestId(SINGLE_DELIVERABLE_DUE_DATE_NAME), {
       target: { value: "2026-07-20" },
     });
+    fireEvent.blur(screen.getByTestId(SINGLE_DELIVERABLE_DUE_DATE_NAME));
 
     expect(screen.getByTestId(EDIT_DELIVERABLE_SAVE_BUTTON_NAME)).toBeDisabled();
 
@@ -160,6 +162,7 @@ describe("EditDeliverableDialog", () => {
     fireEvent.change(screen.getByTestId(SINGLE_DELIVERABLE_DUE_DATE_NAME), {
       target: { value: "2026-07-20" },
     });
+    fireEvent.blur(screen.getByTestId(SINGLE_DELIVERABLE_DUE_DATE_NAME));
 
     await user.type(screen.getByTestId(EDIT_DELIVERABLE_REASON_FIELD_NAME), "Schedule slip");
 

--- a/client/src/components/dialog/deliverable/RequestExtensionDeliverableDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/RequestExtensionDeliverableDialog.test.tsx
@@ -108,6 +108,7 @@ describe("RequestExtensionDeliverableDialog", () => {
     fireEvent.change(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME), {
       target: { value: "2026-03-15" },
     });
+    fireEvent.blur(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME));
     expect(submit).toBeDisabled();
 
     await user.selectOptions(screen.getByTestId(REQUEST_EXTENSION_REASON_FIELD_NAME), "Other");
@@ -124,6 +125,7 @@ describe("RequestExtensionDeliverableDialog", () => {
     fireEvent.change(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME), {
       target: { value: "2026-02-12" }, // equal to due date — invalid
     });
+    fireEvent.blur(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME));
     await user.selectOptions(screen.getByTestId(REQUEST_EXTENSION_REASON_FIELD_NAME), "COVID-19");
     await user.type(screen.getByTestId(REQUEST_EXTENSION_DETAILS_FIELD_NAME), "Delayed");
 
@@ -140,6 +142,7 @@ describe("RequestExtensionDeliverableDialog", () => {
     fireEvent.change(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME), {
       target: { value: "2027-01-15" }, // past expiration
     });
+    fireEvent.blur(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME));
     await user.selectOptions(screen.getByTestId(REQUEST_EXTENSION_REASON_FIELD_NAME), "Other");
     await user.type(screen.getByTestId(REQUEST_EXTENSION_DETAILS_FIELD_NAME), "x");
 
@@ -156,6 +159,7 @@ describe("RequestExtensionDeliverableDialog", () => {
     fireEvent.change(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME), {
       target: { value: "2026-03-15" },
     });
+    fireEvent.blur(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME));
     await user.selectOptions(
       screen.getByTestId(REQUEST_EXTENSION_REASON_FIELD_NAME),
       "Technical Difficulties"
@@ -194,6 +198,7 @@ describe("RequestExtensionDeliverableDialog", () => {
     fireEvent.change(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME), {
       target: { value: "2026-03-15" },
     });
+    fireEvent.blur(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME));
     await user.selectOptions(screen.getByTestId(REQUEST_EXTENSION_REASON_FIELD_NAME), "Other");
     await user.type(screen.getByTestId(REQUEST_EXTENSION_DETAILS_FIELD_NAME), "Need more time");
 

--- a/client/src/components/dialog/deliverable/RequestResubmissionDeliverableDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/RequestResubmissionDeliverableDialog.test.tsx
@@ -123,6 +123,7 @@ describe("RequestResubmissionDeliverableDialog", () => {
         target: { value: "2026-03-01" },
       }
     );
+    fireEvent.blur(screen.getByTestId(REQUEST_RESUBMISSION_DATE_FIELD_NAME));
 
     expect(submit).toBeDisabled();
 
@@ -145,6 +146,7 @@ describe("RequestResubmissionDeliverableDialog", () => {
         target: { value: "2026-01-01" },
       }
     );
+    fireEvent.blur(screen.getByTestId(REQUEST_RESUBMISSION_DATE_FIELD_NAME));
 
     await user.type(
       screen.getByTestId(REQUEST_RESUBMISSION_DETAILS_FIELD_NAME),
@@ -172,6 +174,7 @@ describe("RequestResubmissionDeliverableDialog", () => {
         target: { value: "2026-03-15" },
       }
     );
+    fireEvent.blur(screen.getByTestId(REQUEST_RESUBMISSION_DATE_FIELD_NAME));
 
     await user.type(
       screen.getByTestId(REQUEST_RESUBMISSION_DETAILS_FIELD_NAME),
@@ -221,6 +224,7 @@ describe("RequestResubmissionDeliverableDialog", () => {
         target: { value: "2026-03-15" },
       }
     );
+    fireEvent.blur(screen.getByTestId(REQUEST_RESUBMISSION_DATE_FIELD_NAME));
 
     await user.type(
       screen.getByTestId(REQUEST_RESUBMISSION_DETAILS_FIELD_NAME),

--- a/client/src/components/dialog/deliverable/ReviewExtensionDeliverableDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/ReviewExtensionDeliverableDialog.test.tsx
@@ -177,6 +177,7 @@ describe("ReviewExtensionDeliverableDialog", () => {
     fireEvent.change(screen.getByTestId(REVIEW_EXTENSION_NEW_DATE_FIELD_NAME), {
       target: { value: "2099-03-25" },
     });
+    fireEvent.blur(screen.getByTestId(REVIEW_EXTENSION_NEW_DATE_FIELD_NAME));
     await user.click(screen.getByTestId(REVIEW_EXTENSION_SUBMIT_BUTTON_NAME));
 
     await waitFor(() => expect(mockApproveMutation).toHaveBeenCalledTimes(1));

--- a/client/src/components/dialog/deliverable/fields/schedule-type/QuarterlyDeliverableSchedule.test.tsx
+++ b/client/src/components/dialog/deliverable/fields/schedule-type/QuarterlyDeliverableSchedule.test.tsx
@@ -55,6 +55,7 @@ describe("QuarterlyDeliverableSchedule", () => {
     );
 
     fireEvent.change(screen.getByTestId("quarter-3"), { target: { value: "2026-07-15" } });
+    fireEvent.blur(screen.getByTestId("quarter-3"));
 
     expect(onSelectQuarterDate).toHaveBeenCalledWith(2, "2026-07-15");
   });

--- a/client/src/components/dialog/modification/ModificationForm.test.tsx
+++ b/client/src/components/dialog/modification/ModificationForm.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { vi, describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import {
   ModificationForm,
   ModificationFormData,
@@ -258,6 +258,7 @@ describe("ModificationForm", () => {
       const effectiveDateInput = screen.getByLabelText(/Effective Date/);
       await user.clear(effectiveDateInput);
       await user.type(effectiveDateInput, "2024-02-20");
+      fireEvent.blur(effectiveDateInput);
 
       expect(mockSetModificationFormDataField).toHaveBeenCalledWith(
         expect.objectContaining({ effectiveDate: expect.any(String) })

--- a/client/src/components/input/date/DatePicker.test.tsx
+++ b/client/src/components/input/date/DatePicker.test.tsx
@@ -38,39 +38,69 @@ describe("DatePicker component", () => {
     });
   });
 
-  // Range is now enforced by the native (inclusive) min/max attributes and surfaced via the
-  // validation message. handleChange always propagates what the user typed, so the displayed
-  // value can never silently diverge from what the parent state holds.
-  describe("Out-of-range handling (browser-native min/max)", () => {
-    it("always calls onChange with the typed value, even when out of range", () => {
-      render(<DatePicker {...requiredProps} />);
-      const input = screen.getByTestId("test-date");
-
-      fireEvent.input(input, { target: { value: "1899-12-31" } });
-      expect(mockOnChange).toHaveBeenCalledWith("1899-12-31");
-
-      mockOnChange.mockClear();
-      fireEvent.input(input, { target: { value: "2100-01-01" } });
-      expect(mockOnChange).toHaveBeenCalledWith("2100-01-01");
-    });
-
-    it("calls onChange for in-range dates", () => {
+  // The component commits to the parent only on blur — never live during typing. Range is
+  // enforced by the native (inclusive) min/max attributes and surfaced via the validation
+  // message derived from the parent's committed value, so the displayed value can never
+  // silently diverge from what the parent holds.
+  describe("Blur-only commit + range messaging", () => {
+    it("does not propagate any value on input alone (live typing does not churn the parent)", () => {
       render(<DatePicker {...requiredProps} />);
       const input = screen.getByTestId("test-date");
 
       fireEvent.input(input, { target: { value: "2025-03-20" } });
+      fireEvent.input(input, { target: { value: "1899-12-31" } });
+      fireEvent.input(input, { target: { value: "2100-01-01" } });
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+
+    it("commits an in-range value on blur", () => {
+      render(<DatePicker {...requiredProps} />);
+      const input = screen.getByTestId("test-date");
+
+      fireEvent.input(input, { target: { value: "2025-03-20" } });
+      fireEvent.blur(input);
       expect(mockOnChange).toHaveBeenCalledWith("2025-03-20");
     });
 
-    it("calls onChange for the inclusive boundary dates 1900-01-01 and 2099-12-31", () => {
+    it("commits the final value on blur, even when out of range", () => {
+      render(<DatePicker {...requiredProps} />);
+      const input = screen.getByTestId("test-date");
+
+      fireEvent.input(input, { target: { value: "1899-12-31" } });
+      fireEvent.blur(input);
+      expect(mockOnChange).toHaveBeenCalledWith("1899-12-31");
+    });
+
+    // Regression for the year-typing bug: with month/day already filled (value set), the browser
+    // forms transient complete out-of-range dates ("0003-..", "0030-..") as each year digit is
+    // typed. Those must NOT propagate or flash a message during typing; only on blur does the
+    // final value commit.
+    it("does not flash a message or propagate while typing a year over a pre-filled date", () => {
+      render(<DatePicker {...requiredProps} value="2020-05-15" />);
+      const input = screen.getByTestId("test-date");
+
+      fireEvent.input(input, { target: { value: "0003-05-15" } });
+      fireEvent.input(input, { target: { value: "0030-05-15" } });
+      fireEvent.input(input, { target: { value: "0302-05-15" } });
+      fireEvent.input(input, { target: { value: "2026-05-15" } });
+      expect(mockOnChange).not.toHaveBeenCalled();
+      expect(screen.queryByText(/Date must be on or/)).not.toBeInTheDocument();
+
+      fireEvent.blur(input);
+      expect(mockOnChange).toHaveBeenCalledWith("2026-05-15");
+    });
+
+    it("commits inclusive boundary dates 1900-01-01 and 2099-12-31 on blur", () => {
       render(<DatePicker {...requiredProps} />);
       const input = screen.getByTestId("test-date");
 
       fireEvent.input(input, { target: { value: "1900-01-01" } });
+      fireEvent.blur(input);
       expect(mockOnChange).toHaveBeenCalledWith("1900-01-01");
 
       mockOnChange.mockClear();
       fireEvent.input(input, { target: { value: "2099-12-31" } });
+      fireEvent.blur(input);
       expect(mockOnChange).toHaveBeenCalledWith("2099-12-31");
     });
 
@@ -141,6 +171,7 @@ describe("DatePicker component", () => {
       expect(input.type).toBe("date");
 
       fireEvent.input(input, { target: { value: "2025-01-15" } });
+      fireEvent.blur(input);
       expect(mockOnChange).toHaveBeenCalledWith("2025-01-15");
     });
   });
@@ -150,13 +181,16 @@ describe("DatePicker component", () => {
       render(<DatePicker {...requiredProps} />);
       const input = screen.getByTestId("test-date");
       fireEvent.input(input, { target: { value: "2024-02-29" } });
+      fireEvent.blur(input);
       expect(mockOnChange).toHaveBeenCalledWith("2024-02-29");
     });
 
-    it("calls onChange when existing value is cleared", () => {
+    it("commits a cleared value on blur", () => {
       render(<DatePicker {...requiredProps} value="2024-01-15" />);
       const input = screen.getByTestId("test-date");
       fireEvent.input(input, { target: { value: "" } });
+      expect(mockOnChange).not.toHaveBeenCalled();
+      fireEvent.blur(input);
       expect(mockOnChange).toHaveBeenCalledWith("");
     });
   });
@@ -197,6 +231,23 @@ describe("DatePicker component", () => {
       rerender(<DatePicker {...requiredProps} value="" />);
 
       expect(input.value).toBe("2024-01-15");
+    });
+
+    // Regression for "editing a subfield scopes me out". While the user edits one subfield of an
+    // existing date, the browser briefly reports an incomplete date and the parent propagates a
+    // changed value. Writing to the focused input would drop focus and break the mm→dd→yyyy
+    // advance / close the calendar, so the ref-sync must skip the write while the input is focused.
+    it("does not reset the input DOM value while the input is focused", () => {
+      const { rerender } = render(<DatePicker {...requiredProps} value="2020-05-15" />);
+      const input = screen.getByTestId("test-date") as HTMLInputElement;
+
+      input.focus();
+      input.value = "2020-08-15"; // user's in-progress subfield edit
+
+      rerender(<DatePicker {...requiredProps} value="" />);
+
+      expect(input.value).toBe("2020-08-15");
+      expect(document.activeElement).toBe(input);
     });
   });
 

--- a/client/src/components/input/date/DatePicker.test.tsx
+++ b/client/src/components/input/date/DatePicker.test.tsx
@@ -38,55 +38,99 @@ describe("DatePicker component", () => {
     });
   });
 
-  describe("Year Validation - 4 Digit Years Between 1900 and 2099", () => {
-    it("accepts valid dates within the 1900-2099 range", () => {
-      render(<DatePicker {...requiredProps} />);
-      const input = screen.getByTestId("test-date");
-
-      fireEvent.input(input, { target: { value: "1901-06-15" } });
-      expect(mockOnChange).toHaveBeenCalledWith("1901-06-15");
-
-      mockOnChange.mockClear();
-      fireEvent.input(input, { target: { value: "2025-03-20" } });
-      expect(mockOnChange).toHaveBeenCalledWith("2025-03-20");
-
-      mockOnChange.mockClear();
-      fireEvent.input(input, { target: { value: "2098-12-25" } });
-      expect(mockOnChange).toHaveBeenCalledWith("2098-12-25");
-    });
-
-    it("does not call onChange for boundary dates (1900-01-01 and 2099-12-31)", () => {
-      render(<DatePicker {...requiredProps} />);
-      const input = screen.getByTestId("test-date");
-
-      fireEvent.input(input, { target: { value: "1900-01-01" } });
-      expect(mockOnChange).not.toHaveBeenCalled();
-
-      fireEvent.input(input, { target: { value: "2099-12-31" } });
-      expect(mockOnChange).not.toHaveBeenCalled();
-    });
-
-    it("rejects dates before 1900", () => {
+  // Range is now enforced by the native (inclusive) min/max attributes and surfaced via the
+  // validation message. handleChange always propagates what the user typed, so the displayed
+  // value can never silently diverge from what the parent state holds.
+  describe("Out-of-range handling (browser-native min/max)", () => {
+    it("always calls onChange with the typed value, even when out of range", () => {
       render(<DatePicker {...requiredProps} />);
       const input = screen.getByTestId("test-date");
 
       fireEvent.input(input, { target: { value: "1899-12-31" } });
-      expect(mockOnChange).not.toHaveBeenCalled();
+      expect(mockOnChange).toHaveBeenCalledWith("1899-12-31");
+
+      mockOnChange.mockClear();
+      fireEvent.input(input, { target: { value: "2100-01-01" } });
+      expect(mockOnChange).toHaveBeenCalledWith("2100-01-01");
     });
 
-    it("rejects dates after 2099", () => {
+    it("calls onChange for in-range dates", () => {
       render(<DatePicker {...requiredProps} />);
       const input = screen.getByTestId("test-date");
 
-      fireEvent.input(input, { target: { value: "2100-01-01" } });
-      expect(mockOnChange).not.toHaveBeenCalled();
+      fireEvent.input(input, { target: { value: "2025-03-20" } });
+      expect(mockOnChange).toHaveBeenCalledWith("2025-03-20");
     });
 
-    it("has min and max attributes set correctly", () => {
+    it("calls onChange for the inclusive boundary dates 1900-01-01 and 2099-12-31", () => {
+      render(<DatePicker {...requiredProps} />);
+      const input = screen.getByTestId("test-date");
+
+      fireEvent.input(input, { target: { value: "1900-01-01" } });
+      expect(mockOnChange).toHaveBeenCalledWith("1900-01-01");
+
+      mockOnChange.mockClear();
+      fireEvent.input(input, { target: { value: "2099-12-31" } });
+      expect(mockOnChange).toHaveBeenCalledWith("2099-12-31");
+    });
+
+    it("shows a default message when the value prop is before the min bound", () => {
+      render(<DatePicker {...requiredProps} value="1899-12-31" />);
+      expect(screen.getByText("Date must be on or after 01/01/1900.")).toBeInTheDocument();
+    });
+
+    it("shows a default message when the value prop is after the max bound", () => {
+      render(<DatePicker {...requiredProps} value="2100-01-01" />);
+      expect(screen.getByText("Date must be on or before 12/31/2099.")).toBeInTheDocument();
+    });
+
+    it("shows no default message for inclusive boundary values", () => {
+      const { rerender } = render(<DatePicker {...requiredProps} value="1900-01-01" />);
+      expect(screen.queryByText(/Date must be on or/)).not.toBeInTheDocument();
+
+      rerender(<DatePicker {...requiredProps} value="2099-12-31" />);
+      expect(screen.queryByText(/Date must be on or/)).not.toBeInTheDocument();
+    });
+
+    it("uses the provided minDate/maxDate in the default message", () => {
+      const { rerender } = render(
+        <DatePicker {...requiredProps} minDate="2026-04-28" value="2026-04-01" />
+      );
+      expect(screen.getByText("Date must be on or after 04/28/2026.")).toBeInTheDocument();
+
+      rerender(<DatePicker {...requiredProps} maxDate="2026-04-28" value="2026-05-01" />);
+      expect(screen.getByText("Date must be on or before 04/28/2026.")).toBeInTheDocument();
+    });
+
+    it("lets getValidationMessage take precedence over the default range message", () => {
+      render(
+        <DatePicker
+          {...requiredProps}
+          value="1899-12-31"
+          getValidationMessage={() => "Custom message"}
+        />
+      );
+      expect(screen.getByText("Custom message")).toBeInTheDocument();
+      expect(screen.queryByText(/Date must be on or after/)).not.toBeInTheDocument();
+    });
+
+    it("has default min and max attributes", () => {
       render(<DatePicker {...requiredProps} />);
       const input = screen.getByTestId("test-date") as HTMLInputElement;
       expect(input.min).toBe("1900-01-01");
       expect(input.max).toBe("2099-12-31");
+    });
+
+    it("forwards minDate to the input's min attribute", () => {
+      render(<DatePicker {...requiredProps} minDate="2026-04-28" />);
+      const input = screen.getByTestId("test-date") as HTMLInputElement;
+      expect(input.min).toBe("2026-04-28");
+    });
+
+    it("forwards maxDate to the input's max attribute", () => {
+      render(<DatePicker {...requiredProps} maxDate="2026-04-28" />);
+      const input = screen.getByTestId("test-date") as HTMLInputElement;
+      expect(input.max).toBe("2026-04-28");
     });
   });
 
@@ -162,12 +206,6 @@ describe("DatePicker component", () => {
       render(<DatePicker {...requiredProps} getValidationMessage={getValidationMessage} />);
       const input = screen.getByTestId("test-date");
       expect(input.className).toContain("border-border-warn");
-    });
-
-    it("forwards minDate to the input's min attribute", () => {
-      render(<DatePicker {...requiredProps} minDate="2026-04-28" />);
-      const input = screen.getByTestId("test-date") as HTMLInputElement;
-      expect(input.min).toBe("2026-04-28");
     });
   });
 });

--- a/client/src/components/input/date/DatePicker.tsx
+++ b/client/src/components/input/date/DatePicker.tsx
@@ -35,25 +35,35 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   getValidationMessage,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
+  const isFocusedRef = useRef(false);
   const inputMin = minDate ?? DEFAULT_MIN_DATE;
   const inputMax = maxDate ?? DEFAULT_MAX_DATE;
 
-  // The input is uncontrolled (defaultValue + ref-sync) instead of fully controlled.
-  // Native <input type="date"> fires input events with value="" while the user is mid-typing the
-  // year subfield (the date is briefly incomplete). A controlled input would re-render on every
-  // such event and wipe the in-progress digits. With this ref-sync pattern, React only touches
-  // the DOM when the value prop changes externally.
+  // The input is uncontrolled (defaultValue + ref-sync). Native <input type="date"> is fragile:
+  // any DOM mutation, parent re-render, or write to .value while the field is focused can drop
+  // focus, reset the mm→dd→yyyy subfield cursor, or close the native calendar. So while the user
+  // is interacting with the field, React stays out — neither writing to the DOM here nor pushing
+  // updates to the parent (see handleBlur). The DOM is only synced from the value prop on
+  // external changes (load/reset) and only when the field is not focused.
   useEffect(() => {
-    if (inputRef.current && inputRef.current.value !== (value ?? "")) {
-      inputRef.current.value = value ?? "";
+    const input = inputRef.current;
+    if (!input || isFocusedRef.current) return;
+    if (input.value !== (value ?? "")) {
+      input.value = value ?? "";
     }
   }, [value]);
 
-  // Always propagate exactly what the user typed/picked, including "". Range is enforced by the
-  // native min/max attributes below and surfaced via the validation message; out-of-range values
-  // are never silently dropped, so what the user sees always matches what the parent holds.
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onChange?.(e.target.value);
+  const handleFocus = () => {
+    isFocusedRef.current = true;
+  };
+
+  // Commit on blur (and only on blur). Propagating live on each keystroke makes the parent
+  // re-render mid-edit, which in this app's dialog/form trees causes focus/calendar loss. Blur
+  // commits the final value — empty (cleared), in-range, or out-of-range — so the displayed
+  // value always matches what the parent holds and the out-of-range message surfaces correctly.
+  const handleBlur = () => {
+    isFocusedRef.current = false;
+    onChange?.(inputRef.current?.value ?? "");
   };
 
   // Default out-of-range message, consistent with the native (inclusive) min/max bounds.
@@ -84,7 +94,8 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         required={isRequired ?? false}
         disabled={isDisabled ?? false}
         defaultValue={value ?? ""}
-        onChange={handleChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
         min={inputMin}
         max={inputMax}
       />

--- a/client/src/components/input/date/DatePicker.tsx
+++ b/client/src/components/input/date/DatePicker.tsx
@@ -5,7 +5,8 @@ import {
   LABEL_CLASSES,
   VALIDATION_MESSAGE_CLASSES,
 } from "components/input/Input";
-import { isAfter, isBefore } from "date-fns";
+import { parseISO } from "date-fns";
+import { formatDate } from "util/formatDate";
 
 const DEFAULT_MIN_DATE = "1900-01-01";
 const DEFAULT_MAX_DATE = "2099-12-31";
@@ -18,6 +19,7 @@ interface DatePickerProps {
   isRequired?: boolean;
   isDisabled?: boolean;
   minDate?: string;
+  maxDate?: string;
   getValidationMessage?: () => string;
 }
 
@@ -29,10 +31,12 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   isRequired,
   isDisabled,
   minDate,
+  maxDate,
   getValidationMessage,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const inputMin = minDate ?? DEFAULT_MIN_DATE;
+  const inputMax = maxDate ?? DEFAULT_MAX_DATE;
 
   // The input is uncontrolled (defaultValue + ref-sync) instead of fully controlled.
   // Native <input type="date"> fires input events with value="" while the user is mid-typing the
@@ -45,17 +49,24 @@ export const DatePicker: React.FC<DatePickerProps> = ({
     }
   }, [value]);
 
+  // Always propagate exactly what the user typed/picked, including "". Range is enforced by the
+  // native min/max attributes below and surfaced via the validation message; out-of-range values
+  // are never silently dropped, so what the user sees always matches what the parent holds.
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newDate = e.target.value;
-    if (
-      newDate === "" ||
-      (isAfter(newDate, DEFAULT_MIN_DATE) && isBefore(newDate, DEFAULT_MAX_DATE))
-    ) {
-      onChange?.(newDate);
-    }
+    onChange?.(e.target.value);
   };
 
-  const validationMessage = getValidationMessage?.() ?? "";
+  // Default out-of-range message, consistent with the native (inclusive) min/max bounds.
+  // A caller-supplied getValidationMessage always takes precedence. Native <input type="date">
+  // emits well-formed YYYY-MM-DD or "", so an ISO string compare is chronologically correct.
+  const getRangeValidationMessage = (): string => {
+    if (!value) return "";
+    if (value < inputMin) return `Date must be on or after ${formatDate(parseISO(inputMin))}.`;
+    if (value > inputMax) return `Date must be on or before ${formatDate(parseISO(inputMax))}.`;
+    return "";
+  };
+
+  const validationMessage = getValidationMessage?.() || getRangeValidationMessage();
 
   return (
     <div className="flex flex-col gap-xs">
@@ -69,13 +80,13 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         id={name}
         name={name}
         data-testid={name}
-        className={`${INPUT_BASE_CLASSES} ${getInputColors(validationMessage ?? "")}`}
+        className={`${INPUT_BASE_CLASSES} ${getInputColors(validationMessage)}`}
         required={isRequired ?? false}
         disabled={isDisabled ?? false}
         defaultValue={value ?? ""}
         onChange={handleChange}
         min={inputMin}
-        max={DEFAULT_MAX_DATE}
+        max={inputMax}
       />
       {validationMessage && <span className={VALIDATION_MESSAGE_CLASSES}>{validationMessage}</span>}
     </div>

--- a/client/src/components/table/ColumnFilter.test.tsx
+++ b/client/src/components/table/ColumnFilter.test.tsx
@@ -460,7 +460,9 @@ describe("ColumnFilter Component", () => {
       const endInput = document.body.querySelector('input[name="date-filter-end"]');
       // Open the start date picker calendar popup by clicking the calendar button
       fireEvent.change(startInput!, { target: { value: "2023-02-01" } });
+      fireEvent.blur(startInput!);
       fireEvent.change(endInput!, { target: { value: "2023-04-01" } });
+      fireEvent.blur(endInput!);
 
       // Wait for the filtered results
       await waitFor(() => {
@@ -485,7 +487,9 @@ describe("ColumnFilter Component", () => {
       const endInput = document.body.querySelector('input[name="date-filter-end"]');
       // Open the start date picker calendar popup by clicking the calendar button
       fireEvent.change(startInput!, { target: { value: "2000-01-01" } });
+      fireEvent.blur(startInput!);
       fireEvent.change(endInput!, { target: { value: "2000-01-02" } });
+      fireEvent.blur(endInput!);
 
       await waitFor(() => {
         expect(
@@ -504,7 +508,9 @@ describe("ColumnFilter Component", () => {
       const endInput = document.body.querySelector('input[name="date-filter-end"]');
 
       fireEvent.change(startInput!, { target: { value: "2023-02-01" } });
+      fireEvent.blur(startInput!);
       fireEvent.change(endInput!, { target: { value: "2023-04-01" } });
+      fireEvent.blur(endInput!);
 
       await user.selectOptions(columnSelect, "Name");
       await waitFor(() => {

--- a/client/src/components/table/tables/DocumentTable.test.tsx
+++ b/client/src/components/table/tables/DocumentTable.test.tsx
@@ -105,7 +105,9 @@ describe("DocumentTable", () => {
     const endInput = document.body.querySelector('input[name="date-filter-end"]');
     // Open the start date picker calendar popup by clicking the calendar button
     fireEvent.change(startInput!, { target: { value: "2025-01-01" } });
+    fireEvent.blur(startInput!);
     fireEvent.change(endInput!, { target: { value: "2025-01-02" } });
+    fireEvent.blur(endInput!);
     const table = screen.getByRole("table");
     // Should show only documents within the range (inclusive)
     expect(within(table).getByText("Final Report")).toBeInTheDocument();


### PR DESCRIPTION
# DEMOS-1937 — Date field fixes

Follow-up to the DEMOS-2004 spike and DEMOS-1800 (which already fixed the main
"can't type the year" bug). This PR cleans up what was left.

## What it fixes

- **The box now matches what gets saved.** Out-of-range dates no longer get
  silently dropped; whatever you leave in the field is what the form holds.
- **Validation limits are consistent.** The browser and our code now agree on
  what's in range (and the range is inclusive on both ends).
- **Editing an existing date no longer breaks.** Typing into a subfield (mm,
  dd, yyyy) keeps focus, the cursor advances normally, and the calendar
  pop-up stays open when you use the arrow keys.
- **Past dates are never trapped.** A prior Due Date or other historical date
  loads, displays, and can still be edited or submitted unchanged.


https://github.com/user-attachments/assets/dc5fc61c-3e14-44c8-a0f9-1f3d40d0a4e6


