### PR TITLE
DEMOS-2148: Remove Some Export and Import Icons / Actions from tables

### DIFF
--- a/client/src/components/table/tables/DocumentTable.test.tsx
+++ b/client/src/components/table/tables/DocumentTable.test.tsx
@@ -25,26 +25,17 @@ describe("DocumentTable", () => {
   beforeEach(() => {
     render(
       <MockedProvider mocks={ALL_MOCKS} addTypename={false}>
-        <DocumentTable applicationId="test-application-id" documents={mockDocuments} />
+        <DocumentTable documents={mockDocuments} />
       </MockedProvider>
     );
   });
 
-  it("renders action buttons (add/edit)", async () => {
+  it("renders action buttons (edit/delete)", async () => {
     await waitFor(() => {
       expect(screen.getByRole("table")).toBeInTheDocument();
     });
-    expect(screen.getByLabelText(/Add Document/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/Edit Document/i)).toBeInTheDocument();
-  });
-
-  it("opens AddDocumentModal when add button is clicked", async () => {
-    await waitFor(() => {
-      expect(screen.getByRole("table")).toBeInTheDocument();
-    });
-    const user = userEvent.setup();
-    await user.click(screen.getByLabelText(/Add Document/i));
-    expect(showUploadDocumentDialog).toHaveBeenCalled();
+    expect(screen.getByLabelText(/Remove Document/i)).toBeInTheDocument();
   });
 
   it("disables Edit button when no or multiple documents are selected, enables for one", async () => {

--- a/client/src/components/table/tables/DocumentTable.tsx
+++ b/client/src/components/table/tables/DocumentTable.tsx
@@ -2,7 +2,7 @@
 import * as React from "react";
 
 import { CircleButton } from "components/button/CircleButton";
-import { DeleteIcon, EditIcon, ImportIcon } from "components/icons";
+import { DeleteIcon, EditIcon } from "components/icons";
 import { ColumnFilter } from "../ColumnFilter";
 import { DocumentColumns } from "../columns/DocumentColumns";
 import { KeywordSearch } from "../KeywordSearch";
@@ -19,14 +19,9 @@ export type DocumentTableDocument = Pick<
   owner: { person: Pick<Person, "fullName"> };
 };
 
-export type DocumentsTableProps = {
-  applicationId: string;
-  documents: DocumentTableDocument[];
-};
-export const DocumentTable: React.FC<DocumentsTableProps> = ({ applicationId, documents }) => {
+export const DocumentTable = ({ documents }: { documents: DocumentTableDocument[] }) => {
   const documentColumns = DocumentColumns();
-  const { showUploadDocumentDialog, showEditDocumentDialog, showRemoveDocumentDialog } =
-    useDialog();
+  const { showEditDocumentDialog, showRemoveDocumentDialog } = useDialog();
   const initialState = {
     sorting: [{ id: "createdAt", desc: true }],
   };
@@ -66,15 +61,6 @@ export const DocumentTable: React.FC<DocumentsTableProps> = ({ applicationId, do
 
             return (
               <div className="flex gap-1 ml-4">
-                <CircleButton
-                  name="add-document"
-                  ariaLabel="Add Document"
-                  tooltip="Add Document"
-                  onClick={() => showUploadDocumentDialog(applicationId)}
-                >
-                  <ImportIcon />
-                </CircleButton>
-
                 <CircleButton
                   name="edit-document"
                   ariaLabel="Edit Document"

--- a/client/src/components/table/tables/TypesTable.test.tsx
+++ b/client/src/components/table/tables/TypesTable.test.tsx
@@ -119,11 +119,9 @@ describe("TypesTable", () => {
   it("disables action buttons when inputDisabled is true", () => {
     render(<TypesTable demonstration={MOCK_DEMONSTRATION} inputDisabled />);
 
-    const addButton = screen.getByTestId("add-type");
     const editButton = screen.getByTestId("edit-type");
     const deleteButton = screen.getByTestId("delete-type");
 
-    expect(addButton).toBeDisabled();
     expect(editButton).toBeDisabled();
     expect(deleteButton).toBeDisabled();
   });

--- a/client/src/components/table/tables/TypesTable.tsx
+++ b/client/src/components/table/tables/TypesTable.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { compareAsc } from "date-fns";
 import { CircleButton } from "components/button/CircleButton";
-import { DeleteIcon, EditIcon, ExportIcon } from "components/icons";
+import { DeleteIcon, EditIcon } from "components/icons";
 import { KeywordSearch } from "../KeywordSearch";
 import { PaginationControls } from "../PaginationControls";
 import { Table } from "../Table";
@@ -119,18 +119,6 @@ export const TypesTable: React.FC<TypesTableProps> = ({
 
             return (
               <div className="flex gap-1 ml-4">
-                <CircleButton
-                  name="add-type"
-                  ariaLabel="Add Type"
-                  disabled={inputDisabled}
-                  onClick={() =>
-                    // !addDisabled && showAddTypeDialog()
-                    console.log("Add Type Clicked")
-                  }
-                >
-                  <ExportIcon />
-                </CircleButton>
-
                 <CircleButton
                   name="edit-type"
                   ariaLabel="Edit Type"

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
@@ -145,7 +145,7 @@ export const DemonstrationTab: React.FC<{ demonstration: DemonstrationTabDemonst
               Add Document
             </IconButton>
           </TabHeader>
-          <DocumentTable applicationId={demonstration.id} documents={demonstration.documents} />
+          <DocumentTable documents={demonstration.documents} />
         </Tab>
         <Tab
           icon={<CharacteristicIcon />}

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.tsx
@@ -3,7 +3,11 @@ import React from "react";
 import { ModificationItem } from "./ModificationTabs";
 import { AddNewIcon, DetailsIcon, ListIcon, OpenFolderIcon } from "components/icons";
 import { ModificationDetailsSummary } from "./ModificationDetailsSummary";
-import { AmendmentWorkflow, ExtensionWorkflow, GET_WORKFLOW_DEMONSTRATION_QUERY } from "components/application";
+import {
+  AmendmentWorkflow,
+  ExtensionWorkflow,
+  GET_WORKFLOW_DEMONSTRATION_QUERY,
+} from "components/application";
 import { DocumentTable } from "components/table/tables/DocumentTable";
 import { IconButton } from "components/button/IconButton";
 import { TabHeader } from "components/table/TabHeader";
@@ -57,12 +61,14 @@ export const ModificationTabSideNav = ({
             icon={<AddNewIcon />}
             name="add-new-document"
             size="small"
-            onClick={() => showUploadDocumentDialog(modificationItem.id, refetchApplicationWorkflow)}
+            onClick={() =>
+              showUploadDocumentDialog(modificationItem.id, refetchApplicationWorkflow)
+            }
           >
             Add Document
           </IconButton>
         </TabHeader>
-        <DocumentTable applicationId={modificationItem.id} documents={modificationItem.documents} />
+        <DocumentTable documents={modificationItem.documents} />
       </Tab>
     </VerticalTabs>
   );


### PR DESCRIPTION
Per DEMOS-2148, removes the export icon from the types table (which had no action) and the import button from the documents table (which was redundant with the more explicit "Add Document" Button)

<img width="2662" height="1553" alt="image" src="https://github.com/user-attachments/assets/264bd1cc-e8b9-4878-8d66-8d8baeb2dffa" />

<img width="2670" height="1426" alt="image" src="https://github.com/user-attachments/assets/938d945a-7f65-431f-9838-6e1c45bde0fd" />
