### PR TITLE
DEMOS-2132 — Extension Date can be after Demonstration Expiration

### DIFF
--- a/client/src/components/dialog/deliverable/RequestExtensionDeliverableDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/RequestExtensionDeliverableDialog.test.tsx
@@ -45,7 +45,6 @@ vi.mock("@apollo/client", async () => {
 const TEST_DELIVERABLE: RequestExtensionDeliverableDialogDeliverable = {
   id: "deliverable-1",
   dueDate: new Date("2026-02-12"),
-  demonstration: { expirationDate: new Date("2026-12-31") },
 };
 
 const setup = (overrides?: Partial<RequestExtensionDeliverableDialogDeliverable>) => {
@@ -133,20 +132,19 @@ describe("RequestExtensionDeliverableDialog", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps Submit disabled when the extension date is after the demonstration expiration", async () => {
+  it("allows extension dates beyond the demonstration expiration", async () => {
     const user = userEvent.setup();
     setup();
 
     fireEvent.change(screen.getByTestId(REQUEST_EXTENSION_DATE_FIELD_NAME), {
-      target: { value: "2027-01-15" }, // past expiration
+      target: { value: "2027-01-15" },
     });
     await user.selectOptions(screen.getByTestId(REQUEST_EXTENSION_REASON_FIELD_NAME), "Other");
     await user.type(screen.getByTestId(REQUEST_EXTENSION_DETAILS_FIELD_NAME), "x");
 
-    expect(screen.getByTestId(REQUEST_EXTENSION_SUBMIT_BUTTON_NAME)).toBeDisabled();
-    expect(
-      screen.getByText("Extension Date cannot be after the Demonstration Expiration Date.")
-    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByTestId(REQUEST_EXTENSION_SUBMIT_BUTTON_NAME)).not.toBeDisabled()
+    );
   });
 
   it("submits the mutation, shows a success toast, and closes the dialog", async () => {
@@ -256,34 +254,23 @@ describe("canRequestExtension", () => {
 
 describe("getExtensionDateValidationMessage", () => {
   const dueDate = new Date("2026-02-12");
-  const expirationDate = new Date("2026-12-31");
 
   it("returns empty for an empty value", () => {
-    expect(getExtensionDateValidationMessage("", dueDate, expirationDate)).toBe("");
+    expect(getExtensionDateValidationMessage("", dueDate)).toBe("");
   });
 
   it("flags dates not after the due date", () => {
-    expect(getExtensionDateValidationMessage("2026-02-12", dueDate, expirationDate)).toBe(
+    expect(getExtensionDateValidationMessage("2026-02-12", dueDate)).toBe(
       "Extension Date must be after the current Due Date."
     );
-    expect(getExtensionDateValidationMessage("2026-01-01", dueDate, expirationDate)).toBe(
+    expect(getExtensionDateValidationMessage("2026-01-01", dueDate)).toBe(
       "Extension Date must be after the current Due Date."
     );
   });
 
-  it("flags dates beyond the demonstration expiration", () => {
-    expect(getExtensionDateValidationMessage("2027-01-15", dueDate, expirationDate)).toBe(
-      "Extension Date cannot be after the Demonstration Expiration Date."
-    );
-  });
-
-  it("skips the expiration check when no expiration date is known", () => {
-    expect(getExtensionDateValidationMessage("2099-01-01", dueDate, null)).toBe("");
-    expect(getExtensionDateValidationMessage("2099-01-01", dueDate, undefined)).toBe("");
-  });
-
-  it("accepts a valid date between due date and expiration", () => {
-    expect(getExtensionDateValidationMessage("2026-06-01", dueDate, expirationDate)).toBe("");
+  it("accepts any valid date after the due date, regardless of demonstration expiration", () => {
+    expect(getExtensionDateValidationMessage("2026-06-01", dueDate)).toBe("");
+    expect(getExtensionDateValidationMessage("2099-01-01", dueDate)).toBe("");
   });
 });
 
@@ -310,27 +297,18 @@ describe("formIsValid / formHasChanges", () => {
 
   it("formIsValid requires all three fields", () => {
     expect(
-      formIsValid({ extensionDate: "", requestReason: "Other", details: "reason" }, dueDate, null)
+      formIsValid({ extensionDate: "", requestReason: "Other", details: "reason" }, dueDate)
     ).toBe(false);
     expect(
-      formIsValid(
-        { extensionDate: "2026-03-01", requestReason: "", details: "reason" },
-        dueDate,
-        null
-      )
+      formIsValid({ extensionDate: "2026-03-01", requestReason: "", details: "reason" }, dueDate)
     ).toBe(false);
     expect(
-      formIsValid(
-        { extensionDate: "2026-03-01", requestReason: "Other", details: "   " },
-        dueDate,
-        null
-      )
+      formIsValid({ extensionDate: "2026-03-01", requestReason: "Other", details: "   " }, dueDate)
     ).toBe(false);
     expect(
       formIsValid(
         { extensionDate: "2026-03-01", requestReason: "Other", details: "reason" },
-        dueDate,
-        null
+        dueDate
       )
     ).toBe(true);
   });

--- a/client/src/components/dialog/deliverable/RequestExtensionDeliverableDialog.tsx
+++ b/client/src/components/dialog/deliverable/RequestExtensionDeliverableDialog.tsx
@@ -60,7 +60,6 @@ export const REQUEST_REASON_OPTIONS: Option[] = DELIVERABLE_EXTENSION_REASON_COD
 export interface RequestExtensionDeliverableDialogDeliverable {
   id: string;
   dueDate: Date;
-  demonstration: { expirationDate?: Date | null };
 }
 
 export interface RequestExtensionFormData {
@@ -77,8 +76,7 @@ export const INITIAL_FORM_DATA: RequestExtensionFormData = {
 
 export const getExtensionDateValidationMessage = (
   extensionDate: string,
-  dueDate: Date,
-  demonstrationExpirationDate: Date | null | undefined
+  dueDate: Date
 ): string => {
   if (extensionDate === "") return "";
   const parsed = parseISO(extensionDate);
@@ -86,21 +84,13 @@ export const getExtensionDateValidationMessage = (
   if (!isAfter(parsed, dueDate)) {
     return "Extension Date must be after the current Due Date.";
   }
-  if (demonstrationExpirationDate && isAfter(parsed, demonstrationExpirationDate)) {
-    return "Extension Date cannot be after the Demonstration Expiration Date.";
-  }
   return "";
 };
 
-export const formIsValid = (
-  form: RequestExtensionFormData,
-  dueDate: Date,
-  demonstrationExpirationDate: Date | null | undefined
-): boolean => {
+export const formIsValid = (form: RequestExtensionFormData, dueDate: Date): boolean => {
   const extensionDateValid =
     form.extensionDate.trim().length > 0 &&
-    getExtensionDateValidationMessage(form.extensionDate, dueDate, demonstrationExpirationDate) ===
-      "";
+    getExtensionDateValidationMessage(form.extensionDate, dueDate) === "";
   return extensionDateValid && form.requestReason.length > 0 && form.details.trim().length > 0;
 };
 
@@ -122,13 +112,11 @@ export const RequestExtensionDeliverableDialog: React.FC<
   const [formData, setFormData] = useState<RequestExtensionFormData>(INITIAL_FORM_DATA);
   const [attemptedSubmit, setAttemptedSubmit] = useState(false);
 
-  const expirationDate = deliverable.demonstration.expirationDate ?? null;
   const extensionDateError = getExtensionDateValidationMessage(
     formData.extensionDate,
-    deliverable.dueDate,
-    expirationDate
+    deliverable.dueDate
   );
-  const isValidForm = formIsValid(formData, deliverable.dueDate, expirationDate);
+  const isValidForm = formIsValid(formData, deliverable.dueDate);
   const hasChanges = formHasChanges(formData);
 
   const handleSubmit = async () => {

--- a/client/src/pages/deliverables/sections/DeliverableButtons.test.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableButtons.test.tsx
@@ -137,7 +137,6 @@ describe("DeliverableButtons", () => {
     expect(mockShowRequestExtensionDeliverableDialog).toHaveBeenCalledWith({
       id: MOCK_DELIVERABLE_1.id,
       dueDate: MOCK_DELIVERABLE_1.dueDate,
-      demonstration: { expirationDate: MOCK_DELIVERABLE_1.demonstration.expirationDate },
     });
   });
 

--- a/client/src/pages/deliverables/sections/DeliverableButtons.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableButtons.tsx
@@ -29,7 +29,6 @@ export const DeliverableButtons = ({
     showRequestExtensionDeliverableDialog({
       id: deliverable.id,
       dueDate: deliverable.dueDate,
-      demonstration: { expirationDate: deliverable.demonstration.expirationDate },
     });
   };
 


### PR DESCRIPTION
# DEMOS-2132 — Extension Date can be after Demonstration Expiration

## The bug

In the **Request Extension** dialog, picking an Extension Date later than the
demonstration's Expiration Date was blocked with:

> Extension Date cannot be after the Demonstration Expiration Date.

That rule shouldn't exist — the requested date only needs to be after the
deliverable's current Due Date. The server already validates that correctly;
this was a client-only over-validation.


https://github.com/user-attachments/assets/d7bc2cd2-08e5-4c4c-8b7b-9adf2ad52998

