### PR TITLE
Demos 1708: removes access to demonstration home page and show pages from state user

### DIFF
--- a/client/src/components/header/DefaultHeaderLower.test.tsx
+++ b/client/src/components/header/DefaultHeaderLower.test.tsx
@@ -79,6 +79,22 @@ describe("DefaultHeaderLower", () => {
     expect(screen.queryByText("Demonstration")).not.toBeInTheDocument();
   });
 
+  it("does not show the Create New menu for state users", () => {
+    mockGetCurrentUser.mockReturnValue({
+      currentUser: {
+        ...mockUsers[0],
+        person: {
+          ...mockUsers[0].person,
+          personType: "demos-state-user",
+        },
+      },
+    });
+
+    render(<DefaultHeaderLower />);
+
+    expect(screen.queryByText("Create New")).not.toBeInTheDocument();
+  });
+
   it("opens CreateDemonstrationDialog when demonstration modal is clicked", () => {
     mockGetCurrentUser.mockReturnValue({
       currentUser: mockUsers[0],

--- a/client/src/components/header/DefaultHeaderLower.tsx
+++ b/client/src/components/header/DefaultHeaderLower.tsx
@@ -23,8 +23,12 @@ const UserGreeting = () => {
 export const DefaultHeaderLower: React.FC = () => {
   const [showDropdown, setShowDropdown] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const { currentUser } = getCurrentUser();
   const { showCreateDemonstrationDialog, showCreateAmendmentDialog, showCreateExtensionDialog } =
     useDialog();
+  const canCreate =
+    currentUser?.person.personType === "demos-admin" ||
+    currentUser?.person.personType === "demos-cms-user";
 
   useEffect(() => {
     // Close dropdown on outside click
@@ -41,51 +45,53 @@ export const DefaultHeaderLower: React.FC = () => {
     <>
       <UserGreeting />
 
-      <div ref={dropdownRef}>
-        <IconButton
-          icon={<AddNewIcon />}
-          name="create-new"
-          data-testid="create-new"
-          onClick={() => setShowDropdown((prev) => !prev)}
-        >
-          Create New
-        </IconButton>
+      {canCreate && (
+        <div ref={dropdownRef}>
+          <IconButton
+            icon={<AddNewIcon />}
+            name="create-new"
+            data-testid="create-new"
+            onClick={() => setShowDropdown((prev) => !prev)}
+          >
+            Create New
+          </IconButton>
 
-        {showDropdown && (
-          <div className="absolute w-[160px] bg-white text-black rounded-[6px] shadow-lg border z-20">
-            <button
-              data-testid="button-create-new-demonstration"
-              onClick={() => {
-                setShowDropdown(false);
-                showCreateDemonstrationDialog();
-              }}
-              className="w-full text-left px-1 py-[10px] hover:bg-gray-100"
-            >
-              Demonstration
-            </button>
-            <button
-              data-testid="button-create-new-amendment"
-              onClick={() => {
-                setShowDropdown(false);
-                showCreateAmendmentDialog();
-              }}
-              className="w-full text-left px-1 py-[10px] hover:bg-gray-100"
-            >
-              Amendment
-            </button>
-            <button
-              data-testid="button-create-new-extension"
-              onClick={() => {
-                setShowDropdown(false);
-                showCreateExtensionDialog();
-              }}
-              className="w-full text-left px-1 py-[10px] hover:bg-gray-100"
-            >
-              Extension
-            </button>
-          </div>
-        )}
-      </div>
+          {showDropdown && (
+            <div className="absolute w-[160px] bg-white text-black rounded-[6px] shadow-lg border z-20">
+              <button
+                data-testid="button-create-new-demonstration"
+                onClick={() => {
+                  setShowDropdown(false);
+                  showCreateDemonstrationDialog();
+                }}
+                className="w-full text-left px-1 py-[10px] hover:bg-gray-100"
+              >
+                Demonstration
+              </button>
+              <button
+                data-testid="button-create-new-amendment"
+                onClick={() => {
+                  setShowDropdown(false);
+                  showCreateAmendmentDialog();
+                }}
+                className="w-full text-left px-1 py-[10px] hover:bg-gray-100"
+              >
+                Amendment
+              </button>
+              <button
+                data-testid="button-create-new-extension"
+                onClick={() => {
+                  setShowDropdown(false);
+                  showCreateExtensionDialog();
+                }}
+                className="w-full text-left px-1 py-[10px] hover:bg-gray-100"
+              >
+                Extension
+              </button>
+            </div>
+          )}
+        </div>
+      )}
     </>
   );
 };

--- a/client/src/router/DemosRouter.test.tsx
+++ b/client/src/router/DemosRouter.test.tsx
@@ -105,10 +105,13 @@ vi.mock("pages/DemonstrationsPage", () => ({
   DemonstrationsPage: () => <div>DemonstrationsPage</div>,
   DEMONSTRATIONS_PAGE_QUERY: {},
 }));
+vi.mock("pages/DemonstrationDetail/index", () => ({
+  DemonstrationDetail: () => <div>DemonstrationDetail</div>,
+}));
 vi.mock("pages/DeliverablesPage", () => ({
   DeliverablesPage: () => <div>DeliverablesPage</div>,
 }));
-vi.mock("pages/reports/ReportsPage", () => ({
+vi.mock("pages/ReportsPage", () => ({
   ReportsPage: () => <div>ReportsPage</div>,
 }));
 
@@ -138,6 +141,22 @@ describe("DemosRouter", () => {
     await waitFor(() => expect(screen.getByText("DemonstrationsPage")).toBeInTheDocument());
   });
 
+  it("redirects state users from /demonstrations to their deliverables home page", async () => {
+    currentUserState.currentUser.person.personType = "demos-state-user";
+    window.history.pushState({}, "Demonstrations", "/demonstrations");
+    render(<DemosRouter />);
+    await waitFor(() => expect(screen.getByText("DeliverablesPage")).toBeInTheDocument());
+    expect(screen.queryByText("DemonstrationsPage")).not.toBeInTheDocument();
+  });
+
+  it("redirects state users from demonstration detail URLs to their deliverables home page", async () => {
+    currentUserState.currentUser.person.personType = "demos-state-user";
+    window.history.pushState({}, "Demonstration Detail", "/demonstrations/demo-1");
+    render(<DemosRouter />);
+    await waitFor(() => expect(screen.getByText("DeliverablesPage")).toBeInTheDocument());
+    expect(screen.queryByText("DemonstrationDetail")).not.toBeInTheDocument();
+  });
+
   it("renders the Deliverables page at /deliverables", async () => {
     window.history.pushState({}, "Deliverables", "/deliverables");
     render(<DemosRouter />);
@@ -147,7 +166,15 @@ describe("DemosRouter", () => {
   it("renders the Reports page at /reports", async () => {
     window.history.pushState({}, "Reports", "/reports");
     render(<DemosRouter />);
-    await waitFor(() => expect(screen.getByText("Reports")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("ReportsPage")).toBeInTheDocument());
+  });
+
+  it("redirects state users from /reports to their deliverables home page", async () => {
+    currentUserState.currentUser.person.personType = "demos-state-user";
+    window.history.pushState({}, "Reports", "/reports");
+    render(<DemosRouter />);
+    await waitFor(() => expect(screen.getByText("DeliverablesPage")).toBeInTheDocument());
+    expect(screen.queryByText("ReportsPage")).not.toBeInTheDocument();
   });
 
   it("renders component debug routes in development mode", async () => {

--- a/client/src/router/DemosRouter.tsx
+++ b/client/src/router/DemosRouter.tsx
@@ -17,6 +17,8 @@ import { DeliverableDetailsManagementPage } from "pages/deliverables/Deliverable
 import { AdminPage } from "pages/admin/AdminPage";
 import { RequireRole } from "./RequireRole";
 
+const DEMONSTRATION_ACCESS_ROLES = ["demos-admin", "demos-cms-user"];
+
 const HomePage = () => {
   const { currentUser } = getCurrentUser();
 
@@ -38,8 +40,22 @@ export const DemosRouter: React.FC = () => {
               <Route element={<DemosLayoutProvider />}>
                 <Route path="*" element={<div>404: Page Not Found</div>} />
                 <Route path="/" element={<HomePage />} />
-                <Route path="demonstrations" element={<DemonstrationsPage />} />
-                <Route path="demonstrations/:id" element={<DemonstrationDetail />} />
+                <Route
+                  path="demonstrations"
+                  element={
+                    <RequireRole allowedRoles={DEMONSTRATION_ACCESS_ROLES}>
+                      <DemonstrationsPage />
+                    </RequireRole>
+                  }
+                />
+                <Route
+                  path="demonstrations/:id"
+                  element={
+                    <RequireRole allowedRoles={DEMONSTRATION_ACCESS_ROLES}>
+                      <DemonstrationDetail />
+                    </RequireRole>
+                  }
+                />
                 <Route path="deliverables" element={<DeliverablesPage />} />
                 <Route
                   path="deliverables/:deliverableId"

--- a/client/src/router/DemosRouter.tsx
+++ b/client/src/router/DemosRouter.tsx
@@ -40,16 +40,14 @@ export const DemosRouter: React.FC = () => {
               <Route element={<DemosLayoutProvider />}>
                 <Route path="*" element={<div>404: Page Not Found</div>} />
                 <Route path="/" element={<HomePage />} />
-                <Route
-                  path="demonstrations"
+                <Route path="demonstrations"
                   element={
                     <RequireRole allowedRoles={DEMONSTRATION_ACCESS_ROLES}>
                       <DemonstrationsPage />
                     </RequireRole>
                   }
                 />
-                <Route
-                  path="demonstrations/:id"
+                <Route path="demonstrations/:id"
                   element={
                     <RequireRole allowedRoles={DEMONSTRATION_ACCESS_ROLES}>
                       <DemonstrationDetail />
@@ -57,20 +55,17 @@ export const DemosRouter: React.FC = () => {
                   }
                 />
                 <Route path="deliverables" element={<DeliverablesPage />} />
-                <Route
-                  path="deliverables/:deliverableId"
+                <Route path="deliverables/:deliverableId"
                   element={<DeliverableDetailsManagementPage />}
                 />
-                <Route
-                  path="reports"
+                <Route path="reports"
                   element={
                     <RequireRole allowedRoles={["demos-admin", "demos-cms-user"]}>
                       <ReportsPage />
                     </RequireRole>
                   }
                 />
-                <Route
-                  path="admin"
+                <Route path="admin"
                   element={
                     <RequireRole allowedRoles={["demos-admin"]}>
                       <AdminPage />


### PR DESCRIPTION
Prior to this, when going to demo pages the SU could gain access. 

This removes the ability for the state user explicitly. Not by lack of data. 
Also, we pull the "create new" button from the header. 
Since SU's can only upload docs. 


https://github.com/user-attachments/assets/0cddb567-b055-4c73-b5bd-3d041cdda9ec

<img width="1000" height="auto" alt="Screenshot 2026-05-26 at 12 03 07" src="https://github.com/user-attachments/assets/322ed5f6-e069-48ab-9ef2-19594dc7fd0d" />


