### PR TITLE
DEMOS-2139: updated state document upload to validate demonstration a…

### DIFF
--- a/server/src/model/documentPendingUpload/documentPendingUploadResolvers.test.ts
+++ b/server/src/model/documentPendingUpload/documentPendingUploadResolvers.test.ts
@@ -10,6 +10,7 @@ import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFie
 import { getS3Adapter } from "../../adapters";
 import { updateAssociatedPhase } from "./updateAssociatedPhase";
 import { handleUploadDocumentToDeliverable } from "./handleUploadDocumentToDeliverable";
+import { validateStateUserCanUploadStateDocumentToDeliverable } from "./validateStateUserCanUploadStateDocumentToDeliverable";
 
 vi.mock("../../errors/checkOptionalNotNullFields", () => ({
   checkOptionalNotNullFields: vi.fn(),
@@ -44,6 +45,10 @@ vi.mock("../deliverable", () => ({
 
 vi.mock("./handleUploadDocumentToDeliverable", () => ({
   handleUploadDocumentToDeliverable: vi.fn(),
+}));
+
+vi.mock("./validateStateUserCanUploadStateDocumentToDeliverable", () => ({
+  validateStateUserCanUploadStateDocumentToDeliverable: vi.fn(),
 }));
 
 const mockTransaction = {} as any;
@@ -178,6 +183,18 @@ describe("documentResolvers", () => {
         description: "Test document description",
         deliverableId: "deliverable-123",
       };
+
+      it("should validate state user can upload state document to deliverable", async () => {
+        await documentPendingUploadResolvers.Mutation.uploadDocumentToDeliverableStateFiles(
+          undefined,
+          { input },
+          { user: { id: "state-user-id", personTypeId: "demos-state-user" } } as GraphQLContext
+        );
+
+        expect(
+          validateStateUserCanUploadStateDocumentToDeliverable
+        ).toHaveBeenCalledExactlyOnceWith("state-user-id", input.applicationId);
+      });
 
       it("should defer to handleUploadDocumentToDeliverable with correct parameters", async () => {
         await documentPendingUploadResolvers.Mutation.uploadDocumentToDeliverableStateFiles(

--- a/server/src/model/documentPendingUpload/documentPendingUploadResolvers.ts
+++ b/server/src/model/documentPendingUpload/documentPendingUploadResolvers.ts
@@ -19,6 +19,7 @@ import { selectUserOrThrow } from "../user/queries";
 import { resolveDeliverable } from "../deliverable";
 import { updateAssociatedPhase } from "./updateAssociatedPhase";
 import { handleUploadDocumentToDeliverable } from "./handleUploadDocumentToDeliverable";
+import { validateStateUserCanUploadStateDocumentToDeliverable } from "./validateStateUserCanUploadStateDocumentToDeliverable";
 
 export const documentPendingUploadResolvers = {
   Mutation: {
@@ -76,8 +77,12 @@ export const documentPendingUploadResolvers = {
       parent: unknown,
       { input }: { input: UploadDocumentToDeliverableInput },
       context: GraphQLContext
-    ): Promise<PrismaDocumentPendingUpload> =>
-      handleUploadDocumentToDeliverable(input, context.user.id, false),
+    ): Promise<PrismaDocumentPendingUpload> => {
+      if (context.user.personTypeId === "demos-state-user") {
+        validateStateUserCanUploadStateDocumentToDeliverable(context.user.id, input.applicationId);
+      }
+      return handleUploadDocumentToDeliverable(input, context.user.id, false);
+    },
   },
 
   DocumentPendingUpload: {

--- a/server/src/model/documentPendingUpload/documentPendingUploadSchema.ts
+++ b/server/src/model/documentPendingUpload/documentPendingUploadSchema.ts
@@ -16,10 +16,10 @@ export const documentPendingUploadSchema = gql`
     description: String
     owner: User!
     documentType: DocumentType!
-    application: Application! @auth(requires: ["Perform CMS Action"])
+    application: Application!
     phaseName: PhaseName @auth(requires: ["Perform CMS Action"])
-    presignedUploadUrl: String! @auth(requires: ["Perform CMS Action"])
-    deliverable: Deliverable @auth(requires: ["Perform CMS Action"])
+    presignedUploadUrl: String!
+    deliverable: Deliverable
     createdAt: DateTime!
     updatedAt: DateTime!
   }

--- a/server/src/model/documentPendingUpload/validateStateUserCanUploadStateDocumentToDeliverable.test.ts
+++ b/server/src/model/documentPendingUpload/validateStateUserCanUploadStateDocumentToDeliverable.test.ts
@@ -1,0 +1,55 @@
+import { describe, beforeEach, expect, it, vi } from "vitest";
+import { validateStateUserCanUploadStateDocumentToDeliverable } from "./validateStateUserCanUploadStateDocumentToDeliverable";
+import { prisma } from "../../prismaClient";
+import { DemonstrationRoleAssignment as PrismaDemonstrationRoleAssignment } from "@prisma/client";
+
+vi.mock("../../prismaClient", () => ({
+  prisma: vi.fn(),
+}));
+
+describe("validateStateUserCanUploadStateDocumentToDeliverable", () => {
+  const regularMocks = {
+    demonstrationRoleAssignment: {
+      findMany: vi.fn(),
+    },
+  };
+
+  const mockPrismaClient = {
+    demonstrationRoleAssignment: {
+      findMany: regularMocks.demonstrationRoleAssignment.findMany,
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma).mockReturnValue(mockPrismaClient as never);
+  });
+
+  it("should throw an error if the user does not have the State Point of Contact role for the demonstration", async () => {
+    vi.mocked(prisma().demonstrationRoleAssignment.findMany).mockResolvedValue([]);
+
+    const userId = "user-id-without-role";
+    const demonstrationId = "demonstration-id";
+
+    await expect(
+      validateStateUserCanUploadStateDocumentToDeliverable(userId, demonstrationId)
+    ).rejects.toThrow("User does not have permission to upload documents to this deliverable.");
+  });
+
+  it("should not throw an error if the user has the State Point of Contact role for the demonstration", async () => {
+    vi.mocked(prisma().demonstrationRoleAssignment.findMany).mockResolvedValue([
+      {
+        personId: "user-id-with-role",
+        roleId: "State Point of Contact",
+        demonstrationId: "demonstration-id",
+      } as PrismaDemonstrationRoleAssignment,
+    ]);
+
+    const userId = "user-id-with-role";
+    const demonstrationId = "demonstration-id";
+
+    await expect(
+      validateStateUserCanUploadStateDocumentToDeliverable(userId, demonstrationId)
+    ).resolves.not.toThrow();
+  });
+});

--- a/server/src/model/documentPendingUpload/validateStateUserCanUploadStateDocumentToDeliverable.ts
+++ b/server/src/model/documentPendingUpload/validateStateUserCanUploadStateDocumentToDeliverable.ts
@@ -1,0 +1,18 @@
+import { prisma } from "../../prismaClient";
+
+export const validateStateUserCanUploadStateDocumentToDeliverable = async (
+  userId: string,
+  demonstrationId: string
+) => {
+  const roleAssignments = await prisma().demonstrationRoleAssignment.findMany({
+    where: {
+      personId: userId,
+      roleId: "State Point of Contact",
+    },
+  });
+  if (
+    !roleAssignments.some((roleAssignment) => roleAssignment.demonstrationId === demonstrationId)
+  ) {
+    throw new Error("User does not have permission to upload documents to this deliverable.");
+  }
+};


### PR DESCRIPTION
found during testing that the auth directives were blocking off too much of the documentPendingUpload object and needed to be relaxed. This is because, while most of the time CMS users are the only ones that can access it, the state users are able to upload and thus need to be able to see at least the presigned upload url. Because this is the one place where a state user has access to the object, only one check is needed in the mutator. It just checks the role and if its a state user, validates they belong to the demonstration theyre uploading on. 