### PR TITLE
DEMOS 1705 + 1773

### DIFF
--- a/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.tsx
+++ b/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.tsx
@@ -465,6 +465,7 @@ export const ApprovalSummaryPhase = ({
           onMarkComplete={handleMarkComplete}
           onMarkIncomplete={handleMarkIncomplete}
           completionDate={applicationDetailsCompletionDate}
+          demonstrationId={demonstrationId}
         />
 
         <DemonstrationTypesSection

--- a/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
+++ b/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
@@ -71,6 +71,7 @@ export const ApplicationDetailsSection = ({
   onMarkComplete,
   onMarkIncomplete,
   completionDate,
+  demonstrationId,
 }: {
   sectionFormData: ApplicationDetailsFormData;
   setSectionFormData: (data: ApplicationDetailsFormData) => void;
@@ -79,6 +80,7 @@ export const ApplicationDetailsSection = ({
   onMarkComplete: () => void;
   onMarkIncomplete: () => void;
   completionDate?: string;
+  demonstrationId?: string;
 }) => {
   const capitalizedType = sectionFormData.applicationType.charAt(0).toUpperCase() + sectionFormData.applicationType.slice(1);
   const isApplicationDetailsComplete = (data: ApplicationDetailsFormData) => {
@@ -221,7 +223,7 @@ export const ApplicationDetailsSection = ({
                 Effective Date
               </div>
               <div className={VALUE_CLASSES}>
-                {sectionFormData.effectiveDate ? formatDate(sectionFormData.effectiveDate) : ""}
+                {sectionFormData.effectiveDate ? formatDate(sectionFormData.effectiveDate) : "-"}
               </div>
             </div>
           ) : (
@@ -237,6 +239,19 @@ export const ApplicationDetailsSection = ({
             />
           )}
         </div>
+
+        {sectionFormData.applicationType !== "demonstration" && (
+          <div className="flex flex-col col-span-4">
+            <div>
+              <div className={LABEL_CLASSES}>
+                Demonstration ID
+              </div>
+              <div className={VALUE_CLASSES}>
+                { demonstrationId || "-" }
+              </div>
+            </div>
+          </div>
+        )}
 
         {sectionFormData.applicationType === "demonstration" && (
           <div className="flex flex-col">
@@ -272,7 +287,7 @@ export const ApplicationDetailsSection = ({
                 {`${capitalizedType} Description`}
               </div>
               <div className={VALUE_CLASSES}>
-                {sectionFormData.description || ""}
+                {sectionFormData.description || "-"}
               </div>
             </div>
           ) : (
@@ -321,7 +336,7 @@ export const ApplicationDetailsSection = ({
                 Signature Level
               </div>
               <div className={VALUE_CLASSES}>
-                {sectionFormData.signatureLevel || ""}
+                {sectionFormData.signatureLevel || "-"}
               </div>
             </div>
           ) : (

--- a/client/src/components/dialog/modification/BaseEditModificationDialog.tsx
+++ b/client/src/components/dialog/modification/BaseEditModificationDialog.tsx
@@ -37,10 +37,24 @@ export const BaseEditModificationDialog: React.FC<{
   }, [modification]);
 
   const handleSubmit = async () => {
+    console.log("formData:", formData);
+    console.log("modification:", modification);
     if (!formData) {
       showError("Form data is not loaded yet.");
       return;
     }
+
+    /*
+     * Database expects null values to explicitly unset fields,
+     * but form fields return empty strings for unset values, so we need to convert them.
+     */
+    if (formData.effectiveDate === "") {
+      formData.effectiveDate = null;
+    }
+    if (formData.signatureLevel === undefined) {
+      formData.signatureLevel = null;
+    }
+
     try {
       await save(formData);
       showSuccess(`${modificationType} updated successfully.`);

--- a/client/src/components/dialog/modification/BaseEditModificationDialog.tsx
+++ b/client/src/components/dialog/modification/BaseEditModificationDialog.tsx
@@ -37,8 +37,6 @@ export const BaseEditModificationDialog: React.FC<{
   }, [modification]);
 
   const handleSubmit = async () => {
-    console.log("formData:", formData);
-    console.log("modification:", modification);
     if (!formData) {
       showError("Form data is not loaded yet.");
       return;

--- a/client/src/components/dialog/modification/EditAmendmentDialog.tsx
+++ b/client/src/components/dialog/modification/EditAmendmentDialog.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Modification, ModificationFormData } from "./ModificationForm";
 import { gql, TypedDocumentNode, useMutation, useQuery } from "@apollo/client";
-import { UpdateAmendmentInput } from "demos-server";
+import { DateTimeOrLocalDate, UpdateAmendmentInput } from "demos-server";
 import { BaseEditModificationDialog } from "./BaseEditModificationDialog";
 
 export const UPDATE_AMENDMENT_MUTATION: TypedDocumentNode<
@@ -49,7 +49,10 @@ export const useUpdateAmendment = (amendmentId: string, refetchQueries: string[]
     await updateAmendment({
       variables: {
         id: amendmentId,
-        input,
+        input: {
+          ...input,
+          effectiveDate: input.effectiveDate as DateTimeOrLocalDate | null | undefined,
+        },
       },
     });
   };

--- a/client/src/components/dialog/modification/EditExtensionDialog.tsx
+++ b/client/src/components/dialog/modification/EditExtensionDialog.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Modification, ModificationFormData } from "./ModificationForm";
 import { gql, TypedDocumentNode, useMutation, useQuery } from "@apollo/client";
-import { UpdateExtensionInput } from "demos-server";
+import { DateTimeOrLocalDate, UpdateExtensionInput } from "demos-server";
 import { BaseEditModificationDialog } from "./BaseEditModificationDialog";
 
 export const UPDATE_EXTENSION_MUTATION: TypedDocumentNode<
@@ -49,7 +49,10 @@ export const useUpdateExtension = (extensionId: string, refetchQueries: string[]
     await updateExtension({
       variables: {
         id: extensionId,
-        input,
+        input: {
+          ...input,
+          effectiveDate: input.effectiveDate as DateTimeOrLocalDate | null | undefined,
+        },
       },
     });
   };

--- a/client/src/components/dialog/modification/ModificationForm.tsx
+++ b/client/src/components/dialog/modification/ModificationForm.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Textarea, TextInput } from "components/input";
-import { LocalDate, SignatureLevel } from "demos-server";
+import { SignatureLevel } from "demos-server";
 import { SelectSignatureLevel } from "components/input/select/SelectSignatureLevel";
 import { SelectDemonstration } from "components/input/select/SelectDemonstration";
 import { DatePicker } from "components/input/date/DatePicker";
@@ -21,9 +21,9 @@ export type ModificationFormData = {
   id?: string;
   name?: string;
   description?: string;
-  signatureLevel?: SignatureLevel;
+  signatureLevel?: SignatureLevel | null;
   demonstrationId?: string;
-  effectiveDate?: LocalDate;
+  effectiveDate?: string | null;
 };
 
 export const isValid = (createModificationFormData: ModificationFormData): boolean => {
@@ -104,10 +104,10 @@ export const ModificationForm: React.FC<{
             <DatePicker
               name="effectiveDate"
               label="Effective Date"
-              value={modificationFormData.effectiveDate}
+              value={modificationFormData.effectiveDate ?? undefined}
               onChange={(date) =>
                 setModificationFormDataField({
-                  effectiveDate: date as LocalDate,
+                  effectiveDate: date as string,
                 })
               }
             />
@@ -133,7 +133,7 @@ export const ModificationForm: React.FC<{
               signatureLevel: signatureLevel,
             })
           }
-          initialValue={modificationFormData.signatureLevel}
+          initialValue={modificationFormData.signatureLevel ?? undefined}
         />
       </div>
     </>

--- a/client/src/pages/DemonstrationDetail/modifications/AmendmentsTab.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/AmendmentsTab.tsx
@@ -14,6 +14,7 @@ export const AmendmentsTab: React.FC<{
   const amendmentsWithType = amendments.map((amendment) => ({
     ...amendment,
     modificationType: "amendment" as const,
+    demonstrationId: demonstrationId,
   }));
 
   return (

--- a/client/src/pages/DemonstrationDetail/modifications/ExtensionsTab.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ExtensionsTab.tsx
@@ -12,6 +12,7 @@ export const ExtensionsTab: React.FC<{
   const extensionsWithType = extensions.map((extension) => ({
     ...extension,
     modificationType: "extension" as const,
+    demonstrationId: demonstrationId,
   }));
 
   const { showCreateExtensionDialog } = useDialog();

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.test.tsx
@@ -31,6 +31,7 @@ describe("ModificationDetailsSummary", () => {
     effectiveDate: new Date("2024-01-15"),
     signatureLevel: "OA",
     documents: [],
+    demonstrationId: "demo-1",
   };
 
   describe("Component Rendering", () => {
@@ -53,6 +54,7 @@ describe("ModificationDetailsSummary", () => {
         status: "Pre-Submission",
         documents: [],
         createdAt: new Date("2024-01-01"),
+        demonstrationId: "demo-2",
       };
       render(<ModificationDetailsSummary modificationItem={mockExtension} />);
       expect(screen.getByText("Extension Title")).toBeInTheDocument();
@@ -103,15 +105,6 @@ describe("ModificationDetailsSummary", () => {
       expect(screen.queryByText("Description")).not.toBeInTheDocument();
     });
 
-    it("does not render signature level section when signature level is not provided", () => {
-      const itemWithoutSignatureLevel: ModificationItem = {
-        ...mockAmendment,
-        signatureLevel: undefined,
-      };
-      render(<ModificationDetailsSummary modificationItem={itemWithoutSignatureLevel} />);
-      expect(screen.queryByText("Signature Level")).not.toBeInTheDocument();
-    });
-
     it("displays placeholder when effective date is not provided", () => {
       const itemWithoutEffectiveDate: ModificationItem = {
         ...mockAmendment,
@@ -137,6 +130,7 @@ describe("ModificationDetailsSummary", () => {
       const extension: ModificationItem = {
         modificationType: "extension",
         id: "mod-minimal",
+        demonstrationId: "demo-2",
         name: "Minimal Modification",
         status: "On-hold",
         documents: [],
@@ -147,8 +141,6 @@ describe("ModificationDetailsSummary", () => {
       expect(screen.getByText("Minimal Modification")).toBeInTheDocument();
       expect(screen.getByText("--/--/----")).toBeInTheDocument();
       expect(screen.getByText("On-hold")).toBeInTheDocument();
-      expect(screen.queryByText("Description")).not.toBeInTheDocument();
-      expect(screen.queryByText("Signature Level")).not.toBeInTheDocument();
     });
   });
 
@@ -185,6 +177,7 @@ describe("ModificationDetailsSummary", () => {
       const mockExtension: ModificationItem = {
         modificationType: "extension",
         id: "ext-456",
+        demonstrationId: "demo-2",
         name: "Test Extension",
         status: "Pre-Submission",
         documents: [],

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.tsx
@@ -31,18 +31,17 @@ const ModificationDetailsFields = ({
       <div className="flex justify-between w-full">
         <Field label={`${labelPrefix} Title`} value={modificationItem.name} />
         <Field label="Effective Date" value={effectiveDateValue} />
-        <Field label="Status" value={modificationItem.status ?? ""} />
+        <Field label="Status" value={modificationItem.status ?? "-"} />
       </div>
-      {modificationItem.description && (
-        <div className="w-full">
-          <Field label={`${labelPrefix} Description`} value={modificationItem.description} />
-        </div>
-      )}
-      {modificationItem.signatureLevel && (
-        <div className="w-full">
-          <Field label="Signature Level" value={modificationItem.signatureLevel} />
-        </div>
-      )}
+      <div className="w-full">
+        <Field label="Demonstration Id" value={modificationItem.demonstrationId ?? "-"} />
+      </div>
+      <div className="w-full">
+        <Field label={`${labelPrefix} Description`} value={modificationItem.description ?? "-"} />
+      </div>
+      <div className="w-full">
+        <Field label="Signature Level" value={modificationItem.signatureLevel ?? "-"} />
+      </div>
     </div>
   );
 };

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.tsx
@@ -34,13 +34,13 @@ const ModificationDetailsFields = ({
         <Field label="Status" value={modificationItem.status ?? "-"} />
       </div>
       <div className="w-full">
-        <Field label="Demonstration Id" value={modificationItem.demonstrationId ?? "-"} />
+        <Field label="Demonstration Id" value={modificationItem.demonstrationId || "-"} />
       </div>
       <div className="w-full">
-        <Field label={`${labelPrefix} Description`} value={modificationItem.description ?? "-"} />
+        <Field label={`${labelPrefix} Description`} value={modificationItem.description || "-"} />
       </div>
       <div className="w-full">
-        <Field label="Signature Level" value={modificationItem.signatureLevel ?? "-"} />
+        <Field label="Signature Level" value={modificationItem.signatureLevel || "-"} />
       </div>
     </div>
   );

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.tsx
@@ -34,7 +34,7 @@ const ModificationDetailsFields = ({
         <Field label="Status" value={modificationItem.status ?? "-"} />
       </div>
       <div className="w-full">
-        <Field label="Demonstration Id" value={modificationItem.demonstrationId || "-"} />
+        <Field label="Demonstration ID" value={modificationItem.demonstrationId || "-"} />
       </div>
       <div className="w-full">
         <Field label={`${labelPrefix} Description`} value={modificationItem.description || "-"} />

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.test.tsx
@@ -36,6 +36,7 @@ vi.mock("components/application", async (importOriginal) => {
 describe("ModificationTabSideNav", () => {
   const mockModificationItem: ModificationItem = {
     id: "1",
+    demonstrationId: "demo-1",
     modificationType: "amendment",
     name: "Test Modification",
     description: "Test Description",

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.test.tsx
@@ -8,6 +8,7 @@ import { DialogProvider } from "components/dialog/DialogContext";
 const createModificationItem = (overrides?: Partial<ModificationItem>): ModificationItem => {
   return {
     id: "default-id",
+    demonstrationId: "default-demo-id",
     modificationType: "amendment",
     name: "Default Item",
     description: undefined,

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.tsx
@@ -12,6 +12,7 @@ const STYLES = {
 
 export type ModificationItem = DemonstrationDetailModification & {
   modificationType: "amendment" | "extension";
+  demonstrationId: string;
 };
 
 const ModificationTab = ({

--- a/server/src/model/amendment/amendmentSchema.ts
+++ b/server/src/model/amendment/amendmentSchema.ts
@@ -92,5 +92,5 @@ export interface UpdateAmendmentInput {
   description?: string | null;
   effectiveDate?: DateTimeOrLocalDate | null;
   status?: ApplicationStatus;
-  signatureLevel?: AmendmentSignatureLevel;
+  signatureLevel?: AmendmentSignatureLevel | null;
 }

--- a/server/src/model/demonstration/demonstrationSchema.ts
+++ b/server/src/model/demonstration/demonstrationSchema.ts
@@ -43,6 +43,8 @@ export const demonstrationSchema = gql`
     demonstrationTypes: [DemonstrationTypeAssignment!]!
     suggestedApplicationTags: [TagName!]! @auth(requires: ["Access CMS Field"])
     deliverables: [Deliverable!]!
+    medicaidId: String!
+    chipId: String
     createdAt: DateTime!
     updatedAt: DateTime!
   }
@@ -102,6 +104,8 @@ export interface Demonstration {
   demonstrationTypes: DemonstrationTypeAssignment[];
   suggestedApplicationTags: TagName[];
   deliverables: Deliverable[];
+  medicaidId: string;
+  chipId?: string;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/server/src/model/demonstration/demonstrationSchema.ts
+++ b/server/src/model/demonstration/demonstrationSchema.ts
@@ -43,8 +43,6 @@ export const demonstrationSchema = gql`
     demonstrationTypes: [DemonstrationTypeAssignment!]!
     suggestedApplicationTags: [TagName!]! @auth(requires: ["Access CMS Field"])
     deliverables: [Deliverable!]!
-    medicaidId: String!
-    chipId: String
     createdAt: DateTime!
     updatedAt: DateTime!
   }
@@ -104,8 +102,6 @@ export interface Demonstration {
   demonstrationTypes: DemonstrationTypeAssignment[];
   suggestedApplicationTags: TagName[];
   deliverables: Deliverable[];
-  medicaidId: string;
-  chipId?: string;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/server/src/model/extension/extensionSchema.ts
+++ b/server/src/model/extension/extensionSchema.ts
@@ -92,5 +92,5 @@ export interface UpdateExtensionInput {
   description?: string | null;
   effectiveDate?: DateTimeOrLocalDate | null;
   status?: ApplicationStatus;
-  signatureLevel?: ExtensionSignatureLevel;
+  signatureLevel?: ExtensionSignatureLevel | null;
 }


### PR DESCRIPTION
### DEMOS-1705
- Adds demonstration ID to the details page and the approval summary details section for amendments and extensions
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/0814064f-cdef-4ab5-896e-64516dccc132" />


### DEMOS-1773
- Instead of hiding unset values for modification details, values are shown as "-"
- Fixes an issue with modifications where dates and signature level could not be unset
<img width="1727" height="1117" alt="image" src="https://github.com/user-attachments/assets/3f484b33-1277-4d6b-9782-ece989c9985b" />
