### PR TITLE
DEMOS-2167: updated the test to remove source passage

### DIFF
--- a/client/src/components/application/phases/ApplicationIntakePhase.test.tsx
+++ b/client/src/components/application/phases/ApplicationIntakePhase.test.tsx
@@ -337,8 +337,6 @@ describe("ApplicationIntakePhase", () => {
       expect(
         screen.getByText("DEMOS AI identified the following tag based on the application text:")
       ).toBeInTheDocument();
-      expect(screen.getByText("Source Passage")).toBeInTheDocument();
-      expect(screen.getByText(/Found in Document X, Page N, Position NN\/NNN/)).toBeInTheDocument();
 
       await userEvent.click(screen.getByTestId("button-confirm-suggested-tag"));
 

--- a/client/src/components/dialog/ConfirmSuggestedSparklyTagDialog.tsx
+++ b/client/src/components/dialog/ConfirmSuggestedSparklyTagDialog.tsx
@@ -64,13 +64,7 @@ export const ConfirmSuggestedSparklyTagDialog = ({
             Remove
           </button>
           <div className={STYLES.rightActions}>
-            {/* <SecondaryButton
-              name="button-improve-suggested-tag"
-              onClick={() => {
-                console.log("Thanks for pressing me. But i don't work yet. :-)");
-              }}>
-              Improve this Suggestion
-            </SecondaryButton> */}
+            {/* Improve Suggestion button goes here */}
             <Button
               name="button-confirm-suggested-tag"
               onClick={() => onConfirm(tagName)}

--- a/client/src/components/dialog/ConfirmSuggestedSparklyTagDialog.tsx
+++ b/client/src/components/dialog/ConfirmSuggestedSparklyTagDialog.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Button, SecondaryButton } from "components/button";
+import { Button } from "components/button";
 import { BaseDialog } from "components/dialog/BaseDialog";
 import { SparklyIcon } from "components/icons";
 import { TagChip } from "components/tags/TagChip";
@@ -25,18 +25,6 @@ type ConfirmSuggestedSparklyTagDialogProps = {
   onRemove: (tagName: TagName) => void;
   isSubmitting?: boolean;
 };
-
-// Apparently NOT part of DEMOS-1638
-const SourcePassagePdfPreviewPlaceholder = ({ tagName }: { tagName: TagName }) => (
-  <div>
-    <h3 className={STYLES.sourceTitle}>Source Passage</h3>
-    <div className={STYLES.sourcePreview}>
-      &quot;...This specifically references {tagName} in the application
-      text...&quot;
-    </div>
-    <div className={STYLES.sourceMeta}>(Found in Document X, Page N, Position NN/NNN)</div>
-  </div>
-);
 
 export const ConfirmSuggestedSparklyTagDialog = ({
   tagName,
@@ -66,8 +54,6 @@ export const ConfirmSuggestedSparklyTagDialog = ({
           />
         </div>
 
-        <SourcePassagePdfPreviewPlaceholder tagName={tagName} />
-
         <div className={STYLES.footer}>
           <button
             type="button"
@@ -78,13 +64,13 @@ export const ConfirmSuggestedSparklyTagDialog = ({
             Remove
           </button>
           <div className={STYLES.rightActions}>
-            <SecondaryButton
+            {/* <SecondaryButton
               name="button-improve-suggested-tag"
               onClick={() => {
                 console.log("Thanks for pressing me. But i don't work yet. :-)");
               }}>
               Improve this Suggestion
-            </SecondaryButton>
+            </SecondaryButton> */}
             <Button
               name="button-confirm-suggested-tag"
               onClick={() => onConfirm(tagName)}


### PR DESCRIPTION
Removed post MVP items. 
Nuked placeholder for source location and the Improve suggestion button. 

Left a comment to show where it goes. 

<img width="880" height="438" alt="Screenshot 2026-05-27 at 16 09 48" src="https://github.com/user-attachments/assets/9976de85-9959-4098-85cc-deb7632dad18" />

<img width="884" height="316" alt="Screenshot 2026-05-27 at 16 23 19" src="https://github.com/user-attachments/assets/20ee13ca-70b2-46dc-a50e-a1b83c544731" />
