### PR TITLE
Bugfix: fix document.cookie call for local development

### DIFF
--- a/client/src/router/DemosApolloProvider.test.tsx
+++ b/client/src/router/DemosApolloProvider.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { DemosApolloProvider } from "./DemosApolloProvider";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { DemosApolloProvider, syncTokensToCookiesInLocal } from "./DemosApolloProvider";
 import type { ApolloLink } from "@apollo/client";
 
 // Intentionally obscure values to avoid snyk confusing it for a real secret.
@@ -118,5 +118,42 @@ describe("DemosApolloProvider", () => {
         "Content-Type": "application/json",
       },
     });
+  });
+});
+
+describe("syncTokensToCookiesInLocal", () => {
+  const cookieSetter = vi.fn();
+  const originalDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, "cookie")!;
+
+  beforeEach(() => {
+    Object.defineProperty(document, "cookie", { configurable: true, set: cookieSetter });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(document, "cookie", originalDescriptor);
+  });
+
+  it("does not write cookies when not in local development", async () => {
+    const { isLocalDevelopment } = await import("config/env");
+    vi.mocked(isLocalDevelopment).mockReturnValue(false);
+
+    syncTokensToCookiesInLocal(FAKE_ID_TOKEN, FAKE_ACCESS_TOKEN);
+
+    expect(cookieSetter).not.toHaveBeenCalled();
+  });
+
+  it("sets both token cookies when in local development", async () => {
+    const { isLocalDevelopment } = await import("config/env");
+    vi.mocked(isLocalDevelopment).mockReturnValue(true);
+
+    syncTokensToCookiesInLocal(FAKE_ID_TOKEN, FAKE_ACCESS_TOKEN);
+
+    expect(cookieSetter).toHaveBeenCalledTimes(2);
+    expect(cookieSetter).toHaveBeenCalledWith(
+      expect.stringContaining(`id_token=${encodeURIComponent(FAKE_ID_TOKEN)}`)
+    );
+    expect(cookieSetter).toHaveBeenCalledWith(
+      expect.stringContaining(`access_token=${encodeURIComponent(FAKE_ACCESS_TOKEN)}`)
+    );
   });
 });

--- a/client/src/router/DemosApolloProvider.tsx
+++ b/client/src/router/DemosApolloProvider.tsx
@@ -14,7 +14,7 @@ import { useAuth } from "react-oidc-context";
 
 const GRAPHQL_ENDPOINT = import.meta.env.VITE_API_URL_PREFIX ?? "/graphql";
 
-function syncTokensToCookiesInDev(idToken: string, accessToken: string) {
+export function syncTokensToCookiesInLocal(idToken: string, accessToken: string) {
   if (!isLocalDevelopment()) return;
   const opts = "; Path=/; SameSite=Lax";
   // document.cookie assignments are additive — each assignment sets one cookie.
@@ -45,7 +45,7 @@ export const DemosApolloProvider: React.FC<{ children: React.ReactNode }> = ({ c
   // In local development, mirror tokens to cookies since we don't
   // go through the backend's /auth/callback route where they would normally be set.
   useEffect(() => {
-    syncTokensToCookiesInDev(auth.user?.id_token ?? "", auth.user?.access_token ?? "");
+    syncTokensToCookiesInLocal(auth.user?.id_token ?? "", auth.user?.access_token ?? "");
   }, [auth.user]);
 
   // Read token per request (not just once)

--- a/client/src/router/DemosApolloProvider.tsx
+++ b/client/src/router/DemosApolloProvider.tsx
@@ -14,6 +14,23 @@ import { useAuth } from "react-oidc-context";
 
 const GRAPHQL_ENDPOINT = import.meta.env.VITE_API_URL_PREFIX ?? "/graphql";
 
+function syncTokensToCookiesInDev(idToken: string, accessToken: string) {
+  if (!isLocalDevelopment()) return;
+  const opts = "; Path=/; SameSite=Lax";
+  // document.cookie assignments are additive — each assignment sets one cookie.
+  // Snyk doesn't like that we don't use the Secure flag here
+  // but this only called in local dev where https is not used.
+  const cookies = [
+    idToken ? `id_token=${encodeURIComponent(idToken)}${opts}` : `id_token=; Max-Age=0${opts}`,
+    accessToken
+      ? `access_token=${encodeURIComponent(accessToken)}${opts}`
+      : `access_token=; Max-Age=0${opts}`,
+  ];
+  for (const cookie of cookies) {
+    document.cookie = cookie;
+  }
+}
+
 export const DemosApolloProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const auth = useAuth();
 
@@ -25,26 +42,10 @@ export const DemosApolloProvider: React.FC<{ children: React.ReactNode }> = ({ c
     );
   }
 
-  // Mirror tokens into cookies for Apollo Sandbox (local dev only)
+  // In local development, mirror tokens to cookies since we don't
+  // go through the backend's /auth/callback route where they would normally be set.
   useEffect(() => {
-    if (!isLocalDevelopment()) return;
-    const idToken = auth.user?.id_token ?? "";
-    const accessToken = auth.user?.access_token ?? "";
-    const opts = "; Path=/; SameSite=Lax";
-    let cookieString = "";
-    if (idToken) {
-      cookieString = `id_token=${encodeURIComponent(idToken)}${opts}`;
-    } else {
-      cookieString = `id_token=; Max-Age=0${opts}`;
-    }
-    if (accessToken) {
-      cookieString = `access_token=${encodeURIComponent(accessToken)}${opts}`;
-    } else {
-      cookieString = `access_token=; Max-Age=0${opts}`;
-    }
-    // Snyk doesn't like that this doesn't have the `Secure` flag
-    // but we only set these cookies in local development where we don't use https.
-    document.cookie = cookieString;
+    syncTokensToCookiesInDev(auth.user?.id_token ?? "", auth.user?.access_token ?? "");
   }, [auth.user]);
 
   // Read token per request (not just once)


### PR DESCRIPTION
I introduced a bug in #1319 by calling `document.cookie` only once it doesn't set both the `id_token` and `access_token` which messed up local dev, this PR fixes it while maintaining only the single `document.cookie` call to show a single issue under snyk.

Also added a unit test to avoid regression here

<img width="1439" height="956" alt="image" src="https://github.com/user-attachments/assets/25c37b02-e550-4613-94d1-0edc0d6fc238" />
