### PR TITLE
DEMOS-2174: Only show non-deliverable document types in the main `Add Document +` dialog

### DIFF
--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -57,14 +57,21 @@ This file provides instructions for AI agents to use when generating or editing 
 
 ## Testing
 
+### Unit Testing
+
 - Place tests next to implementation (`Foo.tsx` and `Foo.test.tsx`).
 - Use `@testing-library/react` with `vitest`; prefer `screen.getByTestId()` queries.
 - Often times `name` attributes are propagated to `data-test-id`, try this approach first.
 - Prefer real behavior over heavy mocking; use `vi.mock(...)` only at clear boundaries.
 - Run tests with `npm run test:once ...`
-- Run linting + typechecking with `npm run lint`
 - Prefer to keep mock data in test files for clarity / isolation rather than in `/mock-data`.
-- For testing behavior with different roles you can use the different variants of `npm run dev:mocks` - `dev:mocks:admin`, `dev:mocks:state`, etc. Some functionality is only available through certain roles. 
+- Use <TestProvider> as needed to provide dependencies such as toasts, auth, routing, etc.
+- Prefer to not mock <DialogProvider>. Also <TestProvider> does not provide dialogs and they should be provided inside of <TestProvider> if needed.
+
+### General Testing
+
+- Run linting + typechecking with `npm run lint`
+- For testing behavior with different roles you can use the different variants of `npm run dev:mocks` - `dev:mocks:admin`, `dev:mocks:state`, etc. Some functionality is only available through certain roles.
 
 ### Mocking Mutations
 

--- a/client/src/components/dialog/DialogContext.tsx
+++ b/client/src/components/dialog/DialogContext.tsx
@@ -125,13 +125,15 @@ export const useDialog = () => {
 
   const showUploadDocumentDialog = (
     applicationId: string,
-    onDocumentUploadSucceeded?: () => void
+    onDocumentUploadSucceeded?: () => void,
+    documentTypeSubset?: DocumentType[]
   ) => {
     context.showDialog(
       <AddDocumentToApplicationDialog
         onClose={context.hideDialog}
         applicationId={applicationId}
         onDocumentUploadSucceeded={onDocumentUploadSucceeded}
+        documentTypeSubset={documentTypeSubset}
       />
     );
   };
@@ -177,9 +179,7 @@ export const useDialog = () => {
     documentTypeSubset?: DocumentType[];
     refetchQueries?: string[];
   }) => {
-    context.showDialog(
-      <AddDocumentToDeliverableDialog onClose={context.hideDialog} {...args} />
-    );
+    context.showDialog(<AddDocumentToDeliverableDialog onClose={context.hideDialog} {...args} />);
   };
 
   const showApplicationIntakeDocumentUploadDialog = (applicationId: string) => {

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.test.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.test.tsx
@@ -1,9 +1,23 @@
 import React from "react";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { NON_DELIVERABLE_DOCUMENT_TYPES } from "demos-server-constants";
+
+const showUploadDocumentDialogMock = vi.fn();
+
+vi.mock("components/dialog/DialogContext", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("components/dialog/DialogContext")>();
+  return {
+    ...actual,
+    useDialog: () => ({
+      showUploadDocumentDialog: showUploadDocumentDialogMock,
+      showApplyDemonstrationTypesDialog: vi.fn(),
+    }),
+  };
+});
 import { DemonstrationTab, DemonstrationTabDemonstration } from "./DemonstrationTab";
 import { TestProvider } from "test-utils/TestProvider";
 import { DialogProvider } from "components/dialog/DialogContext";
@@ -123,6 +137,23 @@ describe("DemonstrationTab", () => {
 
     // Verify documents tab content is rendered
     expect(screen.getByRole("button", { name: "add-new-document" })).toBeInTheDocument();
+  });
+
+  it("calls showUploadDocumentDialog with NON_DELIVERABLE_DOCUMENT_TYPES when Add Document is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProvider(<DemonstrationTab demonstration={mockDemonstration} />);
+
+    const documentsTab = screen.getByRole("button", { name: "Documents (2)" });
+    await user.click(documentsTab);
+
+    const addDocumentButton = screen.getByRole("button", { name: "add-new-document" });
+    await user.click(addDocumentButton);
+
+    expect(showUploadDocumentDialogMock).toHaveBeenCalledWith(
+      mockDemonstration.id,
+      expect.any(Function),
+      NON_DELIVERABLE_DOCUMENT_TYPES
+    );
   });
 
   it("switches to types tab when clicked", async () => {

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.test.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.test.tsx
@@ -1,23 +1,10 @@
 import React from "react";
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { NON_DELIVERABLE_DOCUMENT_TYPES } from "demos-server-constants";
-
-const showUploadDocumentDialogMock = vi.fn();
-
-vi.mock("components/dialog/DialogContext", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("components/dialog/DialogContext")>();
-  return {
-    ...actual,
-    useDialog: () => ({
-      showUploadDocumentDialog: showUploadDocumentDialogMock,
-      showApplyDemonstrationTypesDialog: vi.fn(),
-    }),
-  };
-});
 import { DemonstrationTab, DemonstrationTabDemonstration } from "./DemonstrationTab";
 import { TestProvider } from "test-utils/TestProvider";
 import { DialogProvider } from "components/dialog/DialogContext";
@@ -76,11 +63,9 @@ const mockDemonstration: DemonstrationTabDemonstration = {
 
 const renderWithProvider = (component: React.ReactElement) => {
   return render(
-    <DialogProvider>
-      <TestProvider mocks={deliverableMocks} addTypename={false}>
-        {component}
-      </TestProvider>
-    </DialogProvider>
+    <TestProvider mocks={deliverableMocks} addTypename={false}>
+      <DialogProvider>{component}</DialogProvider>
+    </TestProvider>
   );
 };
 
@@ -139,21 +124,21 @@ describe("DemonstrationTab", () => {
     expect(screen.getByRole("button", { name: "add-new-document" })).toBeInTheDocument();
   });
 
-  it("calls showUploadDocumentDialog with NON_DELIVERABLE_DOCUMENT_TYPES when Add Document is clicked", async () => {
+  it("shows only NON_DELIVERABLE_DOCUMENT_TYPES in the document type dropdown", async () => {
     const user = userEvent.setup();
     renderWithProvider(<DemonstrationTab demonstration={mockDemonstration} />);
 
-    const documentsTab = screen.getByRole("button", { name: "Documents (2)" });
-    await user.click(documentsTab);
+    await user.click(screen.getByRole("button", { name: "Documents (2)" }));
+    await user.click(screen.getByRole("button", { name: "add-new-document" }));
 
-    const addDocumentButton = screen.getByRole("button", { name: "add-new-document" });
-    await user.click(addDocumentButton);
+    await user.click(screen.getByTestId("input-autocomplete-select"));
 
-    expect(showUploadDocumentDialogMock).toHaveBeenCalledWith(
-      mockDemonstration.id,
-      expect.any(Function),
-      NON_DELIVERABLE_DOCUMENT_TYPES
-    );
+    for (const docType of NON_DELIVERABLE_DOCUMENT_TYPES) {
+      expect(screen.getByRole("button", { name: docType })).toBeInTheDocument();
+    }
+    expect(
+      screen.queryByRole("button", { name: "Interim Evaluation Report" })
+    ).not.toBeInTheDocument();
   });
 
   it("switches to types tab when clicked", async () => {

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
@@ -31,6 +31,7 @@ import { ContactsTab } from "./ContactsTab";
 import { useApolloClient } from "@apollo/client/react/hooks/useApolloClient";
 import { TypesTable } from "components/table/tables/TypesTable";
 import { DeliverablesTab } from "./deliverables/DeliverablesTab";
+import { NON_DELIVERABLE_DOCUMENT_TYPES } from "demos-server-constants";
 
 type Role = Pick<DemonstrationRoleAssignment, "role" | "isPrimary"> & {
   person: Pick<Person, "fullName" | "id" | "email" | "personType">;
@@ -140,7 +141,13 @@ export const DemonstrationTab: React.FC<{ demonstration: DemonstrationTabDemonst
               icon={<AddNewIcon />}
               name="add-new-document"
               size="small"
-              onClick={() => showUploadDocumentDialog(demonstration.id, refetchApplicationWorkflow)}
+              onClick={() =>
+                showUploadDocumentDialog(
+                  demonstration.id,
+                  refetchApplicationWorkflow,
+                  NON_DELIVERABLE_DOCUMENT_TYPES
+                )
+              }
             >
               Add Document
             </IconButton>

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.test.tsx
@@ -1,38 +1,22 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ModificationTabSideNav } from "./ModificationTabSideNav";
 import { ModificationItem } from "./ModificationTabs";
 import { TestProvider } from "test-utils/TestProvider";
 import { DialogProvider } from "components/dialog/DialogContext";
 import { NON_DELIVERABLE_DOCUMENT_TYPES } from "demos-server-constants";
 
-const showUploadDocumentDialogMock = vi.fn();
-
-vi.mock("components/dialog/DialogContext", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("components/dialog/DialogContext")>();
-  return {
-    ...actual,
-    useDialog: () => ({
-      showUploadDocumentDialog: showUploadDocumentDialogMock,
-    }),
-  };
-});
-
 vi.mock("components/application", async (importOriginal) => {
   const actual = await importOriginal<typeof import("components/application")>();
 
   return {
     ...actual,
-    AmendmentWorkflow: () => (
-      <div data-testid="amendment-workflow">Amendment Workflow</div>
-    ),
-    ExtensionWorkflow: () => (
-      <div data-testid="extension-workflow">Extension Workflow</div>
-    ),
+    AmendmentWorkflow: () => <div data-testid="amendment-workflow">Amendment Workflow</div>,
+    ExtensionWorkflow: () => <div data-testid="extension-workflow">Extension Workflow</div>,
   };
 });
-
 
 describe("ModificationTabSideNav", () => {
   const mockModificationItem: ModificationItem = {
@@ -54,11 +38,11 @@ describe("ModificationTabSideNav", () => {
 
   const setup = (modificationItem: ModificationItem) => {
     render(
-      <DialogProvider>
-        <TestProvider>
+      <TestProvider>
+        <DialogProvider>
           <ModificationTabSideNav modificationItem={modificationItem} />
-        </TestProvider>
-      </DialogProvider>
+        </DialogProvider>
+      </TestProvider>
     );
   };
 
@@ -141,14 +125,16 @@ describe("ModificationTabSideNav", () => {
     it("displays correct document count in tab label with non-zero documents", () => {
       const modificationWithDocs: ModificationItem = {
         ...mockModificationItem,
-        documents: [{
-          id: "doc1",
-          name: "Document 1",
-          documentType: "General File",
-          description: "Test Document",
-          createdAt: new Date(),
-          owner: { person: { fullName: "Test User" } },
-        }],
+        documents: [
+          {
+            id: "doc1",
+            name: "Document 1",
+            documentType: "General File",
+            description: "Test Document",
+            createdAt: new Date(),
+            owner: { person: { fullName: "Test User" } },
+          },
+        ],
       };
       setup(modificationWithDocs);
 
@@ -159,14 +145,16 @@ describe("ModificationTabSideNav", () => {
     it("render DocumentTable with correct props when Documents tab is selected", () => {
       const modificationWithDocs: ModificationItem = {
         ...mockModificationItem,
-        documents: [{
-          id: "doc1",
-          name: "Document 1",
-          documentType: "General File",
-          description: "Test Document",
-          createdAt: new Date(),
-          owner: { person: { fullName: "Test User" } },
-        }],
+        documents: [
+          {
+            id: "doc1",
+            name: "Document 1",
+            documentType: "General File",
+            description: "Test Document",
+            createdAt: new Date(),
+            owner: { person: { fullName: "Test User" } },
+          },
+        ],
       };
       setup(modificationWithDocs);
 
@@ -176,32 +164,28 @@ describe("ModificationTabSideNav", () => {
       expect(screen.getByText("Document 1")).toBeInTheDocument();
     });
 
-    it("calls showUploadDocumentDialog when Add Document button is clicked", async () => {
+    it("opens the document upload dialog when Add Document button is clicked", () => {
       setup(mockModificationItem);
 
-      const documentsTab = screen.getByTestId("button-documents");
-      fireEvent.click(documentsTab);
+      fireEvent.click(screen.getByTestId("button-documents"));
+      fireEvent.click(screen.getByTestId("add-new-document"));
 
-      const addDocumentButton = screen.getByTestId("add-new-document");
-      fireEvent.click(addDocumentButton);
-
-      expect(showUploadDocumentDialogMock).toHaveBeenCalledTimes(1);
+      expect(screen.getByText("Add New Document")).toBeInTheDocument();
     });
 
-    it("calls showUploadDocumentDialog with NON_DELIVERABLE_DOCUMENT_TYPES as the document type subset", () => {
+    it("shows only NON_DELIVERABLE_DOCUMENT_TYPES in the document type dropdown", async () => {
+      const user = userEvent.setup();
       setup(mockModificationItem);
 
-      const documentsTab = screen.getByTestId("button-documents");
-      fireEvent.click(documentsTab);
+      fireEvent.click(screen.getByTestId("button-documents"));
+      fireEvent.click(screen.getByTestId("add-new-document"));
 
-      const addDocumentButton = screen.getByTestId("add-new-document");
-      fireEvent.click(addDocumentButton);
+      await user.click(screen.getByTestId("input-autocomplete-select"));
 
-      expect(showUploadDocumentDialogMock).toHaveBeenCalledWith(
-        mockModificationItem.id,
-        expect.any(Function),
-        NON_DELIVERABLE_DOCUMENT_TYPES
-      );
+      for (const docType of NON_DELIVERABLE_DOCUMENT_TYPES) {
+        expect(screen.getByText(docType)).toBeInTheDocument();
+      }
+      expect(screen.queryByText("Interim Evaluation Report")).not.toBeInTheDocument();
     });
   });
 });

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.test.tsx
@@ -5,6 +5,7 @@ import { ModificationTabSideNav } from "./ModificationTabSideNav";
 import { ModificationItem } from "./ModificationTabs";
 import { TestProvider } from "test-utils/TestProvider";
 import { DialogProvider } from "components/dialog/DialogContext";
+import { NON_DELIVERABLE_DOCUMENT_TYPES } from "demos-server-constants";
 
 const showUploadDocumentDialogMock = vi.fn();
 
@@ -185,6 +186,22 @@ describe("ModificationTabSideNav", () => {
       fireEvent.click(addDocumentButton);
 
       expect(showUploadDocumentDialogMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls showUploadDocumentDialog with NON_DELIVERABLE_DOCUMENT_TYPES as the document type subset", () => {
+      setup(mockModificationItem);
+
+      const documentsTab = screen.getByTestId("button-documents");
+      fireEvent.click(documentsTab);
+
+      const addDocumentButton = screen.getByTestId("add-new-document");
+      fireEvent.click(addDocumentButton);
+
+      expect(showUploadDocumentDialogMock).toHaveBeenCalledWith(
+        mockModificationItem.id,
+        expect.any(Function),
+        NON_DELIVERABLE_DOCUMENT_TYPES
+      );
     });
   });
 });

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.tsx
@@ -14,6 +14,7 @@ import { TabHeader } from "components/table/TabHeader";
 import { DEMONSTRATION_DETAIL_QUERY } from "../DemonstrationDetail";
 import { useApolloClient } from "@apollo/client/react/hooks/useApolloClient";
 import { useDialog } from "components/dialog/DialogContext";
+import { NON_DELIVERABLE_DOCUMENT_TYPES } from "demos-server-constants";
 
 const TABS = {
   APPLICATION: "application",
@@ -62,7 +63,11 @@ export const ModificationTabSideNav = ({
             name="add-new-document"
             size="small"
             onClick={() =>
-              showUploadDocumentDialog(modificationItem.id, refetchApplicationWorkflow)
+              showUploadDocumentDialog(
+                modificationItem.id,
+                refetchApplicationWorkflow,
+                NON_DELIVERABLE_DOCUMENT_TYPES
+              )
             }
           >
             Add Document

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -175,6 +175,20 @@ export const DOCUMENT_TYPES = [
 ] as const;
 export type DocumentType = (typeof DOCUMENT_TYPES)[number];
 
+export const NON_DELIVERABLE_DOCUMENT_TYPES: DocumentType[] = [
+  "Application Completeness Letter",
+  "Approval Letter",
+  "Final Budget Neutrality Formulation Workbook",
+  "Formal OMB Policy Concurrence Email",
+  "General File",
+  "Internal Completeness Review Form",
+  "Payment Ratio Analysis",
+  "Pre-Submission",
+  "Q&A",
+  "Signed Decision Memo",
+  "State Application",
+] as const;
+
 export const PHASE_NAMES = [
   "Concept",
   "Application Intake",


### PR DESCRIPTION
Per DEMOS-2174 only shows the applicable document types when the user clicks `Add Document +` for demonstrations and modifications (amendments + extensions)


https://github.com/user-attachments/assets/fdecb584-005a-4dda-85b6-15d94599dfbb

