### PR TITLE
Upgrade lambdas/fileprocess npm packages

### DIFF
--- a/lambdas/fileprocess/package-lock.json
+++ b/lambdas/fileprocess/package-lock.json
@@ -8,15 +8,15 @@
       "name": "fileprocess-lambda",
       "version": "1.0.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1045.0",
-        "@aws-sdk/client-secrets-manager": "^3.1045.0",
-        "@aws-sdk/client-sqs": "^3.1045.0",
-        "pg": "^8.20.0",
+        "@aws-sdk/client-s3": "^3.1053.0",
+        "@aws-sdk/client-secrets-manager": "^3.1053.0",
+        "@aws-sdk/client-sqs": "^3.1053.0",
+        "pg": "^8.21.0",
         "pino": "^10.3.1"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.161",
-        "@types/node": "^24.12.3",
+        "@types/node": "^24.12.4",
         "@vitest/coverage-v8": "^3.2.4",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -239,36 +239,28 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1047.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1047.0.tgz",
-      "integrity": "sha512-gk8g31eqvgf7eLCpkVjWs9KL7gYgkomt3FT2o9tbIe6goYrBheN2lHxhCsTn1zFYbt7EwrZXTGkQPIQNIN0c5w==",
+      "version": "3.1057.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1057.0.tgz",
+      "integrity": "sha512-4MV5+ph7WSLEqStKYdWf2EIHIvLpPzV8xN98jWSVJfUpp5j7T8dyN3AROPPsKWvCme8hbx1ybCjtK76ALCZUYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/credential-provider-node": "^3.972.41",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.12",
-        "@aws-sdk/middleware-expect-continue": "^3.972.11",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.18",
-        "@aws-sdk/middleware-host-header": "^3.972.11",
-        "@aws-sdk/middleware-location-constraint": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.12",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.39",
-        "@aws-sdk/middleware-ssec": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.40",
-        "@aws-sdk/region-config-resolver": "^3.972.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.26",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.9",
-        "@aws-sdk/util-user-agent-browser": "^3.972.11",
-        "@aws-sdk/util-user-agent-node": "^3.973.26",
-        "@smithy/core": "^3.24.1",
-        "@smithy/fetch-http-handler": "^5.4.1",
-        "@smithy/node-http-handler": "^4.7.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-node": "^3.972.47",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.17",
+        "@aws-sdk/middleware-expect-continue": "^3.972.14",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.23",
+        "@aws-sdk/middleware-location-constraint": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.44",
+        "@aws-sdk/middleware-ssec": "^3.972.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -276,28 +268,20 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1047.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1047.0.tgz",
-      "integrity": "sha512-jKwVKPssSxB8DbMfZ4lUW5Q6fyeJnjvz76GBsb1fUTWcRxGukzkXd5Di5oTUQnYv+BUen97+ZjTz/Azi6hUmzQ==",
+      "version": "3.1057.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1057.0.tgz",
+      "integrity": "sha512-2AsQ+7SChrQamIe68nMvMpZfXpHWnjwkcaFPFWf9E21+iTnEdIXRqC5v1P2NATrKn0BI6MaG/KlNrOhPOknk8w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/credential-provider-node": "^3.972.41",
-        "@aws-sdk/middleware-host-header": "^3.972.11",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.12",
-        "@aws-sdk/middleware-user-agent": "^3.972.40",
-        "@aws-sdk/region-config-resolver": "^3.972.14",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.9",
-        "@aws-sdk/util-user-agent-browser": "^3.972.11",
-        "@aws-sdk/util-user-agent-node": "^3.973.26",
-        "@smithy/core": "^3.24.1",
-        "@smithy/fetch-http-handler": "^5.4.1",
-        "@smithy/node-http-handler": "^4.7.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-node": "^3.972.47",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -305,29 +289,21 @@
       }
     },
     "node_modules/@aws-sdk/client-sqs": {
-      "version": "3.1047.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1047.0.tgz",
-      "integrity": "sha512-M1uzaKpVifVMHBn2wu/L1gOAnT+uBVl/jq7g/hI1BqnZRJSXpRBuiZBZGzj/BcKogulzUVnSk+mQF4Fk+VpfPA==",
+      "version": "3.1057.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1057.0.tgz",
+      "integrity": "sha512-Qaxt1azI1PwClNkQzt/7N10rTdvC8oBleBxZ3yZWswXgMD/EcZ5sMim925uD75YXgzLwLnxKzF7c4mUxNuCqqw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/credential-provider-node": "^3.972.41",
-        "@aws-sdk/middleware-host-header": "^3.972.11",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.12",
-        "@aws-sdk/middleware-sdk-sqs": "^3.972.23",
-        "@aws-sdk/middleware-user-agent": "^3.972.40",
-        "@aws-sdk/region-config-resolver": "^3.972.14",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.9",
-        "@aws-sdk/util-user-agent-browser": "^3.972.11",
-        "@aws-sdk/util-user-agent-node": "^3.973.26",
-        "@smithy/core": "^3.24.1",
-        "@smithy/fetch-http-handler": "^5.4.1",
-        "@smithy/node-http-handler": "^4.7.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-node": "^3.972.47",
+        "@aws-sdk/middleware-sdk-sqs": "^3.972.26",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -335,16 +311,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.10.tgz",
-      "integrity": "sha512-ZGFFlYynBR78Y/F8b/7y4i4sgW/iGwJSjoM7AZo5Et6vyr4/L0bunN+uzKMsvecCZyqcPp4RRK7Rs17l0kMujg==",
+      "version": "3.974.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.15.tgz",
+      "integrity": "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.24",
-        "@smithy/core": "^3.24.1",
-        "@smithy/signature-v4": "^5.4.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.973.9",
+        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.5",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -352,12 +330,12 @@
       }
     },
     "node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.8.tgz",
-      "integrity": "sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.9.tgz",
+      "integrity": "sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -365,15 +343,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.36.tgz",
-      "integrity": "sha512-gE+CGuPZD1eqUWGSrM8CXDjlwuPujIuwI+IlorD1wE2RcANKKT4jscB9GY1nTJbjmXzD18sycsYbgCG5m3n4/g==",
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.41.tgz",
+      "integrity": "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -381,17 +359,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.38.tgz",
-      "integrity": "sha512-cHZo3bV6zN9joDQ2AYVctfzHTKStxWKwnGu0z7GwCUC+DAtB3qL/+26l+a63RbmFbVvb1JK+0vJKodN3hRMwyw==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.43.tgz",
+      "integrity": "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/fetch-http-handler": "^5.4.1",
-        "@smithy/node-http-handler": "^4.7.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -399,23 +377,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.40.tgz",
-      "integrity": "sha512-0NFGS9I3PD2yMveQqqpwpRdyZVStzgk0Yr2rZHh80kV/QNqQCK5lSrksvU3nBcRNSUF5Uk8rL3Xk0EVR+UVAnA==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.46.tgz",
+      "integrity": "sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/credential-provider-env": "^3.972.36",
-        "@aws-sdk/credential-provider-http": "^3.972.38",
-        "@aws-sdk/credential-provider-login": "^3.972.40",
-        "@aws-sdk/credential-provider-process": "^3.972.36",
-        "@aws-sdk/credential-provider-sso": "^3.972.40",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.40",
-        "@aws-sdk/nested-clients": "^3.997.8",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/credential-provider-imds": "^4.3.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-login": "^3.972.45",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.6",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -423,16 +401,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.40.tgz",
-      "integrity": "sha512-IEIl+UQnrEjZP53TSl91e8LBephi4i1Mt9WZrMgN8pOg6xPOLZdkN1GhsEzjkMD1TQy4Fp2dwWA/9ToTQFOlLA==",
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.45.tgz",
+      "integrity": "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/nested-clients": "^3.997.8",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -440,21 +418,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.41.tgz",
-      "integrity": "sha512-h6BlclpsPGkx7Pv7ukr8oKVqN3jvxnH5n9ZIUQa8focr1ZkKd2MYiPJ2Nv9GI97dohJVJBfZAsTp/qoZL5R1pw==",
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.47.tgz",
+      "integrity": "sha512-HrId+C0DWA5qDIyLG64/kjUB2RNtPypxmABnIctK+TA1P1kHlOYoE/Wf5T5tKOMKgb08P7k/zNyhvfJ3lh5Oag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.36",
-        "@aws-sdk/credential-provider-http": "^3.972.38",
-        "@aws-sdk/credential-provider-ini": "^3.972.40",
-        "@aws-sdk/credential-provider-process": "^3.972.36",
-        "@aws-sdk/credential-provider-sso": "^3.972.40",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.40",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/credential-provider-imds": "^4.3.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/credential-provider-env": "^3.972.41",
+        "@aws-sdk/credential-provider-http": "^3.972.43",
+        "@aws-sdk/credential-provider-ini": "^3.972.46",
+        "@aws-sdk/credential-provider-process": "^3.972.41",
+        "@aws-sdk/credential-provider-sso": "^3.972.45",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/credential-provider-imds": "^4.3.6",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -462,15 +440,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.36.tgz",
-      "integrity": "sha512-eDQ6X7clTAOxXegOx4rGT1hyfusGEYdJGCGo0Ym2+CKeMQBjk+SJSxSVev11NJew5xJHJ/c3hryl2awKaxuSEA==",
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.41.tgz",
+      "integrity": "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -478,17 +456,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.40.tgz",
-      "integrity": "sha512-jaABbsoOkGlKg5kaHetYmUV6mWM57H89ia0Yksom1XxC847mfjmEVb4p7VijS1sjPbXjUii4cftJuwsl4MXkRg==",
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.45.tgz",
+      "integrity": "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/nested-clients": "^3.997.8",
-        "@aws-sdk/token-providers": "3.1047.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/token-providers": "3.1056.0",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -496,16 +474,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.40.tgz",
-      "integrity": "sha512-bfIrM8IIzbRtXRQWx/vNEUBLTImLZyX5uKk8uSdeSAZ4Mj3Yi4UnRJLK4FkQLWErbM3McpVLQ1DaM6XO66Ed5g==",
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.45.tgz",
+      "integrity": "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/nested-clients": "^3.997.8",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -513,15 +491,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.12.tgz",
-      "integrity": "sha512-MAG0Adg7FFEwuoeLbb5SBnXDW7S2EpNTwHnQ4h3pJqSKVQOhOmugyA1MfMh6AD4SAfx0lko4htZdwkNoLqFj5A==",
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.17.tgz",
+      "integrity": "sha512-lbDmWuHenc+kiwCNrxz4MyN6nkxCWyTXPIWuspJN0ibziu+8CXci7vI1bK9MAkwy8cwJOEXNu0gBM5S0uTGRIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -529,14 +507,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.11.tgz",
-      "integrity": "sha512-xpobcctR1AHSrvkiArgTyLffn78Lt9unPMpa/yic9RKn+bOf/5M55UIM6RaPL5xKzI06/GSsTDywTWvzEAbyyw==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.14.tgz",
+      "integrity": "sha512-3TNFEVGO4sWZj9TEXOCZLzGEctXHnaO4fk2EQ8KVaboTbwHmEPEQrm17Xb9koImUIXEw0sgi2xtHjg7LuTS3rA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -544,34 +522,19 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.18.tgz",
-      "integrity": "sha512-2noO+4ARfC+8vOIyvJvQE6bioVaTRkUcPvUoM/jgwXcweZnZovSZ6OCs/cs+NU2p7yvuwuJT/7LkTzBSj5pU4A==",
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.23.tgz",
+      "integrity": "sha512-4nPKARo2lfKvQGUt2fPA5NlS/mEohckdxpuC9ecbjVfj7B7NFFYHeTg+Bf5BEQwdn3yRfUIzFiEkPp8Yuaw3wA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/crc64-nvme": "^3.972.8",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.11.tgz",
-      "integrity": "sha512-CBC6+tVYaOJo7QXgN1zJ4Ba2f3/Cpy4eRViYFimXW/O5Mn8hBmgXXzHu4vy4ubT80YWnp8aCFygr7dTOa14yQg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/crc64-nvme": "^3.972.9",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -579,43 +542,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
-      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.11.tgz",
+      "integrity": "sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.12.tgz",
-      "integrity": "sha512-5eltYxKB4MfdQv7/VhWxRbAVQKow5dz9votRFigTYrWJHMQXwLMltlbk7KFWSZh5NDBySfmjT7Jv/DWfYCmDng==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -623,17 +556,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.39.tgz",
-      "integrity": "sha512-cimoQxecHHNad+lv2g7QJ24Cxqh1P0EULJSxyX4YD95BUIGeGRPumbdEXpHPxNkJRU99DVmh7u16Y+uhFu31Yw==",
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.44.tgz",
+      "integrity": "sha512-8HQsRg1NpX8vR4vNl1E8pyLnqZroq9VSL2vZQVSgBqp6wv6365LzYD08/c9FFh/9FTg7YRc7aTtEmXF0ir/pqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.26",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/signature-v4": "^5.4.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -641,14 +573,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.972.23",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.23.tgz",
-      "integrity": "sha512-qARHuSH/baFMjirXKY/03whYvg7O1+Ja2LMcf2aMBlkTHSH+M/7WpUuRLqdHvLl8n8aKbpz/LjQGYNpYntn0AA==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.26.tgz",
+      "integrity": "sha512-9VjCszKNDgEvHZBcryWpjGY4vwbTZU6hWARsxJZ+SZSglalP/6g8QTIKmKxSKlLle0BvrWhbZ5wlRhktTTkXEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -656,30 +588,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
-      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.11.tgz",
+      "integrity": "sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.40.tgz",
-      "integrity": "sha512-QLpD+HNQtL1Mc49/GRa6RmZvi/TEYBWPevC9F3L+j96IoG3xOSRctdQfbkX0lETb3TX9QQXU1oGYDmAB+YJprA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.9",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -687,43 +602,20 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.8.tgz",
-      "integrity": "sha512-/Vw2M27w+0APfMDzDpvv8auA4WiJ4D22+lC61pMS2M8Wk+4IydeRqh5utbrh+A5gQRxgUYd/xz3tdv8nQlmiHg==",
+      "version": "3.997.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.13.tgz",
+      "integrity": "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/middleware-host-header": "^3.972.11",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.12",
-        "@aws-sdk/middleware-user-agent": "^3.972.40",
-        "@aws-sdk/region-config-resolver": "^3.972.14",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.26",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.9",
-        "@aws-sdk/util-user-agent-browser": "^3.972.11",
-        "@aws-sdk/util-user-agent-node": "^3.973.26",
-        "@smithy/core": "^3.24.1",
-        "@smithy/fetch-http-handler": "^5.4.1",
-        "@smithy/node-http-handler": "^4.7.1",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.14.tgz",
-      "integrity": "sha512-VuLXVmm7+lKVxqFcOItPkXhjbJ02iUfxkxheRu41SfWf6/xrZup2A2SwHZos/LeQGu3SBHeqTQht80Uo3ienPA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/fetch-http-handler": "^5.4.5",
+        "@smithy/node-http-handler": "^4.7.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -731,15 +623,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.26.tgz",
-      "integrity": "sha512-2N62veqdMZBCwQUHsbhtnaovOFjOa5Dn3dAD1nRqFTUXR4QmirT3HZnfus/L1DS08Vm5CkoKmL0iMVt6YbqEag==",
+      "version": "3.996.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.30.tgz",
+      "integrity": "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/signature-v4": "^5.4.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/signature-v4": "^5.4.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -747,16 +638,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1047.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1047.0.tgz",
-      "integrity": "sha512-GwJUeMijpeO2SOGGLRg4q2Nj9foBUBd7hTALYVId+m8fQmA4P2hITp5dmrZFd4AjEkSVmt2eFqmk3TttF7HZeQ==",
+      "version": "3.1056.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1056.0.tgz",
+      "integrity": "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.10",
-        "@aws-sdk/nested-clients": "^3.997.8",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@aws-sdk/core": "^3.974.15",
+        "@aws-sdk/nested-clients": "^3.997.13",
+        "@aws-sdk/types": "^3.973.9",
+        "@smithy/core": "^3.24.5",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -764,27 +655,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
+      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.9.tgz",
-      "integrity": "sha512-ibx8Vd73rCTHekNGeXX8cpGWoBKbNAlwKHL3yjSxxttu5QnNDaSAM7/0MFYDjU31/F4lyrPoQcGirT0ew61xcg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -803,50 +679,13 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.11.tgz",
-      "integrity": "sha512-kq3RS6XQtHMrLFShbkem6h+8fxazB3jEIsbMC6aaSInOciRGE+eGAqTgJ+obO7Euo/pjM8thVqLiLISEH9X9DA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.26.tgz",
-      "integrity": "sha512-9bHR/EERjhrUGyo1qW620ogbGBtCglYB/pEtcm85sVd4/Ah+bwdLI3g1aJf75oNwNwh7+fw+8wOk/OCWHjzVmA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.40",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.1",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
-      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
+      "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.1",
+        "@smithy/types": "^4.14.2",
         "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
@@ -1433,9 +1272,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "funding": [
         {
           "type": "github",
@@ -1812,9 +1651,9 @@
       ]
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
-      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
+      "integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -1826,12 +1665,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
-      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.6.tgz",
+      "integrity": "sha512-tHhdiWZfG1ZIh2YcRfPJmY2gHcBmqbAzqm3ER4TIDFYsSEqTD5tICT7cgQ/kI8LRakxp12myOYyK68XPn7MnHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.3",
+        "@smithy/core": "^3.24.5",
         "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
@@ -1840,12 +1679,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
-      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.5.tgz",
+      "integrity": "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.3",
+        "@smithy/core": "^3.24.5",
         "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
@@ -1854,12 +1693,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.5.tgz",
+      "integrity": "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.3",
+        "@smithy/core": "^3.24.5",
         "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
@@ -1868,12 +1707,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
-      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.5.tgz",
+      "integrity": "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.3",
+        "@smithy/core": "^3.24.5",
         "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
@@ -2787,14 +2626,14 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -2802,7 +2641,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
+        "pg-cloudflare": "^1.4.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -2814,16 +2653,16 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
@@ -2836,18 +2675,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "license": "MIT"
     },
     "node_modules/pg-types": {

--- a/lambdas/fileprocess/package.json
+++ b/lambdas/fileprocess/package.json
@@ -12,15 +12,15 @@
     "lint": "tsc --noEmit --skipLibCheck"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1045.0",
-    "@aws-sdk/client-secrets-manager": "^3.1045.0",
-    "@aws-sdk/client-sqs": "^3.1045.0",
-    "pg": "^8.20.0",
+    "@aws-sdk/client-s3": "^3.1053.0",
+    "@aws-sdk/client-secrets-manager": "^3.1053.0",
+    "@aws-sdk/client-sqs": "^3.1053.0",
+    "pg": "^8.21.0",
     "pino": "^10.3.1"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.161",
-    "@types/node": "^24.12.3",
+    "@types/node": "^24.12.4",
     "@vitest/coverage-v8": "^3.2.4",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"


### PR DESCRIPTION
## Minor and patch updates

All available *minor* and *patch* updates have been installed. See diff for details.

## Major updates are available

The following packages were not updated, but have major version updates available: 
```Checking /home/jenkins/agent/workspace/npm-updates/lambdas/fileprocess/package.json

Major   Potentially breaking API changes
 @types/node          ^24.12.4  →  ^25.9.1
 @vitest/coverage-v8    ^3.2.4  →   ^4.1.7  [cooldown] 4.1.8
 typescript             ^5.9.3  →   ^6.0.3
 vitest                 ^3.2.4  →   ^4.1.7  [cooldown] 4.1.8

```