### PR TITLE
DEMOS-2195: Fix Date handling in EditDemonstrationDialog

### DIFF
--- a/client/src/components/dialog/demonstration/EditDemonstrationDialog.test.tsx
+++ b/client/src/components/dialog/demonstration/EditDemonstrationDialog.test.tsx
@@ -257,7 +257,7 @@ describe("EditDemonstrationDialog", () => {
 });
 
 describe("getUpdateDemonstrationInput", () => {
-  const BASE_FIELDS = {
+  const BASE_DEMONSTRATION = {
     name: "My Demo",
     description: "A description",
     stateId: "AL",
@@ -267,7 +267,7 @@ describe("getUpdateDemonstrationInput", () => {
   };
 
   it("maps name, stateId, and projectOfficerId as-is", () => {
-    const result = getUpdateDemonstrationInput(BASE_FIELDS);
+    const result = getUpdateDemonstrationInput(BASE_DEMONSTRATION);
     expect(result.name).toBe("My Demo");
     expect(result.stateId).toBe("AL");
     expect(result.projectOfficerUserId).toBe("officer-1");
@@ -275,7 +275,7 @@ describe("getUpdateDemonstrationInput", () => {
 
   it("passes through effectiveDate and expirationDate as-is", () => {
     const result = getUpdateDemonstrationInput({
-      ...BASE_FIELDS,
+      ...BASE_DEMONSTRATION,
       effectiveDate: "2024-06-01",
       expirationDate: "2025-06-01",
     });
@@ -283,23 +283,26 @@ describe("getUpdateDemonstrationInput", () => {
     expect(result.expirationDate).toBe("2025-06-01");
   });
 
-  it("passes empty string through for effectiveDate and expirationDate when empty", () => {
+  it("passes null for effectiveDate and expirationDate when empty", () => {
     const result = getUpdateDemonstrationInput({
-      ...BASE_FIELDS,
+      ...BASE_DEMONSTRATION,
       effectiveDate: "",
       expirationDate: "",
     });
-    expect(result.effectiveDate).toBe("");
-    expect(result.expirationDate).toBe("");
+    expect(result.effectiveDate).toBeNull();
+    expect(result.expirationDate).toBeNull();
   });
 
   it("trims whitespace from description", () => {
-    const result = getUpdateDemonstrationInput({ ...BASE_FIELDS, description: "  trimmed  " });
+    const result = getUpdateDemonstrationInput({
+      ...BASE_DEMONSTRATION,
+      description: "  trimmed  ",
+    });
     expect(result.description).toBe("trimmed");
   });
 
   it("sets description to empty string when blank", () => {
-    const result = getUpdateDemonstrationInput({ ...BASE_FIELDS, description: "   " });
+    const result = getUpdateDemonstrationInput({ ...BASE_DEMONSTRATION, description: "   " });
     expect(result.description).toBe("");
   });
 });

--- a/client/src/components/dialog/demonstration/EditDemonstrationDialog.test.tsx
+++ b/client/src/components/dialog/demonstration/EditDemonstrationDialog.test.tsx
@@ -6,10 +6,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import { EditDemonstrationDialog } from "./EditDemonstrationDialog";
 import {
+  EditDemonstrationDialog,
   GET_DEMONSTRATION_BY_ID_QUERY,
   UPDATE_DEMONSTRATION_MUTATION,
+  getUpdateDemonstrationInput,
 } from "./EditDemonstrationDialog";
 import { DIALOG_CANCEL_BUTTON_NAME } from "components/dialog/BaseDialog";
 import { DEMONSTRATION_DIALOG_DESCRIPTION_NAME } from "./DemonstrationDialog";
@@ -252,5 +253,53 @@ describe("EditDemonstrationDialog", () => {
       // If we get here without errors, the mock worked
       expect(submitButton).toBeInTheDocument();
     });
+  });
+});
+
+describe("getUpdateDemonstrationInput", () => {
+  const BASE_FIELDS = {
+    name: "My Demo",
+    description: "A description",
+    stateId: "AL",
+    projectOfficerId: "officer-1",
+    effectiveDate: "",
+    expirationDate: "",
+  };
+
+  it("maps name, stateId, and projectOfficerId as-is", () => {
+    const result = getUpdateDemonstrationInput(BASE_FIELDS);
+    expect(result.name).toBe("My Demo");
+    expect(result.stateId).toBe("AL");
+    expect(result.projectOfficerUserId).toBe("officer-1");
+  });
+
+  it("passes through effectiveDate and expirationDate as-is", () => {
+    const result = getUpdateDemonstrationInput({
+      ...BASE_FIELDS,
+      effectiveDate: "2024-06-01",
+      expirationDate: "2025-06-01",
+    });
+    expect(result.effectiveDate).toBe("2024-06-01");
+    expect(result.expirationDate).toBe("2025-06-01");
+  });
+
+  it("passes empty string through for effectiveDate and expirationDate when empty", () => {
+    const result = getUpdateDemonstrationInput({
+      ...BASE_FIELDS,
+      effectiveDate: "",
+      expirationDate: "",
+    });
+    expect(result.effectiveDate).toBe("");
+    expect(result.expirationDate).toBe("");
+  });
+
+  it("trims whitespace from description", () => {
+    const result = getUpdateDemonstrationInput({ ...BASE_FIELDS, description: "  trimmed  " });
+    expect(result.description).toBe("trimmed");
+  });
+
+  it("sets description to empty string when blank", () => {
+    const result = getUpdateDemonstrationInput({ ...BASE_FIELDS, description: "   " });
+    expect(result.description).toBe("");
   });
 });

--- a/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
@@ -60,7 +60,7 @@ export const UPDATE_DEMONSTRATION_MUTATION = gql`
   }
 `;
 
-const getUpdateDemonstrationInput = (
+export const getUpdateDemonstrationInput = (
   demonstration: DemonstrationDialogFields
 ): UpdateDemonstrationInput => {
   return {

--- a/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
@@ -2,15 +2,13 @@ import React from "react";
 
 import { Loading } from "components/loading/Loading";
 import { useToast } from "components/toast";
-import { Demonstration, UpdateDemonstrationInput } from "demos-server";
+import { Demonstration, LocalDate, UpdateDemonstrationInput } from "demos-server";
 import { DEMONSTRATION_DETAIL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
 import { formatDateForServer } from "util/formatDate";
 
 import { gql, useMutation, useQuery } from "@apollo/client";
 
 import { DemonstrationDialog, DemonstrationDialogFields } from "./DemonstrationDialog";
-import { endOfDay, parseISO } from "date-fns";
-import { TZDate } from "@date-fns/tz";
 
 const SUCCESS_MESSAGE = "Your demonstration has been updated.";
 const ERROR_MESSAGE = "Your demonstration was not updated because of an unknown problem.";
@@ -65,39 +63,17 @@ export const UPDATE_DEMONSTRATION_MUTATION = gql`
 const getUpdateDemonstrationInput = (
   demonstration: DemonstrationDialogFields
 ): UpdateDemonstrationInput => {
-  const input: Record<string, unknown> = {
+  return {
     ...(demonstration.name && { name: demonstration.name }),
     ...(demonstration.stateId && { stateId: demonstration.stateId }),
     ...(demonstration.projectOfficerId && {
       projectOfficerUserId: demonstration.projectOfficerId,
     }),
+    description: demonstration.description?.trim(),
+    effectiveDate: demonstration.effectiveDate as LocalDate,
+    expirationDate: demonstration.expirationDate as LocalDate,
+    sdgDivision: demonstration.sdgDivision,
   };
-
-  if (demonstration.description && demonstration.description.trim() !== "") {
-    input.description = demonstration.description;
-  } else {
-    input.description = null;
-  }
-
-  if (demonstration.effectiveDate && demonstration.effectiveDate.trim() !== "") {
-    input.effectiveDate = parseISO(demonstration.effectiveDate);
-  } else {
-    input.effectiveDate = null;
-  }
-
-  if (demonstration.expirationDate && demonstration.expirationDate.trim() !== "") {
-    input.expirationDate = endOfDay(new TZDate(demonstration.expirationDate, "America/New_York"));
-  } else {
-    input.expirationDate = null;
-  }
-
-  if (demonstration.sdgDivision) {
-    input.sdgDivision = demonstration.sdgDivision;
-  } else {
-    input.sdgDivision = null;
-  }
-
-  return input as UpdateDemonstrationInput;
 };
 
 const getDemonstrationDialogFields = (demonstration: Demonstration): DemonstrationDialogFields => ({

--- a/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
@@ -70,8 +70,8 @@ export const getUpdateDemonstrationInput = (
       projectOfficerUserId: demonstration.projectOfficerId,
     }),
     description: demonstration.description?.trim(),
-    effectiveDate: demonstration.effectiveDate as LocalDate,
-    expirationDate: demonstration.expirationDate as LocalDate,
+    effectiveDate: (demonstration.effectiveDate as LocalDate) || null,
+    expirationDate: (demonstration.expirationDate as LocalDate) || null,
     sdgDivision: demonstration.sdgDivision,
   };
 };


### PR DESCRIPTION
Per DEMOS-2195 fixes the handling of the expiration dates in the EditDemonstrationDialog (and cleans up the effective date to match)

https://github.com/user-attachments/assets/3bcc075d-2ba1-4187-9923-0a9fbb608c08

