### PR TITLE
Fix: Race Condition in `UserContext`

### DIFF
--- a/client/src/components/user/UserContext.tsx
+++ b/client/src/components/user/UserContext.tsx
@@ -38,7 +38,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     skip: !auth.isAuthenticated,
   });
 
-  if (loading) {
+  if (auth.isLoading || loading) {
     return (
       <div className="flex items-center justify-center h-screen w-screen">
         <Loading />

--- a/client/src/router/DemosRouter.tsx
+++ b/client/src/router/DemosRouter.tsx
@@ -16,8 +16,9 @@ import { ReportsPage } from "pages/ReportsPage";
 import { DeliverableDetailsManagementPage } from "pages/deliverables/DeliverableDetailsManagementPage";
 import { AdminPage } from "pages/admin/AdminPage";
 import { RequireRole } from "./RequireRole";
+import { PersonType } from "demos-server";
 
-const DEMONSTRATION_ACCESS_ROLES = ["demos-admin", "demos-cms-user"];
+const DEMONSTRATION_ACCESS_ROLES: PersonType[] = ["demos-admin", "demos-cms-user"];
 
 const HomePage = () => {
   const { currentUser } = getCurrentUser();
@@ -40,14 +41,16 @@ export const DemosRouter: React.FC = () => {
               <Route element={<DemosLayoutProvider />}>
                 <Route path="*" element={<div>404: Page Not Found</div>} />
                 <Route path="/" element={<HomePage />} />
-                <Route path="demonstrations"
+                <Route
+                  path="demonstrations"
                   element={
                     <RequireRole allowedRoles={DEMONSTRATION_ACCESS_ROLES}>
                       <DemonstrationsPage />
                     </RequireRole>
                   }
                 />
-                <Route path="demonstrations/:id"
+                <Route
+                  path="demonstrations/:id"
                   element={
                     <RequireRole allowedRoles={DEMONSTRATION_ACCESS_ROLES}>
                       <DemonstrationDetail />
@@ -55,17 +58,20 @@ export const DemosRouter: React.FC = () => {
                   }
                 />
                 <Route path="deliverables" element={<DeliverablesPage />} />
-                <Route path="deliverables/:deliverableId"
+                <Route
+                  path="deliverables/:deliverableId"
                   element={<DeliverableDetailsManagementPage />}
                 />
-                <Route path="reports"
+                <Route
+                  path="reports"
                   element={
                     <RequireRole allowedRoles={["demos-admin", "demos-cms-user"]}>
                       <ReportsPage />
                     </RequireRole>
                   }
                 />
-                <Route path="admin"
+                <Route
+                  path="admin"
                   element={
                     <RequireRole allowedRoles={["demos-admin"]}>
                       <AdminPage />

--- a/client/src/router/RequireRole.tsx
+++ b/client/src/router/RequireRole.tsx
@@ -1,16 +1,14 @@
 import React from "react";
 import { getCurrentUser } from "components/user/UserContext";
 import { Navigate } from "react-router-dom";
+import { PersonType } from "demos-server";
 
 type RequireRoleProps = {
-  allowedRoles: string[];
+  allowedRoles: PersonType[];
   children: React.ReactNode;
 };
 
-export const RequireRole: React.FC<RequireRoleProps> = ({
-  allowedRoles,
-  children,
-}) => {
+export const RequireRole: React.FC<RequireRoleProps> = ({ allowedRoles, children }) => {
   const { currentUser } = getCurrentUser();
 
   const userRole = currentUser?.person?.personType;


### PR DESCRIPTION
I noticed that `npm run dev:mocks` was being blocked by the `<RequireRole>` component, no matter what user type I used I would get redirected to `/` when going to `demonstrations/...`

Came to realize that this is a race condition that technically affects our real auth flow as well (though less likely to hit). another benefit of using a mocked server, seeing how the system behaves when removing latency!

## Broken
https://github.com/user-attachments/assets/f75eea4c-b7af-4acb-afd1-bcd010d5ea02

## Fixed
https://github.com/user-attachments/assets/defabcfc-c888-45d9-9125-dd8f212ccc17


