### PR TITLE
DEMOS-2107: Update DB parameters to resolve scan findings

### DIFF
--- a/deployment/package.json
+++ b/deployment/package.json
@@ -18,7 +18,7 @@
     "deploy": "cdk deploy --context stage=dev --all --no-change-set --require-approval=never",
     "lint": "eslint ./",
     "lint:fix": "eslint ./ --fix",
-    "synth:dev": "cdk synth --context stage=dev --all",
+    "synth:dev": "cdk synth --context stage=dev --context db=include --all",
     "test": "vitest --mode test",
     "test:ci": "vitest run --no-color --coverage --coverage.reporter=lcov --reporter=default --reporter=vitest-sonar-reporter --outputFile=coverage/test-results.xml",
     "tsc": "tsc --noEmit --skipLibCheck",

--- a/deployment/stacks/database.ts
+++ b/deployment/stacks/database.ts
@@ -12,8 +12,11 @@ import {
   Fn,
   aws_lambda,
   aws_logs,
+  IAspect,
+  CfnResource,
+  Aspects,
 } from "aws-cdk-lib";
-import { Construct } from "constructs";
+import { Construct, IConstruct } from "constructs";
 
 import { DeploymentConfigProperties } from "../config";
 
@@ -82,14 +85,15 @@ export class DatabaseStack extends Stack {
       parameters: {
         shared_preload_libraries: "pg_stat_statements,pg_tle,pg_cron,pgaudit",
         "cron.database_name": "demos",
-        ssl_min_protocol_version: "TLSv1.3",
+        ssl_min_protocol_version: "TLSv1.2",
         log_replication_commands: "on",
         log_disconnections: "on",
         log_connections: "on",
         log_line_prefix: "%m:%r:%u@%d:[%p]:%l:%e:%s:%v:%x:%c:%q%a:",
         log_statement: "ddl",
         log_error_verbosity: "verbose",
-        log_rotation_size: "1000000"
+        log_rotation_size: "1000000",
+        "rds.force_ssl": "1",
       }
     })
 
@@ -108,6 +112,7 @@ export class DatabaseStack extends Stack {
         storageEncrypted: true,
         credentials: aws_rds.Credentials.fromGeneratedSecret("demos_admin", {
           secretName: `${commonProps.project}-${commonProps.stage}-rds-admin`,
+          encryptionKey: rdsKMSKey
         }),
         securityGroups: [rdsSecurityGroup.securityGroup, commonProps.cloudVpnSecurityGroup, sharedServicesSg, cmsSecuritySg],
         publiclyAccessible: false,
@@ -119,9 +124,29 @@ export class DatabaseStack extends Stack {
         cloudwatchLogsRetention: RetentionDays.THREE_MONTHS,
         storageEncryptionKey: rdsKMSKey,
         port: 15432,
-        parameterGroup: parameterGroup
+        parameterGroup: parameterGroup,
+        monitoringInterval:  ["prod", "impl"].includes(commonProps.stage) ?  Duration.seconds(60) : undefined
       }
     );
+
+    const cfnDbInstance = dbInstance.node.defaultChild as aws_rds.CfnDBInstance;
+    cfnDbInstance.cfnOptions.metadata = {
+      checkov: {
+        skip: [{
+          id: "CKV_AWS_161",
+          reason: "Using username/password with auto-rotations for now"
+        },
+        {
+          id: "CKV_AWS_157",
+          reason: "To save costs, lower environments will not use multi-az"
+        },{
+          id: "CKV_AWS_118",
+          reason: "Enhanced monitoring is enabled in IMPL and PROD"
+        }]
+      }
+    };
+
+    Aspects.of(this).add(new SuppressCheckovLogRetentionPolicy());
 
     const cmsCloudLogFunc = aws_lambda.Function.fromFunctionName(
       commonProps.scope,
@@ -200,5 +225,29 @@ export class DatabaseStack extends Stack {
       value: dbInstance.instanceEndpoint.port.toString(),
       exportName: `${commonProps.project}-${commonProps.stage}-rds-port`,
     });
+  }
+}
+
+class SuppressCheckovLogRetentionPolicy implements IAspect {
+  visit(node: IConstruct): void {
+    if (!CfnResource.isCfnResource(node)) return;
+    if (node.cfnResourceType !== "AWS::IAM::Policy") return;
+
+    const path = node.node.path;
+    
+    if (
+      path.includes("/LogRetention") &&
+      path.endsWith("/ServiceRole/DefaultPolicy/Resource")
+    ) {
+      node.addMetadata("checkov", {
+        skip: [
+          {
+            id: "CKV_AWS_111",
+            comment:
+              "CDK-managed LogRetention custom resource role; only used to apply CloudWatch Logs retention. Not worth updating or managing",
+          },
+        ],
+      });
+    }
   }
 }

--- a/deployment/stacks/database.ts
+++ b/deployment/stacks/database.ts
@@ -54,6 +54,13 @@ export class DatabaseStack extends Stack {
       props.vpc
     );
 
+    const cmsSecuritySg = aws_ec2.SecurityGroup.fromLookupByName(
+      commonProps.scope,
+      "cmsSecurityToolsSG",
+      "cmscloud-security-tools",
+      props.vpc
+    );
+
     new CfnOutput(commonProps.scope, "dbSecurityGroupID", {
       value: rdsSecurityGroup.securityGroup.securityGroupId,
       exportName: `${commonProps.project}-${commonProps.stage}-rds-security-group-id`,
@@ -94,7 +101,7 @@ export class DatabaseStack extends Stack {
         credentials: aws_rds.Credentials.fromGeneratedSecret("demos_admin", {
           secretName: `${commonProps.project}-${commonProps.stage}-rds-admin`,
         }),
-        securityGroups: [rdsSecurityGroup.securityGroup, commonProps.cloudVpnSecurityGroup, sharedServicesSg],
+        securityGroups: [rdsSecurityGroup.securityGroup, commonProps.cloudVpnSecurityGroup, sharedServicesSg, cmsSecuritySg],
         publiclyAccessible: false,
         removalPolicy: ["prod", "impl"].includes(commonProps.stage) ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
         deleteAutomatedBackups: true,

--- a/deployment/stacks/database.ts
+++ b/deployment/stacks/database.ts
@@ -112,7 +112,6 @@ export class DatabaseStack extends Stack {
         storageEncrypted: true,
         credentials: aws_rds.Credentials.fromGeneratedSecret("demos_admin", {
           secretName: `${commonProps.project}-${commonProps.stage}-rds-admin`,
-          encryptionKey: rdsKMSKey
         }),
         securityGroups: [rdsSecurityGroup.securityGroup, commonProps.cloudVpnSecurityGroup, sharedServicesSg, cmsSecuritySg],
         publiclyAccessible: false,
@@ -231,23 +230,38 @@ export class DatabaseStack extends Stack {
 class SuppressCheckovLogRetentionPolicy implements IAspect {
   visit(node: IConstruct): void {
     if (!CfnResource.isCfnResource(node)) return;
-    if (node.cfnResourceType !== "AWS::IAM::Policy") return;
+    if (node.cfnResourceType === "AWS::IAM::Policy") {
 
-    const path = node.node.path;
-    
-    if (
-      path.includes("/LogRetention") &&
-      path.endsWith("/ServiceRole/DefaultPolicy/Resource")
-    ) {
-      node.addMetadata("checkov", {
-        skip: [
-          {
-            id: "CKV_AWS_111",
-            comment:
-              "CDK-managed LogRetention custom resource role; only used to apply CloudWatch Logs retention. Not worth updating or managing",
-          },
-        ],
-      });
+      const path = node.node.path;
+
+      if (
+        path.includes("/LogRetention") &&
+        path.endsWith("/ServiceRole/DefaultPolicy/Resource")
+      ) {
+        node.addMetadata("checkov", {
+          skip: [
+            {
+              id: "CKV_AWS_111",
+              comment:
+                "CDK-managed LogRetention custom resource role; only used to apply CloudWatch Logs retention. Not worth updating or managing",
+            },
+          ],
+        });
+      }
+    }
+
+    if (node.cfnResourceType === "AWS::SecretsManager::Secret") {
+      const path = node.node.path
+      if (path.includes("demos-dev-rds/Secret/Resource")) {
+        node.addMetadata("checkov", {
+          skip: [
+            {
+              id: "CKV_AWS_149",
+              reason: "Sticking with AWS owned KMS key for now. Can revisit a CMK in the future"
+            }
+          ]
+        })
+      }
     }
   }
 }

--- a/deployment/stacks/database.ts
+++ b/deployment/stacks/database.ts
@@ -80,8 +80,16 @@ export class DatabaseStack extends Stack {
       name: `demos-${commonProps.stage}-postgres-17`,
       engine,
       parameters: {
-        shared_preload_libraries: "pg_stat_statements,pg_tle,pg_cron",
+        shared_preload_libraries: "pg_stat_statements,pg_tle,pg_cron,pgaudit",
         "cron.database_name": "demos",
+        ssl_min_protocol_version: "TLSv1.3",
+        log_replication_commands: "on",
+        log_disconnections: "on",
+        log_connections: "on",
+        log_line_prefix: "%m:%r:%u@%d:[%p]:%l:%e:%s:%v:%x:%c:%q%a:",
+        log_statement: "ddl",
+        log_error_verbosity: "verbose",
+        log_rotation_size: "1000000"
       }
     })
 


### PR DESCRIPTION
## Overview
The main reason for this change was to get the DB scan for CSRAP and then resolve any findings. Findings that could be resolved by the code were updated in this PR and can be seen in the changes to the database parameters.

The other changes included are related to the DB scan and security.

- A new security group was added so that Cloud Support is able to run their scans
- The pipeline was updated to include the DB stack in the checkov scan. No major changes were made to the CDK code