### PR TITLE
DEMOS-1709: fixed state user permissions for documentExists

### DIFF
--- a/server/src/model/document/documentSchema.ts
+++ b/server/src/model/document/documentSchema.ts
@@ -43,7 +43,7 @@ export const documentSchema = gql`
 
   type Query {
     document(id: ID!): Document! @auth(requires: ["Access CMS Query"])
-    documentExists(documentId: ID!): Boolean! @auth(requires: ["Access CMS Query"])
+    documentExists(documentId: ID!): Boolean!
   }
 `;
 


### PR DESCRIPTION
Nuked the auth attribute for documentExists per convo with @connor-parke-icf  about permissions


<img width="1518" height="1421" alt="Screenshot 2026-06-01 at 15 59 28" src="https://github.com/user-attachments/assets/34d8ea8b-8662-47f6-b0e4-1ad5bef14c76" />

Also edit and delete works. 
<img width="1105" height="661" alt="Screenshot 2026-06-01 at 16 04 38" src="https://github.com/user-attachments/assets/227ee074-ec6e-4f8d-bcdc-7cb07cc27c5c" />

