### PR TITLE
DEMOS-2205: Cloudwatch alarms and alerting

### DIFF
--- a/deployment/app.ts
+++ b/deployment/app.ts
@@ -52,7 +52,8 @@ export async function main(passedContext?: { [key: string]: any }) {
 
   const stage = app.node.getContext("stage");
   const hostEnv = app.node.tryGetContext("hostEnv");
-  const config = await determineDeploymentConfig(stage, hostEnv);
+  const forceAlarms = app.node.tryGetContext("alarms")
+  const config = await determineDeploymentConfig(stage, hostEnv, forceAlarms);
 
   const project = config.project;
 

--- a/deployment/config.ts
+++ b/deployment/config.ts
@@ -24,11 +24,13 @@ export interface DeploymentConfigProperties {
   zapHeaderValue?: string;
   srrConfigured: boolean;
   dataConnectRoleArn: string;
+  enableAlarms?: boolean;
 }
 
 export const determineDeploymentConfig = async (
   stage: string,
-  hostEnv?: string
+  hostEnv?: string,
+  alarms?: string
 ): Promise<DeploymentConfigProperties> => {
   const project = process.env.PROJECT ?? "demos";
 
@@ -47,6 +49,8 @@ export const determineDeploymentConfig = async (
   const isEphemeral = !["dev", "test", "impl", "prod"].includes(stage);
   const hostEnvironment = isEphemeral ? hostEnv ?? "dev" : stage;
   const hostUserPoolId = isEphemeral ? await getUserPoolIdByName(`${project}-${hostEnvironment}-user-pool`) : undefined;
+
+  const enableAlarms = isEphemeral ? alarms == "true" : true
 
   const secretConfig =
     stage == "bootstrap" ? {} : JSON.parse((await getSecret(`${project}-${hostEnvironment}/config`))!);
@@ -85,6 +89,7 @@ export const determineDeploymentConfig = async (
     zScalerIps,
     hostUserPoolId,
     cloudfrontHost,
-    srrConfigured
+    srrConfigured,
+    enableAlarms
   };
 };

--- a/deployment/lib/alarmNotifier.test.ts
+++ b/deployment/lib/alarmNotifier.test.ts
@@ -1,0 +1,101 @@
+import { CloudWatchAlarmEvent } from "aws-lambda";
+import { handler } from "./alarmNotifier";
+
+const { mockSsmSend } = vi.hoisted(() => ({
+  mockSsmSend: vi.fn(),
+}));
+
+vi.mock(import("@aws-sdk/client-ssm"), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    SSMClient: vi.fn().mockImplementation(function () {
+      return {
+        send: mockSsmSend,
+      };
+    }),
+  };
+});
+
+const alarmEvent = {
+  alarmData: {
+    alarmName: "demos-unittest-api-errors",
+    configuration: {
+      description: "[unittest] API Lambda has errors.",
+    },
+    state: {
+      value: "ALARM",
+      reason: "Threshold Crossed",
+    },
+    previousState: {
+      value: "OK",
+    },
+  },
+} as CloudWatchAlarmEvent;
+
+describe("alarmNotifier", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        status: 200,
+        text: async () => "ok",
+      }))
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("posts alarm details to the configured webhook", async () => {
+    mockSsmSend.mockResolvedValueOnce({
+      Parameter: {
+        Value: "https://hooks.slack.test/alarm",
+      },
+    });
+
+    const response = await handler(alarmEvent);
+
+    expect(mockSsmSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: {
+          Name: "/demos/webhookUrl",
+          WithDecryption: true,
+        },
+      })
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://hooks.slack.test/alarm",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          message: "[unittest] API Lambda has errors.",
+          name: "demos-unittest-api-errors",
+          state: "ALARM",
+          reason: "Threshold Crossed",
+          previousState: "OK",
+        }),
+      })
+    );
+    expect(response).toEqual({
+      statusCode: 200,
+      body: "ok",
+    });
+  });
+
+  test("throws when the webhook parameter is blank", async () => {
+    mockSsmSend.mockResolvedValueOnce({
+      Parameter: {
+        Value: "   ",
+      },
+    });
+
+    await expect(handler(alarmEvent)).rejects.toThrow("webhook url is missing");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/deployment/lib/alarmNotifier.ts
+++ b/deployment/lib/alarmNotifier.ts
@@ -1,0 +1,47 @@
+import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
+import {CloudWatchAlarmEvent} from "aws-lambda"
+
+const ssm = new SSMClient({});
+
+async function getParameter(name: string) {
+  const response = await ssm.send(
+    new GetParameterCommand({
+      Name: name,
+      WithDecryption: true,
+    }),
+  );
+
+  return response.Parameter?.Value;
+}
+
+export const handler = async (event: CloudWatchAlarmEvent) => {
+  const webhookUrl = await getParameter(`/demos/webhookUrl`);
+
+  if (!webhookUrl || webhookUrl.trim() == "") {
+    throw new Error("webhook url is missing");
+  }
+
+  const data = event.alarmData;
+  console.log("Received alarm data:", JSON.stringify(data, null, 2));
+
+  const gr = await fetch(webhookUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      message: data.configuration.description,
+      name: data.alarmName,
+      state: data.state.value,
+      reason: data.state.reason,
+      previousState: data.previousState.value,
+    }),
+  });
+
+  const body = await gr.text();
+  const response = {
+    statusCode: gr.status,
+    body: body,
+  };
+  return response;
+};

--- a/deployment/lib/alarms.test.ts
+++ b/deployment/lib/alarms.test.ts
@@ -1,0 +1,103 @@
+import { App, Duration, Stack, aws_cloudwatch, aws_sqs } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import * as alarms from "./alarms";
+
+describe("CloudWatch alarm helpers", () => {
+  test("adds the notifier lambda as the default metric alarm action", () => {
+    const app = new App();
+    const stack = new Stack(app, "metricAlarmTest", {
+      env: {
+        account: "0123456789",
+        region: "us-east-1",
+      },
+    });
+    const queue = new aws_sqs.Queue(stack, "Queue");
+
+    alarms.createSqsVisibleMessagesAlarm({
+      scope: stack,
+      project: "demos",
+      stage: "unittest",
+      id: "QueueVisibleMessagesAlarm",
+      name: "queue-visible-messages",
+      description: "Queue has visible messages.",
+      queue,
+      period: Duration.minutes(5),
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "demos-unittest-queue-visible-messages",
+      AlarmActions: Match.anyValue(),
+      OKActions: Match.anyValue(),
+    });
+    template.hasResourceProperties("AWS::Lambda::Permission", {
+      Action: "lambda:InvokeFunction",
+      FunctionName: Match.anyValue(),
+      Principal: "lambda.alarms.cloudwatch.amazonaws.com",
+      SourceAccount: "0123456789",
+      SourceArn: Match.objectLike({
+        "Fn::GetAtt": Match.arrayWith([
+          Match.stringLikeRegexp("QueueVisibleMessagesAlarm"),
+          "Arn",
+        ]),
+      }),
+    });
+    expect(
+      JSON.stringify(template.findResources("AWS::Lambda::Permission"))
+    ).toContain("demos-unittest-notifier");
+  });
+
+  test("adds the notifier lambda as the default anomaly alarm action", () => {
+    const app = new App();
+    const stack = new Stack(app, "anomalyAlarmTest", {
+      env: {
+        account: "0123456789",
+        region: "us-east-1",
+      },
+    });
+
+    alarms.createAnomalyAlarm({
+      scope: stack,
+      project: "demos",
+      stage: "unittest",
+      id: "LatencyAnomalyAlarm",
+      name: "latency-anomaly",
+      description: "Latency is above its anomaly band.",
+      metric: new aws_cloudwatch.Metric({
+        namespace: "Demos/Test",
+        metricName: "Latency",
+        period: Duration.minutes(5),
+        statistic: "Average",
+      }),
+      evaluationPeriods: 3,
+      datapointsToAlarm: 2,
+    });
+
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "demos-unittest-latency-anomaly",
+      AlarmActions: Match.anyValue(),
+      OKActions: Match.anyValue(),
+    });
+    template.hasResourceProperties("AWS::Lambda::Permission", {
+      Action: "lambda:InvokeFunction",
+      FunctionName: Match.anyValue(),
+      Principal: "lambda.alarms.cloudwatch.amazonaws.com",
+      SourceAccount: "0123456789",
+      SourceArn: Match.objectLike({
+        "Fn::GetAtt": Match.arrayWith([
+          Match.stringLikeRegexp("LatencyAnomalyAlarm"),
+          "Arn",
+        ]),
+      }),
+    });
+    expect(
+      JSON.stringify(template.findResources("AWS::Lambda::Permission"))
+    ).toContain("demos-unittest-notifier");
+  });
+});

--- a/deployment/lib/alarms.ts
+++ b/deployment/lib/alarms.ts
@@ -1,7 +1,9 @@
 import {
   Duration,
+  aws_cloudfront,
   aws_cloudwatch,
   aws_lambda,
+  aws_rds,
   aws_sqs,
 } from "aws-cdk-lib";
 import type { IAlarmAction } from "aws-cdk-lib/aws-cloudwatch";
@@ -60,6 +62,58 @@ export interface DemosSqsVisibleMessagesAlarmProps extends DemosAlarmBaseProps {
   queue: aws_sqs.IQueue;
   period: Duration;
   threshold: number;
+}
+
+export class CloudWatchAlarmRegistry {
+  private readonly lambdaFunctions = new Map<string, aws_lambda.IFunction>();
+  private readonly queues = new Map<string, aws_sqs.IQueue>();
+  private readonly distributions = new Map<string, aws_cloudfront.Distribution>();
+  private readonly databaseInstances = new Map<string, aws_rds.DatabaseInstance>();
+
+  registerLambda<T extends aws_lambda.IFunction>(id: string, lambdaFunction: T): T {
+    this.lambdaFunctions.set(id, lambdaFunction);
+    return lambdaFunction;
+  }
+
+  lambda(id: string): aws_lambda.IFunction {
+    return this.get(this.lambdaFunctions, "Lambda function", id);
+  }
+
+  registerQueue<T extends aws_sqs.IQueue>(id: string, queue: T): T {
+    this.queues.set(id, queue);
+    return queue;
+  }
+
+  queue(id: string): aws_sqs.IQueue {
+    return this.get(this.queues, "SQS queue", id);
+  }
+
+  registerDistribution<T extends aws_cloudfront.Distribution>(id: string, distribution: T): T {
+    this.distributions.set(id, distribution);
+    return distribution;
+  }
+
+  distribution(id: string): aws_cloudfront.Distribution {
+    return this.get(this.distributions, "CloudFront distribution", id);
+  }
+
+  registerDatabaseInstance<T extends aws_rds.DatabaseInstance>(id: string, databaseInstance: T): T {
+    this.databaseInstances.set(id, databaseInstance);
+    return databaseInstance;
+  }
+
+  databaseInstance(id: string): aws_rds.DatabaseInstance {
+    return this.get(this.databaseInstances, "RDS database instance", id);
+  }
+
+  private get<T>(resources: Map<string, T>, kind: string, id: string): T {
+    const resource = resources.get(id);
+    if (resource == null) {
+      throw new Error(`${kind} "${id}" has not been registered for CloudWatch alarms.`);
+    }
+
+    return resource;
+  }
 }
 
 function alarmName(props: Pick<DemosAlarmBaseProps, "project" | "stage" | "name">): string {

--- a/deployment/lib/alarms.ts
+++ b/deployment/lib/alarms.ts
@@ -1,0 +1,192 @@
+import {
+  Duration,
+  aws_cloudwatch,
+  aws_lambda,
+  aws_sqs,
+} from "aws-cdk-lib";
+import type { IAlarmAction } from "aws-cdk-lib/aws-cloudwatch";
+import { Construct } from "constructs";
+
+export interface DemosAlarmBaseProps {
+  scope: Construct;
+  project: string;
+  stage: string;
+  id: string;
+  name: string;
+  description: string;
+  evaluationPeriods: number;
+  datapointsToAlarm?: number;
+  treatMissingData?: aws_cloudwatch.TreatMissingData;
+  alarmActions?: IAlarmAction[];
+}
+
+export interface DemosMetricAlarmProps extends DemosAlarmBaseProps {
+  metric: aws_cloudwatch.IMetric;
+  threshold: number;
+  comparisonOperator: aws_cloudwatch.ComparisonOperator;
+}
+
+export interface DemosAnomalyAlarmProps extends DemosAlarmBaseProps {
+  metric: aws_cloudwatch.IMetric;
+  comparisonOperator?: aws_cloudwatch.ComparisonOperator;
+  stdDevs?: number;
+}
+
+export interface DemosLambdaErrorsAlarmProps extends DemosAlarmBaseProps {
+  lambdaFunction: aws_lambda.IFunction;
+  period: Duration;
+  threshold: number;
+}
+
+export interface DemosLambdaDurationAlarmProps extends DemosAlarmBaseProps {
+  lambdaFunction: aws_lambda.IFunction;
+  period: Duration;
+  threshold: Duration;
+}
+
+export interface DemosLambdaThrottlesAlarmProps extends DemosAlarmBaseProps {
+  lambdaFunction: aws_lambda.IFunction;
+  period: Duration;
+  threshold: number;
+}
+
+export interface DemosSqsOldestMessageAgeAlarmProps extends DemosAlarmBaseProps {
+  queue: aws_sqs.IQueue;
+  period: Duration;
+  threshold: Duration;
+}
+
+export interface DemosSqsVisibleMessagesAlarmProps extends DemosAlarmBaseProps {
+  queue: aws_sqs.IQueue;
+  period: Duration;
+  threshold: number;
+}
+
+function alarmName(props: Pick<DemosAlarmBaseProps, "project" | "stage" | "name">): string {
+  return `${props.project}-${props.stage}-${props.name}`;
+}
+
+function alarmDescription(props: Pick<DemosAlarmBaseProps, "stage" | "description">): string {
+  return `[${props.stage}] ${props.description}`;
+}
+
+export function createMetricAlarm(props: DemosMetricAlarmProps): aws_cloudwatch.Alarm {
+  const alarm = new aws_cloudwatch.Alarm(props.scope, props.id, {
+    alarmName: alarmName(props),
+    alarmDescription: alarmDescription(props),
+    metric: props.metric,
+    threshold: props.threshold,
+    comparisonOperator: props.comparisonOperator,
+    evaluationPeriods: props.evaluationPeriods,
+    datapointsToAlarm: props.datapointsToAlarm,
+    treatMissingData: props.treatMissingData ?? aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+  });
+
+  if (props.alarmActions) {
+    alarm.addAlarmAction(...props.alarmActions);
+  }
+
+  return alarm;
+}
+
+export function createLambdaDurationAlarm(
+  props: DemosLambdaDurationAlarmProps
+): aws_cloudwatch.Alarm {
+  const { lambdaFunction, period, threshold, ...alarmProps } = props;
+
+  return createMetricAlarm({
+    ...alarmProps,
+    metric: lambdaFunction.metricDuration({
+      period,
+      statistic: "Maximum",
+    }),
+    threshold: threshold.toMilliseconds(),
+    comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+  });
+}
+
+export function createLambdaErrorsAlarm(
+  props: DemosLambdaErrorsAlarmProps
+): aws_cloudwatch.Alarm {
+  const { lambdaFunction, period, threshold, ...alarmProps } = props;
+
+  return createMetricAlarm({
+    ...alarmProps,
+    metric: lambdaFunction.metricErrors({
+      period,
+      statistic: "Sum",
+    }),
+    threshold,
+    comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+  });
+}
+
+export function createLambdaThrottlesAlarm(
+  props: DemosLambdaThrottlesAlarmProps
+): aws_cloudwatch.Alarm {
+  const { lambdaFunction, period, threshold, ...alarmProps } = props;
+
+  return createMetricAlarm({
+    ...alarmProps,
+    metric: lambdaFunction.metricThrottles({
+      period,
+      statistic: "Sum",
+    }),
+    threshold,
+    comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+  });
+}
+
+export function createSqsOldestMessageAgeAlarm(
+  props: DemosSqsOldestMessageAgeAlarmProps
+): aws_cloudwatch.Alarm {
+  const { queue, period, threshold, ...alarmProps } = props;
+
+  return createMetricAlarm({
+    ...alarmProps,
+    metric: queue.metricApproximateAgeOfOldestMessage({
+      period,
+      statistic: "Maximum",
+    }),
+    threshold: threshold.toSeconds(),
+    comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+  });
+}
+
+export function createSqsVisibleMessagesAlarm(
+  props: DemosSqsVisibleMessagesAlarmProps
+): aws_cloudwatch.Alarm {
+  const { queue, period, threshold, ...alarmProps } = props;
+
+  return createMetricAlarm({
+    ...alarmProps,
+    metric: queue.metricApproximateNumberOfMessagesVisible({
+      period,
+      statistic: "Maximum",
+    }),
+    threshold,
+    comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+  });
+}
+
+export function createAnomalyAlarm(
+  props: DemosAnomalyAlarmProps
+): aws_cloudwatch.AnomalyDetectionAlarm {
+  const alarm = new aws_cloudwatch.AnomalyDetectionAlarm(props.scope, props.id, {
+    alarmName: alarmName(props),
+    alarmDescription: alarmDescription(props),
+    metric: props.metric,
+    comparisonOperator:
+      props.comparisonOperator ?? aws_cloudwatch.ComparisonOperator.GREATER_THAN_UPPER_THRESHOLD,
+    evaluationPeriods: props.evaluationPeriods,
+    datapointsToAlarm: props.datapointsToAlarm,
+    treatMissingData: props.treatMissingData ?? aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+    stdDevs: props.stdDevs,
+  });
+
+  if (props.alarmActions) {
+    alarm.addAlarmAction(...props.alarmActions);
+  }
+
+  return alarm;
+}

--- a/deployment/lib/alarms.ts
+++ b/deployment/lib/alarms.ts
@@ -2,6 +2,7 @@ import {
   Duration,
   aws_cloudfront,
   aws_cloudwatch,
+  aws_cloudwatch_actions,
   aws_lambda,
   aws_rds,
   aws_sqs,
@@ -124,6 +125,21 @@ function alarmDescription(props: Pick<DemosAlarmBaseProps, "stage" | "descriptio
   return `[${props.stage}] ${props.description}`;
 }
 
+function alarmActions(props: DemosAlarmBaseProps): IAlarmAction[] {
+  const notifierLambda = aws_lambda.Function.fromFunctionName(
+    props.scope,
+    `${props.id}NotifierAlarmActionFunction`,
+    `${props.project}-${props.stage}-notifier`
+  );
+
+  return [
+    new aws_cloudwatch_actions.LambdaAction(notifierLambda, {
+      useUniquePermissionId: true,
+    }),
+    ...(props.alarmActions ?? []),
+  ];
+}
+
 export function createMetricAlarm(props: DemosMetricAlarmProps): aws_cloudwatch.Alarm {
   const alarm = new aws_cloudwatch.Alarm(props.scope, props.id, {
     alarmName: alarmName(props),
@@ -136,9 +152,9 @@ export function createMetricAlarm(props: DemosMetricAlarmProps): aws_cloudwatch.
     treatMissingData: props.treatMissingData ?? aws_cloudwatch.TreatMissingData.NOT_BREACHING,
   });
 
-  if (props.alarmActions) {
-    alarm.addAlarmAction(...props.alarmActions);
-  }
+  const actions = alarmActions(props);
+  alarm.addAlarmAction(...actions);
+  alarm.addOkAction(...actions);
 
   return alarm;
 }
@@ -238,9 +254,9 @@ export function createAnomalyAlarm(
     stdDevs: props.stdDevs,
   });
 
-  if (props.alarmActions) {
-    alarm.addAlarmAction(...props.alarmActions);
-  }
+  const actions = alarmActions(props);
+  alarm.addAlarmAction(...actions);
+  alarm.addOkAction(...actions);
 
   return alarm;
 }

--- a/deployment/lib/budgetNeutralityProcessor.test.ts
+++ b/deployment/lib/budgetNeutralityProcessor.test.ts
@@ -1,5 +1,5 @@
 import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
+import { Match, Template } from "aws-cdk-lib/assertions";
 import { BudgetNeutralityProcessor } from "./budgetNeutralityProcessor";
 import { DeploymentConfigProperties } from "../config";
 import { BUNDLING_STACKS } from "aws-cdk-lib/cx-api";
@@ -40,5 +40,78 @@ describe("BudgetNeutralityProcessor construct", () => {
 
     template.resourceCountIs("AWS::SQS::Queue", 2);
     template.resourceCountIs("AWS::Lambda::Function", 1);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 4);
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "demos-unittest-budget-neutrality-lambda-errors",
+      ComparisonOperator: "GreaterThanThreshold",
+      MetricName: "Errors",
+      Namespace: "AWS/Lambda",
+      Period: 300,
+      Statistic: "Sum",
+      Threshold: 0,
+      TreatMissingData: "notBreaching",
+      Dimensions: Match.arrayWith([
+        Match.objectLike({
+          Name: "FunctionName",
+          Value: Match.objectLike({
+            Ref: Match.stringLikeRegexp("budgetNeutrality"),
+          }),
+        }),
+      ]),
+    });
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "demos-unittest-budget-neutrality-queue-oldest-message-age-high",
+      ComparisonOperator: "GreaterThanThreshold",
+      EvaluationPeriods: 2,
+      DatapointsToAlarm: 2,
+      MetricName: "ApproximateAgeOfOldestMessage",
+      Namespace: "AWS/SQS",
+      Period: 300,
+      Statistic: "Maximum",
+      Threshold: 900,
+      TreatMissingData: "notBreaching",
+      Dimensions: Match.arrayWith([
+        Match.objectLike({
+          Name: "QueueName",
+          Value: Match.anyValue(),
+        }),
+      ]),
+    });
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "demos-unittest-budget-neutrality-lambda-duration-near-timeout",
+      ComparisonOperator: "GreaterThanThreshold",
+      MetricName: "Duration",
+      Namespace: "AWS/Lambda",
+      Period: 300,
+      Statistic: "Maximum",
+      Threshold: 48000,
+      TreatMissingData: "notBreaching",
+      Dimensions: Match.arrayWith([
+        Match.objectLike({
+          Name: "FunctionName",
+          Value: Match.objectLike({
+            Ref: Match.stringLikeRegexp("budgetNeutrality"),
+          }),
+        }),
+      ]),
+    });
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "demos-unittest-budget-neutrality-lambda-throttles",
+      ComparisonOperator: "GreaterThanThreshold",
+      MetricName: "Throttles",
+      Namespace: "AWS/Lambda",
+      Period: 300,
+      Statistic: "Sum",
+      Threshold: 0,
+      TreatMissingData: "notBreaching",
+      Dimensions: Match.arrayWith([
+        Match.objectLike({
+          Name: "FunctionName",
+          Value: Match.objectLike({
+            Ref: Match.stringLikeRegexp("budgetNeutrality"),
+          }),
+        }),
+      ]),
+    });
   });
 });

--- a/deployment/lib/budgetNeutralityProcessor.test.ts
+++ b/deployment/lib/budgetNeutralityProcessor.test.ts
@@ -114,4 +114,29 @@ describe("BudgetNeutralityProcessor construct", () => {
       ]),
     });
   });
+
+  it("does not synthesize alarms when ephemeral", () => {
+    const app = new App({
+      context: {
+        [BUNDLING_STACKS]: [],
+      },
+    });
+
+    const stack = new Stack(app, "budgetNeutralityProcessorTest", {
+      env: { account: "0123456789", region: "us-east-1" },
+    });
+
+    new BudgetNeutralityProcessor(stack, "BudgetNeutralityProcessor", {
+      ...mockProps,
+      isEphemeral: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      kmsKey: new Key(stack, "BudgetNeutralityKmsKey"),
+    });
+
+    const template = Template.fromStack(stack);
+
+    template.resourceCountIs("AWS::SQS::Queue", 2);
+    template.resourceCountIs("AWS::Lambda::Function", 1);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+  });
 });

--- a/deployment/lib/budgetNeutralityProcessor.ts
+++ b/deployment/lib/budgetNeutralityProcessor.ts
@@ -126,7 +126,7 @@ export class BudgetNeutralityProcessor extends Construct {
     props: DeploymentConfigProperties,
     resources: alarms.CloudWatchAlarmRegistry
   ) {
-    if (props.isEphemeral) {
+    if (props.isEphemeral && !props.enableAlarms) {
       return;
     }
 

--- a/deployment/lib/budgetNeutralityProcessor.ts
+++ b/deployment/lib/budgetNeutralityProcessor.ts
@@ -10,6 +10,7 @@ import {
 } from "aws-cdk-lib";
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import * as demosLambda from "./lambda";
+import * as alarms from "./alarms";
 import path from "node:path";
 import { DeploymentConfigProperties } from "../config";
 import { OutputFormat } from "aws-cdk-lib/aws-lambda-nodejs";
@@ -51,6 +52,19 @@ export class BudgetNeutralityProcessor extends Construct {
         queue: this.deadLetterQueue,
         maxReceiveCount: 5,
       },
+    });
+
+    alarms.createSqsOldestMessageAgeAlarm({
+      ...props,
+      scope: this,
+      id: "BudgetNeutralityQueueOldestMessageAgeAlarm",
+      name: "budget-neutrality-queue-oldest-message-age-high",
+      description: "Budget neutrality queue has messages older than 15 minutes.",
+      queue: this.queue,
+      period: Duration.minutes(5),
+      threshold: Duration.minutes(15),
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
     });
 
     const dbSecret = aws_secretsmanager.Secret.fromSecretNameV2(
@@ -103,6 +117,45 @@ export class BudgetNeutralityProcessor extends Construct {
         },
       }
     );
+
+    alarms.createLambdaErrorsAlarm({
+      ...props,
+      scope: this,
+      id: "BudgetNeutralityLambdaErrorsAlarm",
+      name: "budget-neutrality-lambda-errors",
+      description: "Budget neutrality Lambda has one or more errors in a 5-minute period.",
+      lambdaFunction: budgetNeutralityLambda.lambda,
+      period: Duration.minutes(5),
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaDurationAlarm({
+      ...props,
+      scope: this,
+      id: "BudgetNeutralityLambdaDurationAlarm",
+      name: "budget-neutrality-lambda-duration-near-timeout",
+      description: "Budget neutrality Lambda duration is above 80% of its configured timeout.",
+      lambdaFunction: budgetNeutralityLambda.lambda,
+      period: Duration.minutes(5),
+      threshold: Duration.seconds(48),
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaThrottlesAlarm({
+      ...props,
+      scope: this,
+      id: "BudgetNeutralityLambdaThrottlesAlarm",
+      name: "budget-neutrality-lambda-throttles",
+      description: "Budget neutrality Lambda has one or more throttled invocations in a 5-minute period.",
+      lambdaFunction: budgetNeutralityLambda.lambda,
+      period: Duration.minutes(5),
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
 
     budgetNeutralityLambda.lambda.addEventSource(
       new SqsEventSource(this.queue, { batchSize: 1 })

--- a/deployment/lib/budgetNeutralityProcessor.ts
+++ b/deployment/lib/budgetNeutralityProcessor.ts
@@ -31,6 +31,7 @@ export class BudgetNeutralityProcessor extends Construct {
   constructor(scope: Construct, id: string, props: BudgetNeutralityProcessorProps) {
     super(scope, id);
 
+    const alarmResources = new alarms.CloudWatchAlarmRegistry();
     const removalPolicy = props.removalPolicy ?? RemovalPolicy.DESTROY;
 
     this.deadLetterQueue =
@@ -53,19 +54,7 @@ export class BudgetNeutralityProcessor extends Construct {
         maxReceiveCount: 5,
       },
     });
-
-    alarms.createSqsOldestMessageAgeAlarm({
-      ...props,
-      scope: this,
-      id: "BudgetNeutralityQueueOldestMessageAgeAlarm",
-      name: "budget-neutrality-queue-oldest-message-age-high",
-      description: "Budget neutrality queue has messages older than 15 minutes.",
-      queue: this.queue,
-      period: Duration.minutes(5),
-      threshold: Duration.minutes(15),
-      evaluationPeriods: 2,
-      datapointsToAlarm: 2,
-    });
+    alarmResources.registerQueue("budgetNeutrality", this.queue);
 
     const dbSecret = aws_secretsmanager.Secret.fromSecretNameV2(
       this,
@@ -117,6 +106,44 @@ export class BudgetNeutralityProcessor extends Construct {
         },
       }
     );
+    alarmResources.registerLambda("budgetNeutrality", budgetNeutralityLambda.lambda);
+
+    budgetNeutralityLambda.lambda.addEventSource(
+      new SqsEventSource(this.queue, { batchSize: 1 })
+    );
+
+    this.setupCloudWatchAlarms(props, alarmResources);
+
+    this.queue.grantConsumeMessages(budgetNeutralityLambda.lambda);
+    dbSecret.grantRead(budgetNeutralityLambda.lambda);
+    for (const bucket of props.readBuckets ?? []) {
+      bucket.grantRead(budgetNeutralityLambda.lambda);
+    }
+    props.kmsKey.grantEncryptDecrypt(budgetNeutralityLambda.lambda);
+  }
+
+  private setupCloudWatchAlarms(
+    props: DeploymentConfigProperties,
+    resources: alarms.CloudWatchAlarmRegistry
+  ) {
+    if (props.isEphemeral) {
+      return;
+    }
+
+    const alarmPeriod = Duration.minutes(5);
+
+    alarms.createSqsOldestMessageAgeAlarm({
+      ...props,
+      scope: this,
+      id: "BudgetNeutralityQueueOldestMessageAgeAlarm",
+      name: "budget-neutrality-queue-oldest-message-age-high",
+      description: "Budget neutrality queue has messages older than 15 minutes.",
+      queue: resources.queue("budgetNeutrality"),
+      period: alarmPeriod,
+      threshold: Duration.minutes(15),
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
 
     alarms.createLambdaErrorsAlarm({
       ...props,
@@ -124,8 +151,8 @@ export class BudgetNeutralityProcessor extends Construct {
       id: "BudgetNeutralityLambdaErrorsAlarm",
       name: "budget-neutrality-lambda-errors",
       description: "Budget neutrality Lambda has one or more errors in a 5-minute period.",
-      lambdaFunction: budgetNeutralityLambda.lambda,
-      period: Duration.minutes(5),
+      lambdaFunction: resources.lambda("budgetNeutrality"),
+      period: alarmPeriod,
       threshold: 0,
       evaluationPeriods: 1,
       datapointsToAlarm: 1,
@@ -137,8 +164,8 @@ export class BudgetNeutralityProcessor extends Construct {
       id: "BudgetNeutralityLambdaDurationAlarm",
       name: "budget-neutrality-lambda-duration-near-timeout",
       description: "Budget neutrality Lambda duration is above 80% of its configured timeout.",
-      lambdaFunction: budgetNeutralityLambda.lambda,
-      period: Duration.minutes(5),
+      lambdaFunction: resources.lambda("budgetNeutrality"),
+      period: alarmPeriod,
       threshold: Duration.seconds(48),
       evaluationPeriods: 1,
       datapointsToAlarm: 1,
@@ -150,22 +177,11 @@ export class BudgetNeutralityProcessor extends Construct {
       id: "BudgetNeutralityLambdaThrottlesAlarm",
       name: "budget-neutrality-lambda-throttles",
       description: "Budget neutrality Lambda has one or more throttled invocations in a 5-minute period.",
-      lambdaFunction: budgetNeutralityLambda.lambda,
-      period: Duration.minutes(5),
+      lambdaFunction: resources.lambda("budgetNeutrality"),
+      period: alarmPeriod,
       threshold: 0,
       evaluationPeriods: 1,
       datapointsToAlarm: 1,
     });
-
-    budgetNeutralityLambda.lambda.addEventSource(
-      new SqsEventSource(this.queue, { batchSize: 1 })
-    );
-
-    this.queue.grantConsumeMessages(budgetNeutralityLambda.lambda);
-    dbSecret.grantRead(budgetNeutralityLambda.lambda);
-    for (const bucket of props.readBuckets ?? []) {
-      bucket.grantRead(budgetNeutralityLambda.lambda);
-    }
-    props.kmsKey.grantEncryptDecrypt(budgetNeutralityLambda.lambda);
   }
 }

--- a/deployment/lib/lambda.ts
+++ b/deployment/lib/lambda.ts
@@ -126,7 +126,7 @@ export class Lambda extends Construct {
         sourceMap: true,
         externalModules: props.externalModules,
         nodeModules: props.nodeModules,
-        logLevel: LogLevel.VERBOSE,
+        logLevel: LogLevel.ERROR,
         commandHooks: props.commandHooks,
         format: props.format,
         esbuildArgs: props.esbuildArgs,

--- a/deployment/lib/uipathProcessor.test.ts
+++ b/deployment/lib/uipathProcessor.test.ts
@@ -43,6 +43,68 @@ describe("UiPathProcessor construct", () => {
 
     template.resourceCountIs("AWS::SQS::Queue", 2);
     template.resourceCountIs("AWS::Lambda::Function", 1);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 3);
     template.hasResourceProperties("AWS::Lambda::Function", Match.objectLike({}));
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "demos-unittest-uipath-lambda-errors",
+      ComparisonOperator: "GreaterThanThreshold",
+      MetricName: "Errors",
+      Namespace: "AWS/Lambda",
+      Period: 300,
+      Statistic: "Sum",
+      Threshold: 0,
+      TreatMissingData: "notBreaching",
+      Dimensions: Match.arrayWith([
+        Match.objectLike({
+          Name: "FunctionName",
+          Value: Match.objectLike({
+            Ref: Match.stringLikeRegexp("uipath"),
+          }),
+        }),
+      ]),
+    });
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "demos-unittest-uipath-queue-oldest-message-age-high",
+      ComparisonOperator: "GreaterThanThreshold",
+      EvaluationPeriods: 2,
+      DatapointsToAlarm: 2,
+      MetricName: "ApproximateAgeOfOldestMessage",
+      Namespace: "AWS/SQS",
+      Period: 300,
+      Statistic: "Maximum",
+      Threshold: 3600,
+      TreatMissingData: "notBreaching",
+      Dimensions: Match.arrayWith([
+        Match.objectLike({
+          Name: "QueueName",
+          Value: Match.anyValue(),
+        }),
+      ]),
+    });
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "demos-unittest-uipath-lambda-throttles",
+      ComparisonOperator: "GreaterThanThreshold",
+      MetricName: "Throttles",
+      Namespace: "AWS/Lambda",
+      Period: 300,
+      Statistic: "Sum",
+      Threshold: 0,
+      TreatMissingData: "notBreaching",
+      Dimensions: Match.arrayWith([
+        Match.objectLike({
+          Name: "FunctionName",
+          Value: Match.objectLike({
+            Ref: Match.stringLikeRegexp("uipath"),
+          }),
+        }),
+      ]),
+    });
+    template.resourcePropertiesCountIs(
+      "AWS::CloudWatch::Alarm",
+      {
+        AlarmName: "demos-unittest-uipath-lambda-duration-near-timeout",
+      },
+      0
+    );
   });
 });

--- a/deployment/lib/uipathProcessor.test.ts
+++ b/deployment/lib/uipathProcessor.test.ts
@@ -107,4 +107,30 @@ describe("UiPathProcessor construct", () => {
       0
     );
   });
+
+  it("does not synthesize alarms when ephemeral", () => {
+    const app = new App({
+      context: {
+        [BUNDLING_STACKS]: [],
+      },
+    });
+
+    const stack = new Stack(app, "uiPathProcessorTest", {
+      env: { account: "0123456789", region: "us-east-1" },
+    });
+
+    new UiPathProcessor(stack, "UiPathProcessor", {
+      ...mockProps,
+      isEphemeral: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      documentsBucket: new Bucket(stack, "UiPathDocumentsBucket"),
+      kmsKey: new Key(stack, "UiPathKmsKey"),
+    });
+
+    const template = Template.fromStack(stack);
+
+    template.resourceCountIs("AWS::SQS::Queue", 2);
+    template.resourceCountIs("AWS::Lambda::Function", 1);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+  });
 });

--- a/deployment/lib/uipathProcessor.ts
+++ b/deployment/lib/uipathProcessor.ts
@@ -119,7 +119,7 @@ export class UiPathProcessor extends Construct {
     props: DeploymentConfigProperties,
     resources: alarms.CloudWatchAlarmRegistry
   ) {
-    if (props.isEphemeral) {
+    if (props.isEphemeral && !props.enableAlarms) {
       return;
     }
 

--- a/deployment/lib/uipathProcessor.ts
+++ b/deployment/lib/uipathProcessor.ts
@@ -32,6 +32,7 @@ export class UiPathProcessor extends Construct {
   constructor(scope: Construct, id: string, props: UiPathProcessorProps) {
     super(scope, id);
 
+    const alarmResources = new alarms.CloudWatchAlarmRegistry();
     const removalPolicy = props.removalPolicy ?? RemovalPolicy.DESTROY;
 
     this.deadLetterQueue =
@@ -54,19 +55,7 @@ export class UiPathProcessor extends Construct {
         maxReceiveCount: 5,
       },
     });
-
-    alarms.createSqsOldestMessageAgeAlarm({
-      ...props,
-      scope: this,
-      id: "UiPathQueueOldestMessageAgeAlarm",
-      name: "uipath-queue-oldest-message-age-high",
-      description: "UiPath queue has messages older than 60 minutes.",
-      queue: this.queue,
-      period: Duration.minutes(5),
-      threshold: Duration.minutes(60),
-      evaluationPeriods: 2,
-      datapointsToAlarm: 2,
-    });
+    alarmResources.registerQueue("uipath", this.queue);
 
     const clientSecret = aws_secretsmanager.Secret.fromSecretNameV2(
       this,
@@ -108,34 +97,11 @@ export class UiPathProcessor extends Construct {
         NODE_EXTRA_CA_CERTS: "/var/runtime/ca-cert.pem",
       },
     });
-
-    alarms.createLambdaErrorsAlarm({
-      ...props,
-      scope: this,
-      id: "UiPathLambdaErrorsAlarm",
-      name: "uipath-lambda-errors",
-      description: "UiPath Lambda has one or more errors in a 5-minute period.",
-      lambdaFunction: uipathLambda.lambda,
-      period: Duration.minutes(5),
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
-
-    alarms.createLambdaThrottlesAlarm({
-      ...props,
-      scope: this,
-      id: "UiPathLambdaThrottlesAlarm",
-      name: "uipath-lambda-throttles",
-      description: "UiPath Lambda has one or more throttled invocations in a 5-minute period.",
-      lambdaFunction: uipathLambda.lambda,
-      period: Duration.minutes(5),
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
+    alarmResources.registerLambda("uipath", uipathLambda.lambda);
 
     uipathLambda.lambda.addEventSource(new SqsEventSource(this.queue, { batchSize: 1 }));
+
+    this.setupCloudWatchAlarms(props, alarmResources);
 
     // Grants
     this.queue.grantConsumeMessages(uipathLambda.lambda);
@@ -147,5 +113,55 @@ export class UiPathProcessor extends Construct {
     }
 
     props.kmsKey.grantEncryptDecrypt(uipathLambda.lambda);
+  }
+
+  private setupCloudWatchAlarms(
+    props: DeploymentConfigProperties,
+    resources: alarms.CloudWatchAlarmRegistry
+  ) {
+    if (props.isEphemeral) {
+      return;
+    }
+
+    const alarmPeriod = Duration.minutes(5);
+
+    alarms.createSqsOldestMessageAgeAlarm({
+      ...props,
+      scope: this,
+      id: "UiPathQueueOldestMessageAgeAlarm",
+      name: "uipath-queue-oldest-message-age-high",
+      description: "UiPath queue has messages older than 60 minutes.",
+      queue: resources.queue("uipath"),
+      period: alarmPeriod,
+      threshold: Duration.minutes(60),
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createLambdaErrorsAlarm({
+      ...props,
+      scope: this,
+      id: "UiPathLambdaErrorsAlarm",
+      name: "uipath-lambda-errors",
+      description: "UiPath Lambda has one or more errors in a 5-minute period.",
+      lambdaFunction: resources.lambda("uipath"),
+      period: alarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaThrottlesAlarm({
+      ...props,
+      scope: this,
+      id: "UiPathLambdaThrottlesAlarm",
+      name: "uipath-lambda-throttles",
+      description: "UiPath Lambda has one or more throttled invocations in a 5-minute period.",
+      lambdaFunction: resources.lambda("uipath"),
+      period: alarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
   }
 }

--- a/deployment/lib/uipathProcessor.ts
+++ b/deployment/lib/uipathProcessor.ts
@@ -10,6 +10,7 @@ import {
 } from "aws-cdk-lib";
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import * as demosLambda from "./lambda";
+import * as alarms from "./alarms";
 import path from "node:path";
 import { DeploymentConfigProperties } from "../config";
 import { OutputFormat } from "aws-cdk-lib/aws-lambda-nodejs";
@@ -54,6 +55,19 @@ export class UiPathProcessor extends Construct {
       },
     });
 
+    alarms.createSqsOldestMessageAgeAlarm({
+      ...props,
+      scope: this,
+      id: "UiPathQueueOldestMessageAgeAlarm",
+      name: "uipath-queue-oldest-message-age-high",
+      description: "UiPath queue has messages older than 60 minutes.",
+      queue: this.queue,
+      period: Duration.minutes(5),
+      threshold: Duration.minutes(60),
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
     const clientSecret = aws_secretsmanager.Secret.fromSecretNameV2(
       this,
       "UiPathClientSecret",
@@ -93,6 +107,32 @@ export class UiPathProcessor extends Construct {
         CLEAN_BUCKET: cleanReadBucket?.bucketName ?? "",
         NODE_EXTRA_CA_CERTS: "/var/runtime/ca-cert.pem",
       },
+    });
+
+    alarms.createLambdaErrorsAlarm({
+      ...props,
+      scope: this,
+      id: "UiPathLambdaErrorsAlarm",
+      name: "uipath-lambda-errors",
+      description: "UiPath Lambda has one or more errors in a 5-minute period.",
+      lambdaFunction: uipathLambda.lambda,
+      period: Duration.minutes(5),
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaThrottlesAlarm({
+      ...props,
+      scope: this,
+      id: "UiPathLambdaThrottlesAlarm",
+      name: "uipath-lambda-throttles",
+      description: "UiPath Lambda has one or more throttled invocations in a 5-minute period.",
+      lambdaFunction: uipathLambda.lambda,
+      period: Duration.minutes(5),
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
     });
 
     uipathLambda.lambda.addEventSource(new SqsEventSource(this.queue, { batchSize: 1 }));

--- a/deployment/nag-suppressions.ts
+++ b/deployment/nag-suppressions.ts
@@ -21,6 +21,15 @@ export function applyCoreSuppressions(core: Stack, stage: string) {
       }
     ]
   )
+
+  NagSuppressions.addResourceSuppressionsByPath(core, `/demos-${stage}-core/notifier/notifierLambdaExecutionRole/Resource`, 
+    [
+      {
+        id: "AwsSolutions-IAM5",
+        reason: "Permissions given are required for the lambda execution role"
+      }
+    ]
+  )
 }
 
 export function applyUISuppressionsCloudfrontOnly(ui: Stack) {

--- a/deployment/package-lock.json
+++ b/deployment/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1053.0",
         "@eslint/js": "^9.39.4",
+        "@types/aws-lambda": "^8.10.161",
         "@types/node": "^24.12.4",
         "@types/pg": "^8.20.0",
         "@vitest/coverage-v8": "^4.1.7",
@@ -1968,6 +1969,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.161",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
+      "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2896,6 +2904,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2911,6 +2920,7 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
       "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3445,6 +3455,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -3919,6 +3930,7 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -4257,6 +4269,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4300,6 +4313,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
       "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/deployment/package.json
+++ b/deployment/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@aws-sdk/client-secrets-manager": "^3.1053.0",
     "@eslint/js": "^9.39.4",
+    "@types/aws-lambda": "^8.10.161",
     "@types/node": "^24.12.4",
     "@types/pg": "^8.20.0",
     "@vitest/coverage-v8": "^4.1.7",

--- a/deployment/stacks/api.test.ts
+++ b/deployment/stacks/api.test.ts
@@ -288,6 +288,34 @@ describe("Api Stack", () => {
     });
   });
 
+  test("should not create alarms when ephemeral", () => {
+    const app = new App(commongAppArgs);
+    const mockCoreStack = new Stack(app, "mockCore");
+
+    const mockPrivateSubnets = ["subnet-private1", "subnet-private2"];
+    const mockVpc = aws_ec2.Vpc.fromVpcAttributes(mockCoreStack, "mockVpc", {
+      vpcId: "vpc-123456789",
+      availabilityZones: ["us-east-1a", "us-east-1b"],
+      publicSubnetIds: ["subnet-public1", "subnet-public2"],
+      privateSubnetIds: mockPrivateSubnets,
+    });
+
+    const apiStack = new ApiStack(app, "mockApi", {
+      ...mockCommonProps,
+      isEphemeral: true,
+      env: {
+        region: "us-east-1",
+        account: "0123456789",
+      },
+      vpc: mockVpc,
+    });
+
+    const template = Template.fromStack(apiStack);
+
+    template.resourceCountIs("AWS::Lambda::Function", 3);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+  });
+
   test("UiPathProcessor construct synthesizes queue, DLQ, and lambda", () => {
     const app = new App(commongAppArgs);
     const stack = new Stack(app, "uipathTest", {

--- a/deployment/stacks/api.test.ts
+++ b/deployment/stacks/api.test.ts
@@ -26,6 +26,134 @@ const mockCommonProps: DeploymentConfigProperties = {
   dataConnectRoleArn: "arn:aws:iam::1234567890:role/dataconnectrole",
 };
 
+function expectLambdaErrorsAlarm(
+  template: Template,
+  alarmName: string,
+  functionRefPattern: string
+) {
+  template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+    AlarmName: alarmName,
+    ComparisonOperator: "GreaterThanThreshold",
+    EvaluationPeriods: 1,
+    DatapointsToAlarm: 1,
+    MetricName: "Errors",
+    Namespace: "AWS/Lambda",
+    Period: 300,
+    Statistic: "Sum",
+    Threshold: 0,
+    TreatMissingData: "notBreaching",
+    Dimensions: Match.arrayWith([
+      Match.objectLike({
+        Name: "FunctionName",
+        Value: Match.objectLike({
+          Ref: Match.stringLikeRegexp(functionRefPattern),
+        }),
+      }),
+    ]),
+  });
+}
+
+function expectLambdaDurationAlarm(
+  template: Template,
+  alarmName: string,
+  functionRefPattern: string,
+  thresholdMilliseconds: number
+) {
+  template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+    AlarmName: alarmName,
+    ComparisonOperator: "GreaterThanThreshold",
+    EvaluationPeriods: 1,
+    DatapointsToAlarm: 1,
+    MetricName: "Duration",
+    Namespace: "AWS/Lambda",
+    Period: 300,
+    Statistic: "Maximum",
+    Threshold: thresholdMilliseconds,
+    TreatMissingData: "notBreaching",
+    Dimensions: Match.arrayWith([
+      Match.objectLike({
+        Name: "FunctionName",
+        Value: Match.objectLike({
+          Ref: Match.stringLikeRegexp(functionRefPattern),
+        }),
+      }),
+    ]),
+  });
+}
+
+function expectLambdaThrottlesAlarm(
+  template: Template,
+  alarmName: string,
+  functionRefPattern: string
+) {
+  template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+    AlarmName: alarmName,
+    ComparisonOperator: "GreaterThanThreshold",
+    EvaluationPeriods: 1,
+    DatapointsToAlarm: 1,
+    MetricName: "Throttles",
+    Namespace: "AWS/Lambda",
+    Period: 300,
+    Statistic: "Sum",
+    Threshold: 0,
+    TreatMissingData: "notBreaching",
+    Dimensions: Match.arrayWith([
+      Match.objectLike({
+        Name: "FunctionName",
+        Value: Match.objectLike({
+          Ref: Match.stringLikeRegexp(functionRefPattern),
+        }),
+      }),
+    ]),
+  });
+}
+
+function expectSqsOldestMessageAgeAlarm(
+  template: Template,
+  alarmName: string,
+  thresholdSeconds: number
+) {
+  template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+    AlarmName: alarmName,
+    ComparisonOperator: "GreaterThanThreshold",
+    EvaluationPeriods: 2,
+    DatapointsToAlarm: 2,
+    MetricName: "ApproximateAgeOfOldestMessage",
+    Namespace: "AWS/SQS",
+    Period: 300,
+    Statistic: "Maximum",
+    Threshold: thresholdSeconds,
+    TreatMissingData: "notBreaching",
+    Dimensions: Match.arrayWith([
+      Match.objectLike({
+        Name: "QueueName",
+        Value: Match.anyValue(),
+      }),
+    ]),
+  });
+}
+
+function expectSqsVisibleMessagesAlarm(template: Template, alarmName: string) {
+  template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+    AlarmName: alarmName,
+    ComparisonOperator: "GreaterThanThreshold",
+    EvaluationPeriods: 1,
+    DatapointsToAlarm: 1,
+    MetricName: "ApproximateNumberOfMessagesVisible",
+    Namespace: "AWS/SQS",
+    Period: 300,
+    Statistic: "Maximum",
+    Threshold: 0,
+    TreatMissingData: "notBreaching",
+    Dimensions: Match.arrayWith([
+      Match.objectLike({
+        Name: "QueueName",
+        Value: Match.anyValue(),
+      }),
+    ]),
+  });
+}
+
 describe("Api Stack", () => {
   test("should create proper resources when non-ephemeral", () => {
     const app = new App(commongAppArgs);
@@ -62,6 +190,7 @@ describe("Api Stack", () => {
     template.resourceCountIs("AWS::Lambda::Function", 3);
     template.resourceCountIs("AWS::ApiGateway::RestApi", 1);
     template.resourceCountIs("AWS::ApiGateway::Authorizer", 1);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 10);
 
     template.hasOutput("ApiUrl", {
       Export: {
@@ -74,7 +203,70 @@ describe("Api Stack", () => {
     });
     template.hasResourceProperties("AWS::Lambda::Function", {
       FunctionName: "demos-unittest-authorizer",
+      Timeout: 10,
     });
+    template.hasResourceProperties("AWS::Lambda::Function", {
+      FunctionName: "demos-unittest-emailer",
+    });
+
+    expectLambdaErrorsAlarm(
+      template,
+      "demos-unittest-authorizer-lambda-errors",
+      "authorizer"
+    );
+    expectLambdaErrorsAlarm(
+      template,
+      "demos-unittest-graphql-lambda-errors",
+      "graphql"
+    );
+    expectLambdaErrorsAlarm(
+      template,
+      "demos-unittest-emailer-lambda-errors",
+      "emailer"
+    );
+    expectLambdaDurationAlarm(
+      template,
+      "demos-unittest-authorizer-lambda-duration-near-timeout",
+      "authorizer",
+      8000
+    );
+    expectLambdaDurationAlarm(
+      template,
+      "demos-unittest-emailer-lambda-duration-near-timeout",
+      "emailer",
+      48000
+    );
+    expectLambdaThrottlesAlarm(
+      template,
+      "demos-unittest-authorizer-lambda-throttles",
+      "authorizer"
+    );
+    expectLambdaThrottlesAlarm(
+      template,
+      "demos-unittest-graphql-lambda-throttles",
+      "graphql"
+    );
+    expectLambdaThrottlesAlarm(
+      template,
+      "demos-unittest-emailer-lambda-throttles",
+      "emailer"
+    );
+    template.resourcePropertiesCountIs(
+      "AWS::CloudWatch::Alarm",
+      {
+        AlarmName: "demos-unittest-graphql-lambda-duration-near-timeout",
+      },
+      0
+    );
+    expectSqsOldestMessageAgeAlarm(
+      template,
+      "demos-unittest-emailer-queue-oldest-message-age-high",
+      900
+    );
+    expectSqsVisibleMessagesAlarm(
+      template,
+      "demos-unittest-emailer-dlq-visible-messages"
+    );
 
     template.hasResourceProperties("AWS::EC2::SecurityGroupEgress", {
       GroupId: Match.objectEquals({

--- a/deployment/stacks/api.ts
+++ b/deployment/stacks/api.ts
@@ -19,6 +19,7 @@ import { DeploymentConfigProperties } from "../config";
 
 import * as apigateway from "../lib/apigateway";
 import * as lambda from "../lib/lambda";
+import * as alarms from "../lib/alarms";
 import * as securityGroup from "../lib/security-group";
 import { IVpc } from "aws-cdk-lib/aws-ec2";
 import importNumberValue from "../util/importNumberValue";
@@ -53,6 +54,9 @@ export class ApiStack extends Stack {
             )
           ,
     };
+    const lambdaErrorAlarmPeriod = Duration.minutes(5);
+    const sqsOldestMessageAgeAlarmPeriod = Duration.minutes(5);
+    const sqsVisibleMessagesAlarmPeriod = Duration.minutes(5);
 
     const graphqlLambdaSecurityGroup = securityGroup.create({
       ...commonProps,
@@ -142,9 +146,46 @@ export class ApiStack extends Stack {
         externalModules: ["aws-sdk"],
         nodeModules: ["jsonwebtoken", "jwks-rsa", "pino"],
         depsLockFilePath: path.join(rel, "package-lock.json"),
+        timeout: Duration.seconds(10),
       },
       "authorizer"
     );
+
+    alarms.createLambdaErrorsAlarm({
+      ...commonProps,
+      id: "AuthorizerLambdaErrorsAlarm",
+      name: "authorizer-lambda-errors",
+      description: "Authorizer Lambda has one or more errors in a 5-minute period.",
+      lambdaFunction: authorizerLambda.lambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaDurationAlarm({
+      ...commonProps,
+      id: "AuthorizerLambdaDurationAlarm",
+      name: "authorizer-lambda-duration-near-timeout",
+      description: "Authorizer Lambda duration is above 80% of its configured timeout.",
+      lambdaFunction: authorizerLambda.lambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: Duration.seconds(8),
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaThrottlesAlarm({
+      ...commonProps,
+      id: "AuthorizerLambdaThrottlesAlarm",
+      name: "authorizer-lambda-throttles",
+      description: "Authorizer Lambda has one or more throttled invocations in a 5-minute period.",
+      lambdaFunction: authorizerLambda.lambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
 
     const tokenAuthorizer = new aws_apigateway.TokenAuthorizer(
       commonProps.scope,
@@ -194,6 +235,30 @@ export class ApiStack extends Stack {
       },
       "graphql"
     );
+    alarms.createLambdaErrorsAlarm({
+      ...commonProps,
+      id: "GraphqlLambdaErrorsAlarm",
+      name: "graphql-lambda-errors",
+      description: "GraphQL Lambda has one or more errors in a 5-minute period.",
+      lambdaFunction: graphqlLambda.lambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaThrottlesAlarm({
+      ...commonProps,
+      id: "GraphqlLambdaThrottlesAlarm",
+      name: "graphql-lambda-throttles",
+      description: "GraphQL Lambda has one or more throttled invocations in a 5-minute period.",
+      lambdaFunction: graphqlLambda.lambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
     dbSecret.grantRead(graphqlLambda.lambda.role);
     uploadBucket.grantPut(graphqlLambda.lambda.role);
     cleanBucket.grantDelete(graphqlLambda.lambda.role);
@@ -222,6 +287,18 @@ export class ApiStack extends Stack {
       encryptionMasterKey: kmsKey,
     });
 
+    alarms.createSqsVisibleMessagesAlarm({
+      ...commonProps,
+      id: "EmailerDlqVisibleMessagesAlarm",
+      name: "emailer-dlq-visible-messages",
+      description: "Emailer DLQ contains one or more messages.",
+      queue: deadLetterQueue,
+      period: sqsVisibleMessagesAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
     const emailQueue = new Queue(this, "EmailerQueue", {
       removalPolicy: RemovalPolicy.DESTROY,
       enforceSSL: true,
@@ -232,6 +309,18 @@ export class ApiStack extends Stack {
       encryption: QueueEncryption.KMS,
       encryptionMasterKey: kmsKey,
       visibilityTimeout: emailerTimeout,
+    });
+
+    alarms.createSqsOldestMessageAgeAlarm({
+      ...commonProps,
+      id: "EmailerQueueOldestMessageAgeAlarm",
+      name: "emailer-queue-oldest-message-age-high",
+      description: "Emailer queue has messages older than 15 minutes.",
+      queue: emailQueue,
+      period: sqsOldestMessageAgeAlarmPeriod,
+      threshold: Duration.minutes(15),
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
     });
 
     const emailerLambdaSecurityGroup = securityGroup.create({
@@ -295,6 +384,42 @@ export class ApiStack extends Stack {
           return [];
         },
       },
+    });
+
+    alarms.createLambdaErrorsAlarm({
+      ...commonProps,
+      id: "EmailerLambdaErrorsAlarm",
+      name: "emailer-lambda-errors",
+      description: "Emailer Lambda has one or more errors in a 5-minute period.",
+      lambdaFunction: emailerLambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaDurationAlarm({
+      ...commonProps,
+      id: "EmailerLambdaDurationAlarm",
+      name: "emailer-lambda-duration-near-timeout",
+      description: "Emailer Lambda duration is above 80% of its configured timeout.",
+      lambdaFunction: emailerLambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: Duration.seconds(48),
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaThrottlesAlarm({
+      ...commonProps,
+      id: "EmailerLambdaThrottlesAlarm",
+      name: "emailer-lambda-throttles",
+      description: "Emailer Lambda has one or more throttled invocations in a 5-minute period.",
+      lambdaFunction: emailerLambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
     });
 
     if (commonProps.stage != "prod") {

--- a/deployment/stacks/api.ts
+++ b/deployment/stacks/api.ts
@@ -342,7 +342,7 @@ export class ApiStack extends Stack {
     props: DeploymentConfigProperties,
     resources: alarms.CloudWatchAlarmRegistry
   ) {
-    if (props.isEphemeral) {
+    if (props.isEphemeral && !props.enableAlarms) {
       return;
     }
 

--- a/deployment/stacks/api.ts
+++ b/deployment/stacks/api.ts
@@ -54,9 +54,7 @@ export class ApiStack extends Stack {
             )
           ,
     };
-    const lambdaErrorAlarmPeriod = Duration.minutes(5);
-    const sqsOldestMessageAgeAlarmPeriod = Duration.minutes(5);
-    const sqsVisibleMessagesAlarmPeriod = Duration.minutes(5);
+    const alarmResources = new alarms.CloudWatchAlarmRegistry();
 
     const graphqlLambdaSecurityGroup = securityGroup.create({
       ...commonProps,
@@ -150,42 +148,7 @@ export class ApiStack extends Stack {
       },
       "authorizer"
     );
-
-    alarms.createLambdaErrorsAlarm({
-      ...commonProps,
-      id: "AuthorizerLambdaErrorsAlarm",
-      name: "authorizer-lambda-errors",
-      description: "Authorizer Lambda has one or more errors in a 5-minute period.",
-      lambdaFunction: authorizerLambda.lambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
-
-    alarms.createLambdaDurationAlarm({
-      ...commonProps,
-      id: "AuthorizerLambdaDurationAlarm",
-      name: "authorizer-lambda-duration-near-timeout",
-      description: "Authorizer Lambda duration is above 80% of its configured timeout.",
-      lambdaFunction: authorizerLambda.lambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: Duration.seconds(8),
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
-
-    alarms.createLambdaThrottlesAlarm({
-      ...commonProps,
-      id: "AuthorizerLambdaThrottlesAlarm",
-      name: "authorizer-lambda-throttles",
-      description: "Authorizer Lambda has one or more throttled invocations in a 5-minute period.",
-      lambdaFunction: authorizerLambda.lambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
+    alarmResources.registerLambda("authorizer", authorizerLambda.lambda.lambda);
 
     const tokenAuthorizer = new aws_apigateway.TokenAuthorizer(
       commonProps.scope,
@@ -235,29 +198,7 @@ export class ApiStack extends Stack {
       },
       "graphql"
     );
-    alarms.createLambdaErrorsAlarm({
-      ...commonProps,
-      id: "GraphqlLambdaErrorsAlarm",
-      name: "graphql-lambda-errors",
-      description: "GraphQL Lambda has one or more errors in a 5-minute period.",
-      lambdaFunction: graphqlLambda.lambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
-
-    alarms.createLambdaThrottlesAlarm({
-      ...commonProps,
-      id: "GraphqlLambdaThrottlesAlarm",
-      name: "graphql-lambda-throttles",
-      description: "GraphQL Lambda has one or more throttled invocations in a 5-minute period.",
-      lambdaFunction: graphqlLambda.lambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
+    alarmResources.registerLambda("graphql", graphqlLambda.lambda.lambda);
 
     dbSecret.grantRead(graphqlLambda.lambda.role);
     uploadBucket.grantPut(graphqlLambda.lambda.role);
@@ -286,18 +227,7 @@ export class ApiStack extends Stack {
       encryption: QueueEncryption.KMS,
       encryptionMasterKey: kmsKey,
     });
-
-    alarms.createSqsVisibleMessagesAlarm({
-      ...commonProps,
-      id: "EmailerDlqVisibleMessagesAlarm",
-      name: "emailer-dlq-visible-messages",
-      description: "Emailer DLQ contains one or more messages.",
-      queue: deadLetterQueue,
-      period: sqsVisibleMessagesAlarmPeriod,
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
+    alarmResources.registerQueue("emailerDeadLetter", deadLetterQueue);
 
     const emailQueue = new Queue(this, "EmailerQueue", {
       removalPolicy: RemovalPolicy.DESTROY,
@@ -310,18 +240,7 @@ export class ApiStack extends Stack {
       encryptionMasterKey: kmsKey,
       visibilityTimeout: emailerTimeout,
     });
-
-    alarms.createSqsOldestMessageAgeAlarm({
-      ...commonProps,
-      id: "EmailerQueueOldestMessageAgeAlarm",
-      name: "emailer-queue-oldest-message-age-high",
-      description: "Emailer queue has messages older than 15 minutes.",
-      queue: emailQueue,
-      period: sqsOldestMessageAgeAlarmPeriod,
-      threshold: Duration.minutes(15),
-      evaluationPeriods: 2,
-      datapointsToAlarm: 2,
-    });
+    alarmResources.registerQueue("emailer", emailQueue);
 
     const emailerLambdaSecurityGroup = securityGroup.create({
       ...commonProps,
@@ -385,42 +304,7 @@ export class ApiStack extends Stack {
         },
       },
     });
-
-    alarms.createLambdaErrorsAlarm({
-      ...commonProps,
-      id: "EmailerLambdaErrorsAlarm",
-      name: "emailer-lambda-errors",
-      description: "Emailer Lambda has one or more errors in a 5-minute period.",
-      lambdaFunction: emailerLambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
-
-    alarms.createLambdaDurationAlarm({
-      ...commonProps,
-      id: "EmailerLambdaDurationAlarm",
-      name: "emailer-lambda-duration-near-timeout",
-      description: "Emailer Lambda duration is above 80% of its configured timeout.",
-      lambdaFunction: emailerLambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: Duration.seconds(48),
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
-
-    alarms.createLambdaThrottlesAlarm({
-      ...commonProps,
-      id: "EmailerLambdaThrottlesAlarm",
-      name: "emailer-lambda-throttles",
-      description: "Emailer Lambda has one or more throttled invocations in a 5-minute period.",
-      lambdaFunction: emailerLambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
+    alarmResources.registerLambda("emailer", emailerLambda.lambda);
 
     if (commonProps.stage != "prod") {
       const allowListParam = aws_ssm.StringParameter.fromStringParameterName(
@@ -444,11 +328,156 @@ export class ApiStack extends Stack {
       })
     );
 
+    this.setupCloudWatchAlarms(props, alarmResources);
+
     // Outputs
 
     new CfnOutput(this, "ApiUrl", {
       value: apigateway_outputs.apiGatewayRestApiUrl,
       exportName: `${commonProps.stage}ApiGWUrl`,
+    });
+  }
+
+  private setupCloudWatchAlarms(
+    props: DeploymentConfigProperties,
+    resources: alarms.CloudWatchAlarmRegistry
+  ) {
+    if (props.isEphemeral) {
+      return;
+    }
+
+    const lambdaAlarmPeriod = Duration.minutes(5);
+    const sqsOldestMessageAgeAlarmPeriod = Duration.minutes(5);
+    const sqsVisibleMessagesAlarmPeriod = Duration.minutes(5);
+
+    alarms.createLambdaErrorsAlarm({
+      ...props,
+      scope: this,
+      id: "AuthorizerLambdaErrorsAlarm",
+      name: "authorizer-lambda-errors",
+      description: "Authorizer Lambda has one or more errors in a 5-minute period.",
+      lambdaFunction: resources.lambda("authorizer"),
+      period: lambdaAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaDurationAlarm({
+      ...props,
+      scope: this,
+      id: "AuthorizerLambdaDurationAlarm",
+      name: "authorizer-lambda-duration-near-timeout",
+      description: "Authorizer Lambda duration is above 80% of its configured timeout.",
+      lambdaFunction: resources.lambda("authorizer"),
+      period: lambdaAlarmPeriod,
+      threshold: Duration.seconds(8),
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaThrottlesAlarm({
+      ...props,
+      scope: this,
+      id: "AuthorizerLambdaThrottlesAlarm",
+      name: "authorizer-lambda-throttles",
+      description: "Authorizer Lambda has one or more throttled invocations in a 5-minute period.",
+      lambdaFunction: resources.lambda("authorizer"),
+      period: lambdaAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaErrorsAlarm({
+      ...props,
+      scope: this,
+      id: "GraphqlLambdaErrorsAlarm",
+      name: "graphql-lambda-errors",
+      description: "GraphQL Lambda has one or more errors in a 5-minute period.",
+      lambdaFunction: resources.lambda("graphql"),
+      period: lambdaAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaThrottlesAlarm({
+      ...props,
+      scope: this,
+      id: "GraphqlLambdaThrottlesAlarm",
+      name: "graphql-lambda-throttles",
+      description: "GraphQL Lambda has one or more throttled invocations in a 5-minute period.",
+      lambdaFunction: resources.lambda("graphql"),
+      period: lambdaAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createSqsVisibleMessagesAlarm({
+      ...props,
+      scope: this,
+      id: "EmailerDlqVisibleMessagesAlarm",
+      name: "emailer-dlq-visible-messages",
+      description: "Emailer DLQ contains one or more messages.",
+      queue: resources.queue("emailerDeadLetter"),
+      period: sqsVisibleMessagesAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createSqsOldestMessageAgeAlarm({
+      ...props,
+      scope: this,
+      id: "EmailerQueueOldestMessageAgeAlarm",
+      name: "emailer-queue-oldest-message-age-high",
+      description: "Emailer queue has messages older than 15 minutes.",
+      queue: resources.queue("emailer"),
+      period: sqsOldestMessageAgeAlarmPeriod,
+      threshold: Duration.minutes(15),
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createLambdaErrorsAlarm({
+      ...props,
+      scope: this,
+      id: "EmailerLambdaErrorsAlarm",
+      name: "emailer-lambda-errors",
+      description: "Emailer Lambda has one or more errors in a 5-minute period.",
+      lambdaFunction: resources.lambda("emailer"),
+      period: lambdaAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaDurationAlarm({
+      ...props,
+      scope: this,
+      id: "EmailerLambdaDurationAlarm",
+      name: "emailer-lambda-duration-near-timeout",
+      description: "Emailer Lambda duration is above 80% of its configured timeout.",
+      lambdaFunction: resources.lambda("emailer"),
+      period: lambdaAlarmPeriod,
+      threshold: Duration.seconds(48),
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaThrottlesAlarm({
+      ...props,
+      scope: this,
+      id: "EmailerLambdaThrottlesAlarm",
+      name: "emailer-lambda-throttles",
+      description: "Emailer Lambda has one or more throttled invocations in a 5-minute period.",
+      lambdaFunction: resources.lambda("emailer"),
+      period: lambdaAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
     });
   }
 }

--- a/deployment/stacks/core.ts
+++ b/deployment/stacks/core.ts
@@ -1,4 +1,4 @@
-import { CfnOutput, Stack, StackProps, aws_iam, aws_cognito, aws_ec2, RemovalPolicy, aws_s3, Duration, aws_kms } from "aws-cdk-lib";
+import { CfnOutput, Stack, StackProps, aws_iam, aws_cognito, aws_ec2, RemovalPolicy, aws_s3, Duration, aws_kms, aws_ssm } from "aws-cdk-lib";
 import { Construct } from "constructs";
 
 import { DeploymentConfigProperties } from "../config";
@@ -7,6 +7,8 @@ import * as cognito from "../lib/cognito";
 import * as ssm from "../lib/ssm-parameter";
 import * as securityGroup from "../lib/security-group";
 import { Bucket } from "aws-cdk-lib/aws-s3";
+import * as lambda from "../lib/lambda";
+import * as path from "node:path"
 
 export class CoreStack extends Stack {
   public readonly cognito_outputs: aws_cognito.UserPool | aws_cognito.IUserPool;
@@ -183,6 +185,28 @@ export class CoreStack extends Stack {
       enableKeyRotation: true,
       alias: `alias/demos-${props.stage}-lambda-env`,
     });
+
+    const notifierPath = path.join(".", "lib");
+    const rel = path.resolve(notifierPath);
+    const notifierLambda = lambda.create(
+      {
+        ...commonProps,
+        entry: path.join(rel, "alarmNotifier.ts"),
+        handler: "index.handler",
+        asCode: false,
+        timeout: Duration.seconds(10),
+      },
+      "notifier"
+    );
+const webhookUrl = aws_ssm.StringParameter.fromSecureStringParameterAttributes(
+  this,
+  "webhookParam",
+  {
+    parameterName: "/demos/webhookUrl",
+  }
+);
+
+webhookUrl.grantRead(notifierLambda.lambda.role);
 
     new CfnOutput(commonProps.scope, "secretsManagerVpceSg", {
       value: secretsManagerEndpointSG.securityGroupId,

--- a/deployment/stacks/database.test.ts
+++ b/deployment/stacks/database.test.ts
@@ -152,6 +152,43 @@ describe("Database Stack", () => {
     });
   });
 
+  test("should not create alarms when ephemeral", () => {
+    const app = new App();
+    const mockCoreStack = new Stack(app, "mockCore");
+
+    const mockPrivateSubnets = ["subnet-private1", "subnet-private2"];
+    const mockVpc = aws_ec2.Vpc.fromVpcAttributes(mockCoreStack, "mockVpc", {
+      vpcId: "vpc-123456789",
+      availabilityZones: ["us-east-1a", "us-east-1b"],
+      publicSubnetIds: ["subnet-public1", "subnet-public2"],
+      privateSubnetIds: mockPrivateSubnets,
+    });
+
+    const mockSecurityGroupId = "sg-1234abcd";
+    const mockSecurityGroup = aws_ec2.SecurityGroup.fromSecurityGroupId(
+      mockCoreStack,
+      "mockSecurityGroup",
+      mockSecurityGroupId,
+    );
+
+    const databaseStack = new DatabaseStack(app, "mockDatabase", {
+      ...mockCommonProps,
+      isEphemeral: true,
+      env: {
+        region: "us-east-1",
+        account: "0123456789",
+      },
+      vpc: mockVpc,
+      cloudVpnSecurityGroup: mockSecurityGroup,
+      secretsManagerVpceSg: mockSecurityGroup,
+    });
+
+    const template = Template.fromStack(databaseStack);
+
+    template.resourceCountIs("AWS::RDS::DBInstance", 1);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+  });
+
   test("should retain rds for impl/prod", () => {
     const app = new App();
     const mockCoreStack = new Stack(app, "mockCore");

--- a/deployment/stacks/database.test.ts
+++ b/deployment/stacks/database.test.ts
@@ -16,6 +16,37 @@ const mockCommonProps: DeploymentConfigProperties = {
   dataConnectRoleArn: "arn:aws:iam::1234567890:role/dataconnectrole",
 };
 
+function expectRdsAlarm(
+  template: Template,
+  props: {
+    alarmName: string;
+    metricName: string;
+    comparisonOperator: string;
+    threshold: number;
+    evaluationPeriods?: number;
+    datapointsToAlarm?: number;
+  }
+) {
+  template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+    AlarmName: props.alarmName,
+    ComparisonOperator: props.comparisonOperator,
+    EvaluationPeriods: props.evaluationPeriods ?? 2,
+    DatapointsToAlarm: props.datapointsToAlarm ?? 2,
+    MetricName: props.metricName,
+    Namespace: "AWS/RDS",
+    Period: 300,
+    Statistic: "Average",
+    Threshold: props.threshold,
+    TreatMissingData: "notBreaching",
+    Dimensions: Match.arrayWith([
+      Match.objectLike({
+        Name: "DBInstanceIdentifier",
+        Value: Match.anyValue(),
+      }),
+    ]),
+  });
+}
+
 describe("Database Stack", () => {
   test("should create proper resources when non-ephemeral", () => {
     const app = new App();
@@ -52,6 +83,7 @@ describe("Database Stack", () => {
     template.resourceCountIs("AWS::EC2::SecurityGroup", 2);
     template.resourceCountIs("AWS::RDS::DBInstance", 1);
     template.resourceCountIs("AWS::KMS::Key", 1);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 7);
 
     template.hasResource("AWS::RDS::DBInstance", {
       DeletionPolicy: "Delete",
@@ -60,6 +92,51 @@ describe("Database Stack", () => {
     template.hasResourceProperties("AWS::RDS::DBInstance", {
       Engine: "postgres",
       DBInstanceClass: "db.t4g.micro",
+    });
+
+    expectRdsAlarm(template, {
+      alarmName: "demos-unittest-rds-free-storage-space-low",
+      metricName: "FreeStorageSpace",
+      comparisonOperator: "LessThanThreshold",
+      threshold: 5368709120,
+    });
+    expectRdsAlarm(template, {
+      alarmName: "demos-unittest-rds-cpu-utilization-high",
+      metricName: "CPUUtilization",
+      comparisonOperator: "GreaterThanThreshold",
+      threshold: 80,
+      evaluationPeriods: 3,
+      datapointsToAlarm: 3,
+    });
+    expectRdsAlarm(template, {
+      alarmName: "demos-unittest-rds-database-connections-high",
+      metricName: "DatabaseConnections",
+      comparisonOperator: "GreaterThanThreshold",
+      threshold: 80,
+    });
+    expectRdsAlarm(template, {
+      alarmName: "demos-unittest-rds-freeable-memory-low",
+      metricName: "FreeableMemory",
+      comparisonOperator: "LessThanThreshold",
+      threshold: 134217728,
+    });
+    expectRdsAlarm(template, {
+      alarmName: "demos-unittest-rds-read-latency-high",
+      metricName: "ReadLatency",
+      comparisonOperator: "GreaterThanThreshold",
+      threshold: 0.1,
+    });
+    expectRdsAlarm(template, {
+      alarmName: "demos-unittest-rds-write-latency-high",
+      metricName: "WriteLatency",
+      comparisonOperator: "GreaterThanThreshold",
+      threshold: 0.1,
+    });
+    expectRdsAlarm(template, {
+      alarmName: "demos-unittest-rds-disk-queue-depth-high",
+      metricName: "DiskQueueDepth",
+      comparisonOperator: "GreaterThanThreshold",
+      threshold: 5,
     });
 
     template.hasOutput("dbHost", {

--- a/deployment/stacks/database.ts
+++ b/deployment/stacks/database.ts
@@ -46,6 +46,7 @@ export class DatabaseStack extends Stack {
         props.iamPermissionsBoundaryArn == null
           ? undefined: aws_iam.ManagedPolicy.fromManagedPolicyArn(this, "iamPermissionsBoundary", props.iamPermissionsBoundaryArn),
     };
+    const alarmResources = new alarms.CloudWatchAlarmRegistry();
 
     const rdsSecurityGroup = securityGroup.create({
       ...commonProps,
@@ -129,6 +130,7 @@ export class DatabaseStack extends Stack {
         monitoringInterval:  ["prod", "impl"].includes(commonProps.stage) ?  Duration.seconds(60) : undefined
       }
     );
+    alarmResources.registerDatabaseInstance("rds", dbInstance);
 
     const cfnDbInstance = dbInstance.node.defaultChild as aws_rds.CfnDBInstance;
     cfnDbInstance.cfnOptions.metadata = {
@@ -149,114 +151,7 @@ export class DatabaseStack extends Stack {
 
     Aspects.of(this).add(new SuppressCheckovLogRetentionPolicy());
 
-    const rdsAlarmPeriod = Duration.minutes(5);
-    const gibibyte = 1024 * 1024 * 1024;
-    const mebibyte = 1024 * 1024;
-
-    alarms.createMetricAlarm({
-      ...commonProps,
-      id: "RdsFreeStorageSpaceAlarm",
-      name: "rds-free-storage-space-low",
-      description: "RDS free storage is below 5 GiB.",
-      metric: dbInstance.metricFreeStorageSpace({
-        period: rdsAlarmPeriod,
-        statistic: "Average",
-      }),
-      threshold: 5 * gibibyte,
-      comparisonOperator: aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
-      evaluationPeriods: 2,
-      datapointsToAlarm: 2,
-    });
-
-    alarms.createMetricAlarm({
-      ...commonProps,
-      id: "RdsCpuUtilizationAlarm",
-      name: "rds-cpu-utilization-high",
-      description: "RDS CPU utilization is above 80% for 15 minutes.",
-      metric: dbInstance.metricCPUUtilization({
-        period: rdsAlarmPeriod,
-        statistic: "Average",
-      }),
-      threshold: 80,
-      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: 3,
-      datapointsToAlarm: 3,
-    });
-
-    alarms.createMetricAlarm({
-      ...commonProps,
-      id: "RdsDatabaseConnectionsAlarm",
-      name: "rds-database-connections-high",
-      description: "RDS database connections are above the initial safe threshold.",
-      metric: dbInstance.metricDatabaseConnections({
-        period: rdsAlarmPeriod,
-        statistic: "Average",
-      }),
-      threshold: 80,
-      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: 2,
-      datapointsToAlarm: 2,
-    });
-
-    alarms.createMetricAlarm({
-      ...commonProps,
-      id: "RdsFreeableMemoryAlarm",
-      name: "rds-freeable-memory-low",
-      description: "RDS freeable memory is below 128 MiB.",
-      metric: dbInstance.metricFreeableMemory({
-        period: rdsAlarmPeriod,
-        statistic: "Average",
-      }),
-      threshold: 128 * mebibyte,
-      comparisonOperator: aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
-      evaluationPeriods: 2,
-      datapointsToAlarm: 2,
-    });
-
-    alarms.createMetricAlarm({
-      ...commonProps,
-      id: "RdsReadLatencyAlarm",
-      name: "rds-read-latency-high",
-      description: "RDS read latency is above 100 ms.",
-      metric: dbInstance.metric("ReadLatency", {
-        period: rdsAlarmPeriod,
-        statistic: "Average",
-      }),
-      threshold: 0.1,
-      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: 2,
-      datapointsToAlarm: 2,
-    });
-
-    alarms.createMetricAlarm({
-      ...commonProps,
-      id: "RdsWriteLatencyAlarm",
-      name: "rds-write-latency-high",
-      description: "RDS write latency is above 100 ms.",
-      metric: dbInstance.metric("WriteLatency", {
-        period: rdsAlarmPeriod,
-        statistic: "Average",
-      }),
-      threshold: 0.1,
-      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: 2,
-      datapointsToAlarm: 2,
-    });
-
-    alarms.createMetricAlarm({
-      ...commonProps,
-      id: "RdsDiskQueueDepthAlarm",
-      name: "rds-disk-queue-depth-high",
-      description: "RDS disk queue depth is above 5.",
-      metric: dbInstance.metric("DiskQueueDepth", {
-        period: rdsAlarmPeriod,
-        statistic: "Average",
-      }),
-      threshold: 5,
-      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: 2,
-      datapointsToAlarm: 2,
-    });
+    this.setupCloudWatchAlarms(commonProps, alarmResources);
 
     const cmsCloudLogFunc = aws_lambda.Function.fromFunctionName(
       commonProps.scope,
@@ -334,6 +229,132 @@ export class DatabaseStack extends Stack {
     new CfnOutput(commonProps.scope, "dbPort", {
       value: dbInstance.instanceEndpoint.port.toString(),
       exportName: `${commonProps.project}-${commonProps.stage}-rds-port`,
+    });
+  }
+
+  private setupCloudWatchAlarms(
+    props: DeploymentConfigProperties,
+    resources: alarms.CloudWatchAlarmRegistry
+  ) {
+    if (props.isEphemeral) {
+      return;
+    }
+
+    const dbInstance = resources.databaseInstance("rds");
+    const rdsAlarmPeriod = Duration.minutes(5);
+    const gibibyte = 1024 * 1024 * 1024;
+    const mebibyte = 1024 * 1024;
+
+    alarms.createMetricAlarm({
+      ...props,
+      scope: this,
+      id: "RdsFreeStorageSpaceAlarm",
+      name: "rds-free-storage-space-low",
+      description: "RDS free storage is below 5 GiB.",
+      metric: dbInstance.metricFreeStorageSpace({
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 5 * gibibyte,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createMetricAlarm({
+      ...props,
+      scope: this,
+      id: "RdsCpuUtilizationAlarm",
+      name: "rds-cpu-utilization-high",
+      description: "RDS CPU utilization is above 80% for 15 minutes.",
+      metric: dbInstance.metricCPUUtilization({
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 80,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 3,
+      datapointsToAlarm: 3,
+    });
+
+    alarms.createMetricAlarm({
+      ...props,
+      scope: this,
+      id: "RdsDatabaseConnectionsAlarm",
+      name: "rds-database-connections-high",
+      description: "RDS database connections are above the initial safe threshold.",
+      metric: dbInstance.metricDatabaseConnections({
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 80,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createMetricAlarm({
+      ...props,
+      scope: this,
+      id: "RdsFreeableMemoryAlarm",
+      name: "rds-freeable-memory-low",
+      description: "RDS freeable memory is below 128 MiB.",
+      metric: dbInstance.metricFreeableMemory({
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 128 * mebibyte,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createMetricAlarm({
+      ...props,
+      scope: this,
+      id: "RdsReadLatencyAlarm",
+      name: "rds-read-latency-high",
+      description: "RDS read latency is above 100 ms.",
+      metric: dbInstance.metric("ReadLatency", {
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 0.1,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createMetricAlarm({
+      ...props,
+      scope: this,
+      id: "RdsWriteLatencyAlarm",
+      name: "rds-write-latency-high",
+      description: "RDS write latency is above 100 ms.",
+      metric: dbInstance.metric("WriteLatency", {
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 0.1,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createMetricAlarm({
+      ...props,
+      scope: this,
+      id: "RdsDiskQueueDepthAlarm",
+      name: "rds-disk-queue-depth-high",
+      description: "RDS disk queue depth is above 5.",
+      metric: dbInstance.metric("DiskQueueDepth", {
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 5,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
     });
   }
 }

--- a/deployment/stacks/database.ts
+++ b/deployment/stacks/database.ts
@@ -5,6 +5,7 @@ import {
   aws_iam,
   aws_ec2,
   aws_rds,
+  aws_cloudwatch,
   RemovalPolicy,
   Duration,
   aws_secretsmanager,
@@ -21,6 +22,7 @@ import { Construct, IConstruct } from "constructs";
 import { DeploymentConfigProperties } from "../config";
 
 import * as securityGroup from "../lib/security-group";
+import * as alarms from "../lib/alarms";
 import * as ssm from "../lib/ssm-parameter";
 import { RetentionDays } from "aws-cdk-lib/aws-logs";
 
@@ -146,6 +148,115 @@ export class DatabaseStack extends Stack {
     };
 
     Aspects.of(this).add(new SuppressCheckovLogRetentionPolicy());
+
+    const rdsAlarmPeriod = Duration.minutes(5);
+    const gibibyte = 1024 * 1024 * 1024;
+    const mebibyte = 1024 * 1024;
+
+    alarms.createMetricAlarm({
+      ...commonProps,
+      id: "RdsFreeStorageSpaceAlarm",
+      name: "rds-free-storage-space-low",
+      description: "RDS free storage is below 5 GiB.",
+      metric: dbInstance.metricFreeStorageSpace({
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 5 * gibibyte,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createMetricAlarm({
+      ...commonProps,
+      id: "RdsCpuUtilizationAlarm",
+      name: "rds-cpu-utilization-high",
+      description: "RDS CPU utilization is above 80% for 15 minutes.",
+      metric: dbInstance.metricCPUUtilization({
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 80,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 3,
+      datapointsToAlarm: 3,
+    });
+
+    alarms.createMetricAlarm({
+      ...commonProps,
+      id: "RdsDatabaseConnectionsAlarm",
+      name: "rds-database-connections-high",
+      description: "RDS database connections are above the initial safe threshold.",
+      metric: dbInstance.metricDatabaseConnections({
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 80,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createMetricAlarm({
+      ...commonProps,
+      id: "RdsFreeableMemoryAlarm",
+      name: "rds-freeable-memory-low",
+      description: "RDS freeable memory is below 128 MiB.",
+      metric: dbInstance.metricFreeableMemory({
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 128 * mebibyte,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createMetricAlarm({
+      ...commonProps,
+      id: "RdsReadLatencyAlarm",
+      name: "rds-read-latency-high",
+      description: "RDS read latency is above 100 ms.",
+      metric: dbInstance.metric("ReadLatency", {
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 0.1,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createMetricAlarm({
+      ...commonProps,
+      id: "RdsWriteLatencyAlarm",
+      name: "rds-write-latency-high",
+      description: "RDS write latency is above 100 ms.",
+      metric: dbInstance.metric("WriteLatency", {
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 0.1,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createMetricAlarm({
+      ...commonProps,
+      id: "RdsDiskQueueDepthAlarm",
+      name: "rds-disk-queue-depth-high",
+      description: "RDS disk queue depth is above 5.",
+      metric: dbInstance.metric("DiskQueueDepth", {
+        period: rdsAlarmPeriod,
+        statistic: "Average",
+      }),
+      threshold: 5,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
 
     const cmsCloudLogFunc = aws_lambda.Function.fromFunctionName(
       commonProps.scope,

--- a/deployment/stacks/database.ts
+++ b/deployment/stacks/database.ts
@@ -236,7 +236,7 @@ export class DatabaseStack extends Stack {
     props: DeploymentConfigProperties,
     resources: alarms.CloudWatchAlarmRegistry
   ) {
-    if (props.isEphemeral) {
+    if (props.isEphemeral && !props.enableAlarms) {
       return;
     }
 

--- a/deployment/stacks/fileUpload.test.ts
+++ b/deployment/stacks/fileUpload.test.ts
@@ -312,5 +312,6 @@ describe("File Upload Stack", () => {
       },
       0,
     );
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
   });
 });

--- a/deployment/stacks/fileUpload.test.ts
+++ b/deployment/stacks/fileUpload.test.ts
@@ -22,6 +22,134 @@ const commongAppArgs = {
   },
 };
 
+function expectLambdaErrorsAlarm(
+  template: Template,
+  alarmName: string,
+  functionRefPattern: string
+) {
+  template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+    AlarmName: alarmName,
+    ComparisonOperator: "GreaterThanThreshold",
+    EvaluationPeriods: 1,
+    DatapointsToAlarm: 1,
+    MetricName: "Errors",
+    Namespace: "AWS/Lambda",
+    Period: 300,
+    Statistic: "Sum",
+    Threshold: 0,
+    TreatMissingData: "notBreaching",
+    Dimensions: Match.arrayWith([
+      Match.objectLike({
+        Name: "FunctionName",
+        Value: Match.objectLike({
+          Ref: Match.stringLikeRegexp(functionRefPattern),
+        }),
+      }),
+    ]),
+  });
+}
+
+function expectLambdaDurationAlarm(
+  template: Template,
+  alarmName: string,
+  functionRefPattern: string,
+  thresholdMilliseconds: number
+) {
+  template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+    AlarmName: alarmName,
+    ComparisonOperator: "GreaterThanThreshold",
+    EvaluationPeriods: 1,
+    DatapointsToAlarm: 1,
+    MetricName: "Duration",
+    Namespace: "AWS/Lambda",
+    Period: 300,
+    Statistic: "Maximum",
+    Threshold: thresholdMilliseconds,
+    TreatMissingData: "notBreaching",
+    Dimensions: Match.arrayWith([
+      Match.objectLike({
+        Name: "FunctionName",
+        Value: Match.objectLike({
+          Ref: Match.stringLikeRegexp(functionRefPattern),
+        }),
+      }),
+    ]),
+  });
+}
+
+function expectLambdaThrottlesAlarm(
+  template: Template,
+  alarmName: string,
+  functionRefPattern: string
+) {
+  template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+    AlarmName: alarmName,
+    ComparisonOperator: "GreaterThanThreshold",
+    EvaluationPeriods: 1,
+    DatapointsToAlarm: 1,
+    MetricName: "Throttles",
+    Namespace: "AWS/Lambda",
+    Period: 300,
+    Statistic: "Sum",
+    Threshold: 0,
+    TreatMissingData: "notBreaching",
+    Dimensions: Match.arrayWith([
+      Match.objectLike({
+        Name: "FunctionName",
+        Value: Match.objectLike({
+          Ref: Match.stringLikeRegexp(functionRefPattern),
+        }),
+      }),
+    ]),
+  });
+}
+
+function expectSqsOldestMessageAgeAlarm(
+  template: Template,
+  alarmName: string,
+  thresholdSeconds: number
+) {
+  template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+    AlarmName: alarmName,
+    ComparisonOperator: "GreaterThanThreshold",
+    EvaluationPeriods: 2,
+    DatapointsToAlarm: 2,
+    MetricName: "ApproximateAgeOfOldestMessage",
+    Namespace: "AWS/SQS",
+    Period: 300,
+    Statistic: "Maximum",
+    Threshold: thresholdSeconds,
+    TreatMissingData: "notBreaching",
+    Dimensions: Match.arrayWith([
+      Match.objectLike({
+        Name: "QueueName",
+        Value: Match.anyValue(),
+      }),
+    ]),
+  });
+}
+
+function expectSqsVisibleMessagesAlarm(template: Template, alarmName: string) {
+  template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+    AlarmName: alarmName,
+    ComparisonOperator: "GreaterThanThreshold",
+    EvaluationPeriods: 1,
+    DatapointsToAlarm: 1,
+    MetricName: "ApproximateNumberOfMessagesVisible",
+    Namespace: "AWS/SQS",
+    Period: 300,
+    Statistic: "Maximum",
+    Threshold: 0,
+    TreatMissingData: "notBreaching",
+    Dimensions: Match.arrayWith([
+      Match.objectLike({
+        Name: "QueueName",
+        Value: Match.anyValue(),
+      }),
+    ]),
+  });
+}
+
 describe("File Upload Stack", () => {
   test("should create proper resources when non-ephemeral", () => {
     const app = new App(commongAppArgs);
@@ -55,6 +183,97 @@ describe("File Upload Stack", () => {
     });
 
     template.resourceCountIs("AWS::S3::Bucket", 7)
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 16);
+
+    expectLambdaErrorsAlarm(
+      template,
+      "demos-unittest-file-process-lambda-errors",
+      "fileProcess"
+    );
+    expectLambdaErrorsAlarm(
+      template,
+      "demos-unittest-delete-infected-file-lambda-errors",
+      "deleteInfectedFile"
+    );
+    expectLambdaErrorsAlarm(
+      template,
+      "demos-unittest-uipath-lambda-errors",
+      "uipath"
+    );
+    expectLambdaErrorsAlarm(
+      template,
+      "demos-unittest-budget-neutrality-lambda-errors",
+      "budgetNeutrality"
+    );
+    expectLambdaDurationAlarm(
+      template,
+      "demos-unittest-file-process-lambda-duration-near-timeout",
+      "fileProcess",
+      24000
+    );
+    expectLambdaDurationAlarm(
+      template,
+      "demos-unittest-delete-infected-file-lambda-duration-near-timeout",
+      "deleteInfectedFile",
+      24000
+    );
+    expectLambdaDurationAlarm(
+      template,
+      "demos-unittest-budget-neutrality-lambda-duration-near-timeout",
+      "budgetNeutrality",
+      48000
+    );
+    expectLambdaThrottlesAlarm(
+      template,
+      "demos-unittest-file-process-lambda-throttles",
+      "fileProcess"
+    );
+    expectLambdaThrottlesAlarm(
+      template,
+      "demos-unittest-delete-infected-file-lambda-throttles",
+      "deleteInfectedFile"
+    );
+    expectLambdaThrottlesAlarm(
+      template,
+      "demos-unittest-uipath-lambda-throttles",
+      "uipath"
+    );
+    expectLambdaThrottlesAlarm(
+      template,
+      "demos-unittest-budget-neutrality-lambda-throttles",
+      "budgetNeutrality"
+    );
+    template.resourcePropertiesCountIs(
+      "AWS::CloudWatch::Alarm",
+      {
+        AlarmName: "demos-unittest-uipath-lambda-duration-near-timeout",
+      },
+      0
+    );
+    expectSqsOldestMessageAgeAlarm(
+      template,
+      "demos-unittest-file-upload-queue-oldest-message-age-high",
+      900
+    );
+    expectSqsOldestMessageAgeAlarm(
+      template,
+      "demos-unittest-delete-infected-file-queue-oldest-message-age-high",
+      3600
+    );
+    expectSqsOldestMessageAgeAlarm(
+      template,
+      "demos-unittest-uipath-queue-oldest-message-age-high",
+      3600
+    );
+    expectSqsOldestMessageAgeAlarm(
+      template,
+      "demos-unittest-budget-neutrality-queue-oldest-message-age-high",
+      900
+    );
+    expectSqsVisibleMessagesAlarm(
+      template,
+      "demos-unittest-file-workflow-dlq-visible-messages"
+    );
 
   });
 

--- a/deployment/stacks/fileupload.ts
+++ b/deployment/stacks/fileupload.ts
@@ -38,13 +38,12 @@ export class FileUploadStack extends Stack {
 
     super(scope, id, props);
 
+    const alarmResources = new alarms.CloudWatchAlarmRegistry();
+
     const kmsKey = new aws_kms.Key(this, "queueKey", {
       enableKeyRotation: true,
       alias: `alias/demos-${props.stage}-file-upload-sqs`,
     });
-    const lambdaErrorAlarmPeriod = Duration.minutes(5);
-    const sqsOldestMessageAgeAlarmPeriod = Duration.minutes(5);
-    const sqsVisibleMessagesAlarmPeriod = Duration.minutes(5);
 
     const deadLetterQueue = new Queue(this, "FileUploadDLQ", {
       removalPolicy: RemovalPolicy.DESTROY,
@@ -52,20 +51,7 @@ export class FileUploadStack extends Stack {
       encryption: QueueEncryption.KMS,
       encryptionMasterKey: kmsKey,
     });
-
-    alarms.createSqsVisibleMessagesAlarm({
-      ...props,
-      scope: this,
-      id: "FileWorkflowDlqVisibleMessagesAlarm",
-      name: "file-workflow-dlq-visible-messages",
-      description:
-        "File upload, infected-file cleanup, UiPath, or budget-neutrality DLQ contains one or more messages.",
-      queue: deadLetterQueue,
-      period: sqsVisibleMessagesAlarmPeriod,
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
+    alarmResources.registerQueue("fileWorkflowDeadLetter", deadLetterQueue);
 
     const uploadQueue = new Queue(this, "FileUploadQueue", {
       removalPolicy: RemovalPolicy.DESTROY,
@@ -77,19 +63,7 @@ export class FileUploadStack extends Stack {
       encryption: QueueEncryption.KMS,
       encryptionMasterKey: kmsKey,
     });
-
-    alarms.createSqsOldestMessageAgeAlarm({
-      ...props,
-      scope: this,
-      id: "FileUploadQueueOldestMessageAgeAlarm",
-      name: "file-upload-queue-oldest-message-age-high",
-      description: "File upload queue has messages older than 15 minutes.",
-      queue: uploadQueue,
-      period: sqsOldestMessageAgeAlarmPeriod,
-      threshold: Duration.minutes(15),
-      evaluationPeriods: 2,
-      datapointsToAlarm: 2,
-    });
+    alarmResources.registerQueue("fileUpload", uploadQueue);
 
     const deleteInfectedFileQueue = new Queue(this, "DeleteInfectedFileQueue", {
       removalPolicy: RemovalPolicy.DESTROY,
@@ -101,19 +75,7 @@ export class FileUploadStack extends Stack {
         queue: deadLetterQueue,
       },
     });
-
-    alarms.createSqsOldestMessageAgeAlarm({
-      ...props,
-      scope: this,
-      id: "DeleteInfectedFileQueueOldestMessageAgeAlarm",
-      name: "delete-infected-file-queue-oldest-message-age-high",
-      description: "Delete infected file queue has messages older than 60 minutes.",
-      queue: deleteInfectedFileQueue,
-      period: sqsOldestMessageAgeAlarmPeriod,
-      threshold: Duration.minutes(60),
-      evaluationPeriods: 2,
-      datapointsToAlarm: 2,
-    });
+    alarmResources.registerQueue("deleteInfectedFile", deleteInfectedFileQueue);
 
     const accessLogs = new Bucket(this, "fileUploadAccessLogBucket", {
       encryption: aws_s3.BucketEncryption.S3_MANAGED,
@@ -438,45 +400,7 @@ export class FileUploadStack extends Stack {
       },
       depsLockFilePath: "../lambdas/fileprocess/package-lock.json",
     });
-
-    alarms.createLambdaErrorsAlarm({
-      ...props,
-      scope: this,
-      id: "FileProcessLambdaErrorsAlarm",
-      name: "file-process-lambda-errors",
-      description: "File processing Lambda has one or more errors in a 5-minute period.",
-      lambdaFunction: fileProcessLambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
-
-    alarms.createLambdaDurationAlarm({
-      ...props,
-      scope: this,
-      id: "FileProcessLambdaDurationAlarm",
-      name: "file-process-lambda-duration-near-timeout",
-      description: "File processing Lambda duration is above 80% of its configured timeout.",
-      lambdaFunction: fileProcessLambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: Duration.seconds(24),
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
-
-    alarms.createLambdaThrottlesAlarm({
-      ...props,
-      scope: this,
-      id: "FileProcessLambdaThrottlesAlarm",
-      name: "file-process-lambda-throttles",
-      description: "File processing Lambda has one or more throttled invocations in a 5-minute period.",
-      lambdaFunction: fileProcessLambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
+    alarmResources.registerLambda("fileProcess", fileProcessLambda.lambda);
 
     fileProcessLambda.lambda.addEventSource(
       new SqsEventSource(uploadQueue, {
@@ -514,45 +438,7 @@ export class FileUploadStack extends Stack {
       },
       depsLockFilePath: "../lambdas/deleteinfectedfile/package-lock.json",
     });
-
-    alarms.createLambdaErrorsAlarm({
-      ...props,
-      scope: this,
-      id: "DeleteInfectedFileLambdaErrorsAlarm",
-      name: "delete-infected-file-lambda-errors",
-      description: "Delete infected file Lambda has one or more errors in a 5-minute period.",
-      lambdaFunction: deleteInfectedFileLambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
-
-    alarms.createLambdaDurationAlarm({
-      ...props,
-      scope: this,
-      id: "DeleteInfectedFileLambdaDurationAlarm",
-      name: "delete-infected-file-lambda-duration-near-timeout",
-      description: "Delete infected file Lambda duration is above 80% of its configured timeout.",
-      lambdaFunction: deleteInfectedFileLambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: Duration.seconds(24),
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
-
-    alarms.createLambdaThrottlesAlarm({
-      ...props,
-      scope: this,
-      id: "DeleteInfectedFileLambdaThrottlesAlarm",
-      name: "delete-infected-file-lambda-throttles",
-      description: "Delete infected file Lambda has one or more throttled invocations in a 5-minute period.",
-      lambdaFunction: deleteInfectedFileLambda.lambda,
-      period: lambdaErrorAlarmPeriod,
-      threshold: 0,
-      evaluationPeriods: 1,
-      datapointsToAlarm: 1,
-    });
+    alarmResources.registerLambda("deleteInfectedFile", deleteInfectedFileLambda.lambda);
 
     deleteInfectedFileLambda.lambda.addEventSource(
       new SqsEventSource(deleteInfectedFileQueue, {
@@ -601,6 +487,8 @@ export class FileUploadStack extends Stack {
     );
     budgetNeutralityProcessor.queue.grantSendMessages(fileProcessLambda.lambda);
 
+    this.setupCloudWatchAlarms(props, alarmResources);
+
     new CfnOutput(this, "cleanBucketName", {
       exportName: `${props.stage}CleanBucketName`,
       value: cleanBucket.bucketName,
@@ -644,6 +532,137 @@ export class FileUploadStack extends Stack {
     new CfnOutput(this, "budgetNeutralityQueueArn", {
       exportName: `${props.stage}BudgetNeutralityQueueArn`,
       value: budgetNeutralityProcessor.queue.queueArn,
+    });
+  }
+
+  private setupCloudWatchAlarms(
+    props: DeploymentConfigProperties,
+    resources: alarms.CloudWatchAlarmRegistry
+  ) {
+    if (props.isEphemeral) {
+      return;
+    }
+
+    const lambdaAlarmPeriod = Duration.minutes(5);
+    const sqsOldestMessageAgeAlarmPeriod = Duration.minutes(5);
+    const sqsVisibleMessagesAlarmPeriod = Duration.minutes(5);
+
+    alarms.createSqsVisibleMessagesAlarm({
+      ...props,
+      scope: this,
+      id: "FileWorkflowDlqVisibleMessagesAlarm",
+      name: "file-workflow-dlq-visible-messages",
+      description:
+        "File upload, infected-file cleanup, UiPath, or budget-neutrality DLQ contains one or more messages.",
+      queue: resources.queue("fileWorkflowDeadLetter"),
+      period: sqsVisibleMessagesAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createSqsOldestMessageAgeAlarm({
+      ...props,
+      scope: this,
+      id: "FileUploadQueueOldestMessageAgeAlarm",
+      name: "file-upload-queue-oldest-message-age-high",
+      description: "File upload queue has messages older than 15 minutes.",
+      queue: resources.queue("fileUpload"),
+      period: sqsOldestMessageAgeAlarmPeriod,
+      threshold: Duration.minutes(15),
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createSqsOldestMessageAgeAlarm({
+      ...props,
+      scope: this,
+      id: "DeleteInfectedFileQueueOldestMessageAgeAlarm",
+      name: "delete-infected-file-queue-oldest-message-age-high",
+      description: "Delete infected file queue has messages older than 60 minutes.",
+      queue: resources.queue("deleteInfectedFile"),
+      period: sqsOldestMessageAgeAlarmPeriod,
+      threshold: Duration.minutes(60),
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createLambdaErrorsAlarm({
+      ...props,
+      scope: this,
+      id: "FileProcessLambdaErrorsAlarm",
+      name: "file-process-lambda-errors",
+      description: "File processing Lambda has one or more errors in a 5-minute period.",
+      lambdaFunction: resources.lambda("fileProcess"),
+      period: lambdaAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaDurationAlarm({
+      ...props,
+      scope: this,
+      id: "FileProcessLambdaDurationAlarm",
+      name: "file-process-lambda-duration-near-timeout",
+      description: "File processing Lambda duration is above 80% of its configured timeout.",
+      lambdaFunction: resources.lambda("fileProcess"),
+      period: lambdaAlarmPeriod,
+      threshold: Duration.seconds(24),
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaThrottlesAlarm({
+      ...props,
+      scope: this,
+      id: "FileProcessLambdaThrottlesAlarm",
+      name: "file-process-lambda-throttles",
+      description: "File processing Lambda has one or more throttled invocations in a 5-minute period.",
+      lambdaFunction: resources.lambda("fileProcess"),
+      period: lambdaAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaErrorsAlarm({
+      ...props,
+      scope: this,
+      id: "DeleteInfectedFileLambdaErrorsAlarm",
+      name: "delete-infected-file-lambda-errors",
+      description: "Delete infected file Lambda has one or more errors in a 5-minute period.",
+      lambdaFunction: resources.lambda("deleteInfectedFile"),
+      period: lambdaAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaDurationAlarm({
+      ...props,
+      scope: this,
+      id: "DeleteInfectedFileLambdaDurationAlarm",
+      name: "delete-infected-file-lambda-duration-near-timeout",
+      description: "Delete infected file Lambda duration is above 80% of its configured timeout.",
+      lambdaFunction: resources.lambda("deleteInfectedFile"),
+      period: lambdaAlarmPeriod,
+      threshold: Duration.seconds(24),
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaThrottlesAlarm({
+      ...props,
+      scope: this,
+      id: "DeleteInfectedFileLambdaThrottlesAlarm",
+      name: "delete-infected-file-lambda-throttles",
+      description: "Delete infected file Lambda has one or more throttled invocations in a 5-minute period.",
+      lambdaFunction: resources.lambda("deleteInfectedFile"),
+      period: lambdaAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
     });
   }
 }

--- a/deployment/stacks/fileupload.ts
+++ b/deployment/stacks/fileupload.ts
@@ -19,6 +19,7 @@ import { Bucket, HttpMethods } from "aws-cdk-lib/aws-s3";
 import { Queue, QueueEncryption } from "aws-cdk-lib/aws-sqs";
 import { SqsEventSource } from "aws-cdk-lib/aws-lambda-event-sources";
 import * as lambda from "../lib/lambda";
+import * as alarms from "../lib/alarms";
 import { IVpc } from "aws-cdk-lib/aws-ec2";
 import { DeploymentConfigProperties } from "../config";
 import * as securityGroup from "../lib/security-group";
@@ -41,12 +42,29 @@ export class FileUploadStack extends Stack {
       enableKeyRotation: true,
       alias: `alias/demos-${props.stage}-file-upload-sqs`,
     });
+    const lambdaErrorAlarmPeriod = Duration.minutes(5);
+    const sqsOldestMessageAgeAlarmPeriod = Duration.minutes(5);
+    const sqsVisibleMessagesAlarmPeriod = Duration.minutes(5);
 
     const deadLetterQueue = new Queue(this, "FileUploadDLQ", {
       removalPolicy: RemovalPolicy.DESTROY,
       enforceSSL: true,
       encryption: QueueEncryption.KMS,
       encryptionMasterKey: kmsKey,
+    });
+
+    alarms.createSqsVisibleMessagesAlarm({
+      ...props,
+      scope: this,
+      id: "FileWorkflowDlqVisibleMessagesAlarm",
+      name: "file-workflow-dlq-visible-messages",
+      description:
+        "File upload, infected-file cleanup, UiPath, or budget-neutrality DLQ contains one or more messages.",
+      queue: deadLetterQueue,
+      period: sqsVisibleMessagesAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
     });
 
     const uploadQueue = new Queue(this, "FileUploadQueue", {
@@ -60,6 +78,19 @@ export class FileUploadStack extends Stack {
       encryptionMasterKey: kmsKey,
     });
 
+    alarms.createSqsOldestMessageAgeAlarm({
+      ...props,
+      scope: this,
+      id: "FileUploadQueueOldestMessageAgeAlarm",
+      name: "file-upload-queue-oldest-message-age-high",
+      description: "File upload queue has messages older than 15 minutes.",
+      queue: uploadQueue,
+      period: sqsOldestMessageAgeAlarmPeriod,
+      threshold: Duration.minutes(15),
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
     const deleteInfectedFileQueue = new Queue(this, "DeleteInfectedFileQueue", {
       removalPolicy: RemovalPolicy.DESTROY,
       enforceSSL: true,
@@ -69,6 +100,19 @@ export class FileUploadStack extends Stack {
         maxReceiveCount: 5,
         queue: deadLetterQueue,
       },
+    });
+
+    alarms.createSqsOldestMessageAgeAlarm({
+      ...props,
+      scope: this,
+      id: "DeleteInfectedFileQueueOldestMessageAgeAlarm",
+      name: "delete-infected-file-queue-oldest-message-age-high",
+      description: "Delete infected file queue has messages older than 60 minutes.",
+      queue: deleteInfectedFileQueue,
+      period: sqsOldestMessageAgeAlarmPeriod,
+      threshold: Duration.minutes(60),
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
     });
 
     const accessLogs = new Bucket(this, "fileUploadAccessLogBucket", {
@@ -395,6 +439,45 @@ export class FileUploadStack extends Stack {
       depsLockFilePath: "../lambdas/fileprocess/package-lock.json",
     });
 
+    alarms.createLambdaErrorsAlarm({
+      ...props,
+      scope: this,
+      id: "FileProcessLambdaErrorsAlarm",
+      name: "file-process-lambda-errors",
+      description: "File processing Lambda has one or more errors in a 5-minute period.",
+      lambdaFunction: fileProcessLambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaDurationAlarm({
+      ...props,
+      scope: this,
+      id: "FileProcessLambdaDurationAlarm",
+      name: "file-process-lambda-duration-near-timeout",
+      description: "File processing Lambda duration is above 80% of its configured timeout.",
+      lambdaFunction: fileProcessLambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: Duration.seconds(24),
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaThrottlesAlarm({
+      ...props,
+      scope: this,
+      id: "FileProcessLambdaThrottlesAlarm",
+      name: "file-process-lambda-throttles",
+      description: "File processing Lambda has one or more throttled invocations in a 5-minute period.",
+      lambdaFunction: fileProcessLambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
     fileProcessLambda.lambda.addEventSource(
       new SqsEventSource(uploadQueue, {
         batchSize: 1,
@@ -430,6 +513,45 @@ export class FileUploadStack extends Stack {
         NODE_EXTRA_CA_CERTS: "/var/runtime/ca-cert.pem",
       },
       depsLockFilePath: "../lambdas/deleteinfectedfile/package-lock.json",
+    });
+
+    alarms.createLambdaErrorsAlarm({
+      ...props,
+      scope: this,
+      id: "DeleteInfectedFileLambdaErrorsAlarm",
+      name: "delete-infected-file-lambda-errors",
+      description: "Delete infected file Lambda has one or more errors in a 5-minute period.",
+      lambdaFunction: deleteInfectedFileLambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaDurationAlarm({
+      ...props,
+      scope: this,
+      id: "DeleteInfectedFileLambdaDurationAlarm",
+      name: "delete-infected-file-lambda-duration-near-timeout",
+      description: "Delete infected file Lambda duration is above 80% of its configured timeout.",
+      lambdaFunction: deleteInfectedFileLambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: Duration.seconds(24),
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+    });
+
+    alarms.createLambdaThrottlesAlarm({
+      ...props,
+      scope: this,
+      id: "DeleteInfectedFileLambdaThrottlesAlarm",
+      name: "delete-infected-file-lambda-throttles",
+      description: "Delete infected file Lambda has one or more throttled invocations in a 5-minute period.",
+      lambdaFunction: deleteInfectedFileLambda.lambda,
+      period: lambdaErrorAlarmPeriod,
+      threshold: 0,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
     });
 
     deleteInfectedFileLambda.lambda.addEventSource(

--- a/deployment/stacks/fileupload.ts
+++ b/deployment/stacks/fileupload.ts
@@ -539,7 +539,7 @@ export class FileUploadStack extends Stack {
     props: DeploymentConfigProperties,
     resources: alarms.CloudWatchAlarmRegistry
   ) {
-    if (props.isEphemeral) {
+    if (props.isEphemeral && !props.enableAlarms) {
       return;
     }
 

--- a/deployment/stacks/ui.test.ts
+++ b/deployment/stacks/ui.test.ts
@@ -18,6 +18,54 @@ const mockCommonProps: DeploymentConfigProperties = {
   dataConnectRoleArn: "arn:aws:iam::1234567890:role/dataconnectrole",
 };
 
+function expectWafBlockedRequestsAnomalyAlarm(
+  template: Template,
+  props: {
+    alarmName: string;
+    rule: string;
+    webAcl: string;
+    region: string | ReturnType<typeof Match.anyValue>;
+  }
+) {
+  template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+    AlarmName: props.alarmName,
+    ComparisonOperator: "GreaterThanUpperThreshold",
+    EvaluationPeriods: 3,
+    DatapointsToAlarm: 2,
+    ThresholdMetricId: Match.anyValue(),
+    Metrics: Match.arrayWith([
+      Match.objectLike({
+        Expression: Match.stringLikeRegexp("ANOMALY_DETECTION_BAND"),
+      }),
+      Match.objectLike({
+        MetricStat: Match.objectLike({
+          Metric: Match.objectLike({
+            MetricName: "BlockedRequests",
+            Namespace: "AWS/WAFV2",
+            Dimensions: Match.arrayWith([
+              Match.objectLike({
+                Name: "Region",
+                Value: props.region,
+              }),
+              Match.objectLike({
+                Name: "Rule",
+                Value: props.rule,
+              }),
+              Match.objectLike({
+                Name: "WebACL",
+                Value: props.webAcl,
+              }),
+            ]),
+          }),
+          Period: 300,
+          Stat: "Sum",
+        }),
+      }),
+    ]),
+    TreatMissingData: "notBreaching",
+  });
+}
+
 describe("UI Stack", () => {
   test("should create only basic cloudfront config when srr is not configured", () => {
     const app = new App();
@@ -76,6 +124,7 @@ describe("UI Stack", () => {
     // addition to the actual bucket deployment
     template.resourceCountIs("Custom::CDKBucketDeployment", 2);
     template.resourceCountIs("AWS::WAFv2::WebACL", 2);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 5);
 
     template.hasResourceProperties("AWS::CloudFront::Distribution", {
       DistributionConfig: Match.objectLike({
@@ -109,6 +158,96 @@ describe("UI Stack", () => {
     const cacheBehaviors = dist.Properties.DistributionConfig.CacheBehaviors;
     expect(cacheBehaviors.length).toEqual(1);
     expect(cacheBehaviors[0].TargetOriginId).toEqual(apiOrigin.Id);
+  });
+
+  test("should create CloudFront error rate alarms", () => {
+    const app = new App();
+
+    const uiStack = new UiStack(app, "mockUi", {
+      ...mockCommonProps,
+      env: {
+        region: "us-east-1",
+        account: "0123456789",
+      },
+      cognitoParamNames: {
+        authority: "authority",
+        clientId: "clientId",
+      },
+    });
+
+    const template = Template.fromStack(uiStack);
+
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "demos-unittest-cloudfront-5xx-error-rate-high",
+      ComparisonOperator: "GreaterThanThreshold",
+      EvaluationPeriods: 2,
+      DatapointsToAlarm: 2,
+      MetricName: "5xxErrorRate",
+      Namespace: "AWS/CloudFront",
+      Statistic: "Average",
+      Threshold: 1,
+      TreatMissingData: "notBreaching",
+    });
+
+    template.hasResourceProperties("AWS::CloudWatch::Alarm", {
+      AlarmName: "demos-unittest-cloudfront-4xx-error-rate-anomaly",
+      ComparisonOperator: "GreaterThanUpperThreshold",
+      EvaluationPeriods: 3,
+      DatapointsToAlarm: 2,
+      ThresholdMetricId: Match.anyValue(),
+      Metrics: Match.arrayWith([
+        Match.objectLike({
+          Expression: Match.stringLikeRegexp("ANOMALY_DETECTION_BAND"),
+        }),
+        Match.objectLike({
+          MetricStat: Match.objectLike({
+            Metric: Match.objectLike({
+              MetricName: "4xxErrorRate",
+              Namespace: "AWS/CloudFront",
+            }),
+            Stat: "Average",
+          }),
+        }),
+      ]),
+      TreatMissingData: "notBreaching",
+    });
+  });
+
+  test("should create WAF blocked request anomaly alarms", () => {
+    const app = new App();
+
+    const uiStack = new UiStack(app, "mockUi", {
+      ...mockCommonProps,
+      env: {
+        region: "us-east-1",
+        account: "0123456789",
+      },
+      cognitoParamNames: {
+        authority: "authority",
+        clientId: "clientId",
+      },
+    });
+
+    const template = Template.fromStack(uiStack);
+
+    expectWafBlockedRequestsAnomalyAlarm(template, {
+      alarmName: "demos-unittest-api-waf-missing-cloudfront-header-blocked-requests-anomaly",
+      rule: "DenyWithoutCloudfrontHeader",
+      webAcl: "unittestApiWafMetric",
+      region: Match.anyValue(),
+    });
+    expectWafBlockedRequestsAnomalyAlarm(template, {
+      alarmName: "demos-unittest-api-waf-rate-limiting-blocked-requests-anomaly",
+      rule: "RateLimiting",
+      webAcl: "unittestApiWafMetric",
+      region: Match.anyValue(),
+    });
+    expectWafBlockedRequestsAnomalyAlarm(template, {
+      alarmName: "demos-unittest-cloudfront-waf-rate-limiting-blocked-requests-anomaly",
+      rule: "RateLimiting",
+      webAcl: "WebACL",
+      region: "CloudFront",
+    });
   });
 
   test("should include header passthrough when a zapHeaderValue exists", () => {

--- a/deployment/stacks/ui.test.ts
+++ b/deployment/stacks/ui.test.ts
@@ -250,6 +250,28 @@ describe("UI Stack", () => {
     });
   });
 
+  test("should not create alarms when ephemeral", () => {
+    const app = new App();
+
+    const uiStack = new UiStack(app, "mockUi", {
+      ...mockCommonProps,
+      isEphemeral: true,
+      env: {
+        region: "us-east-1",
+        account: "0123456789",
+      },
+      cognitoParamNames: {
+        authority: "authority",
+        clientId: "clientId",
+      },
+    });
+
+    const template = Template.fromStack(uiStack);
+
+    template.resourceCountIs("AWS::CloudFront::Distribution", 1);
+    template.resourceCountIs("AWS::CloudWatch::Alarm", 0);
+  });
+
   test("should include header passthrough when a zapHeaderValue exists", () => {
     const app = new App();
 

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -48,6 +48,7 @@ export class UiStack extends Stack {
         props.iamPermissionsBoundaryArn == null
           ? undefined : aws_iam.ManagedPolicy.fromManagedPolicyArn(this, "iamPermissionsBoundary", props.iamPermissionsBoundaryArn),
     };
+    const alarmResources = new alarms.CloudWatchAlarmRegistry();
 
     if (!commonProps.srrConfigured) {
       // STOP execution here if the cloudfront distribution has not yet been updated
@@ -211,67 +212,6 @@ export class UiStack extends Stack {
       ]
     });
 
-    const wafBlockedRequestsMetricOptions = {
-      metricName: "BlockedRequests",
-      namespace: "AWS/WAFV2",
-      period: Duration.minutes(5),
-      statistic: "Sum",
-    };
-
-    alarms.createAnomalyAlarm({
-      ...commonProps,
-      id: "ApiWafMissingCloudFrontHeaderBlockedRequestsAnomalyAlarm",
-      name: "api-waf-missing-cloudfront-header-blocked-requests-anomaly",
-      description: "API WAF missing CloudFront header blocked requests are above their expected anomaly band.",
-      metric: new aws_cloudwatch.Metric({
-        ...wafBlockedRequestsMetricOptions,
-        dimensionsMap: {
-          Region: Aws.REGION,
-          Rule: "DenyWithoutCloudfrontHeader",
-          WebACL: `${commonProps.stage}ApiWafMetric`,
-        },
-      }),
-      evaluationPeriods: 3,
-      datapointsToAlarm: 2,
-      stdDevs: 3,
-    });
-
-    alarms.createAnomalyAlarm({
-      ...commonProps,
-      id: "ApiWafRateLimitingBlockedRequestsAnomalyAlarm",
-      name: "api-waf-rate-limiting-blocked-requests-anomaly",
-      description: "API WAF rate limiting blocked requests are above their expected anomaly band.",
-      metric: new aws_cloudwatch.Metric({
-        ...wafBlockedRequestsMetricOptions,
-        dimensionsMap: {
-          Region: Aws.REGION,
-          Rule: "RateLimiting",
-          WebACL: `${commonProps.stage}ApiWafMetric`,
-        },
-      }),
-      evaluationPeriods: 3,
-      datapointsToAlarm: 2,
-      stdDevs: 3,
-    });
-
-    alarms.createAnomalyAlarm({
-      ...commonProps,
-      id: "CloudFrontWafRateLimitingBlockedRequestsAnomalyAlarm",
-      name: "cloudfront-waf-rate-limiting-blocked-requests-anomaly",
-      description: "CloudFront WAF rate limiting blocked requests are above their expected anomaly band.",
-      metric: new aws_cloudwatch.Metric({
-        ...wafBlockedRequestsMetricOptions,
-        dimensionsMap: {
-          Region: "CloudFront",
-          Rule: "RateLimiting",
-          WebACL: "WebACL",
-        },
-      }),
-      evaluationPeriods: 3,
-      datapointsToAlarm: 2,
-      stdDevs: 3,
-    });
-
     const cognitoDomain = Fn.importValue(`${commonProps.stage}CognitoDomain`);
     const uploadBucketName = Fn.importValue(`${commonProps.stage}UploadBucketName`);
     const cleanBucketName = Fn.importValue(`${commonProps.stage}CleanBucketName`);
@@ -368,34 +308,9 @@ export class UiStack extends Stack {
       comment: `Env Name: ${commonProps.stage}`,
     });
     distribution.applyRemovalPolicy(commonProps.isDev ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN);
+    alarmResources.registerDistribution("cloudfront", distribution);
 
-    const cloudFrontErrorMetricOptions = {
-      period: Duration.minutes(5),
-      statistic: "Average",
-    };
-
-    alarms.createMetricAlarm({
-      ...commonProps,
-      id: "CloudFront5xxErrorRateAlarm",
-      name: "cloudfront-5xx-error-rate-high",
-      description: "CloudFront 5xx error rate is above 1% for 10 minutes.",
-      metric: distribution.metric5xxErrorRate(cloudFrontErrorMetricOptions),
-      threshold: 1,
-      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-      evaluationPeriods: 2,
-      datapointsToAlarm: 2,
-    });
-
-    alarms.createAnomalyAlarm({
-      ...commonProps,
-      id: "CloudFront4xxErrorRateAnomalyAlarm",
-      name: "cloudfront-4xx-error-rate-anomaly",
-      description: "CloudFront 4xx error rate is above its expected anomaly band.",
-      metric: distribution.metric4xxErrorRate(cloudFrontErrorMetricOptions),
-      evaluationPeriods: 3,
-      datapointsToAlarm: 2,
-      stdDevs: 2,
-    });
+    this.setupCloudWatchAlarms(commonProps, alarmResources);
 
     Tags.of(distribution).add("Name", `demos-${commonProps.stage}-cloudfront-dist`);
 
@@ -460,6 +375,110 @@ export class UiStack extends Stack {
     new CfnOutput(this, "Cloudfront URL", {
       value: applicationEndpointUrl,
       exportName: `${commonProps.stage}CloudfrontUrl`,
+    });
+  }
+
+  private setupCloudWatchAlarms(
+    props: DeploymentConfigProperties,
+    resources: alarms.CloudWatchAlarmRegistry
+  ) {
+    if (props.isEphemeral) {
+      return;
+    }
+
+    const distribution = resources.distribution("cloudfront");
+    const wafBlockedRequestsMetricOptions = {
+      metricName: "BlockedRequests",
+      namespace: "AWS/WAFV2",
+      period: Duration.minutes(5),
+      statistic: "Sum",
+    };
+
+    alarms.createAnomalyAlarm({
+      ...props,
+      scope: this,
+      id: "ApiWafMissingCloudFrontHeaderBlockedRequestsAnomalyAlarm",
+      name: "api-waf-missing-cloudfront-header-blocked-requests-anomaly",
+      description: "API WAF missing CloudFront header blocked requests are above their expected anomaly band.",
+      metric: new aws_cloudwatch.Metric({
+        ...wafBlockedRequestsMetricOptions,
+        dimensionsMap: {
+          Region: Aws.REGION,
+          Rule: "DenyWithoutCloudfrontHeader",
+          WebACL: `${props.stage}ApiWafMetric`,
+        },
+      }),
+      evaluationPeriods: 3,
+      datapointsToAlarm: 2,
+      stdDevs: 3,
+    });
+
+    alarms.createAnomalyAlarm({
+      ...props,
+      scope: this,
+      id: "ApiWafRateLimitingBlockedRequestsAnomalyAlarm",
+      name: "api-waf-rate-limiting-blocked-requests-anomaly",
+      description: "API WAF rate limiting blocked requests are above their expected anomaly band.",
+      metric: new aws_cloudwatch.Metric({
+        ...wafBlockedRequestsMetricOptions,
+        dimensionsMap: {
+          Region: Aws.REGION,
+          Rule: "RateLimiting",
+          WebACL: `${props.stage}ApiWafMetric`,
+        },
+      }),
+      evaluationPeriods: 3,
+      datapointsToAlarm: 2,
+      stdDevs: 3,
+    });
+
+    alarms.createAnomalyAlarm({
+      ...props,
+      scope: this,
+      id: "CloudFrontWafRateLimitingBlockedRequestsAnomalyAlarm",
+      name: "cloudfront-waf-rate-limiting-blocked-requests-anomaly",
+      description: "CloudFront WAF rate limiting blocked requests are above their expected anomaly band.",
+      metric: new aws_cloudwatch.Metric({
+        ...wafBlockedRequestsMetricOptions,
+        dimensionsMap: {
+          Region: "CloudFront",
+          Rule: "RateLimiting",
+          WebACL: "WebACL",
+        },
+      }),
+      evaluationPeriods: 3,
+      datapointsToAlarm: 2,
+      stdDevs: 3,
+    });
+
+    const cloudFrontErrorMetricOptions = {
+      period: Duration.minutes(5),
+      statistic: "Average",
+    };
+
+    alarms.createMetricAlarm({
+      ...props,
+      scope: this,
+      id: "CloudFront5xxErrorRateAlarm",
+      name: "cloudfront-5xx-error-rate-high",
+      description: "CloudFront 5xx error rate is above 1% for 10 minutes.",
+      metric: distribution.metric5xxErrorRate(cloudFrontErrorMetricOptions),
+      threshold: 1,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createAnomalyAlarm({
+      ...props,
+      scope: this,
+      id: "CloudFront4xxErrorRateAnomalyAlarm",
+      name: "cloudfront-4xx-error-rate-anomaly",
+      description: "CloudFront 4xx error rate is above its expected anomaly band.",
+      metric: distribution.metric4xxErrorRate(cloudFrontErrorMetricOptions),
+      evaluationPeriods: 3,
+      datapointsToAlarm: 2,
+      stdDevs: 2,
     });
   }
 }

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -382,7 +382,7 @@ export class UiStack extends Stack {
     props: DeploymentConfigProperties,
     resources: alarms.CloudWatchAlarmRegistry
   ) {
-    if (props.isEphemeral) {
+    if (props.isEphemeral && !props.enableAlarms) {
       return;
     }
 

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -9,6 +9,7 @@ import {
   Duration,
   aws_certificatemanager,
   aws_cloudfront_origins,
+  aws_cloudwatch,
   aws_wafv2,
   Fn,
   Aws,
@@ -21,6 +22,7 @@ import { Construct } from "constructs";
 import { DeploymentConfigProperties } from "../config";
 
 import * as uiDeploy from "../lib/ui-deploy";
+import * as alarms from "../lib/alarms";
 import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { DemosLogGroup } from "../lib/logGroup";
 import { accessDeniedBodyName, createCloudfrontRules, createRegionalRules } from "../lib/waf";
@@ -209,6 +211,67 @@ export class UiStack extends Stack {
       ]
     });
 
+    const wafBlockedRequestsMetricOptions = {
+      metricName: "BlockedRequests",
+      namespace: "AWS/WAFV2",
+      period: Duration.minutes(5),
+      statistic: "Sum",
+    };
+
+    alarms.createAnomalyAlarm({
+      ...commonProps,
+      id: "ApiWafMissingCloudFrontHeaderBlockedRequestsAnomalyAlarm",
+      name: "api-waf-missing-cloudfront-header-blocked-requests-anomaly",
+      description: "API WAF missing CloudFront header blocked requests are above their expected anomaly band.",
+      metric: new aws_cloudwatch.Metric({
+        ...wafBlockedRequestsMetricOptions,
+        dimensionsMap: {
+          Region: Aws.REGION,
+          Rule: "DenyWithoutCloudfrontHeader",
+          WebACL: `${commonProps.stage}ApiWafMetric`,
+        },
+      }),
+      evaluationPeriods: 3,
+      datapointsToAlarm: 2,
+      stdDevs: 3,
+    });
+
+    alarms.createAnomalyAlarm({
+      ...commonProps,
+      id: "ApiWafRateLimitingBlockedRequestsAnomalyAlarm",
+      name: "api-waf-rate-limiting-blocked-requests-anomaly",
+      description: "API WAF rate limiting blocked requests are above their expected anomaly band.",
+      metric: new aws_cloudwatch.Metric({
+        ...wafBlockedRequestsMetricOptions,
+        dimensionsMap: {
+          Region: Aws.REGION,
+          Rule: "RateLimiting",
+          WebACL: `${commonProps.stage}ApiWafMetric`,
+        },
+      }),
+      evaluationPeriods: 3,
+      datapointsToAlarm: 2,
+      stdDevs: 3,
+    });
+
+    alarms.createAnomalyAlarm({
+      ...commonProps,
+      id: "CloudFrontWafRateLimitingBlockedRequestsAnomalyAlarm",
+      name: "cloudfront-waf-rate-limiting-blocked-requests-anomaly",
+      description: "CloudFront WAF rate limiting blocked requests are above their expected anomaly band.",
+      metric: new aws_cloudwatch.Metric({
+        ...wafBlockedRequestsMetricOptions,
+        dimensionsMap: {
+          Region: "CloudFront",
+          Rule: "RateLimiting",
+          WebACL: "WebACL",
+        },
+      }),
+      evaluationPeriods: 3,
+      datapointsToAlarm: 2,
+      stdDevs: 3,
+    });
+
     const cognitoDomain = Fn.importValue(`${commonProps.stage}CognitoDomain`);
     const uploadBucketName = Fn.importValue(`${commonProps.stage}UploadBucketName`);
     const cleanBucketName = Fn.importValue(`${commonProps.stage}CleanBucketName`);
@@ -305,6 +368,34 @@ export class UiStack extends Stack {
       comment: `Env Name: ${commonProps.stage}`,
     });
     distribution.applyRemovalPolicy(commonProps.isDev ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN);
+
+    const cloudFrontErrorMetricOptions = {
+      period: Duration.minutes(5),
+      statistic: "Average",
+    };
+
+    alarms.createMetricAlarm({
+      ...commonProps,
+      id: "CloudFront5xxErrorRateAlarm",
+      name: "cloudfront-5xx-error-rate-high",
+      description: "CloudFront 5xx error rate is above 1% for 10 minutes.",
+      metric: distribution.metric5xxErrorRate(cloudFrontErrorMetricOptions),
+      threshold: 1,
+      comparisonOperator: aws_cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      evaluationPeriods: 2,
+      datapointsToAlarm: 2,
+    });
+
+    alarms.createAnomalyAlarm({
+      ...commonProps,
+      id: "CloudFront4xxErrorRateAnomalyAlarm",
+      name: "cloudfront-4xx-error-rate-anomaly",
+      description: "CloudFront 4xx error rate is above its expected anomaly band.",
+      metric: distribution.metric4xxErrorRate(cloudFrontErrorMetricOptions),
+      evaluationPeriods: 3,
+      datapointsToAlarm: 2,
+      stdDevs: 2,
+    });
 
     Tags.of(distribution).add("Name", `demos-${commonProps.stage}-cloudfront-dist`);
 


### PR DESCRIPTION
## Overview

We have alerts set up in splunk based on application warnings and errors, but we don't use splunk for infrastructure-related errors. This PR adds several cloudwatch alarms for monitoring the infrastructure, for example database memory consumption, cloudfront error anomalies, etc. Potentially, some of these alerts could be created in Datadog, but they would be delayed based on the ingestion timing. Datadog will be used for higher level alerts and dashboarding, these fine-grained alarms will be left in cloudwatch