### PR TITLE
DEMOS-2179: Allow BN Template file type on CMS File tab for Budget Neutrality deliverables

### DIFF
--- a/client/src/components/dialog/document/AddDocumentToDeliverableDialog.test.tsx
+++ b/client/src/components/dialog/document/AddDocumentToDeliverableDialog.test.tsx
@@ -4,7 +4,9 @@ import React from "react";
 
 import { ToastProvider } from "components/toast/ToastContext";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { DocumentType } from "demos-server";
 
 import { AddDocumentToDeliverableDialog } from "./AddDocumentToDeliverableDialog";
 
@@ -30,7 +32,7 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-const renderDialog = (isCmsFile: boolean) =>
+const renderDialog = (isCmsFile: boolean, documentTypeSubset?: DocumentType[]) =>
   render(
     <ToastProvider>
       <AddDocumentToDeliverableDialog
@@ -38,7 +40,9 @@ const renderDialog = (isCmsFile: boolean) =>
         deliverableId="deliverable-1"
         applicationId="demo-1"
         isCmsFile={isCmsFile}
-        documentTypeSubset={isCmsFile ? undefined : ["General File"]}
+        documentTypeSubset={
+          documentTypeSubset ?? (isCmsFile ? undefined : ["General File"])
+        }
       />
     </ToastProvider>
   );
@@ -57,9 +61,30 @@ describe("AddDocumentToDeliverableDialog", () => {
     expect(screen.getByTestId("input-autocomplete-select")).toBeInTheDocument();
   });
 
-  it("hides the File Type field on the CMS files variant", () => {
+  it("renders the File Type field on the CMS files variant", () => {
     renderDialog(true);
 
-    expect(screen.queryByTestId("input-autocomplete-select")).not.toBeInTheDocument();
+    expect(screen.getByTestId("input-autocomplete-select")).toBeInTheDocument();
+  });
+
+  it("offers both BN Template and General File for Budget Neutrality deliverables on the CMS files variant", () => {
+    renderDialog(true, ["General File", "BN Workbook", "BN Template"]);
+
+    // Opening the filter reveals each selectable option as a button
+    fireEvent.focus(screen.getByTestId("input-autocomplete-select"));
+
+    expect(screen.getByRole("button", { name: "General File" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "BN Template" })).toBeInTheDocument();
+    // BN Workbook is allowed for the deliverable but not offered on the CMS File tab
+    expect(screen.queryByRole("button", { name: "BN Workbook" })).not.toBeInTheDocument();
+  });
+
+  it("offers only General File for non-Budget-Neutrality deliverables on the CMS files variant", () => {
+    renderDialog(true, ["General File", "Monitoring Report"]);
+
+    const fileTypeInput = screen.getByTestId("input-autocomplete-select");
+    // A single option leaves the filter disabled and pinned to General File
+    expect(fileTypeInput).toBeDisabled();
+    expect(fileTypeInput).toHaveValue("General File");
   });
 });

--- a/client/src/components/dialog/document/AddDocumentToDeliverableDialog.tsx
+++ b/client/src/components/dialog/document/AddDocumentToDeliverableDialog.tsx
@@ -55,10 +55,11 @@ export const UPLOAD_DOCUMENT_TO_DELIVERABLE_CMS_FILES_MUTATION: TypedDocumentNod
 
 const CMS_FILE_DEFAULT_DOCUMENT_TYPE: DocumentType = "General File";
 
-const pickCmsDocumentType = (allowed?: DocumentType[]): DocumentType => {
-  if (!allowed || allowed.length === 0) return CMS_FILE_DEFAULT_DOCUMENT_TYPE;
-  if (allowed.includes(CMS_FILE_DEFAULT_DOCUMENT_TYPE)) return CMS_FILE_DEFAULT_DOCUMENT_TYPE;
-  return allowed[0];
+const CMS_FILE_DOCUMENT_TYPES: DocumentType[] = [CMS_FILE_DEFAULT_DOCUMENT_TYPE, "BN Template"];
+
+const getCmsFileDocumentTypeSubset = (allowed: DocumentType[] = []): DocumentType[] => {
+  const subset = CMS_FILE_DOCUMENT_TYPES.filter((type) => allowed.includes(type));
+  return subset.length > 0 ? subset : [CMS_FILE_DEFAULT_DOCUMENT_TYPE];
 };
 
 interface AddDocumentToDeliverableDialogProps {
@@ -80,6 +81,9 @@ export const AddDocumentToDeliverableDialog: React.FC<AddDocumentToDeliverableDi
 }) => {
   const { showError } = useToast();
   const client = useApolloClient();
+  const effectiveDocumentTypeSubset = isCmsFile
+    ? getCmsFileDocumentTypeSubset(documentTypeSubset)
+    : documentTypeSubset;
   const { documentPassedVirusScan } = useDocumentPassedVirusScan();
   const { waitForBNValidation } = useBNValidationStatus();
   const { uploadDocument: uploadStateDocument } = useUploadDocument(
@@ -102,9 +106,7 @@ export const AddDocumentToDeliverableDialog: React.FC<AddDocumentToDeliverableDi
       deliverableId,
       name: dialogFields.name,
       description: dialogFields.description,
-      documentType: isCmsFile
-        ? pickCmsDocumentType(documentTypeSubset)
-        : dialogFields.documentType,
+      documentType: dialogFields.documentType,
     };
 
     const pendingUpload = isCmsFile
@@ -146,10 +148,9 @@ export const AddDocumentToDeliverableDialog: React.FC<AddDocumentToDeliverableDi
       onClose={onClose}
       mode="add"
       onSubmit={handleUpload}
-      documentTypeSubset={documentTypeSubset}
+      documentTypeSubset={effectiveDocumentTypeSubset}
       titleOverride="Upload Document"
-      hideDocumentType={isCmsFile}
-      canEditDocumentType={!isCmsFile && (documentTypeSubset?.length ?? 0) !== 1}
+      canEditDocumentType={(effectiveDocumentTypeSubset?.length ?? 0) !== 1}
     />
   );
 };


### PR DESCRIPTION
On the **CMS File tab**, the upload modal now shows the **File Type** filter. For **Annual / Quarterly Budget Neutrality Report** deliverables it offers both **BN Template** and **General File**. All other deliverable types continue to offer **General File** only.

CMS/Admin users need to upload the BN Template with the correct file type for Budget Neutrality deliverables. Previously the CMS File tab hid the file-type field and forced every upload to `General File`.


https://github.com/user-attachments/assets/8cc6ed83-17d9-44de-84da-ea21eece328e

