### PR TITLE
DEMOS-1783 Attestation dialog on BN notebook upload

### DIFF
--- a/client/src/components/dialog/AttestationDialog.test.tsx
+++ b/client/src/components/dialog/AttestationDialog.test.tsx
@@ -1,0 +1,61 @@
+import "@testing-library/jest-dom";
+
+import React from "react";
+
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { AttestationDialog } from "./AttestationDialog";
+
+const renderDialog = (overrides?: { onConfirm?: () => void; onCancel?: () => void }) => {
+  const onConfirm = overrides?.onConfirm ?? vi.fn();
+  const onCancel = overrides?.onCancel ?? vi.fn();
+  render(<AttestationDialog onConfirm={onConfirm} onCancel={onCancel} />);
+  return { onConfirm, onCancel };
+};
+
+describe("AttestationDialog", () => {
+  it("renders the attestation heading, statement, and acknowledgement checkbox", () => {
+    renderDialog();
+
+    expect(screen.getByRole("heading", { name: "Attestation Required" })).toBeInTheDocument();
+    expect(screen.getByText(/I attest that its content is/i)).toBeInTheDocument();
+    expect(screen.getByTestId("attestation-acknowledge")).toBeInTheDocument();
+  });
+
+  it("disables Confirm until the acknowledgement is checked", () => {
+    renderDialog();
+
+    const confirmButton = screen.getByTestId("button-attestation-confirm");
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("attestation-acknowledge"));
+
+    expect(confirmButton).toBeEnabled();
+  });
+
+  it("calls onConfirm once the acknowledgement is checked and Confirm is clicked", () => {
+    const { onConfirm } = renderDialog();
+
+    fireEvent.click(screen.getByTestId("attestation-acknowledge"));
+    fireEvent.click(screen.getByTestId("button-attestation-confirm"));
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onConfirm when Confirm is clicked without acknowledgement", () => {
+    const { onConfirm } = renderDialog();
+
+    fireEvent.click(screen.getByTestId("button-attestation-confirm"));
+
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("calls onCancel when the dialog is cancelled", () => {
+    const { onCancel } = renderDialog();
+
+    fireEvent.click(screen.getByTestId("button-dialog-cancel"));
+
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+});

--- a/client/src/components/dialog/AttestationDialog.test.tsx
+++ b/client/src/components/dialog/AttestationDialog.test.tsx
@@ -19,7 +19,9 @@ describe("AttestationDialog", () => {
     renderDialog();
 
     expect(screen.getByRole("heading", { name: "Attestation Required" })).toBeInTheDocument();
-    expect(screen.getByText(/I attest that its content is/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/I attest the information included with this submission is true and accurate/i)
+    ).toBeInTheDocument();
     expect(screen.getByTestId("attestation-acknowledge")).toBeInTheDocument();
   });
 

--- a/client/src/components/dialog/AttestationDialog.tsx
+++ b/client/src/components/dialog/AttestationDialog.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from "react";
+
+import { Button } from "components/button";
+import { Checkbox } from "components/input";
+import { InfoIcon } from "components/icons";
+import { tw } from "tags/tw";
+import { BaseDialog } from "./BaseDialog";
+
+const STYLES = {
+  statement: tw`flex items-start gap-2 text-sm text-text-font`,
+  acknowledgement: tw`mt-sm`,
+};
+
+const ATTESTATION_STATEMENT =
+  "By uploading this Budget Neutrality (BN) notebook, I attest that its content is " +
+  "accurate, complete, and compliant with all applicable CMS requirements to the best " +
+  "of my knowledge.";
+
+const ACKNOWLEDGEMENT_LABEL = "I acknowledge and attest to the statement above.";
+
+export const AttestationDialog: React.FC<{
+  onConfirm: () => void;
+  onCancel: () => void;
+}> = ({ onConfirm, onCancel }) => {
+  const [hasAcknowledged, setHasAcknowledged] = useState(false);
+
+  return (
+    <BaseDialog
+      name="attestation-dialog"
+      title="Attestation Required"
+      dialogHasChanges={false}
+      onClose={onCancel}
+      maxWidthClass="max-w-[600px]"
+      actionButton={
+        <Button
+          name="button-attestation-confirm"
+          size="small"
+          disabled={!hasAcknowledged}
+          onClick={onConfirm}
+        >
+          Confirm &amp; Upload
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-sm">
+        <p className={STYLES.statement}>
+          <InfoIcon className="mt-0.5 shrink-0" />
+          <span>{ATTESTATION_STATEMENT}</span>
+        </p>
+
+        <div className={STYLES.acknowledgement}>
+          <Checkbox
+            name="attestation-acknowledge"
+            label={ACKNOWLEDGEMENT_LABEL}
+            checked={hasAcknowledged}
+            onChange={(event) => setHasAcknowledged(event.target.checked)}
+          />
+        </div>
+      </div>
+    </BaseDialog>
+  );
+};

--- a/client/src/components/dialog/AttestationDialog.tsx
+++ b/client/src/components/dialog/AttestationDialog.tsx
@@ -12,9 +12,8 @@ const STYLES = {
 };
 
 const ATTESTATION_STATEMENT =
-  "By uploading this Budget Neutrality (BN) notebook, I attest that its content is " +
-  "accurate, complete, and compliant with all applicable CMS requirements to the best " +
-  "of my knowledge.";
+  "By uploading this Budget Neutrality (BN) notebook, I attest the information included " +
+  "with this submission is true and accurate to the best of my knowledge.";
 
 const ACKNOWLEDGEMENT_LABEL = "I acknowledge and attest to the statement above.";
 

--- a/client/src/components/dialog/document/DocumentDialog.test.tsx
+++ b/client/src/components/dialog/document/DocumentDialog.test.tsx
@@ -1,6 +1,18 @@
-import { describe, it, expect } from "vitest";
-import { checkFormHasChanges } from "./DocumentDialog";
-import type { DocumentDialogFields } from "./DocumentDialog";
+import "@testing-library/jest-dom";
+
+import React from "react";
+
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { ToastProvider } from "components/toast/ToastContext";
+import { DocumentType } from "demos-server";
+import {
+  checkFormHasChanges,
+  documentTypeRequiresAttestation,
+  DocumentDialog,
+} from "./DocumentDialog";
+import type { DocumentDialogFields, DocumentUploadResult } from "./DocumentDialog";
 
 describe("checkFormHasChanges", () => {
   const base: DocumentDialogFields = {
@@ -34,5 +46,85 @@ describe("checkFormHasChanges", () => {
 
   it("ignores id changes", () => {
     expect(checkFormHasChanges(base, { ...base, id: "2" })).toBe(false);
+  });
+});
+
+describe("documentTypeRequiresAttestation", () => {
+  it("requires attestation for BN notebook document types", () => {
+    expect(documentTypeRequiresAttestation("Final Budget Neutrality Formulation Workbook")).toBe(
+      true
+    );
+    expect(documentTypeRequiresAttestation("BN Workbook")).toBe(true);
+  });
+
+  it("does not require attestation for other document types", () => {
+    expect(documentTypeRequiresAttestation("General File")).toBe(false);
+    expect(documentTypeRequiresAttestation("Approval Letter")).toBe(false);
+  });
+});
+
+const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+const renderAddDialog = (documentType: DocumentType, onSubmit: () => Promise<DocumentUploadResult>) =>
+  render(
+    <ToastProvider>
+      <DocumentDialog mode="add" documentTypeSubset={[documentType]} onSubmit={onSubmit} />
+    </ToastProvider>
+  );
+
+const selectFile = (fileName: string) => {
+  const file = new File(["content"], fileName, { type: DOCX_MIME });
+  fireEvent.change(screen.getByTestId("input-file"), { target: { files: [file] } });
+};
+
+describe("DocumentDialog attestation gating", () => {
+  it("shows the attestation dialog and defers upload for a BN notebook", async () => {
+    const onSubmit = vi.fn(() => Promise.resolve<DocumentUploadResult>("succeeded"));
+    renderAddDialog("Final Budget Neutrality Formulation Workbook", onSubmit);
+
+    selectFile("bn-notebook.docx");
+    fireEvent.click(screen.getByTestId("button-confirm-upload-document"));
+
+    expect(
+      await screen.findByRole("heading", { name: "Attestation Required" })
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with the upload after the attestation is confirmed", async () => {
+    const onSubmit = vi.fn(() => Promise.resolve<DocumentUploadResult>("succeeded"));
+    renderAddDialog("Final Budget Neutrality Formulation Workbook", onSubmit);
+
+    selectFile("bn-notebook.docx");
+    fireEvent.click(screen.getByTestId("button-confirm-upload-document"));
+
+    fireEvent.click(await screen.findByTestId("attestation-acknowledge"));
+    fireEvent.click(screen.getByTestId("button-attestation-confirm"));
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it("cancels the upload without submitting when the attestation is dismissed", async () => {
+    const onSubmit = vi.fn(() => Promise.resolve<DocumentUploadResult>("succeeded"));
+    renderAddDialog("Final Budget Neutrality Formulation Workbook", onSubmit);
+
+    selectFile("bn-notebook.docx");
+    fireEvent.click(screen.getByTestId("button-confirm-upload-document"));
+
+    const cancelButtons = await screen.findAllByTestId("button-dialog-cancel");
+    fireEvent.click(cancelButtons[cancelButtons.length - 1]);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("uploads non-BN documents directly without an attestation", async () => {
+    const onSubmit = vi.fn(() => Promise.resolve<DocumentUploadResult>("succeeded"));
+    renderAddDialog("General File", onSubmit);
+
+    selectFile("general.docx");
+    fireEvent.click(screen.getByTestId("button-confirm-upload-document"));
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("heading", { name: "Attestation Required" })).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/dialog/document/DocumentDialog.tsx
+++ b/client/src/components/dialog/document/DocumentDialog.tsx
@@ -12,9 +12,19 @@ import { useFileDrop } from "hooks/file/useFileDrop";
 import { ErrorMessage, UploadStatus, useFileUpload } from "hooks/file/useFileUpload";
 import { tw } from "tags/tw";
 import { Notice } from "components/notice";
+import { AttestationDialog } from "components/dialog/AttestationDialog";
 import { UploadButton } from "./UploadButton";
 
 type DocumentDialogType = "add" | "edit";
+
+// BN notebook uploads require the user to attest to the content before submitting.
+const ATTESTATION_DOCUMENT_TYPES: DocumentType[] = [
+  "Final Budget Neutrality Formulation Workbook",
+  "BN Workbook",
+];
+
+export const documentTypeRequiresAttestation = (documentType: DocumentType): boolean =>
+  ATTESTATION_DOCUMENT_TYPES.includes(documentType);
 
 export type DocumentUploadResult =
   | "succeeded"
@@ -332,6 +342,7 @@ export const DocumentDialog: React.FC<DocumentDialogProps> = ({
   const [documentDialogState, setDocumentDialogState] = useState<DocumentDialogState>("idle");
   const [titleManuallyEdited, setTitleManuallyEdited] = useState(false);
   const [formHasChanges, setFormHasChanges] = useState(false);
+  const [isAttestationOpen, setIsAttestationOpen] = useState(false);
 
   useEffect(() => {
     setFormHasChanges(
@@ -379,6 +390,16 @@ export const DocumentDialog: React.FC<DocumentDialogProps> = ({
       showError(ERROR_MESSAGES.missingField);
       return;
     }
+    // BN notebooks require an attestation before any data is submitted.
+    if (mode === "add" && documentTypeRequiresAttestation(activeDocument.documentType)) {
+      setIsAttestationOpen(true);
+      return;
+    }
+    await handleUpload();
+  };
+
+  const onAttestationConfirmed = async () => {
+    setIsAttestationOpen(false);
     await handleUpload();
   };
 
@@ -404,62 +425,71 @@ export const DocumentDialog: React.FC<DocumentDialogProps> = ({
   const buttonName = mode == "edit" ? "Save Changes" : "Upload Document";
 
   return (
-    <BaseDialog
-      title={dialogTitle}
-      onClose={onClose}
-      dialogHasChanges={formHasChanges}
-      actionButton={
-        <UploadButton
-          onClick={onUploadClick}
-          disabled={isMissing || !formHasChanges}
-          isUploading={documentDialogState === "uploading"}
-          label={buttonName}
-          loadingLabel={mode === "edit" ? "Saving" : "Uploading"}
+    <>
+      <BaseDialog
+        title={dialogTitle}
+        onClose={onClose}
+        dialogHasChanges={formHasChanges}
+        actionButton={
+          <UploadButton
+            onClick={onUploadClick}
+            disabled={isMissing || !formHasChanges}
+            isUploading={documentDialogState === "uploading"}
+            label={buttonName}
+            loadingLabel={mode === "edit" ? "Saving" : "Uploading"}
+          />
+        }
+        cancelButtonIsDisabled={documentDialogState === "uploading"}
+      >
+        {mode !== "edit" ? (
+          <DropTarget
+            file={file}
+            onRemove={() => setFile(null)}
+            fileInputRef={fileInputRef}
+            uploadStatus={uploadStatus}
+            uploadProgress={uploadProgress}
+            handleFileChange={handleFileChange}
+          />
+        ) : (
+          ""
+        )}
+
+        <DocumentDialogNotice
+          documentDialogState={documentDialogState}
+          setDocumentDialogState={setDocumentDialogState}
         />
-      }
-      cancelButtonIsDisabled={documentDialogState === "uploading"}
-    >
-      {mode !== "edit" ? (
-        <DropTarget
-          file={file}
-          onRemove={() => setFile(null)}
-          fileInputRef={fileInputRef}
-          uploadStatus={uploadStatus}
-          uploadProgress={uploadProgress}
-          handleFileChange={handleFileChange}
+
+        <TitleInput
+          value={activeDocument.name}
+          onChange={(val) => {
+            setActiveDocument((prev) => ({ ...prev, name: val }));
+            setTitleManuallyEdited(true);
+          }}
         />
-      ) : (
-        ""
+
+        <DescriptionInput
+          value={activeDocument.description ?? ""}
+          onChange={(val) => setActiveDocument((prev) => ({ ...prev, description: val }))}
+        />
+
+        {!hideDocumentType && (
+          <DocumentTypeInput
+            value={activeDocument.documentType}
+            onSelect={(val) =>
+              setActiveDocument((prev) => ({ ...prev, documentType: val as DocumentType }))
+            }
+            documentTypeSubset={documentTypeSubset}
+            canEditDocumentType={canEditDocumentType}
+          />
+        )}
+      </BaseDialog>
+
+      {isAttestationOpen && (
+        <AttestationDialog
+          onConfirm={onAttestationConfirmed}
+          onCancel={() => setIsAttestationOpen(false)}
+        />
       )}
-
-      <DocumentDialogNotice
-        documentDialogState={documentDialogState}
-        setDocumentDialogState={setDocumentDialogState}
-      />
-
-      <TitleInput
-        value={activeDocument.name}
-        onChange={(val) => {
-          setActiveDocument((prev) => ({ ...prev, name: val }));
-          setTitleManuallyEdited(true);
-        }}
-      />
-
-      <DescriptionInput
-        value={activeDocument.description ?? ""}
-        onChange={(val) => setActiveDocument((prev) => ({ ...prev, description: val }))}
-      />
-
-      {!hideDocumentType && (
-        <DocumentTypeInput
-          value={activeDocument.documentType}
-          onSelect={(val) =>
-            setActiveDocument((prev) => ({ ...prev, documentType: val as DocumentType }))
-          }
-          documentTypeSubset={documentTypeSubset}
-          canEditDocumentType={canEditDocumentType}
-        />
-      )}
-    </BaseDialog>
+    </>
   );
 };


### PR DESCRIPTION
When a user uploads a Budget Neutrality (BN) notebook, an attestation dialog now
appears and must be acknowledged before anything is submitted.

- **Confirm** → upload proceeds as normal.
- **Cancel / dismiss** → upload is cancelled, nothing is submitted.
- Gated on document types `Final Budget Neutrality Formulation Workbook` and `BN Workbook`.


<img width="704" height="747" alt="image" src="https://github.com/user-attachments/assets/48e742bb-05d5-4640-b237-68c2cce92dda" />
