### PR TITLE
DEMOS-2124-make-triggers-more-conditional

### DIFF
--- a/data/docs/DEMOS_Data_Model.mmd
+++ b/data/docs/DEMOS_Data_Model.mmd
@@ -554,7 +554,7 @@ erDiagram
     CONSTRAINT_CHECK check_demonstration_non_null_fields_when_approved "Validate that required fields exist if demonstration is approved."
     CONSTRAINT_CHECK check_demonstration_name_trimmed "Validate that the trim of the name is identical to the name."
     CONSTRAINT_CHECK check_demonstration_description_trimmed "Validate that the trim of the description is identical to the description."
-    CONSTRAINT_TRIGGER_DEFERRABLE_AFTER_INSERT_OR_UPDATE check_demonstration_primary_project_officer "Check that a primary project officer exists for this demonstration."
+    CONSTRAINT_TRIGGER_DEFERRABLE_AFTER_INSERT check_demonstration_primary_project_officer "Check that a primary project officer exists for this demonstration."
     TRIGGER_BEFORE_DELETE check_that_main_record_deleted_from_application "Verify that no corresponding record exists in the application table."
     TRIGGER_BEFORE_UPDATE _disable_redundant_updates "Disable redundant database updates."
     TRIGGER_BEFORE_UPDATE check_demonstration_type_exists_for_approved_demonstrations "Check that approved demonstrations have at least one demonstration type."

--- a/data/utilities/scripts/history_trigger_generator.py
+++ b/data/utilities/scripts/history_trigger_generator.py
@@ -171,7 +171,7 @@ def get_trigger_code(prisma_lines: List[str]) -> str:
     old_name_list = old_name_list.replace("                ", "", 1)
 
     query = f"""
-    CREATE OR REPLACE FUNCTION {APP_SCHEMA}.log_changes_{table_name}()
+    CREATE FUNCTION {APP_SCHEMA}.log_changes_{table_name}()
     RETURNS TRIGGER AS $$
     BEGIN
         IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -202,7 +202,7 @@ def get_trigger_code(prisma_lines: List[str]) -> str:
     END;
     $$ LANGUAGE plpgsql;
 
-    CREATE OR REPLACE TRIGGER log_changes_{table_name}
+    CREATE TRIGGER log_changes_{table_name}
     AFTER INSERT OR UPDATE OR DELETE ON {APP_SCHEMA}.{table_name}
     FOR EACH ROW EXECUTE FUNCTION {APP_SCHEMA}.log_changes_{table_name}();"""
     query = query.replace("\n", "", 1)

--- a/server/src/sql/functions.sql
+++ b/server/src/sql/functions.sql
@@ -121,7 +121,7 @@ END;
 $$;
 
 CREATE CONSTRAINT TRIGGER check_demonstration_primary_project_officer
-AFTER INSERT OR UPDATE ON demos_app.demonstration
+AFTER INSERT ON demos_app.demonstration
 DEFERRABLE INITIALLY DEFERRED
 FOR EACH ROW
 EXECUTE FUNCTION demos_app.check_demonstration_primary_project_officer();
@@ -161,7 +161,7 @@ END;
 $$;
 
 CREATE CONSTRAINT TRIGGER check_demonstration_retains_primary_project_officer
-AFTER UPDATE OR DELETE ON demos_app.primary_demonstration_role_assignment
+AFTER UPDATE OF role_id OR DELETE ON demos_app.primary_demonstration_role_assignment
 DEFERRABLE INITIALLY DEFERRED
 FOR EACH ROW
 EXECUTE FUNCTION demos_app.check_demonstration_retains_primary_project_officer();
@@ -439,7 +439,7 @@ FOR EACH ROW
 EXECUTE FUNCTION demos_app.check_application_type_record_exists();
 
 -- update_application_current_phase_on_phase_update
-CREATE OR REPLACE FUNCTION demos_app.update_application_current_phase_on_phase_update()
+CREATE FUNCTION demos_app.update_application_current_phase_on_phase_update()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
@@ -520,12 +520,12 @@ END;
 $$;
 
 CREATE TRIGGER update_application_current_phase_on_phase_update
-AFTER UPDATE ON demos_app.application_phase
+AFTER UPDATE OF phase_status_id ON demos_app.application_phase
 FOR EACH ROW
 EXECUTE FUNCTION demos_app.update_application_current_phase_on_phase_update();
 
 -- update_application_status_on_phase_update
-CREATE OR REPLACE FUNCTION demos_app.update_application_status_on_phase_update()
+CREATE FUNCTION demos_app.update_application_status_on_phase_update()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
@@ -623,7 +623,7 @@ END;
 $$;
 
 CREATE TRIGGER update_application_status_on_phase_update
-AFTER UPDATE ON demos_app.application_phase
+AFTER UPDATE OF phase_id, phase_status_id ON demos_app.application_phase
 FOR EACH ROW
 EXECUTE FUNCTION demos_app.update_application_status_on_phase_update();
 
@@ -759,7 +759,7 @@ END;
 $$;
 
 -- disable_redundant_updates
-CREATE OR REPLACE FUNCTION demos_app.disable_redundant_updates()
+CREATE FUNCTION demos_app.disable_redundant_updates()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
@@ -1049,7 +1049,7 @@ FOR EACH ROW
 EXECUTE FUNCTION demos_app.check_suggestion_has_extract();
 
 -- check_demonstration_type_exists_for_approved_demos
-CREATE OR REPLACE FUNCTION demos_app.check_demonstration_type_exists_for_approved_demonstrations()
+CREATE FUNCTION demos_app.check_demonstration_type_exists_for_approved_demonstrations()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
@@ -1115,7 +1115,7 @@ FOR EACH ROW
 EXECUTE FUNCTION demos_app.check_demonstration_type_exists_for_approved_demonstrations();
 
 CREATE TRIGGER check_demonstration_type_exists_for_approved_demonstrations
-BEFORE UPDATE ON demos_app.demonstration
+BEFORE UPDATE of status_id ON demos_app.demonstration
 FOR EACH ROW
 EXECUTE FUNCTION demos_app.check_demonstration_type_exists_for_approved_demonstrations();
 
@@ -1283,7 +1283,7 @@ END;
 $$;
 
 CREATE TRIGGER change_open_ended_due_dates_to_expiration_date
-AFTER UPDATE ON demos_app.demonstration
+AFTER UPDATE OF expiration_date ON demos_app.demonstration
 FOR EACH ROW
 EXECUTE FUNCTION demos_app.change_open_ended_due_dates_to_expiration_date();
 

--- a/server/src/sql/history_triggers.sql
+++ b/server/src/sql/history_triggers.sql
@@ -45,7 +45,7 @@ BEGIN
 END
 $$;
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_amendment()
+CREATE FUNCTION demos_app.log_changes_amendment()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -120,11 +120,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_amendment
+CREATE TRIGGER log_changes_amendment
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.amendment
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_amendment();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_application()
+CREATE FUNCTION demos_app.log_changes_application()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -159,11 +159,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_application
+CREATE TRIGGER log_changes_application
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.application
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_application();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_application_date()
+CREATE FUNCTION demos_app.log_changes_application_date()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -210,11 +210,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_application_date
+CREATE TRIGGER log_changes_application_date
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.application_date
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_application_date();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_application_note()
+CREATE FUNCTION demos_app.log_changes_application_note()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -261,11 +261,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_application_note
+CREATE TRIGGER log_changes_application_note
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.application_note
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_application_note();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_application_phase()
+CREATE FUNCTION demos_app.log_changes_application_phase()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -312,11 +312,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_application_phase
+CREATE TRIGGER log_changes_application_phase
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.application_phase
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_application_phase();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_application_tag_assignment()
+CREATE FUNCTION demos_app.log_changes_application_tag_assignment()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -355,11 +355,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_application_tag_assignment
+CREATE TRIGGER log_changes_application_tag_assignment
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.application_tag_assignment
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_application_tag_assignment();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_application_tag_suggestion()
+CREATE FUNCTION demos_app.log_changes_application_tag_suggestion()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -410,11 +410,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_application_tag_suggestion
+CREATE TRIGGER log_changes_application_tag_suggestion
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.application_tag_suggestion
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_application_tag_suggestion();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_application_tag_suggestion_extract()
+CREATE FUNCTION demos_app.log_changes_application_tag_suggestion_extract()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -473,11 +473,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_application_tag_suggestion_extract
+CREATE TRIGGER log_changes_application_tag_suggestion_extract
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.application_tag_suggestion_extract
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_application_tag_suggestion_extract();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_budget_neutrality_workbook()
+CREATE FUNCTION demos_app.log_changes_budget_neutrality_workbook()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -536,11 +536,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_budget_neutrality_workbook
+CREATE TRIGGER log_changes_budget_neutrality_workbook
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.budget_neutrality_workbook
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_budget_neutrality_workbook();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_deliverable()
+CREATE FUNCTION demos_app.log_changes_deliverable()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -619,11 +619,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_deliverable
+CREATE TRIGGER log_changes_deliverable
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.deliverable
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_deliverable();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_deliverable_action()
+CREATE FUNCTION demos_app.log_changes_deliverable_action()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -710,11 +710,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_deliverable_action
+CREATE TRIGGER log_changes_deliverable_action
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.deliverable_action
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_deliverable_action();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_deliverable_demonstration_type()
+CREATE FUNCTION demos_app.log_changes_deliverable_demonstration_type()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -753,11 +753,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_deliverable_demonstration_type
+CREATE TRIGGER log_changes_deliverable_demonstration_type
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.deliverable_demonstration_type
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_deliverable_demonstration_type();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_deliverable_extension()
+CREATE FUNCTION demos_app.log_changes_deliverable_extension()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -816,11 +816,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_deliverable_extension
+CREATE TRIGGER log_changes_deliverable_extension
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.deliverable_extension
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_deliverable_extension();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_demonstration()
+CREATE FUNCTION demos_app.log_changes_demonstration()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -903,11 +903,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_demonstration
+CREATE TRIGGER log_changes_demonstration
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.demonstration
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_demonstration();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_demonstration_role_assignment()
+CREATE FUNCTION demos_app.log_changes_demonstration_role_assignment()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -958,11 +958,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_demonstration_role_assignment
+CREATE TRIGGER log_changes_demonstration_role_assignment
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.demonstration_role_assignment
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_demonstration_role_assignment();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_demonstration_type_tag_assignment()
+CREATE FUNCTION demos_app.log_changes_demonstration_type_tag_assignment()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1017,11 +1017,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_demonstration_type_tag_assignment
+CREATE TRIGGER log_changes_demonstration_type_tag_assignment
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.demonstration_type_tag_assignment
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_demonstration_type_tag_assignment();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_document()
+CREATE FUNCTION demos_app.log_changes_document()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1108,11 +1108,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_document
+CREATE TRIGGER log_changes_document
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.document
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_document();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_document_infected()
+CREATE FUNCTION demos_app.log_changes_document_infected()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1199,11 +1199,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_document_infected
+CREATE TRIGGER log_changes_document_infected
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.document_infected
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_document_infected();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_document_pending_upload()
+CREATE FUNCTION demos_app.log_changes_document_pending_upload()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1278,11 +1278,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_document_pending_upload
+CREATE TRIGGER log_changes_document_pending_upload
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.document_pending_upload
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_document_pending_upload();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_extension()
+CREATE FUNCTION demos_app.log_changes_extension()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1357,11 +1357,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_extension
+CREATE TRIGGER log_changes_extension
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.extension
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_extension();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_person()
+CREATE FUNCTION demos_app.log_changes_person()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1416,11 +1416,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_person
+CREATE TRIGGER log_changes_person
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.person
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_person();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_person_state()
+CREATE FUNCTION demos_app.log_changes_person_state()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1455,11 +1455,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_person_state
+CREATE TRIGGER log_changes_person_state
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.person_state
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_person_state();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_primary_demonstration_role_assignment()
+CREATE FUNCTION demos_app.log_changes_primary_demonstration_role_assignment()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1498,11 +1498,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_primary_demonstration_role_assignment
+CREATE TRIGGER log_changes_primary_demonstration_role_assignment
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.primary_demonstration_role_assignment
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_primary_demonstration_role_assignment();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_private_comment()
+CREATE FUNCTION demos_app.log_changes_private_comment()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1557,11 +1557,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_private_comment
+CREATE TRIGGER log_changes_private_comment
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.private_comment
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_private_comment();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_public_comment()
+CREATE FUNCTION demos_app.log_changes_public_comment()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1612,11 +1612,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_public_comment
+CREATE TRIGGER log_changes_public_comment
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.public_comment
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_public_comment();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_reference()
+CREATE FUNCTION demos_app.log_changes_reference()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1675,11 +1675,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_reference
+CREATE TRIGGER log_changes_reference
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.reference
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_reference();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_reference_agreement()
+CREATE FUNCTION demos_app.log_changes_reference_agreement()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1734,11 +1734,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_reference_agreement
+CREATE TRIGGER log_changes_reference_agreement
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.reference_agreement
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_reference_agreement();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_reference_configuration()
+CREATE FUNCTION demos_app.log_changes_reference_configuration()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1781,11 +1781,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_reference_configuration
+CREATE TRIGGER log_changes_reference_configuration
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.reference_configuration
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_reference_configuration();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_reference_demonstration_type()
+CREATE FUNCTION demos_app.log_changes_reference_demonstration_type()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1824,11 +1824,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_reference_demonstration_type
+CREATE TRIGGER log_changes_reference_demonstration_type
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.reference_demonstration_type
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_reference_demonstration_type();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_reference_tag_assignment()
+CREATE FUNCTION demos_app.log_changes_reference_tag_assignment()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1867,11 +1867,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_reference_tag_assignment
+CREATE TRIGGER log_changes_reference_tag_assignment
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.reference_tag_assignment
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_reference_tag_assignment();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_role_permission()
+CREATE FUNCTION demos_app.log_changes_role_permission()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1910,11 +1910,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_role_permission
+CREATE TRIGGER log_changes_role_permission
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.role_permission
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_role_permission();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_system_role_assignment()
+CREATE FUNCTION demos_app.log_changes_system_role_assignment()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -1957,11 +1957,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_system_role_assignment
+CREATE TRIGGER log_changes_system_role_assignment
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.system_role_assignment
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_system_role_assignment();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_tag()
+CREATE FUNCTION demos_app.log_changes_tag()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -2012,11 +2012,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_tag
+CREATE TRIGGER log_changes_tag
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.tag
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_tag();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_tag_name()
+CREATE FUNCTION demos_app.log_changes_tag_name()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -2055,11 +2055,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_tag_name
+CREATE TRIGGER log_changes_tag_name
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.tag_name
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_tag_name();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_uipath_result()
+CREATE FUNCTION demos_app.log_changes_uipath_result()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -2122,11 +2122,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_uipath_result
+CREATE TRIGGER log_changes_uipath_result
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.uipath_result
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_uipath_result();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_uipath_value()
+CREATE FUNCTION demos_app.log_changes_uipath_value()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -2201,11 +2201,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_uipath_value
+CREATE TRIGGER log_changes_uipath_value
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.uipath_value
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_uipath_value();
 
-CREATE OR REPLACE FUNCTION demos_app.log_changes_users()
+CREATE FUNCTION demos_app.log_changes_users()
 RETURNS TRIGGER AS $$
 BEGIN
     IF TG_OP IN ('INSERT', 'UPDATE') THEN
@@ -2256,6 +2256,6 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER log_changes_users
+CREATE TRIGGER log_changes_users
 AFTER INSERT OR UPDATE OR DELETE ON demos_app.users
 FOR EACH ROW EXECUTE FUNCTION demos_app.log_changes_users();


### PR DESCRIPTION
This does three main cleanup items on the idempotent parts of the DB code.

- History triggers are no longer generated with `CREATE OR REPLACE`. This was a leftover from before we had the loop at the start that deletes them all.
- `check_demonstration_primary_project_officer` no longer runs when we are updating `demonstration`. Nothing in an update should change the primary project officer anyway, so this was unnecessary, and it was causing me some issues with #1369. I think this was here originally because there was a column for that on the table, but now that it's removed, this can just run `AFTER INSERT`.
- Some other triggers that run on update were narrowed using the `OF column` syntax of PostgreSQL to cause them not to trigger unless the relevant columns are edited. Note that no changes were made to any of the actual function code, so there's some redundancy in the guards that were already placed in the functions in some places. We can always go back and streamline those later.
  - A few `CREATE OR REPLACE` calls in `functions.sql` were removed as well. The only remaining one is specifically in `permissions.sql` for a function we create and drop in the same file; putting it that way ensures that the function will still get created if something got aborted halfway through running before cleanup.