### PR TITLE
DEMOS-2215: removed state id from updateDemonstration calls

### DIFF
--- a/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.tsx
+++ b/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.tsx
@@ -315,7 +315,6 @@ export const ApprovalSummaryPhase = ({
           ? formatDateForServer(parseFormDateString(formData.expirationDate))
           : null,
         sdgDivision: formData.sdgDivision,
-        stateId: formData.stateId,
         projectOfficerUserId: formData.projectOfficerId,
       };
 

--- a/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
+++ b/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react";
 import { CompletableSection } from "layout/completableSection";
-import { SelectUSAStates } from "components/input/select/SelectUSAStates";
 import { Textarea, TextInput } from "components/input";
 import Switch from "react-switch";
 import { SdgDivision, SignatureLevel } from "demos-server";
@@ -33,35 +32,30 @@ export type DemonstrationDetailsFormData = BaseFormData & {
   projectOfficerName: string;
   expirationDate?: string;
   sdgDivision?: SdgDivision;
-  readonlyFields: Partial<Record<
-    | "stateId"
-    | "name"
-    | "projectOfficerId"
-    | "status"
-    | "effectiveDate"
-    | "expirationDate"
-    | "description"
-    | "sdgDivision"
-    | "signatureLevel",
-    boolean
-  >>;
+  readonlyFields: Partial<
+    Record<
+      | "stateId"
+      | "name"
+      | "projectOfficerId"
+      | "status"
+      | "effectiveDate"
+      | "expirationDate"
+      | "description"
+      | "sdgDivision"
+      | "signatureLevel",
+      boolean
+    >
+  >;
 };
 
 export type ModificationDetailsFormData = BaseFormData & {
   applicationType: "amendment" | "extension";
-  readonlyFields: Partial<Record<
-    | "name"
-    | "effectiveDate"
-    | "description"
-    | "signatureLevel",
-    boolean
-  >>;
+  readonlyFields: Partial<
+    Record<"name" | "effectiveDate" | "description" | "signatureLevel", boolean>
+  >;
 };
 
-export type ApplicationDetailsFormData =
-  | DemonstrationDetailsFormData
-  | ModificationDetailsFormData;
-
+export type ApplicationDetailsFormData = DemonstrationDetailsFormData | ModificationDetailsFormData;
 
 export const ApplicationDetailsSection = ({
   sectionFormData,
@@ -82,7 +76,9 @@ export const ApplicationDetailsSection = ({
   completionDate?: string;
   medicaidId?: string;
 }) => {
-  const capitalizedType = sectionFormData.applicationType.charAt(0).toUpperCase() + sectionFormData.applicationType.slice(1);
+  const capitalizedType =
+    sectionFormData.applicationType.charAt(0).toUpperCase() +
+    sectionFormData.applicationType.slice(1);
   const isApplicationDetailsComplete = (data: ApplicationDetailsFormData) => {
     if (data.applicationType === "demonstration") {
       return !!(
@@ -97,11 +93,7 @@ export const ApplicationDetailsSection = ({
       );
     }
 
-    return !!(
-      data.name &&
-      data.effectiveDate &&
-      data.signatureLevel
-    );
+    return !!(data.name && data.effectiveDate && data.signatureLevel);
   };
 
   const requiredFieldsFilled = useMemo(
@@ -110,32 +102,25 @@ export const ApplicationDetailsSection = ({
   );
 
   return (
-    <CompletableSection title="Application Details" isComplete={isComplete} completionDate={completionDate}>
+    <CompletableSection
+      title="Application Details"
+      isComplete={isComplete}
+      completionDate={completionDate}
+    >
       <p className="text-sm text-text-placeholder mt-1 mb-2">
-        Confirm all {sectionFormData.applicationType} information including dates and status are accurate.
+        Confirm all {sectionFormData.applicationType} information including dates and status are
+        accurate.
       </p>
       <div className="grid grid-cols-4 gap-8 text-sm text-text-placeholder">
         {sectionFormData.applicationType === "demonstration" && (
           <div className="flex flex-col">
-            {sectionFormData.readonlyFields.stateId ? (
-              <div>
-                <div className={LABEL_CLASSES}>
-                  <span className="text-text-warn mr-xs">*</span>
-                  State/Territory
-                </div>
-                <div className={VALUE_CLASSES}>
-                  {sectionFormData.stateName || ""}
-                </div>
+            <div>
+              <div className={LABEL_CLASSES}>
+                <span className="text-text-warn mr-xs">*</span>
+                State/Territory
               </div>
-            ) : (
-              <SelectUSAStates
-                label="State/Territory"
-                value={sectionFormData.stateId}
-                isRequired
-                isDisabled={isReadonly}
-                onSelect={(stateId) => setSectionFormData({ ...sectionFormData, stateId })}
-              />
-            )}
+              <div className={VALUE_CLASSES}>{sectionFormData.stateName || ""}</div>
+            </div>
           </div>
         )}
         <div className="flex flex-col col-span-3">
@@ -145,9 +130,7 @@ export const ApplicationDetailsSection = ({
                 <span className="text-text-warn mr-xs">*</span>
                 {capitalizedType} Title
               </div>
-              <div className={VALUE_CLASSES}>
-                {sectionFormData.name || ""}
-              </div>
+              <div className={VALUE_CLASSES}>{sectionFormData.name || ""}</div>
             </div>
           ) : (
             <TextInput
@@ -170,9 +153,7 @@ export const ApplicationDetailsSection = ({
                   <span className="text-text-warn mr-xs">*</span>
                   Project Officer
                 </div>
-                <div className={VALUE_CLASSES}>
-                  {sectionFormData.projectOfficerName || ""}
-                </div>
+                <div className={VALUE_CLASSES}>{sectionFormData.projectOfficerName || ""}</div>
               </div>
             ) : (
               <SelectUsers
@@ -197,9 +178,7 @@ export const ApplicationDetailsSection = ({
                   <span className="text-text-warn mr-xs">*</span>
                   Status
                 </div>
-                <div className={VALUE_CLASSES}>
-                  {sectionFormData.status || ""}
-                </div>
+                <div className={VALUE_CLASSES}>{sectionFormData.status || ""}</div>
               </div>
             ) : (
               <TextInput
@@ -243,12 +222,8 @@ export const ApplicationDetailsSection = ({
         {sectionFormData.applicationType !== "demonstration" && (
           <div className="flex flex-col col-span-4">
             <div>
-              <div className={LABEL_CLASSES}>
-                Demonstration ID
-              </div>
-              <div className={VALUE_CLASSES}>
-                { medicaidId || "-" }
-              </div>
+              <div className={LABEL_CLASSES}>Demonstration ID</div>
+              <div className={VALUE_CLASSES}>{medicaidId || "-"}</div>
             </div>
           </div>
         )}
@@ -283,12 +258,8 @@ export const ApplicationDetailsSection = ({
         <div className="flex flex-col col-span-4">
           {sectionFormData.readonlyFields.description || isComplete ? (
             <div>
-              <div className={LABEL_CLASSES}>
-                {`${capitalizedType} Description`}
-              </div>
-              <div className={VALUE_CLASSES}>
-                {sectionFormData.description || "-"}
-              </div>
+              <div className={LABEL_CLASSES}>{`${capitalizedType} Description`}</div>
+              <div className={VALUE_CLASSES}>{sectionFormData.description || "-"}</div>
             </div>
           ) : (
             <Textarea
@@ -310,17 +281,13 @@ export const ApplicationDetailsSection = ({
                   <span className="text-text-warn mr-xs">*</span>
                   SDG Division
                 </div>
-                <div className={VALUE_CLASSES}>
-                  {sectionFormData.sdgDivision || ""}
-                </div>
+                <div className={VALUE_CLASSES}>{sectionFormData.sdgDivision || ""}</div>
               </div>
             ) : (
               <SelectSdgDivision
                 key={`sdg-${sectionFormData.sdgDivision || "empty"}`}
                 initialValue={sectionFormData.sdgDivision}
-                onSelect={(sdgDivision) =>
-                  setSectionFormData({ ...sectionFormData, sdgDivision })
-                }
+                onSelect={(sdgDivision) => setSectionFormData({ ...sectionFormData, sdgDivision })}
                 isDisabled={isReadonly}
                 isRequired
               />
@@ -335,9 +302,7 @@ export const ApplicationDetailsSection = ({
                 <span className="text-text-warn mr-xs">*</span>
                 Signature Level
               </div>
-              <div className={VALUE_CLASSES}>
-                {sectionFormData.signatureLevel || "-"}
-              </div>
+              <div className={VALUE_CLASSES}>{sectionFormData.signatureLevel || "-"}</div>
             </div>
           ) : (
             <SelectSignatureLevel
@@ -361,9 +326,7 @@ export const ApplicationDetailsSection = ({
       <div className="border-t-1 border-gray-dark mt-4">
         <div className="flex justify-end items-center mt-2 gap-2">
           <span className="text-sm font-semibold text-text-font">
-            <span className="text-text-warn mr-xs">*</span>
-            {" "}
-            Mark Complete
+            <span className="text-text-warn mr-xs">*</span> Mark Complete
           </span>
           <Switch
             checked={isComplete}

--- a/client/src/components/dialog/demonstration/DemonstrationDialog.test.tsx
+++ b/client/src/components/dialog/demonstration/DemonstrationDialog.test.tsx
@@ -205,7 +205,7 @@ describe("DemonstrationDialog", () => {
 
   it("should enable submit button when form has changes and is valid", async () => {
     const user = userEvent.setup();
-    const { getByTestId } = render(getDemonstrationDialog("edit"));
+    const { getByTestId } = render(getDemonstrationDialog("create"));
 
     const submitButton = getByTestId(SUBMIT_BUTTON_TEST_ID);
     expect(submitButton).toBeDisabled();

--- a/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
@@ -12,6 +12,8 @@ import { DatePicker } from "components/input/date/DatePicker";
 import { EXPIRATION_DATE_ERROR_MESSAGE } from "util/messages";
 import { SubmitButton } from "components/button/SubmitButton";
 import { isBefore } from "date-fns";
+import { Input } from "components/input/Input";
+import { STATES_AND_TERRITORIES } from "demos-server-constants";
 
 export const DEMONSTRATION_DIALOG_DESCRIPTION_NAME = "textarea-demonstration-description";
 export const DEFAULT_DEMONSTRATION_SIGNATURE_LEVEL = "OA" as SignatureLevel;
@@ -167,12 +169,25 @@ export const DemonstrationDialog: React.FC<{
     >
       <form id="demonstration-form" className="flex flex-col gap-[24px]">
         <div className="grid grid-cols-3 gap-[24px]">
-          <SelectUSAStates
-            label="State/Territory"
-            value={activeDemonstration.stateId}
-            isRequired
-            onSelect={(stateId) => handleChange({ ...activeDemonstration, stateId })}
-          />
+          {mode === "create" ? (
+            <SelectUSAStates
+              label="State/Territory"
+              value={activeDemonstration.stateId}
+              isRequired
+              onSelect={(stateId) => handleChange({ ...activeDemonstration, stateId })}
+            />
+          ) : (
+            <Input
+              type="text"
+              name="state-display"
+              label="State/Territory"
+              value={
+                STATES_AND_TERRITORIES.find((state) => state.id === activeDemonstration.stateId)
+                  ?.name
+              }
+              isDisabled
+            />
+          )}
           <div className="col-span-2">
             <TextInput
               name="input-demonstration-title"
@@ -227,9 +242,7 @@ export const DemonstrationDialog: React.FC<{
             initialValue={DEFAULT_DEMONSTRATION_SIGNATURE_LEVEL}
             allowedSignatureLevels={["OA"]}
             isDisabled
-            onSelect={(signatureLevel) =>
-              handleChange({ ...activeDemonstration, signatureLevel })
-            }
+            onSelect={(signatureLevel) => handleChange({ ...activeDemonstration, signatureLevel })}
           />
         </div>
       </form>

--- a/client/src/components/dialog/demonstration/EditDemonstrationDialog.test.tsx
+++ b/client/src/components/dialog/demonstration/EditDemonstrationDialog.test.tsx
@@ -269,7 +269,6 @@ describe("getUpdateDemonstrationInput", () => {
   it("maps name, stateId, and projectOfficerId as-is", () => {
     const result = getUpdateDemonstrationInput(BASE_DEMONSTRATION);
     expect(result.name).toBe("My Demo");
-    expect(result.stateId).toBe("AL");
     expect(result.projectOfficerUserId).toBe("officer-1");
   });
 

--- a/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
@@ -65,7 +65,6 @@ export const getUpdateDemonstrationInput = (
 ): UpdateDemonstrationInput => {
   return {
     ...(demonstration.name && { name: demonstration.name }),
-    ...(demonstration.stateId && { stateId: demonstration.stateId }),
     ...(demonstration.projectOfficerId && {
       projectOfficerUserId: demonstration.projectOfficerId,
     }),


### PR DESCRIPTION
wasnt as difficult as i thought. Just removes stateId from the data that gets packaged up and sent to the update mutator. We only do this in two places, in the Update Demonstration dialog and in phase 8 of the application process. Instead of the state dropdown, we are going to just display the state. 

https://github.com/user-attachments/assets/ee02c5d4-0b91-4488-be1a-8ae679d9626c

As an aside, the create and edit demonstration dialogs are getting pretty unwieldy. As a refactor item, it would be great to fully separate them into two separate dialogs since their display and behaviors are divergent enough to warrant it
