### PR TITLE
DEMOS-2124-return-actual-chip-medicaid-values

### DIFF
--- a/server/src/model/demonstration/demonstrationResolvers.test.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.test.ts
@@ -46,7 +46,10 @@ import { getManyDocuments } from "../document";
 import { selectManyApplicationPhases } from "../applicationPhase/queries";
 import { selectManyApplicationTagAssignments } from "../applicationTagAssignment/queries";
 import { ApplicationTagAssignmentQueryResult } from "../applicationTagAssignment/queries";
-import { selectManyDemonstrationTypeTagAssignments } from "../demonstrationTypeTagAssignment/queries";
+import {
+  selectDemonstrationTypeTagAssignment,
+  selectManyDemonstrationTypeTagAssignments,
+} from "../demonstrationTypeTagAssignment/queries";
 import { DemonstrationTypeTagAssignmentQueryResult } from "../demonstrationTypeTagAssignment/queries";
 import {
   selectDemonstrationRoleAssignmentOrThrow,
@@ -91,6 +94,7 @@ vi.mock("../applicationTagSuggestion/queries", () => ({
 }));
 
 vi.mock("../demonstrationTypeTagAssignment/queries", () => ({
+  selectDemonstrationTypeTagAssignment: vi.fn(),
   selectManyDemonstrationTypeTagAssignments: vi.fn(),
 }));
 
@@ -491,6 +495,46 @@ describe("demonstrationResolvers", () => {
 
       const result = demonstrationResolvers.Demonstration.clearanceLevel(demonstration);
       expect(result).toBe(demonstration.clearanceLevelId);
+    });
+  });
+
+  describe("Demonstration.chipId", () => {
+    it("returns null if the demonstration type is not present", async () => {
+      const demonstration: Partial<PrismaDemonstration> = {
+        id: testValues.demonstrationId,
+        chipId: "21-W-99999/10",
+      };
+
+      const result = await demonstrationResolvers.Demonstration.chipId(
+        demonstration as PrismaDemonstration
+      );
+      expect(selectDemonstrationTypeTagAssignment).toHaveBeenCalledExactlyOnceWith({
+        demonstrationId: testValues.demonstrationId,
+        tagNameId: "Children's Health Insurance Program (CHIP)",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("returns the CHIP ID if the demonstration type is present", async () => {
+      const mockResult: Partial<DemonstrationTypeTagAssignmentQueryResult> = {
+        demonstrationId: testValues.demonstrationId,
+      };
+      vi.mocked(selectDemonstrationTypeTagAssignment).mockResolvedValue(
+        mockResult as DemonstrationTypeTagAssignmentQueryResult
+      );
+      const demonstration: Partial<PrismaDemonstration> = {
+        id: testValues.demonstrationId,
+        chipId: "21-W-99999/10",
+      };
+
+      const result = await demonstrationResolvers.Demonstration.chipId(
+        demonstration as PrismaDemonstration
+      );
+      expect(selectDemonstrationTypeTagAssignment).toHaveBeenCalledExactlyOnceWith({
+        demonstrationId: testValues.demonstrationId,
+        tagNameId: "Children's Health Insurance Program (CHIP)",
+      });
+      expect(result).toBe(demonstration.chipId);
     });
   });
 

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -38,7 +38,10 @@ import { getManyExtensions } from "../extension";
 import { getManyDocuments } from "../document";
 import { selectManyApplicationPhases } from "../applicationPhase/queries";
 import { selectManyApplicationTagAssignments } from "../applicationTagAssignment/queries";
-import { selectManyDemonstrationTypeTagAssignments } from "../demonstrationTypeTagAssignment/queries";
+import {
+  selectDemonstrationTypeTagAssignment,
+  selectManyDemonstrationTypeTagAssignments,
+} from "../demonstrationTypeTagAssignment/queries";
 import {
   selectDemonstrationRoleAssignmentOrThrow,
   selectManyDemonstrationRoleAssignments,
@@ -323,6 +326,16 @@ export const demonstrationResolvers = {
         }
       ),
     deliverables: resolveManyDeliverables,
-    medicaidId: (): string => "11-W-99999/8", // Placeholder value to be updated in DEMOS-2124
-  }
+    chipId: async (parent: PrismaDemonstration): Promise<string | null> => {
+      const chipDemonstrationType = await selectDemonstrationTypeTagAssignment({
+        demonstrationId: parent.id,
+        tagNameId: "Children's Health Insurance Program (CHIP)",
+      });
+      if (!chipDemonstrationType) {
+        return null;
+      } else {
+        return parent.chipId;
+      }
+    },
+  },
 };

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -331,10 +331,10 @@ export const demonstrationResolvers = {
         demonstrationId: parent.id,
         tagNameId: "Children's Health Insurance Program (CHIP)",
       });
-      if (!chipDemonstrationType) {
-        return null;
-      } else {
+      if (chipDemonstrationType) {
         return parent.chipId;
+      } else {
+        return null;
       }
     },
   },


### PR DESCRIPTION
Now that Medicaid ID and CHIP ID are properly produced in the DB and guaranteed to exist, this was actually really fast to implement. I replaced `medicaidId` with `chipId` entirely in the resolver, because there's no need for customization of `medicaidId`. (It was briefly confusing that everything was showing the CHIP ID in the front-end initially, but I realized its because it directly resolved the fields since the GQL and Prisma models have the same name.)

Tested it locally. Adding the CHIP tag makes the CHIP ID appear, removing it makes it disappear again.