### PR TITLE
DEMOS-2210: 508 Compliance - `<hr>` elements get `aria-hidden`

### DIFF
--- a/client/src/components/application/amendment/AmendmentWorkflow.tsx
+++ b/client/src/components/application/amendment/AmendmentWorkflow.tsx
@@ -50,22 +50,9 @@ export const GET_AMENDMENT_WORKFLOW_QUERY = gql`
   ${WORKFLOW_DOCUMENT_FIELDS}
 `;
 
-export type ApplicationWorkflowAmendment =
-  WorkflowApplication &
-  Pick<
-    Amendment,
-    "name" |
-    "description" |
-    "effectiveDate" |
-    "signatureLevel" |
-    "status"
-  > & {
-    demonstration: Pick<
-        Demonstration,
-        | "id"
-        | "status"
-        | "medicaidId"
-      > & {
+export type ApplicationWorkflowAmendment = WorkflowApplication &
+  Pick<Amendment, "name" | "description" | "effectiveDate" | "signatureLevel" | "status"> & {
+    demonstration: Pick<Demonstration, "id" | "status" | "medicaidId"> & {
       demonstrationTypes: Pick<
         DemonstrationTypeAssignment,
         | "demonstrationTypeName"
@@ -95,7 +82,7 @@ export const AmendmentWorkflow = ({ amendmentId }: { amendmentId: string }) => {
           <h3 className="text-brand text-2xl font-bold">APPLICATION</h3>
           <ApplicationStatusBadge applicationStatus={data.amendment.status} />
         </div>
-        <hr className="text-border-rules" />
+        <hr className="text-border-rules" aria-hidden="true" />
         <PhaseSelector application={data.amendment} workflowApplicationType="amendment" />
       </div>
     );

--- a/client/src/components/application/demonstration/DemonstrationWorkflow.tsx
+++ b/client/src/components/application/demonstration/DemonstrationWorkflow.tsx
@@ -98,7 +98,7 @@ export const DemonstrationWorkflow = ({ demonstrationId }: { demonstrationId: st
           <h3 className="text-brand text-2xl font-bold">APPLICATION</h3>
           <ApplicationStatusBadge applicationStatus={data.demonstration.status} />
         </div>
-        <hr className="text-border-rules" />
+        <hr className="text-border-rules" aria-hidden="true" />
         <PhaseSelector application={data.demonstration} workflowApplicationType="demonstration" />
       </div>
     );

--- a/client/src/components/application/extension/ExtensionWorkflow.tsx
+++ b/client/src/components/application/extension/ExtensionWorkflow.tsx
@@ -49,22 +49,9 @@ export const GET_EXTENSION_WORKFLOW_QUERY = gql`
   ${WORKFLOW_DOCUMENT_FIELDS}
 `;
 
-export type ApplicationWorkflowExtension =
-  WorkflowApplication &
-  Pick<
-    Extension,
-    "name" |
-    "description" |
-    "effectiveDate" |
-    "signatureLevel" |
-    "status"
-  > & {
-    demonstration: Pick<
-        Demonstration,
-        | "id"
-        | "status"
-        | "medicaidId"
-      > & {
+export type ApplicationWorkflowExtension = WorkflowApplication &
+  Pick<Extension, "name" | "description" | "effectiveDate" | "signatureLevel" | "status"> & {
+    demonstration: Pick<Demonstration, "id" | "status" | "medicaidId"> & {
       demonstrationTypes: Pick<
         DemonstrationTypeAssignment,
         | "demonstrationTypeName"
@@ -94,7 +81,7 @@ export const ExtensionWorkflow = ({ extensionId }: { extensionId: string }) => {
           <h3 className="text-brand text-2xl font-bold">APPLICATION</h3>
           <ApplicationStatusBadge applicationStatus={data.extension.status} />
         </div>
-        <hr className="text-border-rules" />
+        <hr className="text-border-rules" aria-hidden="true" />
         <PhaseSelector application={data.extension} workflowApplicationType="extension" />
       </div>
     );

--- a/client/src/components/dialog/BaseDialog.tsx
+++ b/client/src/components/dialog/BaseDialog.tsx
@@ -89,7 +89,7 @@ export const BaseDialog: React.FC<BaseDialogProps> = ({
               ×
             </button>
             <h2 className={TITLE}>{title}</h2>
-            <hr className={HR} />
+            <hr className={HR} aria-hidden="true" />
           </>
         )}
 
@@ -97,7 +97,7 @@ export const BaseDialog: React.FC<BaseDialogProps> = ({
 
         {actionButton && (
           <>
-            <hr className={HR} />
+            <hr className={HR} aria-hidden="true" />
             <div className="flex justify-end gap-[24px]">
               <SecondaryButton
                 name={DIALOG_CANCEL_BUTTON_NAME}

--- a/client/src/layout/SideNav.tsx
+++ b/client/src/layout/SideNav.tsx
@@ -26,7 +26,7 @@ const SIDE_NAV_STYLES = "h-full bg-white transition-all duration-300 flex flex-c
 
 const navLinks: NavLink[] = [
   { label: "Demonstrations", href: "/demonstrations", icon: <CompareIcon /> },
-  { label: "Deliverables", href: "/deliverables", icon: <FileIcon />},
+  { label: "Deliverables", href: "/deliverables", icon: <FileIcon /> },
   { label: "Reports", href: "/reports", icon: <FolderIcon /> },
 ];
 
@@ -173,7 +173,7 @@ export const SideNav = () => {
   const DebugLinks = () => {
     return (
       <DebugOnly>
-        <hr className="my-2 border-t border-gray-200" />
+        <hr className="my-2 border-t border-gray-200" aria-hidden="true" />
         <NavLinks isCollapsed={isCollapsed} navLinks={debugNavLinks} />
       </DebugOnly>
     );


### PR DESCRIPTION
Per DEMOS-2210 I believe this one addresses the problem of extra text being announced before the `Cancel` and `Submit` buttons. The ticket doesn't mention which text is being read out but it seems likely that "Separator" may be announced for some screen readers  (as this can be semantically important if a separator is used to create a quasi-list or something)

Upon re-test I will ask the tester specifically which text is being read out if this doesn't address it, but this change is accurate for our purposes anyhow (these separators are just decorative and shouldn't be in the aria tree)