### PR TITLE
DEMOS-2226: made auth capable of picking from a list

### DIFF
--- a/server/src/auth/userContext.test.ts
+++ b/server/src/auth/userContext.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthorizationClaims } from "./auth.util";
-import { findOrCreateContextUserFromClaims } from "./userContext";
+import { findOrCreateContextUserFromClaims, getPersonTypeFromClaims } from "./userContext";
 
 vi.mock("../prismaClient", () => ({
   prisma: vi.fn(),
@@ -36,7 +36,7 @@ describe("findOrCreateContextUserFromClaims", () => {
   const claims: AuthorizationClaims = {
     sub: "sub-123",
     email: "user@example.com",
-    role: "demos-admin",
+    role: "unrelated-role1,demos-admin,unrelated-role2",
     givenName: "Test",
     familyName: "User",
     externalUserId: "external-123",
@@ -141,7 +141,7 @@ describe("findOrCreateContextUserFromClaims", () => {
     });
     expect(mockTransaction.person.create).toHaveBeenCalledExactlyOnceWith({
       data: {
-        personTypeId: claims.role,
+        personTypeId: "demos-admin",
         email: claims.email,
         firstName: claims.givenName,
         lastName: claims.familyName,
@@ -180,6 +180,55 @@ describe("findOrCreateContextUserFromClaims", () => {
       cognitoSubject: claims.sub,
       personTypeId: "demos-admin",
       permissions: ["permission-1", "permission-2"],
+    });
+  });
+
+  describe("getPersonTypeFromClaims", () => {
+    it("correctly extracts the person type from a single value", async () => {
+      const claims: AuthorizationClaims = {
+        role: "demos-admin",
+      } as AuthorizationClaims;
+
+      const result = getPersonTypeFromClaims(claims);
+      expect(result).toBe("demos-admin");
+    });
+
+    it("correctly extracts the person type from multiple values", async () => {
+      const claims: AuthorizationClaims = {
+        role: "demos-cms-user,unrelated-role1,unrelated-role2",
+      } as AuthorizationClaims;
+
+      const result = getPersonTypeFromClaims(claims);
+      expect(result).toBe("demos-cms-user");
+    });
+
+    it("throws an error if role is empty", async () => {
+      const claims: AuthorizationClaims = {
+        role: "",
+      } as AuthorizationClaims;
+
+      expect(() => getPersonTypeFromClaims(claims)).toThrow(
+        `User with cognito subject ${claims.sub} does not have any applicable roles`
+      );
+    });
+
+    it("throws an error if no applicable roles are found", async () => {
+      const claims: AuthorizationClaims = {
+        role: "unrecognized-role",
+      } as AuthorizationClaims;
+
+      expect(() => getPersonTypeFromClaims(claims)).toThrow(
+        `User with cognito subject ${claims.sub} does not have any applicable roles`
+      );
+    });
+
+    it("throws an error if multiple applicable roles are found", async () => {
+      const claims: AuthorizationClaims = {
+        role: "demos-admin,demos-cms-user",
+      } as AuthorizationClaims;
+      expect(() => getPersonTypeFromClaims(claims)).toThrow(
+        `Claims with cognito subject ${claims.sub} has multiple applicable roles: demos-admin, demos-cms-user`
+      );
     });
   });
 });

--- a/server/src/auth/userContext.ts
+++ b/server/src/auth/userContext.ts
@@ -2,6 +2,7 @@ import { prisma } from "../prismaClient";
 import { Permission, SystemRole, UserType } from "../types";
 import { AuthorizationClaims } from "./auth.util";
 import { upsertUserSession } from "../model/userSession/queries";
+import { USER_TYPES } from "../constants";
 
 const initialUserTypeRoles: Record<UserType, SystemRole> = {
   "demos-admin": "Admin User",
@@ -16,11 +17,27 @@ export type ContextUser = {
   permissions: Permission[];
 };
 
+export const getPersonTypeFromClaims = (claims: AuthorizationClaims): UserType => {
+  const claimsRoles = claims.role.split(",").map((role) => role.trim());
+  const applicableRoles = USER_TYPES.filter((userType) => claimsRoles.includes(userType));
+  if (applicableRoles.length === 0) {
+    throw new Error(`User with cognito subject ${claims.sub} does not have any applicable roles`);
+  } else if (applicableRoles.length > 1) {
+    throw new Error(
+      `Claims with cognito subject ${claims.sub} has multiple applicable roles: ${applicableRoles.join(", ")}`
+    );
+  }
+
+  return applicableRoles[0];
+};
+
 async function createNewUserFromClaims(claims: AuthorizationClaims): Promise<ContextUser> {
+  const personTypeId = getPersonTypeFromClaims(claims);
+
   return await prisma().$transaction(async (tx) => {
     const person = await tx.person.create({
       data: {
-        personTypeId: claims.role,
+        personTypeId,
         email: claims.email,
         firstName: claims.givenName,
         lastName: claims.familyName,


### PR DESCRIPTION
simple change to have the create user function of the auth capable of finding the relevant person type among the value of the claims.role field, which is actually a comma-separated list of values rather than always a single value. Used basic string and array functions to do this, and tested for various configurations of the role being, or not being, or being _too_ present. Validated locally after reseeding and saw my users are still created 
<img width="851" height="279" alt="image" src="https://github.com/user-attachments/assets/ec223fb3-2288-4b24-99bd-91b0d6967abe" />
