### PR TITLE
DEMOS-1819-basic-report-running-infrastructure

### DIFF
--- a/data/docs/DEMOS_Data_Model.mmd
+++ b/data/docs/DEMOS_Data_Model.mmd
@@ -168,6 +168,9 @@ erDiagram
   demonstration_type_tag_type_limit ||--|{ reference_demonstration_type : "FK151"
   tag_type ||--|| reference_tag_type_limit : "FK152"
   reference_tag_type_limit ||--|{ reference_tag_assignment : "FK153"
+  users ||--|{ on_demand_report : "FK156"
+  on_demand_report }|--|| on_demand_report_type : "FK157"
+  on_demand_report }|--|| on_demand_report_status : "FK158"
   application_tag_suggestion }|..|| application : ""
 
   %% Static Constraints
@@ -232,6 +235,14 @@ erDiagram
   }
 
   note_type:::staticConstraint {
+    text id PK
+  }
+
+  on_demand_report_status:::staticConstraint {
+    text id PK
+  }
+
+  on_demand_report_type:::staticConstraint {
     text id PK
   }
 
@@ -672,6 +683,16 @@ erDiagram
     TRIGGER_BEFORE_UPDATE _disable_redundant_updates "Disable redundant database updates."
     TRIGGER_BEFORE_INSERT_OR_UPDATE trim_input_text_fields "Trim input text fields."
     HAS_HISTORY true
+  }
+
+  on_demand_report:::dataTable {
+    uuid id PK
+    text s3_path
+    uuid requesting_user_id FK "FK156: requesting_user_id ∈ users.id"
+    text report_type_id FK "FK157: report_type_id ∈ on_demand_report_type.id"
+    text status_id FK "FK158: status_id ∈ on_demand_report_status.id"
+    timestamptz report_generated_at
+    CONSTRAINT_CHECK check_non_empty_s3_path "Validate that the S3 path is not empty or only whitespace."
   }
 
   person:::dataTable {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -27,7 +27,8 @@
         "jsonwebtoken": "^9.0.3",
         "jwks-rsa": "^3.2.2",
         "pg": "^8.21.0",
-        "pino": "^10.3.1"
+        "pino": "^10.3.1",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.1053.0",
@@ -64,9 +65,9 @@
         "read-excel-file": "^8.0.3"
       },
       "devDependencies": {
-        "@types/node": "^25.6.2",
+        "@types/node": "^25.9.1",
         "typescript": "^5.9.3",
-        "vitest": "^4.1.5"
+        "vitest": "^4.1.7"
       }
     },
     "node_modules/@apollo/cache-control-types": {
@@ -8312,6 +8313,15 @@
       "dependencies": {
         "grammex": "^3.1.11",
         "graphmatch": "^1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -32,8 +32,8 @@
   },
   "scripts": {
     "clean": "rm -rf dist; npm ci",
-    "build": "prisma generate && tsc && esbuild dist/server.js --bundle --platform=node --outfile=build/server.cjs --minify --external:@yaacovcr/transform && cp -r src/reports/queries build/",
-    "build:ci": "prisma generate && tsc && esbuild dist/server.js --bundle --platform=node --outfile=build/server.cjs --minify --external:@yaacovcr/transform && cp -r src/reports/queries build/",
+    "build": "prisma generate && tsc && esbuild dist/server.js --bundle --platform=node --outfile=build/server.cjs --minify --external:@yaacovcr/transform && cp -r src/onDemandReports/queries build/",
+    "build:ci": "prisma generate && tsc && esbuild dist/server.js --bundle --platform=node --outfile=build/server.cjs --minify --external:@yaacovcr/transform && cp -r src/onDemandReports/queries build/",
     "depcheck": "depcheck",
     "pretest": "prisma generate",
     "predev": "prisma generate",

--- a/server/package.json
+++ b/server/package.json
@@ -27,12 +27,13 @@
     "jsonwebtoken": "^9.0.3",
     "jwks-rsa": "^3.2.2",
     "pg": "^8.21.0",
-    "pino": "^10.3.1"
+    "pino": "^10.3.1",
+    "zod": "^4.4.3"
   },
   "scripts": {
     "clean": "rm -rf dist; npm ci",
-    "build": "prisma generate && tsc && esbuild dist/server.js --bundle --platform=node --outfile=build/server.cjs --minify --external:@yaacovcr/transform",
-    "build:ci": "prisma generate && tsc && esbuild dist/server.js --bundle --platform=node --outfile=build/server.cjs --minify --external:@yaacovcr/transform",
+    "build": "prisma generate && tsc && esbuild dist/server.js --bundle --platform=node --outfile=build/server.cjs --minify --external:@yaacovcr/transform && cp -r src/reports/queries build/",
+    "build:ci": "prisma generate && tsc && esbuild dist/server.js --bundle --platform=node --outfile=build/server.cjs --minify --external:@yaacovcr/transform && cp -r src/reports/queries build/",
     "depcheck": "depcheck",
     "pretest": "prisma generate",
     "predev": "prisma generate",

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -517,5 +517,5 @@ export const SYSTEM_ROLES = ["Admin User", "CMS User", "State User"] as const;
 
 export const REFERENCE_CONFIGURATION_STATUSES = ["Inactive", "Active"] as const;
 
-export const ON_DEMAND_REPORT_NAMES = ["Basic Test Report"] as const;
+export const ON_DEMAND_REPORT_TYPES = ["Basic Test Report"] as const;
 export const ON_DEMAND_REPORT_STATUS = ["Available"] as const;

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -518,4 +518,4 @@ export const SYSTEM_ROLES = ["Admin User", "CMS User", "State User"] as const;
 export const REFERENCE_CONFIGURATION_STATUSES = ["Inactive", "Active"] as const;
 
 export const ON_DEMAND_REPORT_TYPES = ["Basic Test Report"] as const;
-export const ON_DEMAND_REPORT_STATUS = ["Available"] as const;
+export const ON_DEMAND_REPORT_STATUSES = ["Available"] as const;

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -516,3 +516,6 @@ export const PERMISSIONS = [
 export const SYSTEM_ROLES = ["Admin User", "CMS User", "State User"] as const;
 
 export const REFERENCE_CONFIGURATION_STATUSES = ["Inactive", "Active"] as const;
+
+export const ON_DEMAND_REPORT_NAMES = ["Basic Test Report"] as const;
+export const ON_DEMAND_REPORT_STATUS = ["Available"] as const;

--- a/server/src/errors/errorCodes.test.ts
+++ b/server/src/errors/errorCodes.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
+import { GraphQLError } from "graphql";
 import {
   isCustomInternalErrorCode,
   getPublicErrorCodeFromInternal,
+  getPublicErrorMessageFromCode,
+  throwCustomGQLError,
   formatGraphQLErrorCode,
   CustomInternalErrorCode,
   CustomPublicErrorCode,
@@ -25,6 +28,41 @@ describe("errorCodes", () => {
       expect(
         getPublicErrorCodeFromInternal("REFERENCE_NOT_FOUND" satisfies CustomInternalErrorCode)
       ).toBe("REFERENCE_ERROR" satisfies CustomPublicErrorCode);
+    });
+  });
+
+  describe("getPublicErrorMessageFromCode", () => {
+    it("returns the custom message when one is defined for the public code", () => {
+      expect(
+        getPublicErrorMessageFromCode(
+          "ON_DEMAND_REPORT_ERROR" satisfies CustomPublicErrorCode,
+          "original message"
+        )
+      ).toBe("An error occurred while running an on-demand report.");
+    });
+
+    it("returns the original message when no custom message is defined for the public code", () => {
+      expect(
+        getPublicErrorMessageFromCode(
+          "REFERENCE_ERROR" satisfies CustomPublicErrorCode,
+          "original message"
+        )
+      ).toBe("original message");
+    });
+  });
+
+  describe("throwCustomGQLError", () => {
+    it("throws a GraphQLError with the given message and internal error code", () => {
+      try {
+        throwCustomGQLError("something failed", "REFERENCE_NOT_FOUND");
+        throw new Error("Expected throwCustomGQLError to throw, but it did not.");
+      } catch (error) {
+        expect(error).toBeInstanceOf(GraphQLError);
+        if (error instanceof GraphQLError) {
+          expect(error.message).toBe("something failed");
+          expect(error.extensions.code).toBe("REFERENCE_NOT_FOUND");
+        }
+      }
     });
   });
 

--- a/server/src/errors/errorCodes.ts
+++ b/server/src/errors/errorCodes.ts
@@ -1,4 +1,4 @@
-import { GraphQLFormattedError } from "graphql";
+import { GraphQLError, GraphQLFormattedError } from "graphql";
 
 export const CUSTOM_INTERNAL_ERROR_CODES = [
   "ON_DEMAND_REPORT_ZOD_ERROR",
@@ -21,11 +21,6 @@ export function isCustomInternalErrorCode(value: string): value is CustomInterna
   return (CUSTOM_INTERNAL_ERROR_CODES as readonly string[]).includes(value);
 }
 
-const CUSTOM_PUBLIC_ERROR_MESSAGES: Record<CustomPublicErrorCode, string | undefined> = {
-  ON_DEMAND_REPORT_ERROR: "An error occurred while running an on-demand report.",
-  REFERENCE_ERROR: undefined,
-};
-
 export const CUSTOM_ERROR_CODES: Record<
   CustomInternalErrorCode,
   { publicErrorCode: CustomPublicErrorCode; logLevel: ErrorLogLevel }
@@ -38,6 +33,11 @@ export const CUSTOM_ERROR_CODES: Record<
   REFERENCE_AGREEMENT_NOT_ACTIVE: { publicErrorCode: "REFERENCE_ERROR", logLevel: "debug" },
 } as const;
 
+const CUSTOM_PUBLIC_ERROR_MESSAGES: Record<CustomPublicErrorCode, string | undefined> = {
+  ON_DEMAND_REPORT_ERROR: "An error occurred while running an on-demand report.",
+  REFERENCE_ERROR: undefined,
+};
+
 export function getPublicErrorCodeFromInternal(
   errorCode: CustomInternalErrorCode
 ): CustomPublicErrorCode {
@@ -49,6 +49,14 @@ export function getPublicErrorMessageFromCode(
   originalMessage: string
 ): string {
   return CUSTOM_PUBLIC_ERROR_MESSAGES[publicErrorCode] ?? originalMessage;
+}
+
+export function throwCustomGQLError(message: string, errorCode: CustomInternalErrorCode): void {
+  throw new GraphQLError(message, {
+    extensions: {
+      code: errorCode,
+    },
+  });
 }
 
 export function formatGraphQLErrorCode(

--- a/server/src/errors/errorCodes.ts
+++ b/server/src/errors/errorCodes.ts
@@ -1,14 +1,15 @@
 import { GraphQLFormattedError } from "graphql";
 
 export const CUSTOM_INTERNAL_ERROR_CODES = [
-  "REFERENCE_NOT_FOUND",
+  "ON_DEMAND_REPORT_ZOD_ERROR",
   "REFERENCE_AGREEMENT_ERROR",
-  "REFERENCE_NOT_ACTIVE",
-  "REFERENCE_AGREEMENT_NOT_FOUND",
   "REFERENCE_AGREEMENT_NOT_ACTIVE",
+  "REFERENCE_AGREEMENT_NOT_FOUND",
+  "REFERENCE_NOT_ACTIVE",
+  "REFERENCE_NOT_FOUND",
 ] as const;
 
-export const CUSTOM_PUBLIC_ERROR_CODES = ["REFERENCE_ERROR"] as const;
+export const CUSTOM_PUBLIC_ERROR_CODES = ["REFERENCE_ERROR", "ON_DEMAND_REPORT_ERROR"] as const;
 
 export const ERROR_LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
 
@@ -20,10 +21,16 @@ export function isCustomInternalErrorCode(value: string): value is CustomInterna
   return (CUSTOM_INTERNAL_ERROR_CODES as readonly string[]).includes(value);
 }
 
+const CUSTOM_PUBLIC_ERROR_MESSAGES: Record<CustomPublicErrorCode, string | undefined> = {
+  ON_DEMAND_REPORT_ERROR: "An error occurred while running an on-demand report.",
+  REFERENCE_ERROR: undefined,
+};
+
 export const CUSTOM_ERROR_CODES: Record<
   CustomInternalErrorCode,
   { publicErrorCode: CustomPublicErrorCode; logLevel: ErrorLogLevel }
 > = {
+  ON_DEMAND_REPORT_ZOD_ERROR: { publicErrorCode: "ON_DEMAND_REPORT_ERROR", logLevel: "error" },
   REFERENCE_NOT_FOUND: { publicErrorCode: "REFERENCE_ERROR", logLevel: "debug" },
   REFERENCE_AGREEMENT_ERROR: { publicErrorCode: "REFERENCE_ERROR", logLevel: "debug" },
   REFERENCE_NOT_ACTIVE: { publicErrorCode: "REFERENCE_ERROR", logLevel: "debug" },
@@ -37,6 +44,13 @@ export function getPublicErrorCodeFromInternal(
   return CUSTOM_ERROR_CODES[errorCode].publicErrorCode;
 }
 
+export function getPublicErrorMessageFromCode(
+  publicErrorCode: CustomPublicErrorCode,
+  originalMessage: string
+): string {
+  return CUSTOM_PUBLIC_ERROR_MESSAGES[publicErrorCode] ?? originalMessage;
+}
+
 export function formatGraphQLErrorCode(
   formattedError: GraphQLFormattedError
 ): GraphQLFormattedError {
@@ -45,8 +59,13 @@ export function formatGraphQLErrorCode(
   // In the specific case of a masking, rewrite it
   if (typeof internalErrorCode === "string" && isCustomInternalErrorCode(internalErrorCode)) {
     const publicErrorCode = getPublicErrorCodeFromInternal(internalErrorCode);
+    const publicErrorMessage = getPublicErrorMessageFromCode(
+      publicErrorCode,
+      formattedError.message
+    );
     return {
       ...formattedError,
+      message: publicErrorMessage,
       extensions: { ...formattedError.extensions, code: publicErrorCode },
     };
   }

--- a/server/src/model/demonstration/demonstration.prisma
+++ b/server/src/model/demonstration/demonstration.prisma
@@ -11,8 +11,8 @@ model Demonstration {
   currentPhaseId    String    @map("current_phase_id")
   stateId           String    @map("state_id")
   clearanceLevelId  String    @default("CMS (OSORA)") @map("clearance_level_id")
-  medicaidId        String    @map("medicaid_id") @default(dbgenerated())
-  chipId            String    @map("chip_id") @default(dbgenerated())
+  medicaidId        String    @default(dbgenerated()) @map("medicaid_id")
+  chipId            String    @default(dbgenerated()) @map("chip_id")
   createdAt         DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt         DateTime  @updatedAt @map("updated_at") @db.Timestamptz
 

--- a/server/src/model/graphql.ts
+++ b/server/src/model/graphql.ts
@@ -83,6 +83,12 @@ import { extensionResolvers } from "./extension/extensionResolvers.js";
 import { noteTypeSchema } from "./noteType/noteTypeSchema.js";
 import { noteTypeResolvers } from "./noteType/noteTypeResolvers.js";
 
+import { onDemandReportSchema } from "./onDemandReport/onDemandReportSchema";
+import { onDemandReportResolvers } from "./onDemandReport/onDemandReportResolvers";
+
+import { onDemandReportTypeSchema } from "./onDemandReportType/onDemandReportTypeSchema";
+import { onDemandReportTypeResolvers } from "./onDemandReportType/onDemandReportTypeResolvers";
+
 import { permissionSchema } from "./permission/permissionSchema.js";
 import { permissionResolvers } from "./permission/permissionResolvers.js";
 
@@ -182,6 +188,8 @@ export const typeDefs = [
   documentTypeSchema,
   extensionSchema,
   noteTypeSchema,
+  onDemandReportSchema,
+  onDemandReportTypeSchema,
   permissionSchema,
   personSchema,
   personTypeSchema,
@@ -232,6 +240,8 @@ export const resolvers = [
   documentTypeResolvers,
   extensionResolvers,
   noteTypeResolvers,
+  onDemandReportResolvers,
+  onDemandReportTypeResolvers,
   permissionResolvers,
   personResolvers,
   personTypeResolvers,

--- a/server/src/model/migrations/20260604191542_prisma_add_on_demand_report_tables/migration.sql
+++ b/server/src/model/migrations/20260604191542_prisma_add_on_demand_report_tables/migration.sql
@@ -3,10 +3,11 @@ SET search_path TO demos_app;
 -- CreateTable
 CREATE TABLE "on_demand_report" (
     "id" UUID NOT NULL,
+    "s3_path" TEXT NOT NULL,
     "requesting_user_id" UUID NOT NULL,
     "report_type_id" TEXT NOT NULL,
     "status_id" TEXT NOT NULL,
-    "report_generated_at" TIMESTAMP(3) NOT NULL,
+    "report_generated_at" TIMESTAMPTZ NOT NULL,
 
     CONSTRAINT "on_demand_report_pkey" PRIMARY KEY ("id")
 );

--- a/server/src/model/migrations/20260604191542_prisma_add_on_demand_report_tables/migration.sql
+++ b/server/src/model/migrations/20260604191542_prisma_add_on_demand_report_tables/migration.sql
@@ -1,0 +1,35 @@
+SET search_path TO demos_app;
+
+-- CreateTable
+CREATE TABLE "on_demand_report" (
+    "id" UUID NOT NULL,
+    "requesting_user_id" UUID NOT NULL,
+    "report_type_id" TEXT NOT NULL,
+    "status_id" TEXT NOT NULL,
+    "report_generated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "on_demand_report_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "on_demand_report_status" (
+    "id" TEXT NOT NULL,
+
+    CONSTRAINT "on_demand_report_status_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "on_demand_report_type" (
+    "id" TEXT NOT NULL,
+
+    CONSTRAINT "on_demand_report_type_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "on_demand_report" ADD CONSTRAINT "on_demand_report_requesting_user_id_fkey" FOREIGN KEY ("requesting_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "on_demand_report" ADD CONSTRAINT "on_demand_report_report_type_id_fkey" FOREIGN KEY ("report_type_id") REFERENCES "on_demand_report_type"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "on_demand_report" ADD CONSTRAINT "on_demand_report_status_id_fkey" FOREIGN KEY ("status_id") REFERENCES "on_demand_report_status"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/src/model/migrations/20260604191621_add_on_demand_report_tables/migration.sql
+++ b/server/src/model/migrations/20260604191621_add_on_demand_report_tables/migration.sql
@@ -1,3 +1,11 @@
+ALTER TABLE
+    demos_app.on_demand_report
+ADD CONSTRAINT
+    check_non_empty_s3_path
+CHECK (
+    trim(s3_path) != ''
+);
+
 INSERT INTO
     demos_app.on_demand_report_status
 VALUES

--- a/server/src/model/migrations/20260604191621_add_on_demand_report_tables/migration.sql
+++ b/server/src/model/migrations/20260604191621_add_on_demand_report_tables/migration.sql
@@ -1,0 +1,9 @@
+INSERT INTO
+    demos_app.on_demand_report_status
+VALUES
+    ('Available');
+
+INSERT INTO
+    demos_app.on_demand_report_type
+VALUES
+    ('Basic Test Report');

--- a/server/src/model/onDemandReport/onDemandReport.prisma
+++ b/server/src/model/onDemandReport/onDemandReport.prisma
@@ -1,0 +1,16 @@
+// Flags: NO_CREATED_TS, NO_UPDATED_TS, NO_HISTORY
+// File logs when on demand reports are generated, intended as append-only
+model OnDemandReport {
+  id                String   @db.Uuid
+  requestingUserId  String   @map("requesting_user_id") @db.Uuid
+  reportTypeId      String   @map("report_type_id")
+  statusId          String   @map("status_id")
+  reportGeneratedAt DateTime @map("report_generated_at")
+
+  requestingUser User                 @relation(fields: [requestingUserId], references: [id])
+  reportType     OnDemandReportType   @relation(fields: [reportTypeId], references: [id])
+  status         OnDemandReportStatus @relation(fields: [statusId], references: [id])
+
+  @@id([id])
+  @@map("on_demand_report")
+}

--- a/server/src/model/onDemandReport/onDemandReport.prisma
+++ b/server/src/model/onDemandReport/onDemandReport.prisma
@@ -1,11 +1,12 @@
 // Flags: NO_CREATED_TS, NO_UPDATED_TS, NO_HISTORY
 // File logs when on demand reports are generated, intended as append-only
 model OnDemandReport {
-  id                String   @db.Uuid
+  id                String   @default(uuid()) @db.Uuid
+  s3Path            String   @map("s3_path")
   requestingUserId  String   @map("requesting_user_id") @db.Uuid
   reportTypeId      String   @map("report_type_id")
   statusId          String   @map("status_id")
-  reportGeneratedAt DateTime @map("report_generated_at")
+  reportGeneratedAt DateTime @map("report_generated_at") @db.Timestamptz
 
   requestingUser User                 @relation(fields: [requestingUserId], references: [id])
   reportType     OnDemandReportType   @relation(fields: [reportTypeId], references: [id])

--- a/server/src/model/onDemandReport/onDemandReportResolvers.test.ts
+++ b/server/src/model/onDemandReport/onDemandReportResolvers.test.ts
@@ -1,0 +1,72 @@
+// Vitest and other helpers
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Types
+import { ZodError } from "zod";
+import { GraphQLError } from "graphql";
+
+// Functions under test
+import { onDemandReportResolvers } from "./onDemandReportResolvers";
+
+// Mock imports
+vi.mock("../../onDemandReports", () => ({
+  runOnDemandReport: vi.fn(),
+}));
+
+vi.mock("../../prismaClient", () => ({
+  prisma: vi.fn(),
+}));
+
+import { runOnDemandReport } from "../../onDemandReports";
+import { prisma } from "../../prismaClient";
+
+describe("onDemandReportResolvers", () => {
+  const mockPrismaClient = {} as any;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(prisma).mockReturnValue(mockPrismaClient);
+  });
+
+  describe("Mutation.generateOnDemandReport", () => {
+    it("calls runOnDemandReport with the correct report type and prisma client", async () => {
+      await onDemandReportResolvers.Mutation.generateOnDemandReport(undefined, {
+        reportType: "Basic Test Report",
+      });
+
+      expect(runOnDemandReport).toHaveBeenCalledExactlyOnceWith(
+        "Basic Test Report",
+        mockPrismaClient
+      );
+    });
+
+    it("throws an expected GraphQLError when runOnDemandReport throws a ZodError", async () => {
+      const zodError = new ZodError([]);
+      vi.mocked(runOnDemandReport).mockRejectedValue(zodError);
+
+      try {
+        await onDemandReportResolvers.Mutation.generateOnDemandReport(undefined, {
+          reportType: "Basic Test Report",
+        });
+        throw new Error("Expected generateOnDemandReport to throw, but it did not.");
+      } catch (error) {
+        expect(error).toBeInstanceOf(GraphQLError);
+        if (error instanceof GraphQLError) {
+          expect(error.message).toContain("Basic Test Report");
+          expect(error.extensions.code).toBe("ON_DEMAND_REPORT_ZOD_ERROR");
+        }
+      }
+    });
+
+    it("re-throws non-ZodErrors without wrapping them", async () => {
+      const originalError = new Error("unexpected database failure");
+      vi.mocked(runOnDemandReport).mockRejectedValue(originalError);
+
+      await expect(
+        onDemandReportResolvers.Mutation.generateOnDemandReport(undefined, {
+          reportType: "Basic Test Report",
+        })
+      ).rejects.toThrow("unexpected database failure");
+    });
+  });
+});

--- a/server/src/model/onDemandReport/onDemandReportResolvers.ts
+++ b/server/src/model/onDemandReport/onDemandReportResolvers.ts
@@ -8,8 +8,8 @@ export const onDemandReportResolvers = {
   Mutation: {
     generateOnDemandReport: async (parent: unknown, args: { reportType: OnDemandReportType }) => {
       try {
-        const results = await runOnDemandReport(args.reportType, prisma());
-        return JSON.stringify(results);
+        await runOnDemandReport(args.reportType, prisma());
+        return "The query for the report ran successfully!";
       } catch (error) {
         if (error instanceof ZodError) {
           throwCustomGQLError(

--- a/server/src/model/onDemandReport/onDemandReportResolvers.ts
+++ b/server/src/model/onDemandReport/onDemandReportResolvers.ts
@@ -2,8 +2,7 @@ import { ZodError } from "zod";
 import { runOnDemandReport } from "../../onDemandReports";
 import { prisma } from "../../prismaClient";
 import { OnDemandReportType } from "../../types";
-import { GraphQLError } from "graphql/error";
-import { CustomInternalErrorCode } from "../../errors/errorCodes";
+import { throwCustomGQLError } from "../../errors/errorCodes";
 
 export const onDemandReportResolvers = {
   Mutation: {
@@ -13,14 +12,12 @@ export const onDemandReportResolvers = {
         return JSON.stringify(results);
       } catch (error) {
         if (error instanceof ZodError) {
-          throw new GraphQLError(
+          throwCustomGQLError(
             `Running the on-demand ${args.reportType} report caused a Zod validation error.`,
-            {
-              extensions: {
-                code: "ON_DEMAND_REPORT_ZOD_ERROR" satisfies CustomInternalErrorCode,
-              },
-            }
+            "ON_DEMAND_REPORT_ZOD_ERROR"
           );
+        } else {
+          throw error;
         }
       }
     },

--- a/server/src/model/onDemandReport/onDemandReportResolvers.ts
+++ b/server/src/model/onDemandReport/onDemandReportResolvers.ts
@@ -1,0 +1,28 @@
+import { ZodError } from "zod";
+import { runOnDemandReport } from "../../onDemandReports";
+import { prisma } from "../../prismaClient";
+import { OnDemandReportType } from "../../types";
+import { GraphQLError } from "graphql/error";
+import { CustomInternalErrorCode } from "../../errors/errorCodes";
+
+export const onDemandReportResolvers = {
+  Mutation: {
+    generateOnDemandReport: async (parent: unknown, args: { reportType: OnDemandReportType }) => {
+      try {
+        const results = await runOnDemandReport(args.reportType, prisma());
+        return JSON.stringify(results);
+      } catch (error) {
+        if (error instanceof ZodError) {
+          throw new GraphQLError(
+            `Running the on-demand ${args.reportType} report caused a Zod validation error.`,
+            {
+              extensions: {
+                code: "ON_DEMAND_REPORT_ZOD_ERROR" satisfies CustomInternalErrorCode,
+              },
+            }
+          );
+        }
+      }
+    },
+  },
+};

--- a/server/src/model/onDemandReport/onDemandReportSchema.ts
+++ b/server/src/model/onDemandReport/onDemandReportSchema.ts
@@ -3,5 +3,6 @@ import { gql } from "graphql-tag";
 export const onDemandReportSchema = gql`
   type Mutation {
     generateOnDemandReport(reportType: OnDemandReportType!): String!
+      @auth(requires: ["Perform CMS Action"])
   }
 `;

--- a/server/src/model/onDemandReport/onDemandReportSchema.ts
+++ b/server/src/model/onDemandReport/onDemandReportSchema.ts
@@ -1,0 +1,7 @@
+import { gql } from "graphql-tag";
+
+export const onDemandReportSchema = gql`
+  type Mutation {
+    generateOnDemandReport(reportType: OnDemandReportType!): String!
+  }
+`;

--- a/server/src/model/onDemandReportStatus/onDemandReportStatus.prisma
+++ b/server/src/model/onDemandReportStatus/onDemandReportStatus.prisma
@@ -1,0 +1,9 @@
+// Flags: STATIC_CONSTRAINT
+model OnDemandReportStatus {
+  id String
+
+  onDemandReports OnDemandReport[]
+
+  @@id([id])
+  @@map("on_demand_report_status")
+}

--- a/server/src/model/onDemandReportType/onDemandReportType.prisma
+++ b/server/src/model/onDemandReportType/onDemandReportType.prisma
@@ -1,0 +1,9 @@
+// Flags: STATIC_CONSTRAINT
+model OnDemandReportType {
+  id String
+
+  onDemandReports OnDemandReport[]
+
+  @@id([id])
+  @@map("on_demand_report_type")
+}

--- a/server/src/model/onDemandReportType/onDemandReportTypeResolvers.ts
+++ b/server/src/model/onDemandReportType/onDemandReportTypeResolvers.ts
@@ -1,0 +1,10 @@
+import { generateCustomSetScalar } from "../../customScalarResolvers";
+import { ON_DEMAND_REPORT_TYPES } from "../../constants";
+
+export const onDemandReportTypeResolvers = {
+  OnDemandReportType: generateCustomSetScalar(
+    ON_DEMAND_REPORT_TYPES,
+    "OnDemandReportType",
+    "A string name for an on-demand report."
+  ),
+};

--- a/server/src/model/onDemandReportType/onDemandReportTypeSchema.ts
+++ b/server/src/model/onDemandReportType/onDemandReportTypeSchema.ts
@@ -1,0 +1,5 @@
+import gql from "graphql-tag";
+
+export const onDemandReportTypeSchema = gql`
+  scalar OnDemandReportType
+`;

--- a/server/src/model/user/user.prisma
+++ b/server/src/model/user/user.prisma
@@ -19,6 +19,7 @@ model User {
   references                    Reference[]
   referenceAgreements           ReferenceAgreement[]
   referenceAgreementAcceptances ReferenceAgreementAcceptance[]
+  onDemandReportsRequested      OnDemandReport[]
 
   @@id([id])
   @@unique([id, personTypeId]) // Not required by Postgres, but Prisma requires this notation

--- a/server/src/onDemandReports/index.ts
+++ b/server/src/onDemandReports/index.ts
@@ -1,0 +1,2 @@
+export { onDemandReportConfigurations } from "./onDemandReportConfigurations";
+export { runOnDemandReport } from "./runOnDemandReport";

--- a/server/src/onDemandReports/index.ts
+++ b/server/src/onDemandReports/index.ts
@@ -1,2 +1,1 @@
-export { onDemandReportConfigurations } from "./onDemandReportConfigurations";
 export { runOnDemandReport } from "./runOnDemandReport";

--- a/server/src/onDemandReports/onDemandReportConfigurations.ts
+++ b/server/src/onDemandReports/onDemandReportConfigurations.ts
@@ -1,8 +1,8 @@
-import z from "zod";
+import { z } from "zod";
 import { OnDemandReportType } from "../types";
 import { basicTestReportSchema } from "./schemas/basicTestReportSchema";
 
-export const onDemandReportConfigurations: Record<
+export const ON_DEMAND_REPORT_CONFIGURATIONS: Record<
   OnDemandReportType,
   { queryFile: string; reportRowSchema: z.ZodType<unknown> }
 > = {

--- a/server/src/onDemandReports/onDemandReportConfigurations.ts
+++ b/server/src/onDemandReports/onDemandReportConfigurations.ts
@@ -1,9 +1,9 @@
 import z from "zod";
-import { OnDemandReportName } from "../types";
+import { OnDemandReportType } from "../types";
 import { basicTestReportSchema } from "./schemas/basicTestReportSchema";
 
 export const onDemandReportConfigurations: Record<
-  OnDemandReportName,
+  OnDemandReportType,
   { queryFile: string; reportRowSchema: z.ZodType<unknown> }
 > = {
   "Basic Test Report": {

--- a/server/src/onDemandReports/onDemandReportConfigurations.ts
+++ b/server/src/onDemandReports/onDemandReportConfigurations.ts
@@ -1,0 +1,13 @@
+import z from "zod";
+import { OnDemandReportName } from "../types";
+import { basicTestReportSchema } from "./schemas/basicTestReportSchema";
+
+export const onDemandReportConfigurations: Record<
+  OnDemandReportName,
+  { queryFile: string; reportRowSchema: z.ZodType<unknown> }
+> = {
+  "Basic Test Report": {
+    queryFile: "basicTestReport.sql",
+    reportRowSchema: basicTestReportSchema,
+  },
+};

--- a/server/src/onDemandReports/queries/basicTestReport.sql
+++ b/server/src/onDemandReports/queries/basicTestReport.sql
@@ -1,0 +1,8 @@
+SELECT
+    id,
+    name,
+    description
+FROM
+    demos_app.demonstration
+ORDER BY
+    created_at DESC;

--- a/server/src/onDemandReports/queries/basicTestReport.sql
+++ b/server/src/onDemandReports/queries/basicTestReport.sql
@@ -1,8 +1,11 @@
 SELECT
     id,
     name,
-    description
+    description,
+    state_id AS state,
+    status_id AS status
 FROM
     demos_app.demonstration
 ORDER BY
-    created_at DESC;
+    created_at DESC
+LIMIT 5;

--- a/server/src/onDemandReports/runOnDemandReport.test.ts
+++ b/server/src/onDemandReports/runOnDemandReport.test.ts
@@ -1,0 +1,69 @@
+// Vitest and other helpers
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Types
+import type { prisma } from "../prismaClient";
+
+// Functions under test
+import { runOnDemandReport } from "./runOnDemandReport";
+
+// Mock imports
+vi.mock("fs", () => ({
+  readFileSync: vi.fn(),
+}));
+
+vi.mock("./onDemandReportConfigurations", () => ({
+  ON_DEMAND_REPORT_CONFIGURATIONS: {
+    "Basic Test Report": {
+      queryFile: "basicTestReport.sql",
+      reportRowSchema: { _isMockSchema: true },
+    },
+  },
+}));
+
+vi.mock("zod", () => ({
+  z: { array: vi.fn() },
+}));
+
+import { readFileSync } from "fs";
+import { z } from "zod";
+import { ON_DEMAND_REPORT_CONFIGURATIONS } from "./onDemandReportConfigurations";
+
+describe("runOnDemandReport", () => {
+  const mockQueryRawUnsafe = vi.fn();
+  const mockClient: Partial<ReturnType<typeof prisma>> = { $queryRawUnsafe: mockQueryRawUnsafe };
+  const mockParse = vi.fn();
+  const mockZodArray: Partial<z.ZodArray<z.ZodTypeAny>> = { parse: mockParse };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(readFileSync).mockReturnValue("SELECT 1");
+    vi.mocked(z.array).mockReturnValue(mockZodArray as z.ZodArray<z.ZodTypeAny>);
+    mockQueryRawUnsafe.mockResolvedValue([{ some: "data" }]);
+    mockParse.mockReturnValue([]);
+  });
+
+  it("reads the SQL file for the given report type", async () => {
+    await runOnDemandReport("Basic Test Report", mockClient as ReturnType<typeof prisma>);
+
+    expect(readFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("basicTestReport.sql"),
+      "utf-8"
+    );
+  });
+
+  it("executes the SQL from the query file against the client", async () => {
+    await runOnDemandReport("Basic Test Report", mockClient as ReturnType<typeof prisma>);
+
+    expect(mockClient.$queryRawUnsafe).toHaveBeenCalledExactlyOnceWith("SELECT 1");
+  });
+
+  it("passes the report schema and query results to zod for parsing", async () => {
+    await runOnDemandReport("Basic Test Report", mockClient as ReturnType<typeof prisma>);
+
+    expect(z.array).toHaveBeenCalledWith(
+      ON_DEMAND_REPORT_CONFIGURATIONS["Basic Test Report"].reportRowSchema
+    );
+    expect(mockParse).toHaveBeenCalledExactlyOnceWith([{ some: "data" }]);
+  });
+});

--- a/server/src/onDemandReports/runOnDemandReport.ts
+++ b/server/src/onDemandReports/runOnDemandReport.ts
@@ -3,8 +3,8 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { OnDemandReportType } from "../types";
 import { prisma } from "../prismaClient";
-import z from "zod";
-import { onDemandReportConfigurations } from "./onDemandReportConfigurations";
+import { z } from "zod";
+import { ON_DEMAND_REPORT_CONFIGURATIONS } from "./onDemandReportConfigurations";
 
 const __currentDir = dirname(fileURLToPath(import.meta.url));
 
@@ -12,7 +12,7 @@ export async function runOnDemandReport(
   onDemandReportType: OnDemandReportType,
   client: ReturnType<typeof prisma>
 ) {
-  const { queryFile, reportRowSchema } = onDemandReportConfigurations[onDemandReportType];
+  const { queryFile, reportRowSchema } = ON_DEMAND_REPORT_CONFIGURATIONS[onDemandReportType];
   const sqlToRun = readFileSync(join(__currentDir, "queries", queryFile), "utf-8");
   const results = await client.$queryRawUnsafe(sqlToRun);
   return z.array(reportRowSchema).parse(results);

--- a/server/src/onDemandReports/runOnDemandReport.ts
+++ b/server/src/onDemandReports/runOnDemandReport.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { OnDemandReportName } from "../types";
+import { PrismaClient } from "@prisma/client";
+import z from "zod";
+import { onDemandReportConfigurations } from ".";
+
+export async function runOnDemandReport(
+  onDemandReportName: OnDemandReportName,
+  client: PrismaClient
+) {
+  const { queryFile, reportRowSchema } = onDemandReportConfigurations[onDemandReportName];
+  const sqlToRun = readFileSync(join(__dirname, "queries", queryFile), "utf-8");
+  const results = await client.$queryRawUnsafe(sqlToRun);
+  return z.array(reportRowSchema).parse(results);
+}

--- a/server/src/onDemandReports/runOnDemandReport.ts
+++ b/server/src/onDemandReports/runOnDemandReport.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "url";
 import { OnDemandReportType } from "../types";
 import { prisma } from "../prismaClient";
 import z from "zod";
-import { onDemandReportConfigurations } from ".";
+import { onDemandReportConfigurations } from "./onDemandReportConfigurations";
 
 const __currentDir = dirname(fileURLToPath(import.meta.url));
 

--- a/server/src/onDemandReports/runOnDemandReport.ts
+++ b/server/src/onDemandReports/runOnDemandReport.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from "fs";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { OnDemandReportType } from "../types";
 import { prisma } from "../prismaClient";
 import { z } from "zod";

--- a/server/src/onDemandReports/runOnDemandReport.ts
+++ b/server/src/onDemandReports/runOnDemandReport.ts
@@ -1,16 +1,19 @@
 import { readFileSync } from "fs";
-import { join } from "path";
-import { OnDemandReportName } from "../types";
-import { PrismaClient } from "@prisma/client";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { OnDemandReportType } from "../types";
+import { prisma } from "../prismaClient";
 import z from "zod";
 import { onDemandReportConfigurations } from ".";
 
+const __currentDir = dirname(fileURLToPath(import.meta.url));
+
 export async function runOnDemandReport(
-  onDemandReportName: OnDemandReportName,
-  client: PrismaClient
+  onDemandReportType: OnDemandReportType,
+  client: ReturnType<typeof prisma>
 ) {
-  const { queryFile, reportRowSchema } = onDemandReportConfigurations[onDemandReportName];
-  const sqlToRun = readFileSync(join(__dirname, "queries", queryFile), "utf-8");
+  const { queryFile, reportRowSchema } = onDemandReportConfigurations[onDemandReportType];
+  const sqlToRun = readFileSync(join(__currentDir, "queries", queryFile), "utf-8");
   const results = await client.$queryRawUnsafe(sqlToRun);
   return z.array(reportRowSchema).parse(results);
 }

--- a/server/src/onDemandReports/schemas/basicTestReportSchema.ts
+++ b/server/src/onDemandReports/schemas/basicTestReportSchema.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
+import { APPLICATION_STATUS, STATES_AND_TERRITORIES } from "../../constants";
 
-export const basicTestReportSchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  description: z.string().nullable(),
-});
+export const basicTestReportSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string().nullable(),
+    state: z.enum(STATES_AND_TERRITORIES.map((state) => state.id)),
+    status: z.enum(APPLICATION_STATUS),
+  })
+  .strict();

--- a/server/src/onDemandReports/schemas/basicTestReportSchema.ts
+++ b/server/src/onDemandReports/schemas/basicTestReportSchema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const basicTestReportSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  description: z.string().nullable(),
+});

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -30,7 +30,7 @@ import {
   TAG_TYPES,
   UIPATH_RESULT_STATUSES,
   USER_TYPES,
-  ON_DEMAND_REPORT_STATUS,
+  ON_DEMAND_REPORT_STATUSES,
 } from "./constants.js";
 
 export type {
@@ -182,4 +182,4 @@ export type Permission = (typeof PERMISSIONS)[number];
 export type SystemRole = (typeof SYSTEM_ROLES)[number];
 export type ReferenceConfigurationStatus = (typeof REFERENCE_CONFIGURATION_STATUSES)[number];
 export type OnDemandReportType = (typeof ON_DEMAND_REPORT_TYPES)[number];
-export type OnDemandReportStatus = (typeof ON_DEMAND_REPORT_STATUS)[number];
+export type OnDemandReportStatus = (typeof ON_DEMAND_REPORT_STATUSES)[number];

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -17,7 +17,7 @@ import {
   PERSON_TYPES,
   PHASE_STATUS,
   REFERENCE_CONFIGURATION_STATUSES,
-  ON_DEMAND_REPORT_NAMES,
+  ON_DEMAND_REPORT_TYPES,
   REVIEW_PHASE_DATE_TYPES,
   REVIEW_PHASE_NOTE_TYPES,
   ROLES,
@@ -181,5 +181,5 @@ export type DeliverableExtensionStatus = (typeof DELIVERABLE_EXTENSION_STATUSES)
 export type Permission = (typeof PERMISSIONS)[number];
 export type SystemRole = (typeof SYSTEM_ROLES)[number];
 export type ReferenceConfigurationStatus = (typeof REFERENCE_CONFIGURATION_STATUSES)[number];
-export type OnDemandReportName = (typeof ON_DEMAND_REPORT_NAMES)[number];
+export type OnDemandReportType = (typeof ON_DEMAND_REPORT_TYPES)[number];
 export type OnDemandReportStatus = (typeof ON_DEMAND_REPORT_STATUS)[number];

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -17,6 +17,7 @@ import {
   PERSON_TYPES,
   PHASE_STATUS,
   REFERENCE_CONFIGURATION_STATUSES,
+  ON_DEMAND_REPORT_NAMES,
   REVIEW_PHASE_DATE_TYPES,
   REVIEW_PHASE_NOTE_TYPES,
   ROLES,
@@ -29,6 +30,7 @@ import {
   TAG_TYPES,
   UIPATH_RESULT_STATUSES,
   USER_TYPES,
+  ON_DEMAND_REPORT_STATUS,
 } from "./constants.js";
 
 export type {
@@ -179,3 +181,5 @@ export type DeliverableExtensionStatus = (typeof DELIVERABLE_EXTENSION_STATUSES)
 export type Permission = (typeof PERMISSIONS)[number];
 export type SystemRole = (typeof SYSTEM_ROLES)[number];
 export type ReferenceConfigurationStatus = (typeof REFERENCE_CONFIGURATION_STATUSES)[number];
+export type OnDemandReportName = (typeof ON_DEMAND_REPORT_NAMES)[number];
+export type OnDemandReportStatus = (typeof ON_DEMAND_REPORT_STATUS)[number];


### PR DESCRIPTION
This is the basics of the report-running infrastructure - there is a lot of work yet to come, but this is the initial stuff and I thought breaking the code into smaller PRs might be easier to review. This adds a concept of an on-demand report to the database and a module for configuring and running arbitrary SQL reports, along with a simple test resolver that calls it to confirm it works. This also adds `zod` to help verify what's coming in - because this is the first time we're going to write SQL directly and then need to work with the objects that come back I felt validation was a good idea to ensure that we don't have drift between the SQL query and the type in TS.