### PR TITLE
Demonstration types chip

### DIFF
--- a/client/src/components/dialog/DemonstrationTypes/ApplyDemonstrationTypesDialog.tsx
+++ b/client/src/components/dialog/DemonstrationTypes/ApplyDemonstrationTypesDialog.tsx
@@ -5,12 +5,7 @@ import { DemonstrationTypesList } from "./DemonstrationTypesList";
 import { AddDemonstrationTypesForm } from "./AddDemonstrationTypesForm";
 import { useToast } from "components/toast";
 import { Button } from "components/button";
-import {
-  TagName,
-  LocalDate,
-  SetDemonstrationTypesInput,
-  TagStatus,
-} from "demos-server";
+import { TagName, LocalDate, SetDemonstrationTypesInput, TagStatus } from "demos-server";
 import { gql, TypedDocumentNode, useMutation } from "@apollo/client";
 
 export type DemonstrationType = {
@@ -27,6 +22,7 @@ export const ASSIGN_DEMONSTRATION_TYPES_DIALOG_MUTATION: TypedDocumentNode<
       demonstrationTypes: {
         demonstrationTypeName: TagName;
       };
+      chipId: string;
     };
   },
   { input: SetDemonstrationTypesInput }
@@ -37,6 +33,7 @@ export const ASSIGN_DEMONSTRATION_TYPES_DIALOG_MUTATION: TypedDocumentNode<
       demonstrationTypes {
         demonstrationTypeName
       }
+      chipId
     }
   }
 `;

--- a/client/src/components/dialog/DemonstrationTypes/EditDemonstrationTypeDialog.tsx
+++ b/client/src/components/dialog/DemonstrationTypes/EditDemonstrationTypeDialog.tsx
@@ -13,8 +13,8 @@ import { gql, TypedDocumentNode, useMutation } from "@apollo/client";
 import { DatePicker } from "components/input/date/DatePicker";
 import { formatDateForServer, getTodayEst } from "util/formatDate";
 
-type Demonstration = Pick<ServerDemonstration, "id" | "chipId"> & {
-  demonstrationTypes: Pick<DemonstrationTypeAssignment, "demonstrationTypeName">[];
+type Demonstration = Pick<ServerDemonstration, "id"> & {
+  demonstrationTypes: DemonstrationType[];
 };
 
 export type DemonstrationType = Pick<
@@ -32,7 +32,9 @@ type DemonstrationTypeFormData = Pick<
 
 export const EDIT_DEMONSTRATION_TYPES_DIALOG_MUTATION: TypedDocumentNode<
   {
-    setDemonstrationTypes: Demonstration;
+    setDemonstrationTypes: Pick<Demonstration, "id"> & {
+      demonstrationTypes: Pick<DemonstrationTypeAssignment, "demonstrationTypeName">[];
+    };
   },
   { input: SetDemonstrationTypesInput }
 > = gql`
@@ -42,7 +44,6 @@ export const EDIT_DEMONSTRATION_TYPES_DIALOG_MUTATION: TypedDocumentNode<
       demonstrationTypes {
         demonstrationTypeName
       }
-      chipId
     }
   }
 `;

--- a/client/src/components/dialog/DemonstrationTypes/EditDemonstrationTypeDialog.tsx
+++ b/client/src/components/dialog/DemonstrationTypes/EditDemonstrationTypeDialog.tsx
@@ -13,8 +13,8 @@ import { gql, TypedDocumentNode, useMutation } from "@apollo/client";
 import { DatePicker } from "components/input/date/DatePicker";
 import { formatDateForServer, getTodayEst } from "util/formatDate";
 
-type Demonstration = Pick<ServerDemonstration, "id"> & {
-  demonstrationTypes: DemonstrationType[];
+type Demonstration = Pick<ServerDemonstration, "id" | "chipId"> & {
+  demonstrationTypes: Pick<DemonstrationTypeAssignment, "demonstrationTypeName">[];
 };
 
 export type DemonstrationType = Pick<
@@ -32,9 +32,7 @@ type DemonstrationTypeFormData = Pick<
 
 export const EDIT_DEMONSTRATION_TYPES_DIALOG_MUTATION: TypedDocumentNode<
   {
-    setDemonstrationTypes: Pick<Demonstration, "id"> & {
-      demonstrationTypes: Pick<DemonstrationTypeAssignment, "demonstrationTypeName">[];
-    };
+    setDemonstrationTypes: Demonstration;
   },
   { input: SetDemonstrationTypesInput }
 > = gql`
@@ -44,6 +42,7 @@ export const EDIT_DEMONSTRATION_TYPES_DIALOG_MUTATION: TypedDocumentNode<
       demonstrationTypes {
         demonstrationTypeName
       }
+      chipId
     }
   }
 `;

--- a/client/src/components/dialog/DemonstrationTypes/RemoveDemonstrationTypesDialog.tsx
+++ b/client/src/components/dialog/DemonstrationTypes/RemoveDemonstrationTypesDialog.tsx
@@ -12,12 +12,12 @@ import {
 import { ErrorIcon } from "components/icons";
 import { gql, TypedDocumentNode, useMutation } from "@apollo/client";
 
-type Demonstration = Pick<ServerDemonstration, "id" | "chipId"> & {
-  demonstrationTypes: Pick<DemonstrationTypeAssignment, "demonstrationTypeName">[];
-};
-
 export const REMOVE_DEMONSTRATION_TYPES_DIALOG_MUTATION: TypedDocumentNode<
-  { setDemonstrationTypes: Demonstration },
+  {
+    setDemonstrationTypes: Pick<ServerDemonstration, "id" | "chipId"> & {
+      demonstrationTypes: Pick<DemonstrationTypeAssignment, "demonstrationTypeName">[];
+    };
+  },
   { input: SetDemonstrationTypesInput }
 > = gql`
   mutation removeDemonstrationTypes($input: SetDemonstrationTypesInput!) {

--- a/client/src/components/dialog/DemonstrationTypes/RemoveDemonstrationTypesDialog.tsx
+++ b/client/src/components/dialog/DemonstrationTypes/RemoveDemonstrationTypesDialog.tsx
@@ -12,7 +12,7 @@ import {
 import { ErrorIcon } from "components/icons";
 import { gql, TypedDocumentNode, useMutation } from "@apollo/client";
 
-type Demonstration = Pick<ServerDemonstration, "id"> & {
+type Demonstration = Pick<ServerDemonstration, "id" | "chipId"> & {
   demonstrationTypes: Pick<DemonstrationTypeAssignment, "demonstrationTypeName">[];
 };
 
@@ -26,6 +26,7 @@ export const REMOVE_DEMONSTRATION_TYPES_DIALOG_MUTATION: TypedDocumentNode<
       demonstrationTypes {
         demonstrationTypeName
       }
+      chipId
     }
   }
 `;


### PR DESCRIPTION
create and delete demo types mutations now return chipId, updating the frontend display

https://github.com/user-attachments/assets/362fd2aa-55c4-4aff-8eba-6f0e60108c8f

