### PR TITLE
DEMOS-2211 add aria roles and labels for my demonstrations tabs

### DIFF
--- a/client/src/layout/Tabs/Tabs.tsx
+++ b/client/src/layout/Tabs/Tabs.tsx
@@ -59,7 +59,7 @@ export const Tabs: React.FC<TabsProps> = ({
 
   return (
     <div className="block">
-      <div className="flex">
+      <div className="flex" role="tablist">
         {visibleTabs.map((tab) => {
           const { label, value } = tab.props;
           const isSelected = value === selectedValue;
@@ -71,6 +71,8 @@ export const Tabs: React.FC<TabsProps> = ({
               onClick={() => handleTabSelect(value)}
               className={styles.getButtonStyles(isSelected)}
               aria-selected={isSelected}
+              aria-controls={`${value}-panel`}
+              role="tab"
             >
               <div className="flex items-center gap-1">{label}</div>
             </button>
@@ -79,7 +81,9 @@ export const Tabs: React.FC<TabsProps> = ({
         <div className="flex-1 border-b-1 border-b-gray-dark"></div>
       </div>
 
-      <div className={styles.contentStyles}>{selectedTab?.props.children}</div>
+      <div className={styles.contentStyles} id={`${selectedValue}-panel`} role="tabpanel">
+        {selectedTab?.props.children}
+      </div>
     </div>
   );
 };

--- a/client/src/pages/DemonstrationDetail/DemonstrationDetail.test.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetail.test.tsx
@@ -79,11 +79,11 @@ describe("DemonstrationDetail", () => {
     renderWithRouter();
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Demonstration Details/i })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /Demonstration Details/i })).toBeInTheDocument();
     });
 
-    expect(screen.getByRole("button", { name: /Amendments \(2\)/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Extensions \(1\)/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Amendments \(2\)/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Extensions \(1\)/i })).toBeInTheDocument();
   });
 
   it("renders on demonstration details tab by default", async () => {
@@ -146,7 +146,7 @@ describe("DemonstrationDetail", () => {
     });
 
     // Click on Amendments tab
-    const amendmentsTab = screen.getByRole("button", { name: /Amendments \(2\)/i });
+    const amendmentsTab = screen.getByRole("tab", { name: /Amendments \(2\)/i });
     await user.click(amendmentsTab);
 
     await waitFor(() => {
@@ -161,7 +161,7 @@ describe("DemonstrationDetail", () => {
     );
 
     // Click on Extensions tab
-    const extensionsTab = screen.getByRole("button", { name: /Extensions \(1\)/i });
+    const extensionsTab = screen.getByRole("tab", { name: /Extensions \(1\)/i });
     await user.click(extensionsTab);
 
     await waitFor(() => {
@@ -176,7 +176,7 @@ describe("DemonstrationDetail", () => {
     );
 
     // Click back to Demonstration Details tab
-    const detailsTab = screen.getByRole("button", { name: /Demonstration Details/i });
+    const detailsTab = screen.getByRole("tab", { name: /Demonstration Details/i });
     await user.click(detailsTab);
 
     await waitFor(() => {


### PR DESCRIPTION
Adds a few accessibility parameters for the landing page tab panels:
<img width="1196" height="80" alt="image" src="https://github.com/user-attachments/assets/b90472b8-d4f6-4a43-a940-a6ec4bfcf696" />
