### PR TITLE
DEMOS-1283 Client-side BN Workbook pre-upload validation

### DIFF
--- a/client/src/components/dialog/document/DocumentDialog.test.tsx
+++ b/client/src/components/dialog/document/DocumentDialog.test.tsx
@@ -2,8 +2,8 @@ import "@testing-library/jest-dom";
 
 import React from "react";
 
-import { describe, it, expect, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { ToastProvider } from "components/toast/ToastContext";
 import { DocumentType } from "demos-server";
@@ -13,6 +13,16 @@ import {
   DocumentDialog,
 } from "./DocumentDialog";
 import type { DocumentDialogFields, DocumentUploadResult } from "./DocumentDialog";
+
+const parseBNFile = vi.fn();
+const rule = vi.fn();
+
+vi.mock("demos-shared-library/dist/src/BN/index.js", () => ({
+  parseBNFile: (...args: unknown[]) => parseBNFile(...args),
+}));
+vi.mock("demos-shared-library/dist/src/BN/rulesets/v1/index.js", () => ({
+  validations: [rule],
+}));
 
 describe("checkFormHasChanges", () => {
   const base: DocumentDialogFields = {
@@ -126,5 +136,64 @@ describe("DocumentDialog attestation gating", () => {
 
     expect(onSubmit).toHaveBeenCalledOnce();
     expect(screen.queryByRole("heading", { name: "Attestation Required" })).not.toBeInTheDocument();
+  });
+});
+
+const XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+const selectWorkbook = (fileName = "wb.xlsx") => {
+  const file = new File(["xlsx-bytes"], fileName, { type: XLSX_MIME });
+  fireEvent.change(screen.getByTestId("input-file"), { target: { files: [file] } });
+};
+
+describe("DocumentDialog BN Workbook pre-validation", () => {
+  beforeEach(() => {
+    parseBNFile.mockReset();
+    rule.mockReset();
+  });
+
+  it("blocks upload and surfaces the rule errors when validation fails", async () => {
+    const onSubmit = vi.fn(() => Promise.resolve<DocumentUploadResult>("succeeded"));
+    parseBNFile.mockResolvedValue([{ sheet: "Sheet1", data: [] }]);
+    rule.mockReturnValue({ code: "1", message: "Error: C Report Tab - missing data." });
+
+    renderAddDialog("BN Workbook", onSubmit);
+    selectWorkbook();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bn-prevalidation-errors")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/missing data/)).toBeInTheDocument();
+    expect(screen.getByTestId("button-confirm-upload-document")).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("button-confirm-upload-document"));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("shows the success notice and unblocks upload when every rule passes", async () => {
+    const onSubmit = vi.fn(() => Promise.resolve<DocumentUploadResult>("succeeded"));
+    parseBNFile.mockResolvedValue([{ sheet: "Sheet1", data: [] }]);
+    rule.mockReturnValue(null);
+
+    renderAddDialog("BN Workbook", onSubmit);
+    selectWorkbook();
+
+    await waitFor(() => {
+      expect(screen.getByText("File Validated Successfully")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("button-confirm-upload-document")).not.toBeDisabled();
+  });
+
+  it("does not run validation for non-BN-Workbook document types", async () => {
+    const onSubmit = vi.fn(() => Promise.resolve<DocumentUploadResult>("succeeded"));
+
+    renderAddDialog("General File", onSubmit);
+    selectWorkbook();
+
+    expect(parseBNFile).not.toHaveBeenCalled();
+    expect(rule).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("bn-prevalidation-errors")).not.toBeInTheDocument();
+    expect(screen.queryByText("File Validated Successfully")).not.toBeInTheDocument();
+    expect(screen.getByTestId("button-confirm-upload-document")).not.toBeDisabled();
   });
 });

--- a/client/src/components/dialog/document/DocumentDialog.tsx
+++ b/client/src/components/dialog/document/DocumentDialog.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import { SecondaryButton } from "components/button";
 import { BaseDialog } from "components/dialog/BaseDialog";
-import { ExitIcon, FileIcon } from "components/icons";
+import { ErrorIcon, ExitIcon, FileIcon } from "components/icons";
 import { TextInput } from "components/input";
 import { DocumentTypeInput } from "components/input/document/DocumentTypeInput";
 import { getInputColors, INPUT_BASE_CLASSES, LABEL_CLASSES } from "components/input/Input";
@@ -14,6 +14,10 @@ import { tw } from "tags/tw";
 import { Notice } from "components/notice";
 import { AttestationDialog } from "components/dialog/AttestationDialog";
 import { UploadButton } from "./UploadButton";
+import {
+  BNPreValidationState,
+  useBNWorkbookPreValidation,
+} from "./useBNWorkbookPreValidation";
 
 type DocumentDialogType = "add" | "edit";
 
@@ -234,6 +238,49 @@ const DropTarget: React.FC<{
   );
 };
 
+const BNPreValidationNotice: React.FC<{ state: BNPreValidationState }> = ({ state }) => {
+  if (state.status === "idle") return null;
+  if (state.status === "validating") {
+    return (
+      <div className="px-2 py-1 text-sm text-text-placeholder" role="status" aria-live="polite">
+        Validating workbook...
+      </div>
+    );
+  }
+  if (state.status === "valid") {
+    return (
+      <div className="px-2 py-1">
+        <Notice title="File Validated Successfully" variant="success" />
+      </div>
+    );
+  }
+  return (
+    <div
+      className="px-2 py-1"
+      role="alert"
+      aria-live="assertive"
+      data-testid="bn-prevalidation-errors"
+    >
+      <div className="flex items-start gap-2 px-1 py-1 text-sm bg-white text-text-font border border-l-[10px] border-border-warn">
+        <span className="shrink-0 pt-0-5" aria-hidden="true">
+          <ErrorIcon />
+        </span>
+        <div className="flex-1 leading-2 space-y-2">
+          <p className="text-[15px] font-bold text-text-font">An Error has occurred</p>
+          {state.errors.map((error, index) => (
+            <p
+              key={`${error.code}-${index}`}
+              className="text-sm text-text-placeholder whitespace-pre-line"
+            >
+              {error.message}
+            </p>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
 const DocumentDialogNotice = ({
   documentDialogState,
   setDocumentDialogState,
@@ -359,6 +406,8 @@ export const DocumentDialog: React.FC<DocumentDialogProps> = ({
     onErrorCallback: (msg: ErrorMessage) => showError(msg),
   });
 
+  const bnPreValidation = useBNWorkbookPreValidation(file, activeDocument.documentType);
+
   useEffect(() => {
     if (mode === "add" && file && !titleManuallyEdited && !activeDocument.name.trim()) {
       const base = file.name.replace(/\.[^.]+$/, "");
@@ -383,6 +432,11 @@ export const DocumentDialog: React.FC<DocumentDialogProps> = ({
 
   const isMissing =
     (mode === "add" && !file) || !activeDocument.documentType || !activeDocument.name.trim();
+
+  const isBNPreValidationBlocking =
+    mode === "add" &&
+    !!file &&
+    (bnPreValidation.status === "validating" || bnPreValidation.status === "invalid");
 
   const onUploadClick = async () => {
     if (documentDialogState === "uploading") return;
@@ -433,7 +487,7 @@ export const DocumentDialog: React.FC<DocumentDialogProps> = ({
         actionButton={
           <UploadButton
             onClick={onUploadClick}
-            disabled={isMissing || !formHasChanges}
+            disabled={isMissing || !formHasChanges || isBNPreValidationBlocking}
             isUploading={documentDialogState === "uploading"}
             label={buttonName}
             loadingLabel={mode === "edit" ? "Saving" : "Uploading"}
@@ -453,6 +507,8 @@ export const DocumentDialog: React.FC<DocumentDialogProps> = ({
         ) : (
           ""
         )}
+
+        <BNPreValidationNotice state={bnPreValidation} />
 
         <DocumentDialogNotice
           documentDialogState={documentDialogState}

--- a/client/src/components/dialog/document/useBNWorkbookPreValidation.test.tsx
+++ b/client/src/components/dialog/document/useBNWorkbookPreValidation.test.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { DocumentType } from "demos-server";
+
+import {
+  BNPreValidationState,
+  useBNWorkbookPreValidation,
+} from "./useBNWorkbookPreValidation";
+
+const parseBNFile = vi.fn();
+const rule1 = vi.fn();
+const rule2 = vi.fn();
+
+vi.mock("demos-shared-library/dist/src/BN/index.js", () => ({
+  parseBNFile: (...args: unknown[]) => parseBNFile(...args),
+}));
+vi.mock("demos-shared-library/dist/src/BN/rulesets/v1/index.js", () => ({
+  validations: [rule1, rule2],
+}));
+
+const Probe: React.FC<{ file: File | null; documentType: DocumentType }> = ({
+  file,
+  documentType,
+}) => {
+  const state = useBNWorkbookPreValidation(file, documentType);
+  return <span data-testid="state">{JSON.stringify(state)}</span>;
+};
+
+const readState = (): BNPreValidationState =>
+  JSON.parse(screen.getByTestId("state").textContent ?? '{"status":"idle"}');
+
+const makeFile = (name = "wb.xlsx") =>
+  new File(["xlsx-bytes"], name, {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  });
+
+beforeEach(() => {
+  parseBNFile.mockReset();
+  rule1.mockReset();
+  rule2.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useBNWorkbookPreValidation", () => {
+  it("stays idle when no file is selected", () => {
+    render(<Probe file={null} documentType="BN Workbook" />);
+    expect(readState().status).toBe("idle");
+    expect(parseBNFile).not.toHaveBeenCalled();
+  });
+
+  it("stays idle when document type is not BN Workbook", () => {
+    render(<Probe file={makeFile()} documentType="General File" />);
+    expect(readState().status).toBe("idle");
+    expect(parseBNFile).not.toHaveBeenCalled();
+  });
+
+  it("returns valid when every rule returns null", async () => {
+    parseBNFile.mockResolvedValue([{ sheet: "Sheet1", data: [] }]);
+    rule1.mockReturnValue(null);
+    rule2.mockReturnValue(null);
+
+    render(<Probe file={makeFile()} documentType="BN Workbook" />);
+
+    await waitFor(() => expect(readState().status).toBe("valid"));
+  });
+
+  it("collects every rule's error verbatim when rules return them", async () => {
+    parseBNFile.mockResolvedValue([{ sheet: "Sheet1", data: [] }]);
+    rule1.mockReturnValue({ code: "1", message: "Error: C Report Tab - missing data." });
+    rule2.mockReturnValue({
+      code: "5",
+      message: "Error: C Report - 'Data Pulled On' field is blank.",
+    });
+
+    render(<Probe file={makeFile()} documentType="BN Workbook" />);
+
+    await waitFor(() => {
+      const state = readState();
+      expect(state.status).toBe("invalid");
+      if (state.status === "invalid") {
+        expect(state.errors).toEqual([
+          { code: "1", message: "Error: C Report Tab - missing data." },
+          { code: "5", message: "Error: C Report - 'Data Pulled On' field is blank." },
+        ]);
+      }
+    });
+  });
+
+  it("returns invalid with a PARSE_ERROR when the file cannot be parsed", async () => {
+    parseBNFile.mockRejectedValue(new Error("bad xlsx"));
+
+    render(<Probe file={makeFile("not-really.xlsx")} documentType="BN Workbook" />);
+
+    await waitFor(() => {
+      const state = readState();
+      expect(state.status).toBe("invalid");
+      if (state.status === "invalid") {
+        expect(state.errors[0]?.code).toBe("PARSE_ERROR");
+      }
+    });
+  });
+
+  it("survives a throwing rule and still surfaces other rules' results", async () => {
+    parseBNFile.mockResolvedValue([{ sheet: "Sheet1", data: [] }]);
+    rule1.mockImplementation(() => {
+      throw new Error('Sheet "C Report" not found');
+    });
+    rule2.mockReturnValue({ code: "2", message: "Error: Reporting Year missing." });
+
+    render(<Probe file={makeFile()} documentType="BN Workbook" />);
+
+    await waitFor(() => {
+      const state = readState();
+      expect(state.status).toBe("invalid");
+      if (state.status === "invalid") {
+        expect(state.errors).toHaveLength(2);
+        expect(state.errors[0]?.code).toBe("RULE_ERROR");
+        expect(state.errors[0]?.message).toContain('Sheet "C Report" not found');
+        expect(state.errors[1]?.code).toBe("2");
+      }
+    });
+  });
+});

--- a/client/src/components/dialog/document/useBNWorkbookPreValidation.ts
+++ b/client/src/components/dialog/document/useBNWorkbookPreValidation.ts
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react";
+
+import { BudgetNeutralityValidationError, DocumentType } from "demos-server";
+
+const BN_WORKBOOK_DOCUMENT_TYPE: DocumentType = "BN Workbook";
+
+const PARSE_ERROR: BudgetNeutralityValidationError = {
+  code: "PARSE_ERROR",
+  message: "Unable to read the workbook. Please upload a valid .xlsx file.",
+};
+
+const buildRuleError = (cause: unknown): BudgetNeutralityValidationError => ({
+  code: "RULE_ERROR",
+  message:
+    cause instanceof Error
+      ? `Workbook is missing expected structure: ${cause.message}.`
+      : "Workbook is missing expected structure.",
+});
+
+export type BNPreValidationState =
+  | { status: "idle" }
+  | { status: "validating" }
+  | { status: "valid" }
+  | { status: "invalid"; errors: BudgetNeutralityValidationError[] };
+
+const IDLE: BNPreValidationState = { status: "idle" };
+
+export const useBNWorkbookPreValidation = (
+  file: File | null,
+  documentType: DocumentType
+): BNPreValidationState => {
+  const [state, setState] = useState<BNPreValidationState>(IDLE);
+
+  useEffect(() => {
+    if (!file || documentType !== BN_WORKBOOK_DOCUMENT_TYPE) {
+      setState(IDLE);
+      return;
+    }
+
+    let cancelled = false;
+    setState({ status: "validating" });
+
+    (async () => {
+      const [{ parseBNFile }, { validations }] = await Promise.all([
+        import("demos-shared-library/dist/src/BN/index.js"),
+        import("demos-shared-library/dist/src/BN/rulesets/v1/index.js"),
+      ]);
+
+      let data;
+      try {
+        data = await parseBNFile(file);
+      } catch (parseError) {
+        if (cancelled) return;
+        console.error("BN workbook parse failed:", parseError);
+        setState({ status: "invalid", errors: [PARSE_ERROR] });
+        return;
+      }
+
+      // Run each rule independently so one rule throwing doesn't suppress the rest.
+      const errors: BudgetNeutralityValidationError[] = [];
+      for (const rule of validations) {
+        try {
+          const error = rule(data);
+          if (error) errors.push(error);
+        } catch (ruleError) {
+          console.error("BN validation rule threw:", ruleError);
+          errors.push(buildRuleError(ruleError));
+        }
+      }
+
+      if (cancelled) return;
+      setState(errors.length === 0 ? { status: "valid" } : { status: "invalid", errors });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [file, documentType]);
+
+  return state;
+};


### PR DESCRIPTION
Before a user uploads a BN Workbook, parse it in the browser and run it through
the shared validation library (`shared_library/BN`, the same one the lambda
uses server-side). If any rule fails, show the errors inline and **block the
upload** until a valid file is picked.

The post-upload polling from the original DEMOS-1283 still runs as before — the
lambda remains the source of truth. This adds client-side validation as a fast
first check.

## UX

| Doc type | Behavior |
|---|---|
| `BN Workbook` + invalid file | Red bordered notice listing every rule error, Upload button disabled |
| `BN Workbook` + valid file | Green "File Validated Successfully" notice, Upload enabled |
| `BN Workbook` + still parsing | "Validating workbook..." line, Upload disabled |
| Any other doc type | No validation runs, Upload enabled normally |


<img width="684" height="795" alt="image" src="https://github.com/user-attachments/assets/490107bb-bd40-48e7-b5d9-31aea6dc1ef1" />


https://github.com/user-attachments/assets/a4fe89b4-181b-4eb3-b8b2-c36f14aa8b27

