### PR TITLE
Disable data trace on the api gateway

### DIFF
--- a/deployment/lib/apigateway.test.ts
+++ b/deployment/lib/apigateway.test.ts
@@ -35,6 +35,12 @@ describe("ApiGateway", () => {
 
     template.hasResourceProperties("AWS::ApiGateway::Stage", {
       StageName: mockCommonProps.stage,
+      MethodSettings: Match.arrayWith([
+        Match.objectLike({
+          DataTraceEnabled: false,
+          LoggingLevel: "INFO",
+        }),
+      ]),
     });
 
     template.hasResourceProperties("AWS::ApiGateway::Method", {

--- a/deployment/lib/apigateway.ts
+++ b/deployment/lib/apigateway.ts
@@ -19,7 +19,7 @@ export function create(props: CommonProps) {
       stageName: props.stage,
       tracingEnabled: true,
       loggingLevel: aws_apigateway.MethodLoggingLevel.INFO,
-      dataTraceEnabled: true,
+      dataTraceEnabled: false,
       metricsEnabled: false,
       throttlingBurstLimit: 5000,
       throttlingRateLimit: 10000,

--- a/deployment/lib/uipathProcessor.ts
+++ b/deployment/lib/uipathProcessor.ts
@@ -83,7 +83,7 @@ export class UiPathProcessor extends Construct {
       timeout: Duration.minutes(15),
       asCode: false,
       externalModules: ["@aws-sdk", "@aws-sdk/client-secrets-manager", "@aws-sdk/client-s3"],
-      nodeModules: ["axios", "axios-oauth-client", "dotenv", "form-data", "pino", "pino-pretty", "pg", "file-type"],
+      nodeModules: ["axios", "axios-oauth-client", "dotenv", "form-data", "pino", "pino-pretty", "pg", "file-type", "axios-error-redact"],
       vpc: props.vpc,
       securityGroup: props.securityGroup,
       format: OutputFormat.ESM,


### PR DESCRIPTION
Since we have not needed it for any troubleshooting in the lower environments, this is being disabled to prevent any sensitive data logging

https://docs.aws.amazon.com/apigateway/latest/api/API_MethodSetting.html

```
This can be useful to troubleshoot APIs, but can result in logging sensitive data. We recommend that you don't enable this option for production APIs.
```