### PR TITLE
DEMOS-2085 - Fix for post submission deliverable documents

### DIFF
--- a/client/src/pages/deliverables/sections/CmsFilesTab.tsx
+++ b/client/src/pages/deliverables/sections/CmsFilesTab.tsx
@@ -17,6 +17,7 @@ export type CmsFilesTabProps = {
   onEdit?: (file: DeliverableFileRow) => void;
   onDelete?: (fileIds: string[]) => void;
   disabled?: boolean;
+  deleteDisabled?: boolean;
   showActions?: boolean;
 };
 
@@ -26,6 +27,7 @@ export const CmsFilesTab: React.FC<CmsFilesTabProps> = ({
   onEdit,
   onDelete,
   disabled = false,
+  deleteDisabled = false,
   showActions = true,
 }) => {
   const columns = makeCmsFileColumns({ showSelect: showActions });
@@ -46,6 +48,7 @@ export const CmsFilesTab: React.FC<CmsFilesTabProps> = ({
       onEdit={onEdit}
       onDelete={onDelete}
       disabled={disabled}
+      deleteDisabled={deleteDisabled}
       showActions={showActions}
     />
   );

--- a/client/src/pages/deliverables/sections/DeliverableFileTable.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableFileTable.tsx
@@ -29,6 +29,7 @@ export type DeliverableFileTableProps = {
   onDelete?: (fileIds: string[]) => void;
   footer?: React.ReactNode;
   disabled?: boolean;
+  deleteDisabled?: boolean;
   showActions?: boolean;
 };
 
@@ -48,6 +49,7 @@ export const DeliverableFileTable: React.FC<DeliverableFileTableProps> = ({
   onDelete,
   footer,
   disabled = false,
+  deleteDisabled = false,
   showActions = true,
 }) => (
   <div data-testid={testId} className="flex flex-col gap-1">
@@ -80,12 +82,14 @@ export const DeliverableFileTable: React.FC<DeliverableFileTableProps> = ({
               selectedCount,
               rule: { kind: "exactly", count: 1 },
             });
-            const deleteTooltip = selectionTooltip({
-              action: "Delete",
-              nounSingular: "File",
-              selectedCount,
-              rule: { kind: "atLeast", count: 1 },
-            });
+            const deleteTooltip = deleteDisabled
+              ? "Files cannot be deleted after the deliverable has been submitted."
+              : selectionTooltip({
+                action: "Delete",
+                nounSingular: "File",
+                selectedCount,
+                rule: { kind: "atLeast", count: 1 },
+              });
 
             return (
               <div className="flex gap-1 ml-4">
@@ -102,7 +106,7 @@ export const DeliverableFileTable: React.FC<DeliverableFileTableProps> = ({
                   name={deleteButtonName}
                   ariaLabel={deleteAriaLabel}
                   tooltip={deleteTooltip}
-                  disabled={disabled || selectedCount < 1}
+                  disabled={disabled || deleteDisabled || selectedCount < 1}
                   onClick={() => onDelete?.(selectedRows.map((row) => row.id))}
                 >
                   <DeleteIcon />

--- a/client/src/pages/deliverables/sections/FileAndHistoryTabs.test.tsx
+++ b/client/src/pages/deliverables/sections/FileAndHistoryTabs.test.tsx
@@ -11,6 +11,7 @@ import { TestProvider } from "test-utils/TestProvider";
 import { FileAndHistoryTabs } from "./FileAndHistoryTabs";
 import {
   STATE_FILES_ADD_BUTTON_NAME,
+  STATE_FILES_DELETE_BUTTON_NAME,
   STATE_FILES_TAB_NAME,
   STATE_FILES_SUBMIT_BUTTON_NAME,
 } from "./StateFilesTab";
@@ -305,5 +306,33 @@ describe("FileAndHistoryTabs", () => {
 
       expect(screen.getByTestId(STATE_FILES_ADD_BUTTON_NAME)).not.toBeDisabled();
     });
+  });
+
+  describe("delete lock by status", () => {
+    it.each(["Upcoming", "Past Due"] as const)(
+      "enables Delete on the State Files tab once a row is selected for status %s",
+      async (status) => {
+        const user = userEvent.setup();
+        setup({ status });
+
+        await user.click(screen.getByTestId("select-row-state-file-1"));
+
+        expect(screen.getByTestId(STATE_FILES_DELETE_BUTTON_NAME)).not.toBeDisabled();
+      }
+    );
+
+    it.each(["Submitted", "Under CMS Review"] as const)(
+      "keeps Delete disabled on the State Files tab even with a row selected for status %s",
+      async (status) => {
+        const user = userEvent.setup();
+        setup({ status });
+
+        await user.click(screen.getByTestId("select-row-state-file-1"));
+
+        expect(screen.getByTestId(STATE_FILES_DELETE_BUTTON_NAME)).toBeDisabled();
+        // Add/Edit remain available until a final status.
+        expect(screen.getByTestId(STATE_FILES_ADD_BUTTON_NAME)).not.toBeDisabled();
+      }
+    );
   });
 });

--- a/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
+++ b/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
@@ -46,6 +46,18 @@ export const RESUBMISSION_DISABLED_STATUSES: ReadonlySet<DeliverableStatus> =
 export const isResubmissionDisabled = (status: DeliverableStatus): boolean =>
   RESUBMISSION_DISABLED_STATUSES.has(status);
 
+// Documents may only be deleted before the deliverable has been submitted. Once it
+// is Submitted, Under CMS Review, or in any final status, files are locked from
+// deletion for every user (Add/Edit remain available until a final status — see
+// isDeliverableEditable). Expressed as an allow-list so any new status defaults to locked.
+export const FILE_DELETION_ALLOWED_STATUSES: ReadonlySet<DeliverableStatus> = new Set([
+  "Upcoming",
+  "Past Due",
+]);
+
+export const isFileDeletionLocked = (status: DeliverableStatus): boolean =>
+  !FILE_DELETION_ALLOWED_STATUSES.has(status);
+
 const CMS_STAFF_PERSON_TYPES: ReadonlySet<PersonType> = new Set(["demos-admin", "demos-cms-user"]);
 
 const STATE_FILE_MANAGER_PERSON_TYPES: ReadonlySet<PersonType> = new Set([
@@ -89,6 +101,7 @@ export const FileAndHistoryTabs: React.FC<{
   const cmsFiles = deliverable.cmsDocuments;
   const historyRows: DeliverableHistoryRow[] = deliverable.deliverableActions.map(toHistoryRow);
   const isFinalized = !isDeliverableEditable(deliverable.status);
+  const isDeleteLocked = isFileDeletionLocked(deliverable.status);
   const refetchAfterFileChange = [DELIVERABLE_DETAILS_QUERY];
 
   if (!currentUser) {
@@ -175,6 +188,7 @@ export const FileAndHistoryTabs: React.FC<{
           <StateFilesTab
             files={stateFiles}
             disabled={isFinalized || !canManageStateFiles}
+            deleteDisabled={isDeleteLocked}
             onAdd={canManageStateFiles ? handleAddStateFile : undefined}
             onEdit={canManageStateFiles ? handleEditStateFile : undefined}
             onDelete={canManageStateFiles ? handleDeleteFiles : undefined}
@@ -184,6 +198,7 @@ export const FileAndHistoryTabs: React.FC<{
           <CmsFilesTab
             files={cmsFiles}
             disabled={isFinalized || !canManageCmsFiles}
+            deleteDisabled={isDeleteLocked}
             showActions={canManageCmsFiles}
             onAdd={canManageCmsFiles ? handleAddCmsFile : undefined}
             onEdit={canManageCmsFiles ? handleEditCmsFile : undefined}

--- a/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
+++ b/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
@@ -46,10 +46,6 @@ export const RESUBMISSION_DISABLED_STATUSES: ReadonlySet<DeliverableStatus> =
 export const isResubmissionDisabled = (status: DeliverableStatus): boolean =>
   RESUBMISSION_DISABLED_STATUSES.has(status);
 
-// Documents may only be deleted before the deliverable has been submitted. Once it
-// is Submitted, Under CMS Review, or in any final status, files are locked from
-// deletion for every user (Add/Edit remain available until a final status — see
-// isDeliverableEditable). Expressed as an allow-list so any new status defaults to locked.
 export const FILE_DELETION_ALLOWED_STATUSES: ReadonlySet<DeliverableStatus> = new Set([
   "Upcoming",
   "Past Due",

--- a/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
+++ b/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
@@ -178,4 +178,25 @@ describe("StateFilesTab", () => {
       expect(screen.getByTestId(STATE_FILES_DELETE_BUTTON_NAME)).toBeDisabled();
     });
   });
+
+  describe("when deleteDisabled", () => {
+    it("keeps Delete disabled even when rows are selected", async () => {
+      const user = userEvent.setup();
+      renderTab({ deleteDisabled: true });
+
+      await user.click(screen.getByTestId("select-row-file-a"));
+
+      expect(screen.getByTestId(STATE_FILES_DELETE_BUTTON_NAME)).toBeDisabled();
+    });
+
+    it("still allows Add and Edit", async () => {
+      const user = userEvent.setup();
+      renderTab({ deleteDisabled: true });
+
+      expect(screen.getByTestId(STATE_FILES_ADD_BUTTON_NAME)).not.toBeDisabled();
+
+      await user.click(screen.getByTestId("select-row-file-a"));
+      expect(screen.getByTestId(STATE_FILES_EDIT_BUTTON_NAME)).not.toBeDisabled();
+    });
+  });
 });

--- a/client/src/pages/deliverables/sections/StateFilesTab.tsx
+++ b/client/src/pages/deliverables/sections/StateFilesTab.tsx
@@ -19,6 +19,7 @@ export type StateFilesTabProps = {
   onEdit?: (file: DeliverableFileRow) => void;
   onDelete?: (fileIds: string[]) => void;
   disabled?: boolean;
+  deleteDisabled?: boolean;
 };
 
 export const StateFilesTab: React.FC<StateFilesTabProps> = ({
@@ -27,6 +28,7 @@ export const StateFilesTab: React.FC<StateFilesTabProps> = ({
   onEdit,
   onDelete,
   disabled = false,
+  deleteDisabled = false,
 }) => {
   const columns = makeStateFileColumns();
 
@@ -46,6 +48,7 @@ export const StateFilesTab: React.FC<StateFilesTabProps> = ({
       onEdit={onEdit}
       onDelete={onDelete}
       disabled={disabled}
+      deleteDisabled={deleteDisabled}
     />
   );
 };

--- a/server/src/model/document/documentData.test.ts
+++ b/server/src/model/document/documentData.test.ts
@@ -7,9 +7,14 @@ import { log } from "../../log";
 import { PrismaTransactionClient } from "../../prismaClient";
 import { handleDeleteDocument } from "./handleDeleteDocument";
 import { validateDocumentCanBeDeleted } from "./validateDocumentCanBeDeleted";
+import { selectDeliverableOrThrow } from "../deliverable/queries/selectDeliverableOrThrow";
 
 vi.mock("../../auth", () => ({
   buildAuthorizationFilter: vi.fn(),
+}));
+
+vi.mock("../deliverable/queries/selectDeliverableOrThrow", () => ({
+  selectDeliverableOrThrow: vi.fn(),
 }));
 
 vi.mock("../../log", () => ({
@@ -355,7 +360,7 @@ describe("documentData", () => {
     });
 
     it("deletes and returns the document when found and user has permission to delete it", async () => {
-      const document = { id: "document-1" } as PrismaDocument;
+      const document = { id: "document-1", deliverableId: null } as PrismaDocument;
       vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
       vi.mocked(selectDocument).mockResolvedValueOnce(document);
       vi.mocked(handleDeleteDocument).mockResolvedValueOnce(document);
@@ -364,9 +369,35 @@ describe("documentData", () => {
 
       expect(buildAuthorizationFilter).toHaveBeenCalledOnce();
       expect(buildAuthorizationFilter).toHaveBeenCalledWith(user, expect.any(Function));
-      expect(validateDocumentCanBeDeleted).toHaveBeenCalledExactlyOnceWith(document);
+      expect(selectDeliverableOrThrow).not.toHaveBeenCalled();
+      expect(validateDocumentCanBeDeleted).toHaveBeenCalledExactlyOnceWith({
+        ...document,
+        deliverableStatus: null,
+      });
       expect(handleDeleteDocument).toHaveBeenCalledExactlyOnceWith(where, mockTransaction);
       expect(result).toStrictEqual(document);
+    });
+
+    it("passes the deliverable status to validation when the document is attached to a deliverable", async () => {
+      const document = { id: "document-1", deliverableId: "deliverable-1" } as PrismaDocument;
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      vi.mocked(selectDocument).mockResolvedValueOnce(document);
+      vi.mocked(selectDeliverableOrThrow).mockResolvedValueOnce({
+        id: "deliverable-1",
+        statusId: "Under CMS Review",
+      } as Awaited<ReturnType<typeof selectDeliverableOrThrow>>);
+      vi.mocked(handleDeleteDocument).mockResolvedValueOnce(document);
+
+      await removeDocument(where, user, mockTransaction);
+
+      expect(selectDeliverableOrThrow).toHaveBeenCalledExactlyOnceWith(
+        { id: "deliverable-1" },
+        mockTransaction
+      );
+      expect(validateDocumentCanBeDeleted).toHaveBeenCalledExactlyOnceWith({
+        ...document,
+        deliverableStatus: "Under CMS Review",
+      });
     });
   });
 });

--- a/server/src/model/document/documentData.ts
+++ b/server/src/model/document/documentData.ts
@@ -4,6 +4,8 @@ import { selectDocument, selectManyDocuments, updateDocument } from "./queries";
 import { PrismaTransactionClient } from "../../prismaClient";
 import { log } from "../../log";
 import { isAStatePointOfContactAssociatedWithDeliverable } from "../deliverable/deliverableData";
+import { selectDeliverableOrThrow } from "../deliverable/queries/selectDeliverableOrThrow";
+import { DeliverableStatus } from "../../constants";
 import { handleDeleteDocument } from "./handleDeleteDocument";
 import { validateDocumentCanBeDeleted } from "./validateDocumentCanBeDeleted";
 
@@ -158,7 +160,11 @@ export async function removeDocument(
     );
 
     if (authorizedDocument) {
-      validateDocumentCanBeDeleted(authorizedDocument);
+      const deliverableStatus = authorizedDocument.deliverableId
+        ? ((await selectDeliverableOrThrow({ id: authorizedDocument.deliverableId }, tx))
+            .statusId as DeliverableStatus)
+        : null;
+      validateDocumentCanBeDeleted({ ...authorizedDocument, deliverableStatus });
       return await handleDeleteDocument(where, tx);
     }
   }

--- a/server/src/model/document/validateDocumentCanBeDeleted.test.ts
+++ b/server/src/model/document/validateDocumentCanBeDeleted.test.ts
@@ -19,4 +19,39 @@ describe("validateDocumentCanBeDeleted", () => {
     };
     expect(() => validateDocumentCanBeDeleted(document)).not.toThrow();
   });
+
+  it.each(["Submitted", "Under CMS Review", "Accepted", "Approved", "Received and Filed"] as const)(
+    "should throw an error when the deliverable status is %s",
+    (deliverableStatus) => {
+      const document = {
+        id: "doc3",
+        deliverableSubmissionActionId: null,
+        deliverableStatus,
+      };
+      expect(() => validateDocumentCanBeDeleted(document)).toThrow(
+        `Document with ID doc3 cannot be deleted because its deliverable has been submitted.`
+      );
+    }
+  );
+
+  it.each(["Upcoming", "Past Due"] as const)(
+    "should not throw an error when the deliverable status is %s",
+    (deliverableStatus) => {
+      const document = {
+        id: "doc4",
+        deliverableSubmissionActionId: null,
+        deliverableStatus,
+      };
+      expect(() => validateDocumentCanBeDeleted(document)).not.toThrow();
+    }
+  );
+
+  it("should not throw an error when the document is not attached to a deliverable", () => {
+    const document = {
+      id: "doc5",
+      deliverableSubmissionActionId: null,
+      deliverableStatus: null,
+    };
+    expect(() => validateDocumentCanBeDeleted(document)).not.toThrow();
+  });
 });

--- a/server/src/model/document/validateDocumentCanBeDeleted.ts
+++ b/server/src/model/document/validateDocumentCanBeDeleted.ts
@@ -1,10 +1,6 @@
 import { DeliverableStatus } from "../../constants";
 
-// A document attached to a deliverable can only be deleted before that deliverable
-// has been submitted. Once it is Submitted, Under CMS Review, or in any final status,
-// its files are locked from deletion for every user. (Documents that were part of a
-// submission are additionally pinned via deliverableSubmissionActionId, but documents
-// added after submission are never stamped, so the status check is what guards them.)
+
 export const DOCUMENT_DELETION_LOCKED_DELIVERABLE_STATUSES: ReadonlySet<DeliverableStatus> =
   new Set(["Submitted", "Under CMS Review", "Accepted", "Approved", "Received and Filed"]);
 

--- a/server/src/model/document/validateDocumentCanBeDeleted.ts
+++ b/server/src/model/document/validateDocumentCanBeDeleted.ts
@@ -1,10 +1,30 @@
+import { DeliverableStatus } from "../../constants";
+
+// A document attached to a deliverable can only be deleted before that deliverable
+// has been submitted. Once it is Submitted, Under CMS Review, or in any final status,
+// its files are locked from deletion for every user. (Documents that were part of a
+// submission are additionally pinned via deliverableSubmissionActionId, but documents
+// added after submission are never stamped, so the status check is what guards them.)
+export const DOCUMENT_DELETION_LOCKED_DELIVERABLE_STATUSES: ReadonlySet<DeliverableStatus> =
+  new Set(["Submitted", "Under CMS Review", "Accepted", "Approved", "Received and Filed"]);
+
 export function validateDocumentCanBeDeleted(document: {
   id: string;
   deliverableSubmissionActionId?: string | null;
+  deliverableStatus?: DeliverableStatus | null;
 }): void {
   if (document.deliverableSubmissionActionId) {
     throw new Error(
       `Document with ID ${document.id} cannot be deleted because it is part of a deliverable submission.`
+    );
+  }
+
+  if (
+    document.deliverableStatus &&
+    DOCUMENT_DELETION_LOCKED_DELIVERABLE_STATUSES.has(document.deliverableStatus)
+  ) {
+    throw new Error(
+      `Document with ID ${document.id} cannot be deleted because its deliverable has been submitted.`
     );
   }
 }


### PR DESCRIPTION
Documents on a deliverable's **State Files** and **CMS Files** tabs can now only be
**deleted before the deliverable is submitted**. Add/Edit and View/Download behavior
is unchanged.

## Rules
- **Delete** allowed only when status is `Upcoming` or `Past Due`.
  Blocked for `Submitted`, `Under CMS Review`, `Accepted`, `Approved`, `Received and Filed`.
- **Add / Edit** allowed until a final status (`Accepted`, `Approved`, `Received and Filed`).
- **View / Download** always available (still requires access to the deliverable).
- Applies to **all users** (CMS/Admin and State).
  - CMS/Admin: manage both tabs.
  - State users: manage State Files only; view/download CMS Files.

## The bug
Delete was gated on the same flag as Add/Edit, which only locks the 3 final statuses, so
delete stayed enabled in `Submitted` / `Under CMS Review`. The backend only blocked
documents stamped at submission time, so files **added after** submission could still be
deleted via the API.
<img width="1412" height="883" alt="Screenshot 2026-06-08 at 3 17 43 PM" src="https://github.com/user-attachments/assets/3f7b9050-66ec-448a-93bb-573736a46271" />

