### PR TITLE
DEMOS-2237: Fix UserProvider for Unautenticated Users

### DIFF
--- a/client/src/components/footer/Footer.test.tsx
+++ b/client/src/components/footer/Footer.test.tsx
@@ -20,6 +20,10 @@ vi.mock("hooks/useDownloadReference", () => ({
   useDownloadReference: vi.fn(),
 }));
 
+vi.mock("config/env", () => ({
+  isLocalDevelopment: vi.fn(),
+}));
+
 type UseLazyQueryTuple = ReturnType<typeof useLazyQuery>;
 
 const fetchFaqReferenceMaterial = vi.fn();
@@ -35,7 +39,7 @@ const renderWithProviders = () =>
   );
 
 describe("Footer Component", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     vi.mocked(useLazyQuery).mockReturnValue([
       fetchFaqReferenceMaterial,
@@ -45,6 +49,8 @@ describe("Footer Component", () => {
       downloadReference,
       downloadReferenceAgreement: vi.fn(),
     });
+    const { isLocalDevelopment } = await import("config/env");
+    vi.mocked(isLocalDevelopment).mockReturnValue(false);
   });
 
   it("renders without crashing", () => {
@@ -119,5 +125,25 @@ describe("Footer Component", () => {
   it("displays the address", () => {
     renderWithProviders();
     expect(screen.getByText(DEMOS_ADDRESS)).toBeInTheDocument();
+  });
+
+  it("displays the git commit hash in local development", async () => {
+    vi.stubGlobal("__GIT_COMMIT__", "abc1234");
+    const { isLocalDevelopment } = await import("config/env");
+    vi.mocked(isLocalDevelopment).mockReturnValue(true);
+
+    renderWithProviders();
+
+    expect(screen.getByText(/commit: abc1234/i)).toBeInTheDocument();
+  });
+
+  it("hides the git commit hash outside of local development", async () => {
+    vi.stubGlobal("__GIT_COMMIT__", "abc1234");
+    const { isLocalDevelopment } = await import("config/env");
+    vi.mocked(isLocalDevelopment).mockReturnValue(false);
+
+    renderWithProviders();
+
+    expect(screen.queryByText(/commit:/i)).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/footer/Footer.tsx
+++ b/client/src/components/footer/Footer.tsx
@@ -1,5 +1,6 @@
 import { HhsLogo } from "components/brand/HhsLogo";
 import { LogoSimplified } from "components/brand/LogoSimplified";
+import { DebugOnly } from "components/debug/DebugOnly";
 import { useToast } from "components/toast";
 import React from "react";
 import { tw } from "tags/tw";
@@ -100,7 +101,9 @@ const FooterUpper: React.FC = () => (
 
 const FooterLower: React.FC = () => (
   <div className="flex w-full bg-brand text-white p-1">
-    <div className="w-1/3" />
+    <div className="w-1/3">
+      <DebugOnly>git commit: {__GIT_COMMIT__}</DebugOnly>
+    </div>
     <div className="w-1/3" />
     <div className="w-1/3 text-right">{DEMOS_ADDRESS}</div>
   </div>

--- a/client/src/components/user/UserProvider.tsx
+++ b/client/src/components/user/UserProvider.tsx
@@ -38,8 +38,13 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     );
   }
 
-  // Render authentication failure component if there was an error
-  if (error || !data?.currentUser) {
+  // Not yet authenticated — render children so withAuthenticationRequired can redirect
+  if (!auth.isAuthenticated) {
+    return <>{children}</>;
+  }
+
+  // Render authentication failure component if there was an error or no user data
+  if (error || auth.error || !data?.currentUser) {
     const errorParts = [auth.error?.message, error?.message].filter(Boolean);
     return (
       <UserAuthenticationFailed

--- a/client/types/shims.d.ts
+++ b/client/types/shims.d.ts
@@ -1,3 +1,5 @@
+declare const __GIT_COMMIT__: string;
+
 declare module "graphql-tag" {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export const gql: any;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,12 +1,24 @@
 /// <reference types="vitest" />
+import { execSync } from "child_process";
 import { defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 
+const getGitCommit = (): string => {
+  try {
+    return execSync("git rev-parse --short HEAD").toString().trim();
+  } catch {
+    return "unknown";
+  }
+};
+
 export const config = defineConfig({
   plugins: [react(), tailwindcss(), tsconfigPaths()],
+  define: {
+    __GIT_COMMIT__: JSON.stringify(getGitCommit()),
+  },
   server: {
     port: 3000,
     // Proxy /graphql requests to the server running on port 4000 to avoid CORS issues


### PR DESCRIPTION
Oops, I was using cached creds and realized I broke the flow for when you're signed out. A user that is not authenticated needs to render children, as this will render the sign in page:

I did scope creep a little here and add a git commit line to the footer as well that way we can see in screenshots what commit a change is on, this is guarded by the `<DebugOnly>` component which means it will only render in local development

https://github.com/user-attachments/assets/d070704a-b7a2-4350-ba0f-6a7855d0def9

