### PR TITLE
DEMOS-2217: Edit Deliverables, Deliverable View and Deliverable page, now with mutators hooked up!

### DIFF
--- a/client/src/components/dialog/DialogContext.tsx
+++ b/client/src/components/dialog/DialogContext.tsx
@@ -60,6 +60,11 @@ import {
 } from "./deliverable/ReviewExtensionDeliverableDialog";
 import { ReferenceAgreementDialog } from "./referenceAgreement/ReferenceAgreementDialog";
 
+type EditDeliverableDialogSource = Pick<
+  DeliverableTableRow,
+  "id" | "name" | "deliverableType" | "dueDate" | "cmsOwner" | "demonstrationTypes" | "demonstration"
+>;
+
 type DialogContextType = {
   content: React.ReactNode | null;
   showDialog: (content: React.ReactNode) => void;
@@ -342,7 +347,7 @@ export const useDialog = () => {
   };
 
   const showEditDeliverableDialog = (
-    deliverable: DeliverableTableRow,
+    deliverable: EditDeliverableDialogSource,
     onSave?: (input: EditDeliverableInput, reasonForChange?: string) => Promise<void> | void
   ) => {
     const dialogDeliverable: EditDeliverableDialogDeliverable = {

--- a/client/src/components/dialog/deliverable/EditDeliverableDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/EditDeliverableDialog.test.tsx
@@ -5,11 +5,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import {
   EDIT_DELIVERABLE_DIALOG_TITLE,
+  DELIVERABLE_UPDATE_FAILED_MESSAGE,
   EDIT_DELIVERABLE_REASON_FIELD_NAME,
   EDIT_DELIVERABLE_SAVE_BUTTON_NAME,
   EditDeliverableDialog,
   EditDeliverableDialogDeliverable,
   EditDeliverableInput,
+  UPDATE_DELIVERABLE_MUTATION,
   buildInitialFormData,
   formHasChanges,
   formIsValid,
@@ -25,9 +27,11 @@ import { Tag } from "demos-server";
 import { DELIVERABLE_UPDATED_MESSAGE } from "util/messages";
 
 const mockShowSuccess = vi.fn();
+const mockShowError = vi.fn();
 vi.mock("components/toast", () => ({
   useToast: () => ({
     showSuccess: mockShowSuccess,
+    showError: mockShowError,
   }),
 }));
 
@@ -50,13 +54,14 @@ type OnSaveFn = (input: EditDeliverableInput, reasonForChange?: string) => Promi
 const setup = (overrides?: {
   deliverable?: Partial<EditDeliverableDialogDeliverable>;
   onSave?: OnSaveFn;
+  mocks?: React.ComponentProps<typeof TestProvider>["mocks"];
 }) => {
   const onClose = vi.fn();
   const onSave = overrides?.onSave;
   const deliverable = { ...TEST_DELIVERABLE, ...overrides?.deliverable };
 
   render(
-    <TestProvider mocks={personMocks}>
+    <TestProvider mocks={overrides?.mocks ?? personMocks}>
       <EditDeliverableDialog
         deliverable={deliverable}
         demonstrationTypeTags={MOCK_TAGS}
@@ -179,6 +184,90 @@ describe("EditDeliverableDialog", () => {
     );
     expect(mockShowSuccess).toHaveBeenCalledWith(DELIVERABLE_UPDATED_MESSAGE);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists changes with the updateDeliverable mutation", async () => {
+    const user = userEvent.setup();
+    const mutationMock = {
+      request: {
+        query: UPDATE_DELIVERABLE_MUTATION,
+        variables: {
+          id: "deliverable-1",
+          input: {
+            name: "Updated Quarterly Report",
+            cmsOwnerUserId: "ashokatano",
+            demonstrationTypes: ["Aggregate Cap"],
+          },
+        },
+      },
+      result: {
+        data: {
+          updateDeliverable: {
+            id: "deliverable-1",
+            name: "Updated Quarterly Report",
+            dueDate: new Date("2026-06-15"),
+            cmsOwner: {
+              id: "ashokatano",
+              person: {
+                id: "person-1",
+                fullName: "Ahsoka Tano",
+              },
+            },
+            demonstrationTypes: [{ tagName: "Aggregate Cap", approvalStatus: "Approved" }],
+          },
+        },
+      },
+    };
+    const { onClose } = setup({ mocks: [...personMocks, mutationMock] });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("select-demonstration-type")).toBeInTheDocument()
+    );
+    await user.clear(screen.getByTestId(DELIVERABLE_NAME_FIELD_ID));
+    await user.type(screen.getByTestId(DELIVERABLE_NAME_FIELD_ID), "Updated Quarterly Report");
+    await user.click(screen.getByTestId("select-demonstration-type"));
+    await user.click(screen.getByText("Aggregate Cap"));
+
+    await user.click(screen.getByTestId(EDIT_DELIVERABLE_SAVE_BUTTON_NAME));
+
+    await waitFor(() =>
+      expect(mockShowSuccess).toHaveBeenCalledWith(DELIVERABLE_UPDATED_MESSAGE)
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the modal open and shows an error when updateDeliverable fails", async () => {
+    const user = userEvent.setup();
+    const mutationMock = {
+      request: {
+        query: UPDATE_DELIVERABLE_MUTATION,
+        variables: {
+          id: "deliverable-1",
+          input: {
+            name: "Updated Quarterly Report",
+            cmsOwnerUserId: "ashokatano",
+            demonstrationTypes: ["Aggregate Cap"],
+          },
+        },
+      },
+      error: new Error("Update failed"),
+    };
+    const { onClose } = setup({ mocks: [...personMocks, mutationMock] });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("select-demonstration-type")).toBeInTheDocument()
+    );
+    await user.clear(screen.getByTestId(DELIVERABLE_NAME_FIELD_ID));
+    await user.type(screen.getByTestId(DELIVERABLE_NAME_FIELD_ID), "Updated Quarterly Report");
+    await user.click(screen.getByTestId("select-demonstration-type"));
+    await user.click(screen.getByText("Aggregate Cap"));
+
+    await user.click(screen.getByTestId(EDIT_DELIVERABLE_SAVE_BUTTON_NAME));
+
+    await waitFor(() =>
+      expect(mockShowError).toHaveBeenCalledWith(DELIVERABLE_UPDATE_FAILED_MESSAGE)
+    );
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("does not pass a reason to onSave when the due date was not modified", async () => {

--- a/client/src/components/dialog/deliverable/EditDeliverableDialog.tsx
+++ b/client/src/components/dialog/deliverable/EditDeliverableDialog.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from "react";
+import { gql, useMutation } from "@apollo/client";
 
 import { Button } from "components/button";
 import { BaseDialog } from "components/dialog/BaseDialog";
 import { TextInput } from "components/input";
 import { useToast } from "components/toast";
-import { DeliverableType, DeliverableStatus, Tag } from "demos-server";
-import { format, isBefore } from "date-fns";
+import { DeliverableType, DeliverableStatus, Tag, UpdateDeliverableInput } from "demos-server";
+import { format, isBefore, parseISO } from "date-fns";
 import { DELIVERABLE_UPDATED_MESSAGE } from "util/messages";
-import { getTodayEst } from "util/formatDate";
+import { formatDateForServer, getTodayEst } from "util/formatDate";
 
 import { CMSOwnerField } from "./fields/CMSOwnerField";
 import { DeliverableNameField } from "./fields/DeliverableNameField";
@@ -20,6 +21,29 @@ export const EDIT_DELIVERABLE_DIALOG_TITLE = "Edit Deliverable";
 export const EDIT_DELIVERABLE_DIALOG_NAME = "edit-deliverable-dialog";
 export const EDIT_DELIVERABLE_SAVE_BUTTON_NAME = "button-edit-deliverable-confirm";
 export const EDIT_DELIVERABLE_REASON_FIELD_NAME = "edit-deliverable-reason";
+export const DELIVERABLE_UPDATE_FAILED_MESSAGE =
+  "Your changes could not be saved due to an unknown problem.";
+
+export const UPDATE_DELIVERABLE_MUTATION = gql`
+  mutation UpdateDeliverable($id: ID!, $input: UpdateDeliverableInput!) {
+    updateDeliverable(id: $id, input: $input) {
+      id
+      name
+      dueDate
+      cmsOwner {
+        id
+        person {
+          id
+          fullName
+        }
+      }
+      demonstrationTypes {
+        tagName
+        approvalStatus
+      }
+    }
+  }
+`;
 
 export const NON_EDITABLE_DELIVERABLE_STATUSES: ReadonlySet<DeliverableStatus> = new Set([
   "Accepted",
@@ -110,13 +134,31 @@ export interface EditDeliverableDialogProps {
   onSave?: (input: EditDeliverableInput, reasonForChange?: string) => Promise<void> | void;
 }
 
+const buildUpdateDeliverableInput = (
+  input: EditDeliverableInput,
+  reasonForChange?: string
+): UpdateDeliverableInput => ({
+  name: input.name,
+  cmsOwnerUserId: input.cmsOwnerUserId,
+  demonstrationTypes: input.demonstrationTypes,
+  ...(reasonForChange
+    ? {
+      dueDate: {
+        newDueDate: formatDateForServer(parseISO(input.dueDate)),
+        dateChangeNote: reasonForChange,
+      },
+    }
+    : {}),
+});
+
 export const EditDeliverableDialog: React.FC<EditDeliverableDialogProps> = ({
   onClose,
   deliverable,
   demonstrationTypeTags,
   onSave,
 }) => {
-  const { showSuccess } = useToast();
+  const { showSuccess, showError } = useToast();
+  const [updateDeliverable, { loading: isSaving }] = useMutation(UPDATE_DELIVERABLE_MUTATION);
 
   const initialFormData = buildInitialFormData(deliverable);
   const [formData, setFormData] = useState<EditDeliverableFormData>(initialFormData);
@@ -132,23 +174,35 @@ export const EditDeliverableDialog: React.FC<EditDeliverableDialogProps> = ({
 
   const handleSave = async () => {
     setAttemptedSubmit(true);
-    if (!isFormValid) return;
+    if (!isFormValid || isSaving) return;
 
-    // TODO: wire onSave to the UpdateDeliverable mutation — toast currently fires without persisting.
-    await onSave?.(
-      {
-        id: deliverable.id,
-        name: formData.name.trim(),
-        deliverableType: deliverable.deliverableType,
-        cmsOwnerUserId: formData.cmsOwnerUserId,
-        dueDate: formData.dueDate,
-        demonstrationTypes: formData.demonstrationTypes,
-      },
-      dueDateWasChanged ? formData.reasonForChange.trim() : undefined
-    );
+    const input = {
+      id: deliverable.id,
+      name: formData.name.trim(),
+      deliverableType: deliverable.deliverableType,
+      cmsOwnerUserId: formData.cmsOwnerUserId,
+      dueDate: formData.dueDate,
+      demonstrationTypes: formData.demonstrationTypes,
+    };
+    const reasonForChange = dueDateWasChanged ? formData.reasonForChange.trim() : undefined;
 
-    showSuccess(DELIVERABLE_UPDATED_MESSAGE);
-    onClose();
+    try {
+      if (onSave) {
+        await onSave(input, reasonForChange);
+      } else {
+        await updateDeliverable({
+          variables: {
+            id: input.id,
+            input: buildUpdateDeliverableInput(input, reasonForChange),
+          },
+        });
+      }
+
+      showSuccess(DELIVERABLE_UPDATED_MESSAGE);
+      onClose();
+    } catch {
+      showError(DELIVERABLE_UPDATE_FAILED_MESSAGE);
+    }
   };
 
   return (
@@ -162,9 +216,9 @@ export const EditDeliverableDialog: React.FC<EditDeliverableDialogProps> = ({
         <Button
           name={EDIT_DELIVERABLE_SAVE_BUTTON_NAME}
           onClick={handleSave}
-          disabled={!isFormValid}
+          disabled={!isFormValid || isSaving}
         >
-          Save Changes
+          {isSaving ? "Saving..." : "Save Changes"}
         </Button>
       }
     >

--- a/client/src/mock-data/deliverableMocks.ts
+++ b/client/src/mock-data/deliverableMocks.ts
@@ -47,12 +47,16 @@ export const MOCK_DELIVERABLE_1: DeliverableDetailsManagementDeliverable = {
     state: {
       id: "CA",
     },
+    demonstrationTypes: [],
   },
   cmsOwner: {
+    id: "mock-user",
     person: {
+      id: "mock-user-person",
       fullName: "Mock User",
     },
   },
+  demonstrationTypes: [],
   dueDate: new Date("2024-08-15"),
   status: "Upcoming",
   stateDocuments: [

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
@@ -12,16 +12,21 @@ import {
 import { MOCK_DELIVERABLE_1 } from "mock-data/deliverableMocks";
 import { TestProvider } from "test-utils/TestProvider";
 import { COMMENT_BOX_NAME } from "./sections/comment_box";
-import { DELIVERABLE_INFO_FIELDS_NAME,   BACK_TO_DELIVERABLES_BUTTON_NAME} from "./sections/DeliverableInfoFields";
+import {
+  BACK_TO_DELIVERABLES_BUTTON_NAME,
+  DELIVERABLE_INFO_FIELDS_NAME,
+} from "./sections/DeliverableInfoFields";
 import { FILE_AND_HISTORY_TABS_NAME } from "./sections/FileAndHistoryTabs";
 import { REQUEST_EXTENSION_BUTTON_NAME } from "./sections/DeliverableButtons";
 import { DialogProvider } from "components/dialog/DialogContext";
+import { EDIT_DELIVERABLE_DIALOG_TITLE } from "components/dialog/deliverable/EditDeliverableDialog";
 import {
   DELIVERABLE_REVIEW_NOTICE_NAME,
   START_REVIEW_BUTTON_NAME,
 } from "./sections/PendingReviewNotice";
 import { CurrentUser } from "components/user/UserContext";
 import { developmentMockUser } from "mock-data/userMocks";
+import { personMocks } from "mock-data/personMocks";
 
 const renderAtRoute = (deliverableId: string) =>
   render(
@@ -218,6 +223,16 @@ describe("DeliverableDetailsManagementPage", () => {
 
     expect(await screen.findByTestId("edit-deliverable-button")).not.toBeDisabled();
     expect(screen.getByTestId("delete-deliverable-button")).not.toBeDisabled();
+  });
+
+  it("opens the edit deliverable modal from the header Edit button", async () => {
+    const user = userEvent.setup();
+    const deliverable = { ...MOCK_DELIVERABLE_1, status: "Upcoming" as const };
+    renderWithDeliverable(deliverable, "demos-admin", personMocks);
+
+    await user.click(await screen.findByTestId("edit-deliverable-button"));
+
+    expect(screen.getByText(EDIT_DELIVERABLE_DIALOG_TITLE)).toBeInTheDocument();
   });
 
   it("shows only the Request Extension button for state users", async () => {

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -8,6 +8,7 @@ import {
   Demonstration,
   DocumentType,
   PersonType,
+  Tag,
 } from "demos-server";
 import { Loading } from "components/loading/Loading";
 import { useToast } from "components/toast";
@@ -66,11 +67,21 @@ export const DELIVERABLE_DETAILS_QUERY = gql`
         state {
           id
         }
+        demonstrationTypes {
+          demonstrationTypeName
+          approvalStatus
+        }
       }
       cmsOwner {
+        id
         person {
+          id
           fullName
         }
+      }
+      demonstrationTypes {
+        tagName
+        approvalStatus
       }
       stateDocuments {
         id
@@ -121,8 +132,15 @@ export type DeliverableDetailsManagementDeliverable = Pick<
   "id" | "deliverableType" | "dueDate" | "status" | "name"
 > & {
   allowedDocumentTypes: DocumentType[];
-  demonstration: Pick<Demonstration, "id" | "name" | "expirationDate"> & { state: { id: string } };
-  cmsOwner: { person: { fullName: string } };
+  demonstration: Pick<Demonstration, "id" | "name" | "expirationDate"> & {
+    state: { id: string };
+    demonstrationTypes: {
+      demonstrationTypeName: string;
+      approvalStatus: "Approved" | "Unapproved";
+    }[];
+  };
+  cmsOwner: { id: string; person: { id: string; fullName: string } };
+  demonstrationTypes: Tag[];
   stateDocuments: DeliverableFileRow[];
   cmsDocuments: DeliverableFileRow[];
   deliverableActions: Pick<
@@ -147,7 +165,7 @@ export const DeliverableDetailsManagementPage: React.FC<{
 }> = ({ deliverableId, onBack }) => {
   const { currentUser } = getCurrentUser();
   const { showSuccess, showError } = useToast();
-  const { showReviewExtensionDeliverableDialog } = useDialog();
+  const { showEditDeliverableDialog, showReviewExtensionDeliverableDialog } = useDialog();
   const navigate = useNavigate();
   const { deliverableId: routeDeliverableId } = useParams<{ deliverableId?: string }>();
   const resolvedDeliverableId = deliverableId ?? routeDeliverableId;
@@ -187,7 +205,11 @@ export const DeliverableDetailsManagementPage: React.FC<{
   }, [resolvedDeliverableId, startReviewTrigger, showSuccess, showError]);
 
   const handleDeleteDeliverable = useCallback(() => {}, []);
-  const handleEditDeliverable = useCallback(() => {}, []);
+  const handleEditDeliverable = useCallback(() => {
+    if (data?.deliverable) {
+      showEditDeliverableDialog(data.deliverable);
+    }
+  }, [data?.deliverable, showEditDeliverableDialog]);
 
   const handleBack = useCallback(() => {
     if (onBack) {


### PR DESCRIPTION
Edit Deliverables! It now works!
 
The edit modal now calls the existing updateDeliverable mutation by default, persists name/CMS owner/due date/demo type changes, closes only after success, and shows the exact toast: Changes have been saved to the deliverable. Mutation failures keep the modal open and show an error toast.

Also wired the detail-page header edit button to open the same modal, and expanded the detail query so it has the IDs/tags needed to edit.

Edit from DeliverableInfo section:
<img width="2056" height="1198" alt="Screenshot 2026-06-09 at 11 56 19" src="https://github.com/user-attachments/assets/71c31739-c160-4d2a-8c6d-809e5f0a45bc" />


EDIT From Deliverable List view:
https://github.com/user-attachments/assets/a6f61685-67f0-474d-ac07-d49d3b58a518

