### PR TITLE
DEMOS-2210: Add `aria-label` attributes to buttons

### DIFF
--- a/client/src/components/application/phases/ConceptPhase.tsx
+++ b/client/src/components/application/phases/ConceptPhase.tsx
@@ -256,11 +256,21 @@ export const ConceptPhase = ({
       </div>
 
       <div className={STYLES.actions}>
-        <SecondaryButton name={SKIP_BUTTON_NAME} onClick={onSkip} disabled={!isSkipEnabled}>
+        <SecondaryButton
+          name={SKIP_BUTTON_NAME}
+          ariaLabel="Skip this section"
+          onClick={onSkip}
+          disabled={!isSkipEnabled}
+        >
           Skip
           <ChevronRightIcon />
         </SecondaryButton>
-        <Button name={FINISH_BUTTON_NAME} onClick={onFinish} disabled={!isFinishEnabled}>
+        <Button
+          name={FINISH_BUTTON_NAME}
+          ariaLabel="Finish this section"
+          onClick={onFinish}
+          disabled={!isFinishEnabled}
+        >
           Finish
         </Button>
       </div>

--- a/client/src/components/application/phases/sections/ApplicationUploadSection.tsx
+++ b/client/src/components/application/phases/sections/ApplicationUploadSection.tsx
@@ -33,7 +33,12 @@ export const ApplicationUploadSection: React.FC<Props> = ({
       </h4>
       <p className={STYLES.helper}>{helperText}</p>
 
-      <SecondaryButton onClick={onUploadClick} size="small" name="button-open-upload-modal">
+      <SecondaryButton
+        onClick={onUploadClick}
+        size="small"
+        name="button-open-upload-modal"
+        ariaLabel="Upload"
+      >
         Upload
         <ExportIcon />
       </SecondaryButton>

--- a/client/src/components/button/BaseButton.tsx
+++ b/client/src/components/button/BaseButton.tsx
@@ -70,13 +70,11 @@ export const BaseButton: React.FC<ButtonProps> = ({
   const sizeClasses = getSizeClasses(isCircle, size);
   const circleClasses = getCircleClasses(isCircle);
 
-  const accessibleLabel = tooltip ? `${ariaLabel || name} - ${tooltip}` : ariaLabel || name;
-
   return (
     <button
       name={name}
       data-testid={name}
-      aria-label={accessibleLabel}
+      aria-label={ariaLabel || name}
       type={type}
       onClick={onClick}
       {...(form ? { form } : {})}

--- a/client/src/components/dialog/ApplyTagsDialog.test.tsx
+++ b/client/src/components/dialog/ApplyTagsDialog.test.tsx
@@ -72,7 +72,7 @@ describe("ApplyTagsDialog", () => {
     expect(screen.getByText("Selected Tag(s) (3)")).toBeInTheDocument();
     expect(screen.getByTestId("checkbox-Behavioral Health")).toBeChecked();
     expect(screen.getByTestId("checkbox-Dental")).toBeChecked();
-    expect(screen.getByRole("button", { name: "button-confirm-apply-tags" })).toBeInTheDocument();
+    expect(screen.getByTestId("button-confirm-apply-tags")).toBeInTheDocument();
   });
 
   it("renders empty state when no tags provided", () => {
@@ -92,7 +92,7 @@ describe("ApplyTagsDialog", () => {
     ];
     const { onClose } = setup(selectedTags);
 
-    await user.click(screen.getByRole("button", { name: "button-confirm-apply-tags" }));
+    await user.click(screen.getByTestId("button-confirm-apply-tags"));
 
     expect(mockMutate).toHaveBeenCalledWith({
       variables: {
@@ -115,7 +115,7 @@ describe("ApplyTagsDialog", () => {
       },
     ]);
 
-    const closeButton = screen.getByRole("button", { name: /close/i });
+    const closeButton = screen.getByTestId("button-dialog-close");
     await user.click(closeButton);
 
     expect(onClose).toHaveBeenCalled();
@@ -258,7 +258,7 @@ describe("ApplyTagsDialog", () => {
 
     expect(screen.getByText("Selected Tag(s) (0)")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "button-confirm-apply-tags" }));
+    await user.click(screen.getByTestId("button-confirm-apply-tags"));
 
     expect(mockMutate).toHaveBeenCalledWith({
       variables: {
@@ -285,8 +285,6 @@ describe("ApplyTagsDialog", () => {
   it("renders Apply Tag(s) as action button text", () => {
     setup();
 
-    expect(screen.getByRole("button", { name: "button-confirm-apply-tags" })).toHaveTextContent(
-      "Apply Tag(s)"
-    );
+    expect(screen.getByTestId("button-confirm-apply-tags")).toHaveTextContent("Apply Tag(s)");
   });
 });

--- a/client/src/components/dialog/ApplyTagsDialog.tsx
+++ b/client/src/components/dialog/ApplyTagsDialog.tsx
@@ -279,7 +279,7 @@ export const ApplyTagsDialog: React.FC<ApplyTagsDialogProps> = ({
       onClose={onClose}
       dialogHasChanges={hasChanges}
       actionButton={
-        <Button onClick={handleApply} name="button-confirm-apply-tags">
+        <Button onClick={handleApply} name="button-confirm-apply-tags" ariaLabel="Apply tags">
           Apply Tag(s)
         </Button>
       }

--- a/client/src/components/dialog/BaseDialog.tsx
+++ b/client/src/components/dialog/BaseDialog.tsx
@@ -86,6 +86,7 @@ export const BaseDialog: React.FC<BaseDialogProps> = ({
         {!hideHeader && (
           <>
             <button
+              data-testid="button-dialog-close"
               type="button"
               onClick={onCloseClicked}
               className={CLOSE_BUTTON}

--- a/client/src/components/dialog/BaseDialog.tsx
+++ b/client/src/components/dialog/BaseDialog.tsx
@@ -108,6 +108,7 @@ export const BaseDialog: React.FC<BaseDialogProps> = ({
                 name={DIALOG_CANCEL_BUTTON_NAME}
                 onClick={onCloseClicked}
                 disabled={cancelButtonIsDisabled}
+                ariaLabel="Cancel and close dialog"
               >
                 Cancel
               </SecondaryButton>

--- a/client/src/components/dialog/ConfirmApproveDialog.tsx
+++ b/client/src/components/dialog/ConfirmApproveDialog.tsx
@@ -29,7 +29,11 @@ export const ConfirmApproveDialog: React.FC<ConfirmApproveDialogProps> = ({
       onClose={closeDialog}
       maxWidthClass="max-w-[600px]"
       actionButton={
-        <Button name="button-ca-dialog-approve" onClick={handleSubmitClicked}>
+        <Button
+          name="button-ca-dialog-approve"
+          ariaLabel={`Submit approved ${applicationType}`}
+          onClick={handleSubmitClicked}
+        >
           Submit Approved {applicationType.charAt(0).toUpperCase() + applicationType.slice(1)}
         </Button>
       }
@@ -41,8 +45,8 @@ export const ConfirmApproveDialog: React.FC<ConfirmApproveDialogProps> = ({
           {applicationType === "demonstration" && (
             <>
               {" "}
-              This will finalize the approval process and move the demonstration to the
-              deliverables phase.
+              This will finalize the approval process and move the demonstration to the deliverables
+              phase.
             </>
           )}
         </span>

--- a/client/src/components/dialog/ConfirmCancellationDialog.tsx
+++ b/client/src/components/dialog/ConfirmCancellationDialog.tsx
@@ -37,10 +37,7 @@ export const ConfirmCancellationDialog: React.FC<ConfirmCancellationDialogProps>
   }, [isOpen]);
 
   return (
-    <dialog
-      ref={confirmDialogRef}
-      className={STYLES.CONFIRMATION_DIALOG}
-    >
+    <dialog ref={confirmDialogRef} className={STYLES.CONFIRMATION_DIALOG}>
       <div className="flex flex-col">
         <h2 className={STYLES.TITLE}>Are you sure?</h2>
         <div className={STYLES.MESSAGE}>
@@ -51,10 +48,18 @@ export const ConfirmCancellationDialog: React.FC<ConfirmCancellationDialogProps>
           </span>
         </div>
         <div className={STYLES.BUTTONS}>
-          <SecondaryButton name="button-cc-dialog-cancel" onClick={onClose}>
+          <SecondaryButton
+            name="button-cc-dialog-cancel"
+            ariaLabel="Keep editing"
+            onClick={onClose}
+          >
             Cancel
           </SecondaryButton>
-          <ErrorButton name="button-cc-dialog-discard" onClick={onConfirm}>
+          <ErrorButton
+            name="button-cc-dialog-discard"
+            ariaLabel="Discard changes"
+            onClick={onConfirm}
+          >
             Discard Changes
           </ErrorButton>
         </div>

--- a/client/src/components/dialog/DemonstrationTypes/ApplyDemonstrationTypesDialog.test.tsx
+++ b/client/src/components/dialog/DemonstrationTypes/ApplyDemonstrationTypesDialog.test.tsx
@@ -10,6 +10,7 @@ import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { SELECT_DEMONSTRATION_TYPE_QUERY } from "components/input/select/SelectDemonstrationType";
 import { TagName, LocalDate, Tag } from "demos-server";
 import { ADD_DEMONSTRATION_TYPES_FORM_QUERY } from "./AddDemonstrationTypesForm";
+import { DIALOG_CANCEL_BUTTON_NAME } from "components/dialog/BaseDialog";
 
 const mockShowSuccess = vi.fn();
 const mockShowError = vi.fn();
@@ -159,10 +160,8 @@ describe("ApplyDemonstrationTypesDialog", () => {
   it("renders dialog elements with correct titles", () => {
     renderWithProvider();
     expect(screen.getByRole("heading", { name: "Apply Type(s)" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "button-dialog-cancel" })).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "button-submit-demonstration-dialog" })
-    ).toBeInTheDocument();
+    expect(screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME)).toBeInTheDocument();
+    expect(screen.getByTestId("button-submit-demonstration-dialog")).toBeInTheDocument();
   });
 
   it("renders AddDemonstrationTypesForm component", async () => {
@@ -425,7 +424,7 @@ describe("ApplyDemonstrationTypesDialog", () => {
       await user.click(screen.getByTestId("button-add-demonstration-type"));
 
       // Cancel should trigger confirmation
-      await user.click(screen.getByRole("button", { name: "button-dialog-cancel" }));
+      await user.click(screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME));
 
       expect(screen.getByText("Are you sure?")).toBeInTheDocument();
       expect(

--- a/client/src/components/dialog/ManageContactsDialog.test.tsx
+++ b/client/src/components/dialog/ManageContactsDialog.test.tsx
@@ -389,15 +389,15 @@ describe("ManageContactsDialog", () => {
       expect(screen.getByText("John Doe")).toBeInTheDocument();
     });
 
-    const deleteButton = screen.getByRole("button", { name: "Delete Contact - Delete" });
+    const deleteButton = screen.getByTestId("delete-contact");
     await user.click(deleteButton);
 
     // Wait for confirmation dialog and confirm deletion
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "confirmation-confirm" })).toBeInTheDocument();
+      expect(screen.getByTestId("confirmation-confirm")).toBeInTheDocument();
     });
 
-    const confirmButton = screen.getByRole("button", { name: "confirmation-confirm" });
+    const confirmButton = screen.getByTestId("confirmation-confirm");
     await user.click(confirmButton);
 
     // Contact should be removed from the table
@@ -430,9 +430,7 @@ describe("ManageContactsDialog", () => {
       expect(screen.getByText("John Doe")).toBeInTheDocument();
     });
 
-    const deleteButton = screen.getByRole("button", {
-      name: "Delete Contact - Assign another Primary Project Officer to Delete",
-    });
+    const deleteButton = screen.getByTestId("delete-contact");
     expect(deleteButton).toBeDisabled();
   });
 
@@ -486,23 +484,17 @@ describe("ManageContactsDialog", () => {
 
     // Primary Project Officer should be disabled
     const johnRow = screen.getByText("John Doe").closest("tr");
-    const johnDeleteButton = within(johnRow!).getByRole("button", {
-      name: "Delete Contact - Assign another Primary Project Officer to Delete",
-    });
+    const johnDeleteButton = within(johnRow!).getByTestId("delete-contact");
     expect(johnDeleteButton).toBeDisabled();
 
     // Primary State Point of Contact should be enabled (not a Project Officer)
     const janeRow = screen.getByText("Jane Smith").closest("tr");
-    const janeDeleteButton = within(janeRow!).getByRole("button", {
-      name: "Delete Contact - Delete",
-    });
+    const janeDeleteButton = within(janeRow!).getByTestId("delete-contact");
     expect(janeDeleteButton).not.toBeDisabled();
 
     // Non-primary State Point of Contact should be enabled
     const bobRow = screen.getByText("Bob Wilson").closest("tr");
-    const bobDeleteButton = within(bobRow!).getByRole("button", {
-      name: "Delete Contact - Delete",
-    });
+    const bobDeleteButton = within(bobRow!).getByTestId("delete-contact");
     expect(bobDeleteButton).not.toBeDisabled();
   });
 
@@ -526,7 +518,7 @@ describe("ManageContactsDialog", () => {
 
     renderWithProviders(propsWithContacts);
 
-    const saveButton = screen.getByRole("button", { name: "button-save" });
+    const saveButton = screen.getByTestId("button-save");
     expect(saveButton).toBeDisabled();
   });
 
@@ -558,7 +550,7 @@ describe("ManageContactsDialog", () => {
 
     // Check save button is enabled after contact is properly configured
     await waitFor(() => {
-      const saveButton = screen.getByRole("button", { name: "button-save" });
+      const saveButton = screen.getByTestId("button-save");
       expect(saveButton).not.toBeDisabled();
     });
   });
@@ -592,11 +584,11 @@ describe("ManageContactsDialog", () => {
 
     // Wait for save button to be enabled
     await waitFor(() => {
-      const saveButton = screen.getByRole("button", { name: "button-save" });
+      const saveButton = screen.getByTestId("button-save");
       expect(saveButton).not.toBeDisabled();
     });
 
-    const saveButton = screen.getByRole("button", { name: "button-save" });
+    const saveButton = screen.getByTestId("button-save");
     await user.click(saveButton);
 
     await waitFor(() => {
@@ -609,7 +601,7 @@ describe("ManageContactsDialog", () => {
 
     renderWithProviders();
 
-    const cancelButton = screen.getByRole("button", { name: DIALOG_CANCEL_BUTTON_NAME });
+    const cancelButton = screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME);
     await user.click(cancelButton);
 
     // This would show the cancel confirmation in BaseDialog
@@ -823,7 +815,7 @@ describe("ManageContactsDialog", () => {
         expect(screen.getByText("John Doe")).toBeInTheDocument();
       });
 
-      const deleteButton = screen.getByRole("button", { name: "Delete Contact - Delete" });
+      const deleteButton = screen.getByTestId("delete-contact");
       await user.click(deleteButton);
 
       await waitFor(() => {
@@ -856,10 +848,10 @@ describe("ManageContactsDialog", () => {
 
       renderWithProviders(propsWithContacts);
 
-      const deleteButton = screen.getByRole("button", { name: "Delete Contact - Delete" });
+      const deleteButton = screen.getByTestId("delete-contact");
       await user.click(deleteButton);
 
-      const cancelButton = screen.getByRole("button", { name: "confirmation-cancel" });
+      const cancelButton = screen.getByTestId("confirmation-cancel");
       await user.click(cancelButton);
 
       // Confirmation dialog should be gone
@@ -896,14 +888,14 @@ describe("ManageContactsDialog", () => {
         expect(screen.getByText("John Doe")).toBeInTheDocument();
       });
 
-      const deleteButton = screen.getByRole("button", { name: "Delete Contact - Delete" });
+      const deleteButton = screen.getByTestId("delete-contact");
       await user.click(deleteButton);
 
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: "confirmation-confirm" })).toBeInTheDocument();
+        expect(screen.getByTestId("confirmation-confirm")).toBeInTheDocument();
       });
 
-      const confirmButton = screen.getByRole("button", { name: "confirmation-confirm" });
+      const confirmButton = screen.getByTestId("confirmation-confirm");
       await user.click(confirmButton);
 
       // Contact should be removed from the table
@@ -932,9 +924,7 @@ describe("ManageContactsDialog", () => {
 
       renderWithProviders(propsWithContacts);
 
-      const deleteButton = screen.getByRole("button", {
-        name: "Delete Contact - Assign another Primary Project Officer to Delete",
-      });
+      const deleteButton = screen.getByTestId("delete-contact");
       expect(deleteButton).toBeDisabled();
     });
 
@@ -976,18 +966,14 @@ describe("ManageContactsDialog", () => {
 
       // Find the delete button for the primary Project Officer (John Doe)
       const johnRow = screen.getByText("John Doe (Primary)").closest("tr");
-      const johnDeleteButton = within(johnRow!).getByRole("button", {
-        name: "Delete Contact - Assign another Primary Project Officer to Delete",
-      });
+      const johnDeleteButton = within(johnRow!).getByTestId("delete-contact");
 
       // Primary Project Officer delete button should ALWAYS be disabled
       expect(johnDeleteButton).toBeDisabled();
 
       // Find the delete button for the non-primary Project Officer (Jane Smith)
       const janeRow = screen.getByText("Jane Smith").closest("tr");
-      const janeDeleteButton = within(janeRow!).getByRole("button", {
-        name: "Delete Contact - Delete",
-      });
+      const janeDeleteButton = within(janeRow!).getByTestId("delete-contact");
 
       // Non-primary Project Officer delete button should be enabled when there are multiple POs
       expect(janeDeleteButton).not.toBeDisabled();
@@ -1032,9 +1018,7 @@ describe("ManageContactsDialog", () => {
 
       // Find the delete button for the non-primary Project Officer (Jane Smith)
       const janeRow = screen.getByText("Jane Smith").closest("tr");
-      const deleteButton = within(janeRow!).getByRole("button", {
-        name: "Delete Contact - Delete",
-      });
+      const deleteButton = within(janeRow!).getByTestId("delete-contact");
 
       // Non-primary Project Officer should be deletable
       expect(deleteButton).not.toBeDisabled();
@@ -1042,10 +1026,10 @@ describe("ManageContactsDialog", () => {
       await user.click(deleteButton);
 
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: "confirmation-confirm" })).toBeInTheDocument();
+        expect(screen.getByTestId("confirmation-confirm")).toBeInTheDocument();
       });
 
-      const confirmButton = screen.getByRole("button", { name: "confirmation-confirm" });
+      const confirmButton = screen.getByTestId("confirmation-confirm");
       await user.click(confirmButton);
 
       // Non-primary Project Officer should be removed from the table
@@ -1055,7 +1039,7 @@ describe("ManageContactsDialog", () => {
 
       // Primary Project Officer should still be there
       expect(screen.getByText("John Doe (Primary)")).toBeInTheDocument();
-      const saveButton = screen.getByRole("button", { name: "button-save" });
+      const saveButton = screen.getByTestId("button-save");
       expect(saveButton).not.toBeDisabled();
     });
   });
@@ -1068,7 +1052,7 @@ describe("ManageContactsDialog", () => {
 
       renderWithProviders(props);
 
-      const cancelButton = screen.getByRole("button", { name: DIALOG_CANCEL_BUTTON_NAME });
+      const cancelButton = screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME);
       await user.click(cancelButton);
 
       // Should close immediately without confirmation
@@ -1105,7 +1089,7 @@ describe("ManageContactsDialog", () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Now try to cancel
-      const cancelButton = screen.getByRole("button", { name: DIALOG_CANCEL_BUTTON_NAME });
+      const cancelButton = screen.getByTestId(DIALOG_CANCEL_BUTTON_NAME);
       await user.click(cancelButton);
 
       // Should show confirmation dialog instead of closing immediately
@@ -1126,7 +1110,7 @@ describe("ManageContactsDialog", () => {
     it("disables save button when no contacts are assigned", () => {
       renderWithProviders();
 
-      const saveButton = screen.getByRole("button", { name: "button-save" });
+      const saveButton = screen.getByTestId("button-save");
       expect(saveButton).toBeDisabled();
     });
 
@@ -1150,7 +1134,7 @@ describe("ManageContactsDialog", () => {
 
       renderWithProviders(propsWithContacts);
 
-      const saveButton = screen.getByRole("button", { name: "button-save" });
+      const saveButton = screen.getByTestId("button-save");
       expect(saveButton).toBeDisabled();
     });
 
@@ -1174,7 +1158,7 @@ describe("ManageContactsDialog", () => {
 
       renderWithProviders(propsWithContacts);
 
-      const saveButton = screen.getByRole("button", { name: "button-save" });
+      const saveButton = screen.getByTestId("button-save");
       expect(saveButton).toBeDisabled();
     });
 
@@ -1216,7 +1200,7 @@ describe("ManageContactsDialog", () => {
 
       // Save button should be enabled after making a valid change
       await waitFor(() => {
-        const saveButton = screen.getByRole("button", { name: "button-save" });
+        const saveButton = screen.getByTestId("button-save");
         expect(saveButton).not.toBeDisabled();
       });
     });

--- a/client/src/components/table/columns/DeliverableColumns.tsx
+++ b/client/src/components/table/columns/DeliverableColumns.tsx
@@ -86,7 +86,11 @@ export function DeliverableColumns({
         window.open(`/deliverables/${deliverableId}`, "_blank");
       };
       return (
-        <SecondaryButton onClick={handleClick} name="view-deliverable">
+        <SecondaryButton
+          onClick={handleClick}
+          name="view-deliverable"
+          ariaLabel={`View ${row.original.name}`}
+        >
           View
         </SecondaryButton>
       );

--- a/client/src/components/table/columns/DocumentColumns.tsx
+++ b/client/src/components/table/columns/DocumentColumns.tsx
@@ -54,7 +54,11 @@ export function DocumentColumns() {
           window.open(`/document/${docId}`, "_blank");
         };
         return (
-          <SecondaryButton onClick={handleClick} name="view-document">
+          <SecondaryButton
+            onClick={handleClick}
+            name="view-document"
+            ariaLabel={`View ${row.original.name}`}
+          >
             View
           </SecondaryButton>
         );

--- a/client/src/components/toast/ConfirmationToast.test.tsx
+++ b/client/src/components/toast/ConfirmationToast.test.tsx
@@ -39,7 +39,7 @@ describe("ConfirmationToast", () => {
 
     render(<ConfirmationToast {...defaultProps} onConfirm={onConfirm} />);
 
-    const confirmButton = screen.getByRole("button", { name: "confirmation-confirm" });
+    const confirmButton = screen.getByTestId("confirmation-confirm");
     await user.click(confirmButton);
 
     expect(onConfirm).toHaveBeenCalledTimes(1);
@@ -51,7 +51,7 @@ describe("ConfirmationToast", () => {
 
     render(<ConfirmationToast {...defaultProps} onCancel={onCancel} />);
 
-    const cancelButton = screen.getByRole("button", { name: "confirmation-cancel" });
+    const cancelButton = screen.getByTestId("confirmation-cancel");
     await user.click(cancelButton);
 
     expect(onCancel).toHaveBeenCalledTimes(1);
@@ -82,8 +82,8 @@ describe("ConfirmationToast", () => {
   it("has correct button names for identification", () => {
     render(<ConfirmationToast {...defaultProps} />);
 
-    expect(screen.getByRole("button", { name: "confirmation-confirm" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "confirmation-cancel" })).toBeInTheDocument();
+    expect(screen.getByTestId("confirmation-confirm")).toBeInTheDocument();
+    expect(screen.getByTestId("confirmation-cancel")).toBeInTheDocument();
   });
 
   it("applies correct CSS classes", () => {

--- a/client/src/components/toast/ConfirmationToast.tsx
+++ b/client/src/components/toast/ConfirmationToast.tsx
@@ -29,10 +29,21 @@ export const ConfirmationToast: React.FC<ConfirmationToastProps> = ({
     >
       <p className="text-sm font-bold mb-4 text-gray-900">{message}</p>
       <div className="flex justify-center gap-6">
-        <SecondaryButton name="confirmation-cancel" size="small" onClick={onCancel}>
+        <SecondaryButton
+          name="confirmation-cancel"
+          ariaLabel={cancelText}
+          size="small"
+          onClick={onCancel}
+        >
           {cancelText}
         </SecondaryButton>
-        <ErrorButton name="confirmation-confirm" isOutlined={true} size="small" onClick={onConfirm}>
+        <ErrorButton
+          name="confirmation-confirm"
+          ariaLabel={confirmText}
+          isOutlined={true}
+          size="small"
+          onClick={onConfirm}
+        >
           {confirmText}
         </ErrorButton>
       </div>

--- a/client/src/pages/DocumentDetails/DocumentPreview.tsx
+++ b/client/src/pages/DocumentDetails/DocumentPreview.tsx
@@ -18,7 +18,7 @@ const FilePreviewer = ({
     <embed src={blobUrl} className="w-full h-full" />
   ) : (
     <a href={blobUrl} download={filename} rel="noopener noreferrer">
-      <Button size="large" name="button-download-file">
+      <Button size="large" name="button-download-file" ariaLabel="Download file">
         Download File
       </Button>
     </a>


### PR DESCRIPTION
Per DEMOS-2210 the issue of buttons announcing extra text was coming from them using the `name` attribute as an `aria-label` if none existed. Added some aria labels to read out more helpful text for other buttons even if they weren't quite mentioned in the ticket