### PR TITLE
DEMOS-1783b

### DIFF
--- a/client/src/components/dialog/AttestationDialog.test.tsx
+++ b/client/src/components/dialog/AttestationDialog.test.tsx
@@ -53,11 +53,27 @@ describe("AttestationDialog", () => {
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
-  it("calls onCancel when the dialog is cancelled", () => {
+  it("warns about losing unsaved changes before cancelling, then calls onCancel on discard", () => {
     const { onCancel } = renderDialog();
 
     fireEvent.click(screen.getByTestId("button-dialog-cancel"));
 
+    // Standard cancel/close confirmation must appear before any data is discarded.
+    expect(screen.getByText(/You will lose any unsaved changes/i)).toBeInTheDocument();
+    expect(onCancel).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("button-cc-dialog-discard"));
+
     expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the attestation open when the cancellation is dismissed", () => {
+    const { onCancel } = renderDialog();
+
+    fireEvent.click(screen.getByTestId("button-dialog-cancel"));
+    fireEvent.click(screen.getByTestId("button-cc-dialog-cancel"));
+
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(screen.getByRole("heading", { name: "Attestation Required" })).toBeInTheDocument();
   });
 });

--- a/client/src/components/dialog/AttestationDialog.tsx
+++ b/client/src/components/dialog/AttestationDialog.tsx
@@ -27,7 +27,6 @@ export const AttestationDialog: React.FC<{
     <BaseDialog
       name="attestation-dialog"
       title="Attestation Required"
-      dialogHasChanges={false}
       onClose={onCancel}
       maxWidthClass="max-w-[600px]"
       actionButton={

--- a/client/src/components/dialog/document/DocumentDialog.test.tsx
+++ b/client/src/components/dialog/document/DocumentDialog.test.tsx
@@ -75,10 +75,19 @@ describe("documentTypeRequiresAttestation", () => {
 
 const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
-const renderAddDialog = (documentType: DocumentType, onSubmit: () => Promise<DocumentUploadResult>) =>
+const renderAddDialog = (
+  documentType: DocumentType,
+  onSubmit: () => Promise<DocumentUploadResult>,
+  onClose: () => void = vi.fn()
+) =>
   render(
     <ToastProvider>
-      <DocumentDialog mode="add" documentTypeSubset={[documentType]} onSubmit={onSubmit} />
+      <DocumentDialog
+        mode="add"
+        documentTypeSubset={[documentType]}
+        onSubmit={onSubmit}
+        onClose={onClose}
+      />
     </ToastProvider>
   );
 
@@ -114,9 +123,10 @@ describe("DocumentDialog attestation gating", () => {
     expect(onSubmit).toHaveBeenCalledOnce();
   });
 
-  it("cancels the upload without submitting when the attestation is dismissed", async () => {
+  it("confirms before cancelling the upload when the attestation is dismissed", async () => {
     const onSubmit = vi.fn(() => Promise.resolve<DocumentUploadResult>("succeeded"));
-    renderAddDialog("Final Budget Neutrality Formulation Workbook", onSubmit);
+    const onClose = vi.fn();
+    renderAddDialog("Final Budget Neutrality Formulation Workbook", onSubmit, onClose);
 
     selectFile("bn-notebook.docx");
     fireEvent.click(screen.getByTestId("button-confirm-upload-document"));
@@ -124,6 +134,13 @@ describe("DocumentDialog attestation gating", () => {
     const cancelButtons = await screen.findAllByTestId("button-dialog-cancel");
     fireEvent.click(cancelButtons[cancelButtons.length - 1]);
 
+    // Standard unsaved-changes confirmation must appear before anything is discarded.
+    expect(screen.getByText(/You will lose any unsaved changes/i)).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("button-cc-dialog-discard"));
+
+    expect(onClose).toHaveBeenCalledOnce();
     expect(onSubmit).not.toHaveBeenCalled();
   });
 

--- a/client/src/components/dialog/document/DocumentDialog.tsx
+++ b/client/src/components/dialog/document/DocumentDialog.tsx
@@ -543,7 +543,10 @@ export const DocumentDialog: React.FC<DocumentDialogProps> = ({
       {isAttestationOpen && (
         <AttestationDialog
           onConfirm={onAttestationConfirmed}
-          onCancel={() => setIsAttestationOpen(false)}
+          onCancel={() => {
+            setIsAttestationOpen(false);
+            onClose();
+          }}
         />
       )}
     </>


### PR DESCRIPTION
QA fix — the BN attestation dialog was missing our standard
"Are you sure? You will lose any unsaved changes" cancel/X prompt.

- Cancel / X on the attestation now shows the standard confirmation.
- **Discard Changes** → upload is cancelled (dialog closes, nothing submitted).
- **Cancel** → attestation stays open.
- Confirm & Upload path is unchanged.




<img width="732" height="777" alt="image" src="https://github.com/user-attachments/assets/b3181a11-3697-41d5-b14f-11e1bc579541" />
