### PR TITLE
DEMOS-2085 — Remove Document Type from the Edit Document dialog (Deliverables)

### DIFF
--- a/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
+++ b/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
@@ -142,15 +142,7 @@ export const FileAndHistoryTabs: React.FC<{
     });
   };
 
-  const handleEditStateFile = (file: DeliverableFileRow) => {
-    showEditDocumentDialog(fileRowToDialogFields(file), {
-      canEditDocumentType: true,
-      documentTypeSubset: deliverable.allowedDocumentTypes,
-      refetchQueries: refetchAfterFileChange,
-    });
-  };
-
-  const handleEditCmsFile = (file: DeliverableFileRow) => {
+  const handleEditFile = (file: DeliverableFileRow) => {
     showEditDocumentDialog(fileRowToDialogFields(file), {
       hideDocumentType: true,
       refetchQueries: refetchAfterFileChange,
@@ -186,7 +178,7 @@ export const FileAndHistoryTabs: React.FC<{
             disabled={isFinalized || !canManageStateFiles}
             deleteDisabled={isDeleteLocked}
             onAdd={canManageStateFiles ? handleAddStateFile : undefined}
-            onEdit={canManageStateFiles ? handleEditStateFile : undefined}
+            onEdit={canManageStateFiles ? handleEditFile : undefined}
             onDelete={canManageStateFiles ? handleDeleteFiles : undefined}
           />
         </Tab>
@@ -197,7 +189,7 @@ export const FileAndHistoryTabs: React.FC<{
             deleteDisabled={isDeleteLocked}
             showActions={canManageCmsFiles}
             onAdd={canManageCmsFiles ? handleAddCmsFile : undefined}
-            onEdit={canManageCmsFiles ? handleEditCmsFile : undefined}
+            onEdit={canManageCmsFiles ? handleEditFile : undefined}
             onDelete={canManageCmsFiles ? handleDeleteFiles : undefined}
           />
         </Tab>


### PR DESCRIPTION
Going back to DEMOS-2085: remove the **Document Type** field from the
Deliverables → Edit Document dialog completely, for **both State Files and
CMS Files**, regardless of which user is logged in.


<img width="1920" height="966" alt="image" src="https://github.com/user-attachments/assets/eb25d9a0-9bcd-45ad-a59b-0919ae9a07a1" />
