### PR TITLE
(2/2) DEMOS-2237: Cleanup checks for `!currentUser`

### DIFF
--- a/client/src/components/header/DefaultHeaderLower.tsx
+++ b/client/src/components/header/DefaultHeaderLower.tsx
@@ -8,10 +8,6 @@ import { useDialog } from "components/dialog/DialogContext";
 const UserGreeting = () => {
   const { currentUser } = getCurrentUser();
 
-  if (!currentUser) {
-    return <div>Loading user...</div>;
-  }
-
   return (
     <div>
       <span className="font-bold block">Hello {currentUser.person.fullName}</span>
@@ -27,8 +23,8 @@ export const DefaultHeaderLower: React.FC = () => {
   const { showCreateDemonstrationDialog, showCreateAmendmentDialog, showCreateExtensionDialog } =
     useDialog();
   const canCreate =
-    currentUser?.person.personType === "demos-admin" ||
-    currentUser?.person.personType === "demos-cms-user";
+    currentUser.person.personType === "demos-admin" ||
+    currentUser.person.personType === "demos-cms-user";
 
   useEffect(() => {
     // Close dropdown on outside click

--- a/client/src/layout/PrimaryLayout.tsx
+++ b/client/src/layout/PrimaryLayout.tsx
@@ -20,7 +20,7 @@ export const shouldHideSideNav = (pathname: string, personType?: PersonType) =>
 export const PrimaryLayout = ({ children }: { children: React.ReactNode }) => {
   const location = useLocation();
   const { currentUser } = getCurrentUser();
-  const hideSideNav = shouldHideSideNav(location.pathname, currentUser?.person.personType);
+  const hideSideNav = shouldHideSideNav(location.pathname, currentUser.person.personType);
 
   return (
     <ToastProvider>

--- a/client/src/pages/DeliverablesPage.tsx
+++ b/client/src/pages/DeliverablesPage.tsx
@@ -67,7 +67,7 @@ const DeliverablesTabs: React.FC<{
 
 export const DeliverablesPage: React.FC = () => {
   const { currentUser } = getCurrentUser();
-  const rawPersonType = currentUser?.person.personType;
+  const rawPersonType = currentUser.person.personType;
   const viewMode = rawPersonType as UserType;
   const isStateUser = rawPersonType === "demos-state-user";
   const { data, loading, error } = useQuery<DeliverablesPageQueryResult>(
@@ -76,7 +76,7 @@ export const DeliverablesPage: React.FC = () => {
 
   const deliverables = isStateUser ? getStateUserDeliverables(data) : (data?.deliverables ?? []);
   const myDeliverables = deliverables.filter(
-    (deliverable) => deliverable.cmsOwner.id === currentUser?.id
+    (deliverable) => deliverable.cmsOwner.id === currentUser.id
   );
 
   return (

--- a/client/src/pages/DemonstrationDetail/DemonstrationDetailHeader.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetailHeader.tsx
@@ -103,8 +103,7 @@ export const DemonstrationDetailHeader: React.FC<DemonstrationDetailHeaderProps>
       value: demonstration.expirationDate ? formatDate(demonstration.expirationDate) : "--/--/----",
     },
   ];
-  const canManageDemonstration =
-    !!currentUser && HEADER_ACTION_PERSON_TYPES.has(currentUser.person.personType);
+  const canManageDemonstration = HEADER_ACTION_PERSON_TYPES.has(currentUser.person.personType);
 
   return (
     <div
@@ -122,8 +121,10 @@ export const DemonstrationDetailHeader: React.FC<DemonstrationDetailHeaderProps>
             </a>
             {/* \u00A0 is unicode for non-breaking space */}
             {"\u00A0 > \u00A0"} {demonstration.medicaidId}
-            { demonstration.chipId && (
-              <span>{"\u00A0|\u00A0"} {demonstration.chipId}</span>
+            {demonstration.chipId && (
+              <span>
+                {"\u00A0|\u00A0"} {demonstration.chipId}
+              </span>
             )}
           </span>
           <div className="flex gap-1 items-center -ml-2">
@@ -153,7 +154,7 @@ export const DemonstrationDetailHeader: React.FC<DemonstrationDetailHeaderProps>
                   {displayFields.map((field, index) => (
                     <React.Fragment key={field.label}>
                       <li className="text-[16px] mt-0.5 font-title">
-                        <span className="font-semibold">{field.label}:{" "}</span>
+                        <span className="font-semibold">{field.label}: </span>
                         <span className="font-normal" data-testid={`demonstration-${field.label}`}>
                           {field.value}
                         </span>

--- a/client/src/pages/DemonstrationDetail/deliverables/DeliverablesTab.tsx
+++ b/client/src/pages/DemonstrationDetail/deliverables/DeliverablesTab.tsx
@@ -22,13 +22,14 @@ export const DeliverablesTab = ({
   parentDemonstration: AddDeliverableSlotDemonstration;
 }) => {
   const { showAddDeliverableSlotDialog } = useDialog();
-  const rawPersonType = getCurrentUser().currentUser?.person.personType;
+  const rawPersonType = getCurrentUser().currentUser.person.personType;
   const viewMode = rawPersonType as UserType;
   const navigate = useNavigate();
   const { data, loading, error } = useQuery<DeliverablesQueryResult>(DELIVERABLES_PAGE_QUERY);
-  const deliverables = data?.deliverables.filter(
-    (deliverable) => deliverable.demonstration.id === parentDemonstration.id
-  ) ?? [];
+  const deliverables =
+    data?.deliverables.filter(
+      (deliverable) => deliverable.demonstration.id === parentDemonstration.id
+    ) ?? [];
 
   return (
     <div className="flex flex-col">
@@ -43,9 +44,7 @@ export const DeliverablesTab = ({
         </IconButton>
       </TabHeader>
       {loading && <div className="p-4">Loading deliverables...</div>}
-      {error && (
-        <div className="p-4 text-red-500">Error loading deliverables.</div>
-      )}
+      {error && <div className="p-4 text-red-500">Error loading deliverables.</div>}
       {!loading && !error && (
         <DemonstrationDeliverableTable
           deliverables={deliverables}

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -207,10 +207,6 @@ export const DeliverableDetailsManagementPage: React.FC<{
   if (!resolvedDeliverableId || !data?.deliverable) {
     return <div>Deliverable not found.</div>;
   }
-  if (!currentUser) {
-    throw new Error("DeliverableDetailsManagementPage requires an authenticated user.");
-  }
-
   const userPersonType = currentUser.person.personType;
   const canStartReview =
     REVIEW_STARTER_PERSON_TYPES.has(userPersonType) && data.deliverable.status === "Submitted";

--- a/client/src/pages/deliverables/sections/DeliverableButtons.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableButtons.tsx
@@ -21,9 +21,8 @@ export const DeliverableButtons = ({
 }) => {
   const { showRequestExtensionDeliverableDialog } = useDialog();
   const { currentUser } = getCurrentUser();
-  const userPersonType = currentUser?.person.personType;
-  const canSeeRequestExtension =
-    !!userPersonType && REQUEST_EXTENSION_PERSON_TYPES.has(userPersonType);
+  const userPersonType = currentUser.person.personType;
+  const canSeeRequestExtension = REQUEST_EXTENSION_PERSON_TYPES.has(userPersonType);
 
   const handleRequestExtension = () => {
     showRequestExtensionDeliverableDialog({

--- a/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
+++ b/client/src/pages/deliverables/sections/FileAndHistoryTabs.tsx
@@ -40,8 +40,13 @@ export const SUBMIT_DELIVERABLE_MUTATION = gql`
   }
 `;
 
-export const RESUBMISSION_DISABLED_STATUSES: ReadonlySet<DeliverableStatus> =
-  new Set(["Upcoming", "Past Due", "Accepted", "Approved", "Received and Filed"]);
+export const RESUBMISSION_DISABLED_STATUSES: ReadonlySet<DeliverableStatus> = new Set([
+  "Upcoming",
+  "Past Due",
+  "Accepted",
+  "Approved",
+  "Received and Filed",
+]);
 
 export const isResubmissionDisabled = (status: DeliverableStatus): boolean =>
   RESUBMISSION_DISABLED_STATUSES.has(status);
@@ -91,14 +96,10 @@ export const FileAndHistoryTabs: React.FC<{
   const isFinalized = !isDeliverableEditable(deliverable.status);
   const refetchAfterFileChange = [DELIVERABLE_DETAILS_QUERY];
 
-  if (!currentUser) {
-    throw new Error("FileAndHistoryTabs requires an authenticated user.");
-  }
-
   const userPersonType = currentUser.person.personType;
   const isCmsStaffUser = CMS_STAFF_PERSON_TYPES.has(userPersonType);
-  const isCompleteReviewDisabled = !isCmsStaffUser ||
-    !canCompleteReview(deliverable.status, deliverable.extensionRequests);
+  const isCompleteReviewDisabled =
+    !isCmsStaffUser || !canCompleteReview(deliverable.status, deliverable.extensionRequests);
   const canManageStateFiles = STATE_FILE_MANAGER_PERSON_TYPES.has(userPersonType);
   const canManageCmsFiles = isCmsStaffUser;
 

--- a/client/src/pages/deliverables/sections/comment_box/CommentBox.tsx
+++ b/client/src/pages/deliverables/sections/comment_box/CommentBox.tsx
@@ -3,7 +3,6 @@ import React, { useState } from "react";
 import { MenuCollapseRightIcon } from "components/icons/Navigation/MenuCollapseRightIcon";
 import { CommentIcon } from "components/icons";
 import { SecondaryButton } from "components/button";
-import { getCurrentUser } from "components/user/UserContext";
 import { CommentBoxTabs } from "./CommentBoxTabs";
 import { CommentBoxTextArea } from "./CommentBoxTextArea";
 import { CommentBoxHistory } from "./CommentBoxHistory";
@@ -34,7 +33,6 @@ const CommentBoxHeader = ({ onCollapse }: { onCollapse: () => void }) => (
 );
 
 export const CommentBox = ({ deliverableId }: { deliverableId: string }) => {
-  const { currentUser } = getCurrentUser();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [currentComment, setCurrentComment] = useState("");
   const [commentVisibility, setCommentVisibility] = useState<CommentVisibility>("public");
@@ -45,10 +43,6 @@ export const CommentBox = ({ deliverableId }: { deliverableId: string }) => {
     deliverableId,
     commentVisibility
   );
-
-  if (!currentUser) {
-    return null;
-  }
 
   const handleAddComment = async (commentText: string) => {
     try {

--- a/client/src/pages/deliverables/sections/comment_box/CommentBoxTextArea.tsx
+++ b/client/src/pages/deliverables/sections/comment_box/CommentBoxTextArea.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import { Textarea } from "components/input";
 import { Button } from "components/button";
-import { getCurrentUser } from "components/user/UserContext";
 import { CommentVisibility } from "./Comment";
 
 export const COMMENT_BOX_TEXT_AREA_NAME = "textarea-comment-box";
@@ -21,12 +20,6 @@ export const CommentBoxTextArea = ({
   commentVisibility: CommentVisibility;
   isSubmitting: boolean;
 }) => {
-  const { currentUser } = getCurrentUser();
-
-  if (!currentUser) {
-    throw new Error("Current user is required to render CommentBoxTextArea");
-  }
-
   const handleAddComment = () => {
     if (!isSubmitting && currentComment.trim() !== "") {
       addComment(currentComment);

--- a/client/src/pages/deliverables/sections/comment_box/useComments.ts
+++ b/client/src/pages/deliverables/sections/comment_box/useComments.ts
@@ -85,21 +85,20 @@ function toCommentBoxComment(
 export const useComments = (deliverableId: string, commentVisibility: CommentVisibility) => {
   const { currentUser } = getCurrentUser();
 
-  const userPersonType: PersonType | undefined = currentUser?.person.personType;
+  const userPersonType: PersonType = currentUser.person.personType;
   const isCmsOrAdminUser = userPersonType === "demos-cms-user" || userPersonType === "demos-admin";
 
   const { data: publicData, refetch: refetchPublic } = useQuery<{
     deliverable: { id: string; publicComments: CommentQueryResult[] };
   }>(GET_PUBLIC_COMMENTS_QUERY, {
     variables: { id: deliverableId },
-    skip: !currentUser,
   });
 
   const { data: privateData, refetch: refetchPrivate } = useQuery<{
     deliverable: { id: string; privateComments: CommentQueryResult[] };
   }>(GET_PRIVATE_COMMENTS_QUERY, {
     variables: { id: deliverableId },
-    skip: !currentUser || !isCmsOrAdminUser,
+    skip: !isCmsOrAdminUser,
   });
 
   const [createPublicComment] = useMutation(CREATE_PUBLIC_COMMENT_MUTATION);

--- a/client/src/router/DemosRouter.tsx
+++ b/client/src/router/DemosRouter.tsx
@@ -25,7 +25,7 @@ const DEMONSTRATION_ACCESS_ROLES: PersonType[] = ["demos-admin", "demos-cms-user
 const HomePage = () => {
   const { currentUser } = getCurrentUser();
 
-  return currentUser?.person.personType === "demos-state-user" ? (
+  return currentUser.person.personType === "demos-state-user" ? (
     <DeliverablesPage />
   ) : (
     <DemonstrationsPage />

--- a/client/src/router/RequireRole.test.tsx
+++ b/client/src/router/RequireRole.test.tsx
@@ -79,26 +79,4 @@ describe("RequireRole", () => {
     // Since Navigate goes to "/", we expect protected content NOT to render
     expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
   });
-
-  it("redirects when there is no user", () => {
-    currentUserState.currentUser = null as unknown as typeof currentUserState.currentUser;
-
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <Routes>
-          <Route
-            path="/"
-            element={
-              <RequireRole allowedRoles={["demos-admin"]}>
-                <div>Protected Content</div>
-              </RequireRole>
-            }
-          />
-          <Route path="/redirect" element={<div>Redirected</div>} />
-        </Routes>
-      </MemoryRouter>
-    );
-
-    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
-  });
 });

--- a/client/src/router/RequireRole.tsx
+++ b/client/src/router/RequireRole.tsx
@@ -11,9 +11,9 @@ type RequireRoleProps = {
 export const RequireRole: React.FC<RequireRoleProps> = ({ allowedRoles, children }) => {
   const { currentUser } = getCurrentUser();
 
-  const userRole = currentUser?.person?.personType;
+  const userRole = currentUser.person.personType;
 
-  if (!userRole || !allowedRoles.includes(userRole)) {
+  if (!allowedRoles.includes(userRole)) {
     return <Navigate to="/" replace />;
   }
 


### PR DESCRIPTION
Now that `currentUser` is not optional on the `UserContext` we can clean up all this handling for `if(!currentUser)` around the codebase 🥳 