### PR TITLE
DEMOS-2225: removed extra validation, since its covered elsewhere

### DIFF
--- a/server/src/auth/auth.util.test.ts
+++ b/server/src/auth/auth.util.test.ts
@@ -82,15 +82,6 @@ describe("validateClaims", () => {
     expect(() => validateClaims(claims)).toThrow("Authorizer claims missing required 'role' field");
   });
 
-  it("throws when role is invalid", () => {
-    const claims: Partial<AuthorizationClaims> = {
-      ...validClaims,
-      role: "not-a-real-role",
-    };
-
-    expect(() => validateClaims(claims)).toThrow("Invalid user role: 'not-a-real-role'");
-  });
-
   it("throws when authTime is missing", () => {
     const claims: Partial<AuthorizationClaims> = {
       ...validClaims,

--- a/server/src/auth/auth.util.ts
+++ b/server/src/auth/auth.util.ts
@@ -1,6 +1,4 @@
-import { USER_TYPES } from "../constants.js";
 import { ContextUser, findOrCreateContextUserFromClaims } from "./userContext.js";
-import { UserType } from "../types.js";
 
 export interface GraphQLContext {
   user: ContextUser;
@@ -36,9 +34,6 @@ export function validateClaims(
   }
   if (!claims.role) {
     throw new Error("Authorizer claims missing required 'role' field");
-  }
-  if (!USER_TYPES.includes(claims.role as UserType)) {
-    throw new Error(`Invalid user role: '${claims.role}'`);
   }
   if (!claims.authTime) {
     throw new Error("Authorizer claims missing required 'authTime' field");

--- a/server/src/server.lambda.test.ts
+++ b/server/src/server.lambda.test.ts
@@ -150,8 +150,10 @@ describe("extractClaimsFromEvent", () => {
 
   it("throws when the authorizer claims are invalid", () => {
     const event = makeEvent();
-    (event.requestContext.authorizer as any).role = "not-a-real-role";
+    (event.requestContext.authorizer as any).role = undefined;
 
-    expect(() => extractClaimsFromEvent(event)).toThrow("Invalid user role: 'not-a-real-role'");
+    expect(() => extractClaimsFromEvent(event)).toThrow(
+      "Authorizer claims missing required 'role' field"
+    );
   });
 });


### PR DESCRIPTION
in my previous fix, i had forgotten this one place where the role is validated before progressing through user generation. I removed it, since that validation is handled at the user generation itself, when it extracts the relevant role. 