### PR TITLE
Demos 2253 view documents on phases

### DIFF
--- a/client/src/components/application/phases/sections/DocumentList.test.tsx
+++ b/client/src/components/application/phases/sections/DocumentList.test.tsx
@@ -116,4 +116,27 @@ describe("DocumentList", () => {
 
     expect(mockShowRemoveDocumentDialog).toHaveBeenCalledWith(["doc-1"]);
   });
+
+  it("renders the document icon", () => {
+    render(
+      <TestProvider>
+        <DocumentList documents={mockDocuments} />
+      </TestProvider>
+    );
+
+    const fileIcons = screen.getAllByRole("img", { name: /file/i });
+    expect(fileIcons).toHaveLength(2);
+  });
+
+  it("renders the documentIcon and name as a link pointing towards the document page", () => {
+    render(
+      <TestProvider>
+        <DocumentList documents={mockDocuments} />
+      </TestProvider>
+    );
+
+    const documentLink = screen.getByRole("link", { name: /test document 1/i });
+    expect(documentLink).toHaveAttribute("href", "/document/doc-1");
+    expect(documentLink).toHaveAttribute("target", "_blank");
+  });
 });

--- a/client/src/components/application/phases/sections/DocumentList.tsx
+++ b/client/src/components/application/phases/sections/DocumentList.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DeleteIcon } from "components/icons";
+import { DeleteIcon, FileIcon } from "components/icons";
 import { tw } from "tags/tw";
 import { formatDate } from "util/formatDate";
 import { ApplicationWorkflowDocument } from "components/application";
@@ -7,7 +7,7 @@ import { useDialog } from "components/dialog/DialogContext";
 
 const STYLES = {
   list: tw`mt-4 space-y-3`,
-  fileRow: tw`bg-surface-secondary border border-border-fields px-3 py-2 flex items-center justify-between`,
+  fileRow: tw`bg-surface-secondary border border-border-fields py-2 px-2 flex items-center justify-between`,
   fileMeta: tw`text-xs text-text-placeholder mt-0.5`,
 };
 
@@ -32,16 +32,24 @@ export const DocumentList: React.FC<DocumentListProps> = ({
 
       {documents.map((doc) => (
         <div key={doc.id} className={STYLES.fileRow}>
-          <div>
-            <div className="font-medium">{doc.name}</div>
-            <div className={STYLES.fileMeta}>
-              {doc.createdAt ? formatDate(doc.createdAt) : "--/--/----"}
-              {showDescription && doc.description ? ` • ${doc.description}` : ""}
+          <a
+            className="flex gap-2 items-center text-left w-full"
+            href={`/document/${doc.id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <FileIcon className="w-2 h-2" />
+            <div>
+              <div className="font-medium">{doc.name}</div>
+              <div className={STYLES.fileMeta}>
+                {doc.createdAt ? formatDate(doc.createdAt) : "--/--/----"}
+                {showDescription && doc.description ? ` • ${doc.description}` : ""}
+              </div>
             </div>
-          </div>
+          </a>
 
           <button
-            className="text-red-600 hover:text-red-800 p-1 rounded hover:bg-red-50 transition-colors cursor-pointer"
+            className="text-red-600 hover:text-red-800 rounded hover:bg-red-50 transition-colors cursor-pointer"
             onClick={() => showRemoveDocumentDialog([doc.id])}
             aria-label={`Delete ${doc.name}`}
             title={`Delete ${doc.name}`}

--- a/client/src/components/application/phases/sections/DocumentList.tsx
+++ b/client/src/components/application/phases/sections/DocumentList.tsx
@@ -7,7 +7,7 @@ import { useDialog } from "components/dialog/DialogContext";
 
 const STYLES = {
   list: tw`mt-4 space-y-3`,
-  fileRow: tw`bg-surface-secondary border border-border-fields py-2 px-3 flex items-center justify-between`,
+  fileRow: tw`bg-surface-secondary border border-border-fields py-2 px-2 flex items-center justify-between`,
   fileMeta: tw`text-xs text-text-placeholder mt-0.5`,
 };
 
@@ -49,7 +49,7 @@ export const DocumentList: React.FC<DocumentListProps> = ({
           </a>
 
           <button
-            className="text-red-600 hover:text-red-800 rounded hover:bg-red-50 transition-colors cursor-pointer px-1"
+            className="text-red-600 hover:text-red-800 rounded hover:bg-red-50 transition-colors cursor-pointer px-2"
             onClick={() => showRemoveDocumentDialog([doc.id])}
             aria-label={`Delete ${doc.name}`}
             title={`Delete ${doc.name}`}

--- a/client/src/components/application/phases/sections/DocumentList.tsx
+++ b/client/src/components/application/phases/sections/DocumentList.tsx
@@ -1,12 +1,11 @@
 import React from "react";
-import { DeleteIcon, FileIcon } from "components/icons";
 import { tw } from "tags/tw";
-import { formatDate } from "util/formatDate";
 import { ApplicationWorkflowDocument } from "components/application";
 import { useDialog } from "components/dialog/DialogContext";
+import { DocumentChip } from "components/document/documentChip";
 
 const STYLES = {
-  list: tw`mt-4 space-y-3`,
+  list: tw`mt-4 space-y-2`,
   fileRow: tw`bg-surface-secondary border border-border-fields py-2 px-2 flex items-center justify-between`,
   fileMeta: tw`text-xs text-text-placeholder mt-0.5`,
 };
@@ -19,7 +18,6 @@ export interface DocumentListProps {
 
 export const DocumentList: React.FC<DocumentListProps> = ({
   documents,
-  showDescription = true,
   emptyMessage = "No documents yet.",
 }) => {
   const { showRemoveDocumentDialog } = useDialog();
@@ -31,32 +29,11 @@ export const DocumentList: React.FC<DocumentListProps> = ({
       )}
 
       {documents.map((doc) => (
-        <div key={doc.id} className={STYLES.fileRow}>
-          <a
-            className="flex gap-2 items-center text-left w-full"
-            href={`/document/${doc.id}`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <FileIcon className="w-2 h-2" />
-            <div>
-              <div className="font-medium">{doc.name}</div>
-              <div className={STYLES.fileMeta}>
-                {doc.createdAt ? formatDate(doc.createdAt) : "--/--/----"}
-                {showDescription && doc.description ? ` • ${doc.description}` : ""}
-              </div>
-            </div>
-          </a>
-
-          <button
-            className="text-red-600 hover:text-red-800 rounded hover:bg-red-50 transition-colors cursor-pointer px-2"
-            onClick={() => showRemoveDocumentDialog([doc.id])}
-            aria-label={`Delete ${doc.name}`}
-            title={`Delete ${doc.name}`}
-          >
-            <DeleteIcon className="w-2 h-2" />
-          </button>
-        </div>
+        <DocumentChip
+          document={doc}
+          key={doc.id}
+          onRemove={() => showRemoveDocumentDialog([doc.id])}
+        />
       ))}
     </div>
   );

--- a/client/src/components/application/phases/sections/DocumentList.tsx
+++ b/client/src/components/application/phases/sections/DocumentList.tsx
@@ -7,7 +7,7 @@ import { useDialog } from "components/dialog/DialogContext";
 
 const STYLES = {
   list: tw`mt-4 space-y-3`,
-  fileRow: tw`bg-surface-secondary border border-border-fields py-2 px-2 flex items-center justify-between`,
+  fileRow: tw`bg-surface-secondary border border-border-fields py-2 px-3 flex items-center justify-between`,
   fileMeta: tw`text-xs text-text-placeholder mt-0.5`,
 };
 
@@ -49,7 +49,7 @@ export const DocumentList: React.FC<DocumentListProps> = ({
           </a>
 
           <button
-            className="text-red-600 hover:text-red-800 rounded hover:bg-red-50 transition-colors cursor-pointer"
+            className="text-red-600 hover:text-red-800 rounded hover:bg-red-50 transition-colors cursor-pointer px-1"
             onClick={() => showRemoveDocumentDialog([doc.id])}
             aria-label={`Delete ${doc.name}`}
             title={`Delete ${doc.name}`}

--- a/client/src/components/dialog/document/AddDocumentToApplicationDialog.test.tsx
+++ b/client/src/components/dialog/document/AddDocumentToApplicationDialog.test.tsx
@@ -139,23 +139,6 @@ describe("AddDocumentToApplicationDialog", () => {
     });
   });
 
-  it("truncates and displays file name with title after upload", async () => {
-    setup();
-
-    const longName =
-      "this_is_a_very_long_file_name_that_should_be_truncated_in_the_button_display_but_visible_on_hover.pdf";
-    const file = new File(["content"], longName, { type: "application/pdf" });
-
-    fireEvent.change(screen.getByTestId(FILE_INPUT_TEST_ID), {
-      target: { files: [file] },
-    });
-
-    // Wait for the rendered span to appear with title
-    const titleSpan = await screen.findByTitle(longName);
-
-    expect(titleSpan.textContent).toContain("...");
-  });
-
   it("disables upload and cancel buttons during upload", async () => {
     mockMutationFn.mockImplementation(() => new Promise(() => {})); // never resolves
     setup();

--- a/client/src/components/dialog/document/DocumentDialog.tsx
+++ b/client/src/components/dialog/document/DocumentDialog.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import { SecondaryButton } from "components/button";
 import { BaseDialog } from "components/dialog/BaseDialog";
-import { ErrorIcon, ExitIcon, FileIcon } from "components/icons";
+import { ErrorIcon } from "components/icons";
 import { TextInput } from "components/input";
 import { DocumentTypeInput } from "components/input/document/DocumentTypeInput";
 import { getInputColors, INPUT_BASE_CLASSES, LABEL_CLASSES } from "components/input/Input";
@@ -14,10 +14,8 @@ import { tw } from "tags/tw";
 import { Notice } from "components/notice";
 import { AttestationDialog } from "components/dialog/AttestationDialog";
 import { UploadButton } from "./UploadButton";
-import {
-  BNPreValidationState,
-  useBNWorkbookPreValidation,
-} from "./useBNWorkbookPreValidation";
+import { BNPreValidationState, useBNWorkbookPreValidation } from "./useBNWorkbookPreValidation";
+import { DocumentChip } from "components/document/documentChip";
 
 type DocumentDialogType = "add" | "edit";
 
@@ -44,8 +42,6 @@ const STYLES = {
   dropzoneHeader: tw`text-sm font-bold text-text-font mb-xs`,
   dropzoneOr: tw`text-sm text-text-placeholder mb-sm`,
   fileNote: tw`text-[11px] text-text-placeholder mt-xs leading-tight`,
-  fileChip: tw`w-full border border-border-fields rounded flex items-center justify-between px-sm py-2 mt-sm`,
-  fileChipLeft: tw`flex items-center gap-2 text-sm font-medium text-text-font truncate`,
   fileMetaRow: tw`flex justify-between mt-1 text-[12px] text-text-placeholder font-medium`,
 };
 
@@ -63,7 +59,6 @@ const ALLOWED_FILE_EXTENSIONS = [".pdf", ".doc", ".docx", ".xls", ".xlsx", ".xls
 const ACCEPTED_EXTENSIONS = ALLOWED_FILE_EXTENSIONS.join(",");
 const MAX_FILE_SIZE_MB = 600;
 const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
-const MAX_FILENAME_DISPLAY_LENGTH = 60;
 
 const ERROR_MESSAGES = {
   noFileSelected: "Please select a file to upload.",
@@ -75,12 +70,6 @@ const SUCCESS_MESSAGES = {
   fileUploaded: "Your document has been added.",
   fileUpdated: "Your document has been updated.",
   fileDeleted: "Your document has been removed.",
-};
-
-const abbreviateLongFilename = (str: string, maxLength: number): string => {
-  if (str.length <= maxLength) return str;
-  const half = Math.floor((maxLength - 3) / 2);
-  return `${str.slice(0, half)}...${str.slice(-half)}`;
 };
 
 const TitleInput: React.FC<{ value: string; onChange: (value: string) => void }> = ({
@@ -209,22 +198,7 @@ const DropTarget: React.FC<{
 
       {file && (
         <div className="mt-sm">
-          <div className={STYLES.fileChip}>
-            <span className={STYLES.fileChipLeft} title={file.name}>
-              <FileIcon />
-              <span className="truncate">
-                {abbreviateLongFilename(file.name, MAX_FILENAME_DISPLAY_LENGTH)}
-              </span>
-            </span>
-            <button
-              type="button"
-              aria-label="Remove file"
-              className="p-1 hover:opacity-80"
-              onClick={onRemove}
-            >
-              <ExitIcon />
-            </button>
-          </div>
+          <DocumentChip document={file} onRemove={onRemove} />
           <ProgressBar progress={uploadProgress} uploadStatus={uploadStatus} />
           {uploadProgress > 0 && (
             <div className={STYLES.fileMetaRow}>

--- a/client/src/components/document/documentChip.test.tsx
+++ b/client/src/components/document/documentChip.test.tsx
@@ -1,0 +1,87 @@
+import "@testing-library/jest-dom";
+
+import React from "react";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { DocumentChip } from "./documentChip";
+
+describe("DocumentChip", () => {
+  const baseDocument = {
+    name: "State Application.pdf",
+    documentType: "State Application" as const,
+    createdAt: new Date("2024-01-15T10:00:00Z"),
+  };
+
+  it("renders a preview link when the document has an id", () => {
+    render(<DocumentChip document={{ ...baseDocument, id: "doc-1" }} onRemove={vi.fn()} />);
+
+    const link = screen.getByRole("link", { name: /state application\.pdf/i });
+
+    expect(link).toHaveAttribute("href", "/document/doc-1");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders non-link content when the document has no id", () => {
+    render(<DocumentChip document={baseDocument} onRemove={vi.fn()} />);
+
+    expect(screen.queryByRole("link", { name: /state application\.pdf/i })).not.toBeInTheDocument();
+    expect(screen.getByText("State Application.pdf")).toBeInTheDocument();
+  });
+
+  it("renders metadata when createdAt and documentType are present", () => {
+    render(<DocumentChip document={baseDocument} onRemove={vi.fn()} />);
+
+    expect(screen.getByText(/01\/15\/2024/)).toBeInTheDocument();
+    expect(screen.getByText(/• State Application/)).toBeInTheDocument();
+  });
+
+  it("omits metadata when createdAt or documentType is missing", () => {
+    render(
+      <DocumentChip
+        document={{
+          name: "Pending Upload.pdf",
+        }}
+        onRemove={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText(/--\/--\/----/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/pending upload •/i)).not.toBeInTheDocument();
+  });
+
+  it("calls onRemove when the delete button is clicked", async () => {
+    const user = userEvent.setup();
+    const onRemove = vi.fn();
+
+    render(<DocumentChip document={baseDocument} onRemove={onRemove} />);
+
+    await user.click(screen.getByRole("button", { name: "Delete State Application.pdf" }));
+
+    expect(onRemove).toHaveBeenCalledOnce();
+  });
+
+  it("truncates long names in the UI while preserving the full name in the title", () => {
+    const longName =
+      "this-is-a-very-long-document-name-that-should-be-shortened-for-display-only.pdf";
+
+    render(
+      <DocumentChip
+        document={{
+          ...baseDocument,
+          name: longName,
+        }}
+        onRemove={vi.fn()}
+      />
+    );
+
+    const titleElement = screen.getByTitle(longName);
+
+    expect(titleElement).toBeInTheDocument();
+    expect(titleElement).not.toHaveTextContent(longName);
+    expect(titleElement).toHaveTextContent("...");
+  });
+});

--- a/client/src/components/document/documentChip.tsx
+++ b/client/src/components/document/documentChip.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { ExitIcon, FileIcon } from "components/icons";
+import { tw } from "tags/tw";
+import { formatDate } from "util/formatDate";
+import { DocumentType } from "demos-server-constants";
+
+const abbreviateLongFilename = (str: string): string => {
+  const maxFilenameDisplayLength = 60;
+
+  if (str.length <= maxFilenameDisplayLength) return str;
+  const half = Math.floor((maxFilenameDisplayLength - 3) / 2);
+  return `${str.slice(0, half)}...${str.slice(-half)}`;
+};
+
+const STYLES = {
+  chipContainer: tw`w-full border border-border-fields border-l-4 rounded flex items-stretch mt-sm`,
+  contentContainer: tw`flex flex-1 min-w-0 gap-1 items-center text-left px-sm py-1`,
+  previewLink: tw`hover:bg-surface-hover rounded-l`,
+  fileIcon: tw`w-[24px] h-[24px] text-brand`,
+  titleContainer: tw`flex flex-col justify-center`,
+  name: tw`font-medium`,
+  subtext: tw`text-xs text-text-placeholder mt-0.5`,
+  exitButton: tw`shrink-0 flex items-center cursor-pointer hover:bg-red-50 rounded-r`,
+  exitIconContainer: tw`border-l border-border-fields px-1 h-[50%] flex items-center`,
+  exitIcon: tw`w-[16px] h-[16px]`,
+};
+
+export const DocumentChip: React.FC<{
+  document: {
+    id?: string;
+    name: string;
+    documentType?: DocumentType;
+    createdAt?: Date;
+  };
+  onRemove: () => void;
+}> = ({ document, onRemove }) => {
+  const content = (
+    <>
+      <FileIcon className={STYLES.fileIcon} />
+      <div className={STYLES.titleContainer}>
+        <span className={STYLES.name} title={document.name}>
+          {abbreviateLongFilename(document.name)}
+        </span>
+        {document.createdAt && document.documentType && (
+          <span className={STYLES.subtext}>
+            {formatDate(document.createdAt)}
+            {` • ${document.documentType}`}
+          </span>
+        )}
+      </div>
+    </>
+  );
+
+  return (
+    <>
+      <div className={STYLES.chipContainer}>
+        {document.id ? (
+          <a
+            className={`${STYLES.contentContainer} ${STYLES.previewLink}`}
+            href={`/document/${document.id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {content}
+          </a>
+        ) : (
+          <div className={STYLES.contentContainer}>{content}</div>
+        )}
+
+        <button
+          className={STYLES.exitButton}
+          onClick={onRemove}
+          aria-label={`Delete ${document.name}`}
+          title={`Delete ${document.name}`}
+          type="button"
+        >
+          <div className={STYLES.exitIconContainer}>
+            <ExitIcon className={STYLES.exitIcon} />
+          </div>
+        </button>
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
This ticket started off as mainly getting the documents lists in the phases to function as links to the document preview page. Going through some discussion with design team, found that this would be a good opportunity to a) unify the designs of the document chips in the document list and in the document upload modal, and b) update it to the current figma designs. 

for this i introduced a new DocumentChip component, which both the modal and the listing utilize, which conditionally acts as a link to the preview page. Then i adjusted the designs including the icons, colors, and also changed out the document description for the document type in the Chip. 


https://github.com/user-attachments/assets/85806394-f00c-49c3-87ce-357f2d9f4c90

