### PR TITLE
DEMOS-2255: updated the back button for deliverabls

### DIFF
--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Route, Routes } from "react-router-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   DeliverableDetailsManagementPage,
   DELIVERABLE_DETAILS_QUERY,
@@ -28,21 +28,6 @@ import { CurrentUser } from "components/user/UserContext";
 import { developmentMockUser } from "mock-data/userMocks";
 import { personMocks } from "mock-data/personMocks";
 
-const renderAtRoute = (deliverableId: string) =>
-  render(
-    <TestProvider routerEntries={[`/deliverables/${deliverableId}`]}>
-      <DialogProvider>
-        <Routes>
-          <Route
-            path="/deliverables/:deliverableId"
-            element={<DeliverableDetailsManagementPage />}
-          />
-          <Route path="/deliverables" element={<div>Deliverables list</div>} />
-        </Routes>
-      </DialogProvider>
-    </TestProvider>
-  );
-
 const buildSubmittedDeliverableMock = (overrides?: { submitterName?: string }) => ({
   ...MOCK_DELIVERABLE_1,
   status: "Submitted" as const,
@@ -64,6 +49,28 @@ const buildCurrentUser = (
   ...developmentMockUser,
   person: { ...developmentMockUser.person, personType },
 });
+
+const renderAtRoute = (
+  deliverableId: string,
+  personType: CurrentUser["person"]["personType"] = "demos-cms-user"
+) =>
+  render(
+    <TestProvider
+      currentUser={buildCurrentUser(personType)}
+      routerEntries={[`/deliverables/${deliverableId}`]}
+    >
+      <DialogProvider>
+        <Routes>
+          <Route
+            path="/deliverables/:deliverableId"
+            element={<DeliverableDetailsManagementPage />}
+          />
+          <Route path="/demonstrations/:id" element={<div>Demonstration deliverables list</div>} />
+          <Route path="/" element={<div>State home deliverables list</div>} />
+        </Routes>
+      </DialogProvider>
+    </TestProvider>
+  );
 
 const renderWithDeliverable = (
   deliverable: DeliverableDetailsManagementDeliverable,
@@ -88,7 +95,8 @@ const renderWithDeliverable = (
             path="/deliverables/:deliverableId"
             element={<DeliverableDetailsManagementPage />}
           />
-          <Route path="/deliverables" element={<div>Deliverables list</div>} />
+          <Route path="/demonstrations/:id" element={<div>Demonstration deliverables list</div>} />
+          <Route path="/" element={<div>State home deliverables list</div>} />
         </Routes>
       </DialogProvider>
     </TestProvider>
@@ -128,13 +136,53 @@ describe("DeliverableDetailsManagementPage", () => {
     await waitFor(() => expect(screen.getByTestId(COMMENT_BOX_NAME)).toBeInTheDocument());
   });
 
-  it("navigates back to the deliverables list", async () => {
+  it.each(["demos-cms-user", "demos-admin"] as const)(
+    "navigates %s users back to the demonstration deliverables list",
+    async (personType) => {
+      const user = userEvent.setup();
+      renderAtRoute("1", personType);
+
+      await user.click(await screen.findByTestId(BACK_TO_DELIVERABLES_BUTTON_NAME));
+
+      expect(screen.getByText("Demonstration deliverables list")).toBeInTheDocument();
+    }
+  );
+
+  it("navigates state users back to their home deliverables list", async () => {
     const user = userEvent.setup();
-    renderAtRoute("1");
+    renderAtRoute("1", "demos-state-user");
 
     await user.click(await screen.findByTestId(BACK_TO_DELIVERABLES_BUTTON_NAME));
 
-    expect(screen.getByText("Deliverables list")).toBeInTheDocument();
+    expect(screen.getByText("State home deliverables list")).toBeInTheDocument();
+  });
+
+  it("uses the supplied onBack handler when provided", async () => {
+    const user = userEvent.setup();
+    const onBack = vi.fn();
+    render(
+      <TestProvider
+        currentUser={buildCurrentUser("demos-admin")}
+        mocks={[
+          {
+            request: { query: DELIVERABLE_DETAILS_QUERY, variables: { id: MOCK_DELIVERABLE_1.id } },
+            result: { data: { deliverable: MOCK_DELIVERABLE_1 } },
+          },
+        ]}
+        routerEntries={[`/deliverables/${MOCK_DELIVERABLE_1.id}`]}
+      >
+        <DialogProvider>
+          <DeliverableDetailsManagementPage
+            deliverableId={MOCK_DELIVERABLE_1.id}
+            onBack={onBack}
+          />
+        </DialogProvider>
+      </TestProvider>
+    );
+
+    await user.click(await screen.findByTestId(BACK_TO_DELIVERABLES_BUTTON_NAME));
+
+    expect(onBack).toHaveBeenCalledOnce();
   });
 
   it("toggles more details", async () => {

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -50,6 +50,11 @@ const EDIT_DELETE_PERSON_TYPES: ReadonlySet<PersonType> = new Set([
   "demos-cms-user",
 ]);
 
+const DEMONSTRATION_DELIVERABLES_BACK_PERSON_TYPES: ReadonlySet<PersonType> = new Set([
+  "demos-admin",
+  "demos-cms-user",
+]);
+
 export const GET_DELIVERABLE_DETAILS_QUERY_NAME = "GetDeliverableDetails";
 export const DELIVERABLE_DETAILS_QUERY = gql`
   query ${GET_DELIVERABLE_DETAILS_QUERY_NAME}($id: ID!) {
@@ -178,6 +183,7 @@ export const DeliverableDetailsManagementPage: React.FC<{
     variables: { id: resolvedDeliverableId ?? "" },
     skip: !resolvedDeliverableId,
   });
+  const userPersonType = currentUser.person.personType;
 
   const [startReviewTrigger, { loading: startReviewLoading }] = useMutation(
     START_DELIVERABLE_REVIEW_MUTATION
@@ -217,8 +223,17 @@ export const DeliverableDetailsManagementPage: React.FC<{
       return;
     }
 
-    navigate("/deliverables");
-  }, [navigate, onBack]);
+    if (DEMONSTRATION_DELIVERABLES_BACK_PERSON_TYPES.has(userPersonType)) {
+      const demonstrationId = data?.deliverable?.demonstration?.id;
+      if (!demonstrationId) {
+        throw new Error("Cannot navigate to demonstration deliverables without a demonstration id.");
+      }
+      navigate(`/demonstrations/${demonstrationId}`);
+      return;
+    }
+
+    navigate("/");
+  }, [data?.deliverable?.demonstration?.id, navigate, onBack, userPersonType]);
 
   if (loading) {
     return <Loading />;
@@ -229,7 +244,6 @@ export const DeliverableDetailsManagementPage: React.FC<{
   if (!resolvedDeliverableId || !data?.deliverable) {
     return <div>Deliverable not found.</div>;
   }
-  const userPersonType = currentUser.person.personType;
   const canStartReview =
     REVIEW_STARTER_PERSON_TYPES.has(userPersonType) && data.deliverable.status === "Submitted";
   const isFinalized = !isDeliverableEditable(data.deliverable.status);


### PR DESCRIPTION
Now you get taken back to the demo you're working in as CMS/admin users

# CMS/ADMIN USERS
Demo back button works correctly. 

https://github.com/user-attachments/assets/cfbf4f1b-e9c0-4510-8639-1160549a2279

Deliverable back button: 

https://github.com/user-attachments/assets/eb96f7f4-5e6c-4df4-af43-adf67826e022

State Users: 