### PR TITLE
DEMOS-2218 — Dialog dropdowns get cut off the screen

### DIFF
--- a/client/src/components/input/select/AutoCompleteMultiselect.tsx
+++ b/client/src/components/input/select/AutoCompleteMultiselect.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { ChevronDownIcon } from "components/icons/Symbol/ChevronDownIcon";
+import { useDropdownPosition } from "hooks/useDropdownPosition";
 import { tw } from "tags/tw";
 import { Option } from "./Select";
 
@@ -9,7 +10,9 @@ const INPUT_CLASSES = tw`w-full border border-border-fields rounded px-1 py-1
   disabled:text-text-placeholder placeholder-text-placeholder focus:outline-none
   focus:border-border-focus focus:ring-1 focus:ring-border-focus appearance-none text-sm`;
 const ICON_CLASSES = tw`text-text-placeholder w-2 h-1`;
-const LIST_CLASSES = tw`absolute z-10 w-full bg-surface-white border border-border-fields rounded mt-0.5 max-h-56 overflow-auto shadow-sm`;
+const LIST_CLASSES = tw`absolute z-10 w-full bg-surface-white border border-border-fields rounded overflow-auto shadow-sm`;
+const LIST_DOWN_CLASSES = tw`top-full mt-0.5`;
+const LIST_UP_CLASSES = tw`bottom-full mb-0.5`;
 const ITEM_CLASSES = tw`text-text-font cursor-pointer hover:bg-surface-focus`;
 const ITEM_ACTIVE_CLASSES = tw`bg-surface-focus`;
 const EMPTY_CLASSES = tw`px-2 py-1 text-text-placeholder`;
@@ -43,6 +46,12 @@ export const AutoCompleteMultiselect: React.FC<AutoCompleteMultiselectProps> = (
   const [activeIndex, setActiveIndex] = useState(-1);
   const [selected, setSelected] = useState<string[]>(defaultValues);
   const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { direction: dropdownDirection, maxHeight: dropdownMaxHeight } = useDropdownPosition(
+    inputRef,
+    isOpen
+  );
 
   const selectedLabels = selected
     .map((value) => options.find((option) => option.value === value)?.label ?? value)
@@ -117,6 +126,7 @@ export const AutoCompleteMultiselect: React.FC<AutoCompleteMultiselectProps> = (
 
       <div className="relative w-full">
         <input
+          ref={inputRef}
           data-testid={id ?? "input-autocomplete-multiselect"}
           id={id}
           type="text"
@@ -139,7 +149,12 @@ export const AutoCompleteMultiselect: React.FC<AutoCompleteMultiselectProps> = (
         </div>
 
         {isOpen && (
-          <ul className={LIST_CLASSES} role="listbox" aria-multiselectable="true">
+          <ul
+            className={`${LIST_CLASSES} ${dropdownDirection === "up" ? LIST_UP_CLASSES : LIST_DOWN_CLASSES}`}
+            style={{ maxHeight: dropdownMaxHeight }}
+            role="listbox"
+            aria-multiselectable="true"
+          >
             {filtered.length > 0 ? (
               filtered.map((opt, i) => {
                 const isActive = i === activeIndex;

--- a/client/src/components/input/select/AutoCompleteSelect.tsx
+++ b/client/src/components/input/select/AutoCompleteSelect.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 
 import { ChevronDownIcon } from "components/icons/Symbol/ChevronDownIcon";
+import { useDropdownPosition } from "hooks/useDropdownPosition";
 import { tw } from "tags/tw";
 
 import { getInputColors, INPUT_BASE_CLASSES, LABEL_CLASSES } from "../Input";
@@ -21,7 +22,9 @@ export interface AutoCompleteSelectProps {
 }
 
 const ICON_CLASSES = tw`text-text-placeholder w-2 h-1`;
-const LIST_CLASSES = tw`absolute z-10 w-full bg-surface-white border border-border-fields rounded mt-0.5 max-h-56 overflow-auto shadow-sm`;
+const LIST_CLASSES = tw`absolute z-10 w-full bg-surface-white border border-border-fields rounded overflow-auto shadow-sm`;
+const LIST_DOWN_CLASSES = tw`top-full mt-0.5`;
+const LIST_UP_CLASSES = tw`bottom-full mb-0.5`;
 const ITEM_CLASSES = tw`px-1 py-1 text-sm text-text-font cursor-pointer hover:bg-surface-focus`;
 const ITEM_ACTIVE_CLASSES = tw`bg-surface-focus`;
 const EMPTY_CLASSES = tw`px-2 py-1 text-sm text-text-placeholder`;
@@ -66,6 +69,11 @@ export const AutoCompleteSelect: React.FC<AutoCompleteSelectProps> = ({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const { direction: dropdownDirection, maxHeight: dropdownMaxHeight } = useDropdownPosition(
+    inputRef,
+    isOpen
+  );
 
   const closeSelect = () => {
     setIsOpen(false);
@@ -169,7 +177,14 @@ export const AutoCompleteSelect: React.FC<AutoCompleteSelectProps> = ({
           <ChevronDownIcon className={ICON_CLASSES} />
         </div>
 
-        {isOpen && <ul className={LIST_CLASSES}>{renderDropdownContent()}</ul>}
+        {isOpen && (
+          <ul
+            className={`${LIST_CLASSES} ${dropdownDirection === "up" ? LIST_UP_CLASSES : LIST_DOWN_CLASSES}`}
+            style={{ maxHeight: dropdownMaxHeight }}
+          >
+            {renderDropdownContent()}
+          </ul>
+        )}
       </div>
     </div>
   );

--- a/client/src/hooks/useDropdownPosition.test.ts
+++ b/client/src/hooks/useDropdownPosition.test.ts
@@ -1,0 +1,107 @@
+import { renderHook } from "@testing-library/react";
+import { RefObject } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useDropdownPosition } from "./useDropdownPosition";
+
+const makeTriggerRef = (top: number, height = 40): RefObject<HTMLElement> => {
+  const element = {
+    getBoundingClientRect: () => ({ top, bottom: top + height }) as DOMRect,
+    parentElement: null,
+  } as unknown as HTMLElement;
+  return { current: element };
+};
+
+// Builds a trigger nested inside a clipping ancestor (e.g. a modal with
+// `overflow-y-auto`) so we can exercise modal-aware — not just viewport — bounds.
+const makeTriggerRefInModal = (
+  triggerTop: number,
+  modalRect: { top: number; bottom: number },
+  height = 40
+): RefObject<HTMLElement> => {
+  const modal = {
+    getBoundingClientRect: () => modalRect as DOMRect,
+    parentElement: null,
+  } as unknown as HTMLElement;
+  const element = {
+    getBoundingClientRect: () => ({ top: triggerTop, bottom: triggerTop + height }) as DOMRect,
+    parentElement: modal,
+  } as unknown as HTMLElement;
+  vi.spyOn(window, "getComputedStyle").mockReturnValue({
+    overflowY: "auto",
+  } as CSSStyleDeclaration);
+  return { current: element };
+};
+
+describe("useDropdownPosition", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("opens downward at full height when there is ample room below", () => {
+    vi.stubGlobal("innerHeight", 800);
+    const ref = makeTriggerRef(100);
+
+    const { result } = renderHook(() => useDropdownPosition(ref, true));
+
+    expect(result.current.direction).toBe("down");
+    expect(result.current.maxHeight).toBe(224);
+  });
+
+  it("flips upward when room below is insufficient and there is more room above", () => {
+    vi.stubGlobal("innerHeight", 800);
+    // Trigger near the bottom: ~60px below, ~740px above.
+    const ref = makeTriggerRef(740);
+
+    const { result } = renderHook(() => useDropdownPosition(ref, true));
+
+    expect(result.current.direction).toBe("up");
+    expect(result.current.maxHeight).toBe(224);
+  });
+
+  it("clamps maxHeight to the available space so options stay scrollable", () => {
+    vi.stubGlobal("innerHeight", 300);
+    // ~110px below the trigger, ~150px above — flips up; available above = 150 - 2.
+    const ref = makeTriggerRef(150);
+
+    const { result } = renderHook(() => useDropdownPosition(ref, true));
+
+    expect(result.current.direction).toBe("up");
+    expect(result.current.maxHeight).toBe(148);
+  });
+
+  it("clamps to the modal bounds, not the viewport, when below the trigger is clipped", () => {
+    // Tall viewport with lots of room below, but the trigger sits near the
+    // bottom of a modal that clips at y=460 — the original regression.
+    vi.stubGlobal("innerHeight", 900);
+    const ref = makeTriggerRefInModal(357, { top: 20, bottom: 460 });
+
+    const { result } = renderHook(() => useDropdownPosition(ref, true));
+
+    // ~63px below within the modal vs ~337px above → flips up, clamped to the
+    // modal's upper region rather than the (much larger) viewport space.
+    expect(result.current.direction).toBe("up");
+    expect(result.current.maxHeight).toBe(224);
+  });
+
+  it("opens downward within the modal when there is room below the trigger", () => {
+    vi.stubGlobal("innerHeight", 900);
+    const ref = makeTriggerRefInModal(100, { top: 20, bottom: 700 });
+
+    const { result } = renderHook(() => useDropdownPosition(ref, true));
+
+    expect(result.current.direction).toBe("down");
+    expect(result.current.maxHeight).toBe(224);
+  });
+
+  it("defaults to downward at full height while closed", () => {
+    vi.stubGlobal("innerHeight", 800);
+    const ref = makeTriggerRef(740);
+
+    const { result } = renderHook(() => useDropdownPosition(ref, false));
+
+    expect(result.current.direction).toBe("down");
+    expect(result.current.maxHeight).toBe(224);
+  });
+});

--- a/client/src/hooks/useDropdownPosition.ts
+++ b/client/src/hooks/useDropdownPosition.ts
@@ -1,0 +1,94 @@
+import { RefObject, useLayoutEffect, useState } from "react";
+
+// Matches the `max-h-56` (14rem) cap applied to dropdown option lists.
+const DROPDOWN_MAX_HEIGHT_PX = 224;
+// Gap between the trigger and the list (matches the `mt-0.5`/`mb-0.5` = 2px).
+const GAP_PX = 2;
+
+export interface DropdownPosition {
+  direction: "up" | "down";
+  maxHeight: number;
+}
+
+const isClippingOverflow = (overflow: string) =>
+  overflow === "auto" || overflow === "scroll" || overflow === "hidden";
+
+/**
+ * Finds the vertical bounds within which the dropdown must stay visible. The
+ * list (positioned `absolute` inside its trigger's container) can be clipped by
+ * any scrollable/overflow-hidden ancestor (e.g. a dialog with `overflow-y-auto`),
+ * not just the viewport, so we walk up the tree and tighten the bounds against
+ * every clipping ancestor.
+ */
+const getClippingBounds = (element: HTMLElement): { top: number; bottom: number } => {
+  let top = 0;
+  let bottom = window.innerHeight;
+
+  let ancestor = element.parentElement;
+  while (ancestor) {
+    const { overflowY } = window.getComputedStyle(ancestor);
+    if (isClippingOverflow(overflowY)) {
+      const rect = ancestor.getBoundingClientRect();
+      top = Math.max(top, rect.top);
+      bottom = Math.min(bottom, rect.bottom);
+    }
+    ancestor = ancestor.parentElement;
+  }
+
+  return { top, bottom };
+};
+
+/**
+ * Decides whether a dropdown list should open upward or downward, and how tall
+ * it may be, so its options stay fully visible inside its clipping context (the
+ * viewport and any overflow-clipping ancestor such as a modal).
+ *
+ * The list opens toward whichever side has more room. `maxHeight` is clamped to
+ * the available space on that side (capped at the `max-h-56` design limit) so a
+ * tight space scrolls the options rather than spilling past the modal edge.
+ *
+ * Recomputes on scroll and resize so the list keeps fitting as the modal moves.
+ *
+ * @param triggerRef - Ref to the element the list anchors to (e.g. the input)
+ * @param isOpen - Whether the dropdown is currently open
+ */
+export function useDropdownPosition(
+  triggerRef: RefObject<HTMLElement | null>,
+  isOpen: boolean
+): DropdownPosition {
+  const [position, setPosition] = useState<DropdownPosition>({
+    direction: "down",
+    maxHeight: DROPDOWN_MAX_HEIGHT_PX,
+  });
+
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+
+    const update = () => {
+      const { top, bottom } = trigger.getBoundingClientRect();
+      const bounds = getClippingBounds(trigger);
+      const spaceBelow = bounds.bottom - bottom;
+      const spaceAbove = top - bounds.top;
+
+      const openUp = spaceBelow < DROPDOWN_MAX_HEIGHT_PX && spaceAbove > spaceBelow;
+      const available = (openUp ? spaceAbove : spaceBelow) - GAP_PX;
+      const maxHeight = Math.max(0, Math.min(DROPDOWN_MAX_HEIGHT_PX, available));
+
+      setPosition({ direction: openUp ? "up" : "down", maxHeight });
+    };
+
+    update();
+    // Capture phase so scrolling inside the modal (not just the window) is caught.
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
+  }, [isOpen, triggerRef]);
+
+  return position;
+}


### PR DESCRIPTION
Custom dropdowns (`AutoCompleteSelect`, `AutoCompleteMultiselect`) render their option
list as a `position: absolute` element. Inside a dialog (`overflow-y-auto`), a list near
the bottom of the modal overflowed and got clipped by the modal edge.


New hook `useDropdownPosition(triggerRef, isOpen)` that, on open (and on scroll/resize)

Both select components now apply the direction (flip classes) and the clamped `maxHeight`.
The list stays `absolute` — it never needs to escape the modal, so it can't be clipped.

The "industry standard" for this is a positioning library like **Floating UI**
  (`@floating-ui/react`) — handles flip/shift/clip/scroll robustly — but it's a new
  dependency and a larger refactor of the shared select components.

is clamp-to-fit good enough, or do we want to invest in
Floating UI for the shared dropdown components?


<img width="929" height="543" alt="image" src="https://github.com/user-attachments/assets/b788c55a-3188-4911-abf1-3a366b236498" />
