### PR TITLE
DEMOS-2223-no-state-changes

### DIFF
--- a/server/src/model/amendment/amendmentResolvers.test.ts
+++ b/server/src/model/amendment/amendmentResolvers.test.ts
@@ -345,7 +345,7 @@ describe("amendmentResolvers", () => {
         description: testAmendmentDescription,
       },
     };
-    const expectedCheckOptionalNotNullFieldList = ["demonstrationId", "name", "status"];
+    const expectedCheckOptionalNotNullFieldList = ["demonstrationId", "name"];
     const testEasternTZDate: EasternTZDate = {
       isEasternTZDate: true,
       easternTZDate: new TZDate(2025, 1, 1, 0, 0, 0, 0, "America/New_York"),

--- a/server/src/model/amendment/amendmentResolvers.ts
+++ b/server/src/model/amendment/amendmentResolvers.ts
@@ -64,7 +64,7 @@ export async function __updateAmendment(
   { id, input }: { id: string; input: UpdateAmendmentInput }
 ): Promise<PrismaAmendment> {
   const { effectiveDate } = parseAndValidateEffectiveAndExpirationDates(input);
-  checkOptionalNotNullFields(["demonstrationId", "name", "status"], input);
+  checkOptionalNotNullFields(["demonstrationId", "name"], input);
   try {
     return await prisma().amendment.update({
       where: {
@@ -75,7 +75,6 @@ export async function __updateAmendment(
         name: input.name,
         description: input.description,
         effectiveDate: effectiveDate,
-        statusId: input.status,
         signatureLevelId: input.signatureLevel,
       },
     });

--- a/server/src/model/amendment/amendmentSchema.ts
+++ b/server/src/model/amendment/amendmentSchema.ts
@@ -45,12 +45,12 @@ export const amendmentSchema = gql`
     name: NonEmptyString
     description: String
     effectiveDate: DateTimeOrLocalDate
-    status: ApplicationStatus
     signatureLevel: AmendmentSignatureLevel
   }
 
   type Mutation {
-    createAmendment(input: CreateAmendmentInput!): Amendment! @auth(requires: ["Perform CMS Action"])
+    createAmendment(input: CreateAmendmentInput!): Amendment!
+      @auth(requires: ["Perform CMS Action"])
     updateAmendment(id: ID!, input: UpdateAmendmentInput!): Amendment!
       @auth(requires: ["Perform CMS Action"])
     deleteAmendment(id: ID!): Amendment! @auth(requires: ["Perform CMS Action"])
@@ -91,6 +91,5 @@ export interface UpdateAmendmentInput {
   name?: NonEmptyString;
   description?: string | null;
   effectiveDate?: DateTimeOrLocalDate | null;
-  status?: ApplicationStatus;
   signatureLevel?: AmendmentSignatureLevel | null;
 }

--- a/server/src/model/demonstration/demonstrationResolvers.test.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.test.ts
@@ -721,7 +721,7 @@ describe("demonstrationResolvers", () => {
         name: testValues.demonstrationName,
       },
     };
-    const expectedCheckOptionalNotNullFieldList = ["name", "status", "projectOfficerUserId"];
+    const expectedCheckOptionalNotNullFieldList = ["name", "projectOfficerUserId"];
 
     it("should call update on the demonstration in a transaction", async () => {
       const expectedCall = {

--- a/server/src/model/demonstration/demonstrationResolvers.test.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.test.ts
@@ -721,12 +721,7 @@ describe("demonstrationResolvers", () => {
         name: testValues.demonstrationName,
       },
     };
-    const expectedCheckOptionalNotNullFieldList = [
-      "name",
-      "status",
-      "stateId",
-      "projectOfficerUserId",
-    ];
+    const expectedCheckOptionalNotNullFieldList = ["name", "status", "projectOfficerUserId"];
 
     it("should call update on the demonstration in a transaction", async () => {
       const expectedCall = {

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -126,7 +126,7 @@ export async function __updateDemonstration(
   { id, input }: { id: string; input: UpdateDemonstrationInput }
 ): Promise<PrismaDemonstration> {
   const { effectiveDate, expirationDate } = parseAndValidateEffectiveAndExpirationDates(input);
-  checkOptionalNotNullFields(["name", "status", "projectOfficerUserId"], input);
+  checkOptionalNotNullFields(["name", "projectOfficerUserId"], input);
   try {
     return await prisma().$transaction(async (tx) => {
       const demonstration = await tx.demonstration.update({
@@ -137,7 +137,6 @@ export async function __updateDemonstration(
           effectiveDate: effectiveDate,
           expirationDate: expirationDate,
           sdgDivisionId: input.sdgDivision,
-          statusId: input.status,
         },
       });
 

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -126,7 +126,7 @@ export async function __updateDemonstration(
   { id, input }: { id: string; input: UpdateDemonstrationInput }
 ): Promise<PrismaDemonstration> {
   const { effectiveDate, expirationDate } = parseAndValidateEffectiveAndExpirationDates(input);
-  checkOptionalNotNullFields(["name", "status", "stateId", "projectOfficerUserId"], input);
+  checkOptionalNotNullFields(["name", "status", "projectOfficerUserId"], input);
   try {
     return await prisma().$transaction(async (tx) => {
       const demonstration = await tx.demonstration.update({
@@ -138,7 +138,6 @@ export async function __updateDemonstration(
           expirationDate: expirationDate,
           sdgDivisionId: input.sdgDivision,
           statusId: input.status,
-          stateId: input.stateId,
         },
       });
 

--- a/server/src/model/demonstration/demonstrationSchema.ts
+++ b/server/src/model/demonstration/demonstrationSchema.ts
@@ -63,7 +63,6 @@ export const demonstrationSchema = gql`
     effectiveDate: DateTimeOrLocalDate
     expirationDate: DateTimeOrLocalDate
     sdgDivision: SdgDivision
-    status: ApplicationStatus
     projectOfficerUserId: String
   }
 
@@ -123,6 +122,5 @@ export interface UpdateDemonstrationInput {
   effectiveDate?: DateTimeOrLocalDate | null;
   expirationDate?: DateTimeOrLocalDate | null;
   sdgDivision?: SdgDivision;
-  status?: ApplicationStatus;
   projectOfficerUserId?: string;
 }

--- a/server/src/model/demonstration/demonstrationSchema.ts
+++ b/server/src/model/demonstration/demonstrationSchema.ts
@@ -64,7 +64,6 @@ export const demonstrationSchema = gql`
     expirationDate: DateTimeOrLocalDate
     sdgDivision: SdgDivision
     status: ApplicationStatus
-    stateId: ID
     projectOfficerUserId: String
   }
 
@@ -125,6 +124,5 @@ export interface UpdateDemonstrationInput {
   expirationDate?: DateTimeOrLocalDate | null;
   sdgDivision?: SdgDivision;
   status?: ApplicationStatus;
-  stateId?: string;
   projectOfficerUserId?: string;
 }

--- a/server/src/model/extension/extensionResolvers.test.ts
+++ b/server/src/model/extension/extensionResolvers.test.ts
@@ -353,7 +353,7 @@ describe("extensionResolvers", () => {
         description: testExtensionDescription,
       },
     };
-    const expectedCheckOptionalNotNullFieldList = ["demonstrationId", "name", "status"];
+    const expectedCheckOptionalNotNullFieldList = ["demonstrationId", "name"];
     const testEasternTZDate: EasternTZDate = {
       isEasternTZDate: true,
       easternTZDate: new TZDate(2025, 1, 1, 0, 0, 0, 0, "America/New_York"),

--- a/server/src/model/extension/extensionResolvers.ts
+++ b/server/src/model/extension/extensionResolvers.ts
@@ -64,7 +64,7 @@ export async function __updateExtension(
   { id, input }: { id: string; input: UpdateExtensionInput }
 ): Promise<PrismaExtension> {
   const { effectiveDate } = parseAndValidateEffectiveAndExpirationDates(input);
-  checkOptionalNotNullFields(["demonstrationId", "name", "status"], input);
+  checkOptionalNotNullFields(["demonstrationId", "name"], input);
   try {
     return await prisma().extension.update({
       where: {
@@ -75,7 +75,6 @@ export async function __updateExtension(
         name: input.name,
         description: input.description,
         effectiveDate: effectiveDate,
-        statusId: input.status,
         signatureLevelId: input.signatureLevel,
       },
     });

--- a/server/src/model/extension/extensionSchema.ts
+++ b/server/src/model/extension/extensionSchema.ts
@@ -45,12 +45,12 @@ export const extensionSchema = gql`
     name: NonEmptyString
     description: String
     effectiveDate: DateTimeOrLocalDate
-    status: ApplicationStatus
     signatureLevel: ExtensionSignatureLevel
   }
 
   type Mutation {
-    createExtension(input: CreateExtensionInput!): Extension! @auth(requires: ["Perform CMS Action"])
+    createExtension(input: CreateExtensionInput!): Extension!
+      @auth(requires: ["Perform CMS Action"])
     updateExtension(id: ID!, input: UpdateExtensionInput!): Extension!
       @auth(requires: ["Perform CMS Action"])
     deleteExtension(id: ID!): Extension! @auth(requires: ["Perform CMS Action"])
@@ -91,6 +91,5 @@ export interface UpdateExtensionInput {
   name?: NonEmptyString;
   description?: string | null;
   effectiveDate?: DateTimeOrLocalDate | null;
-  status?: ApplicationStatus;
   signatureLevel?: ExtensionSignatureLevel | null;
 }


### PR DESCRIPTION
Just removes stateId from the back-end. The work that @connor-parke-icf did for the front-end made this a trivial fix. He suggested that we pull the status update fields out as well since those shouldn't be changeable directly anymore, and so I did that as well.