### PR TITLE
DEMOS-2227 add filter for combined status column

### DIFF
--- a/client/src/components/table/columns/DeliverableColumns.tsx
+++ b/client/src/components/table/columns/DeliverableColumns.tsx
@@ -3,7 +3,6 @@ import { createColumnHelper } from "@tanstack/react-table";
 import { createSelectColumnDef } from "./selectColumn";
 import { createDateColumnDef } from "./dateColumn";
 import {
-  DELIVERABLE_STATUSES,
   DELIVERABLE_TYPES,
   STATES_AND_TERRITORIES,
 } from "demos-server-constants";
@@ -19,6 +18,23 @@ type DeliverableColumnsProps = {
   demonstrationNameOptions: Option[];
   cmsOwnerOptions: Option[];
 };
+
+const COMBINED_STATUS_OPTIONS = [
+  "Upcoming",
+  "Upcoming - Extension Requested",
+  "Submitted",
+  "Submitted - Extension Requested",
+  "Past Due",
+  "Past Due - Extension Requested",
+  "Under CMS Review",
+  "Under CMS Review - Extension Requested",
+  "Approved",
+  "Accepted",
+  "Received and Filed",
+].map((status) => ({
+  label: status,
+  value: status,
+}));
 
 export function DeliverableColumns({
   viewMode,
@@ -69,11 +85,7 @@ export function DeliverableColumns({
     meta: {
       filterConfig: {
         filterType: "select",
-        // Extension Requested options not ready yet.
-        options: DELIVERABLE_STATUSES.filter((status) => status !== "Deleted").map((status) => ({
-          label: status,
-          value: status,
-        })),
+        options: COMBINED_STATUS_OPTIONS,
       },
     },
   });

--- a/client/src/components/table/tables/DeliverableTable.tsx
+++ b/client/src/components/table/tables/DeliverableTable.tsx
@@ -52,6 +52,7 @@ export type DeliverableTableRow = Omit<
 
 export type FormattedDeliverableTableRow = DeliverableTableRow & {
   combinedStatus: string;
+  combinedStatusFilter: string;
 };
 
 export type DeliverablesQueryResult = {
@@ -214,6 +215,32 @@ export const formatDeliverableStatus = (
   return formattedStatus;
 };
 
+/*
+ * This generates a value that is used for filtering.
+ * It's needed so the filter can match things like "Submitted (3) - Extension Requested"
+ * without needing to display the resubmission count in the filter options.
+ */
+export const formatDeliverableFilterStatus = (
+  deliverable: Pick<
+    DeliverableTableRow,
+    "status" | "extensionRequests"
+  >
+) => {
+  const { status, extensionRequests } = deliverable;
+
+  if (FINAL_STATUSES.includes(status)) {
+    return status;
+  }
+
+  const hasOpenExtensionRequest = extensionRequests.some(
+    (request) => request.status === "Requested"
+  );
+
+  return hasOpenExtensionRequest
+    ? `${status} - Extension Requested`
+    : status;
+};
+
 export const DeliverableTable: React.FC<{
   deliverables: DeliverableTableRow[];
   emptyRowsMessage?: string;
@@ -228,6 +255,7 @@ export const DeliverableTable: React.FC<{
   const formattedDeliverables = sortDeliverablesByDefault(deliverables).map((deliverable) => ({
     ...deliverable,
     combinedStatus: formatDeliverableStatus(deliverable),
+    combinedStatusFilter: formatDeliverableFilterStatus(deliverable),
   }));
 
   type RenderDeliverableActionButtons = NonNullable<

--- a/client/src/components/table/tables/DemonstrationDeliverableTable.test.tsx
+++ b/client/src/components/table/tables/DemonstrationDeliverableTable.test.tsx
@@ -146,6 +146,7 @@ describe("DemonstrationDeliverableTable", () => {
       dueDate: new Date("2026-01-01"),
       status: "Upcoming" as const,
       combinedStatus: "Upcoming",
+      combinedStatusFilter: "Upcoming",
       ...baseDeliverable,
     };
 

--- a/client/src/components/table/tables/DemonstrationDeliverableTable.tsx
+++ b/client/src/components/table/tables/DemonstrationDeliverableTable.tsx
@@ -10,7 +10,7 @@ import { createDateColumnDef } from "components/table/columns/dateColumn";
 import { highlightCell, KeywordSearch } from "components/table/KeywordSearch";
 import { ColumnFilter } from "components/table/ColumnFilter";
 import { PaginationControls } from "components/table/PaginationControls";
-import { formatDeliverableStatus } from "./DeliverableTable";
+import { formatDeliverableFilterStatus, formatDeliverableStatus } from "./DeliverableTable";
 import { sortDeliverablesByDefault } from "util/sortDeliverables";
 import { getDeliverableFilterOptions } from "./deliverablesFilterOptions";
 import { createSelectColumnDef } from "../columns/selectColumn";
@@ -111,6 +111,7 @@ export const DemonstrationDeliverableTable: React.FC<{
   const formattedDeliverables = sortDeliverablesByDefault(deliverables).map((deliverable) => ({
     ...deliverable,
     combinedStatus: formatDeliverableStatus(deliverable),
+    combinedStatusFilter: formatDeliverableFilterStatus(deliverable),
   }));
 
   return (


### PR DESCRIPTION
This adds a new column to filter on for the combined status column. It allows filtering by values like "Submitted - Extension Requested".

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/da637715-9dfe-4e46-b900-e7b0ff4ac06f" />
