### PR TITLE
Rename: `formatDate` --> `formatDateForDisplay`

### DIFF
--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -58,8 +58,12 @@ This file provides instructions for AI agents to use when generating or editing 
 - Co-locate each `gql` document with the component/hook that owns it.
 - Export query/mutation documents if tests, mocks, or `refetchQueries` need them.
 - After successful mutations, refetch affected queries.
-- All outbound dates must use `formatDateForServer` from `util/formatDate`.
-- Inbound dates may need to use `getDateEst(date)`.
+
+### Dates
+
+- The type `LocalDate` is just an alias for `string`.
+- All outbound dates must use `formatDateForServer` from `util/formatDate`. This may require `as LocalDate` on the type.
+- Inbound dates from the server that should display as a date (no time component) should use `getDateEst(dateFromServer)`
 
 ## Testing
 

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -64,6 +64,7 @@ This file provides instructions for AI agents to use when generating or editing 
 - The type `LocalDate` is just an alias for `string`.
 - All outbound dates must use `formatDateForServer` from `util/formatDate`. This may require `as LocalDate` on the type.
 - Inbound dates from the server that should display as a date (no time component) should use `getDateEst(dateFromServer)`
+- `formatDateForDisplay` should be used only as a final wrapper in case a date should be displayed as mm/dd/yyyy instead of in ISO format.
 
 ## Testing
 

--- a/client/src/components/application/phase-selector/PhaseDate.tsx
+++ b/client/src/components/application/phase-selector/PhaseDate.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { PhaseStatus } from "./PhaseSelector";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 import { tw } from "tags/tw";
 
 const BASE_STYLES = tw`flex flex-col h-full items-center justify-center mt-1 text-md font-bold`;
@@ -46,7 +46,7 @@ export const PhaseDate: React.FC<PhaseDateProps> = ({ phaseStatus, date }) => {
   return (
     <div className={BASE_STYLES}>
       <span className={labelClass}>{label}</span>
-      <span className={dateClass}>{date ? formatDate(date) : "--/--/----"}</span>
+      <span className={dateClass}>{date ? formatDateForDisplay(date) : "--/--/----"}</span>
     </div>
   );
 };

--- a/client/src/components/application/phases/CompletenessPhase.tsx
+++ b/client/src/components/application/phases/CompletenessPhase.tsx
@@ -3,7 +3,7 @@ import React, { useMemo, useState } from "react";
 import { Button, SecondaryButton } from "components/button";
 import { ExportIcon } from "components/icons";
 import { tw } from "tags/tw";
-import { formatDate, formatDateForServer, getDateEst } from "util/formatDate";
+import { formatDateForDisplay, formatDateForServer, getDateEst } from "util/formatDate";
 import { addDays, differenceInCalendarDays, parseISO } from "date-fns";
 import { WorkflowApplication, ApplicationWorkflowDocument } from "components/application";
 import { useToast } from "components/toast";
@@ -51,20 +51,20 @@ const CompletenessNotice = ({
     if (daysLeft > 1) {
       return {
         title: `${daysLeft} days left`,
-        description: `This Demonstration must be declared complete by ${formatDate(noticeDueDateValue)}`,
+        description: `This Demonstration must be declared complete by ${formatDateForDisplay(noticeDueDateValue)}`,
         variant: "warning" as NoticeVariant,
       };
     }
     if (daysLeft === 1) {
       return {
         title: "1 day left in Completion Period",
-        description: `This Demonstration must be declared complete by ${formatDate(noticeDueDateValue)}`,
+        description: `This Demonstration must be declared complete by ${formatDateForDisplay(noticeDueDateValue)}`,
         variant: "error" as NoticeVariant,
       };
     } else {
       return {
         title: `${Math.abs(daysLeft)} days past due`,
-        description: `This Demonstration completeness was due on ${formatDate(noticeDueDateValue)}`,
+        description: `This Demonstration completeness was due on ${formatDateForDisplay(noticeDueDateValue)}`,
         variant: "error" as NoticeVariant,
       };
     }

--- a/client/src/components/application/phases/FederalCommentPhase.tsx
+++ b/client/src/components/application/phases/FederalCommentPhase.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { tw } from "tags/tw";
 import { ApplicationUploadSection } from "components/application/phases/sections";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 import { useDialog } from "components/dialog/DialogContext";
 import { WorkflowApplication, ApplicationWorkflowDocument } from "components/application";
 import { differenceInCalendarDays } from "date-fns";
@@ -61,20 +61,20 @@ const FederalCommentNotice: React.FC<{ phaseEndDate?: Date; phaseComplete: boole
     if (daysLeft > 1) {
       return {
         title: `${daysLeft} days left in Federal Comment Period`,
-        description: `The Federal Comment Period ends on ${formatDate(phaseEndDate)}`,
+        description: `The Federal Comment Period ends on ${formatDateForDisplay(phaseEndDate)}`,
         variant: "warning" as NoticeVariant,
       };
     }
     if (daysLeft === 1) {
       return {
         title: "1 day left in Federal Comment Period",
-        description: `The Federal Comment Period ends on ${formatDate(phaseEndDate)}`,
+        description: `The Federal Comment Period ends on ${formatDateForDisplay(phaseEndDate)}`,
         variant: "error" as NoticeVariant,
       };
     }
     return {
       title: `${Math.abs(daysLeft)} days past due`,
-      description: `The Federal Comment Period ended on ${formatDate(phaseEndDate)}`,
+      description: `The Federal Comment Period ended on ${formatDateForDisplay(phaseEndDate)}`,
       variant: "error" as NoticeVariant,
     };
   };
@@ -123,11 +123,11 @@ export const FederalCommentPhase: React.FC<FederalCommentPhaseProps> = ({
       <div className="flex gap-8 mt-4 text-sm text-text-placeholder">
         <div className="flex flex-col">
           <span className="font-bold">Federal Comment Period Start Date</span>
-          <span>{phaseStartDate ? formatDate(phaseStartDate) : "--/--/----"}</span>
+          <span>{phaseStartDate ? formatDateForDisplay(phaseStartDate) : "--/--/----"}</span>
         </div>
         <div className="flex flex-col">
           <span className="font-bold">Federal Comment Period End Date</span>
-          <span>{phaseEndDate ? formatDate(phaseEndDate) : "--/--/----"}</span>
+          <span>{phaseEndDate ? formatDateForDisplay(phaseEndDate) : "--/--/----"}</span>
         </div>
       </div>
     </div>

--- a/client/src/components/application/phases/approval-package/ApprovalPackagePhase.test.tsx
+++ b/client/src/components/application/phases/approval-package/ApprovalPackagePhase.test.tsx
@@ -21,11 +21,6 @@ vi.mock("components/table/tables/ApprovalPackageTable", () => ({
   ),
 }));
 
-vi.mock("util/formatDate", () => ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  formatDate: (date: string | Date) => "FormattedDate",
-}));
-
 const mockCompletePhase = vi.fn();
 vi.mock("components/application/phase-status/phaseCompletionQueries", () => ({
   useCompletePhase: () => ({

--- a/client/src/components/application/phases/approval-package/ApprovalPackagePhase.tsx
+++ b/client/src/components/application/phases/approval-package/ApprovalPackagePhase.tsx
@@ -8,7 +8,7 @@ import { Button } from "components/button";
 import { useCompletePhase } from "components/application/phase-status/phaseCompletionQueries";
 import { useToast } from "components/toast";
 import { FAILED_TO_SAVE_MESSAGE, getPhaseCompletedMessage } from "util/messages";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 import { REQUIRED_DOCUMENT_TYPES } from "./approvalPackagePhaseData";
 
 export interface ApprovalPackagePhaseProps {
@@ -50,7 +50,7 @@ export const ApprovalPackagePhase = ({
       name: doc.name || "-",
       description: doc.description || "-",
       uploadedBy: doc.owner?.person?.fullName || "-",
-      uploadedDate: formatDate(doc.createdAt) || "-",
+      uploadedDate: formatDateForDisplay(doc.createdAt) || "-",
       document: doc,
     };
   });

--- a/client/src/components/application/phases/approval-package/approvalPackagePhaseData.test.tsx
+++ b/client/src/components/application/phases/approval-package/approvalPackagePhaseData.test.tsx
@@ -27,11 +27,6 @@ vi.mock("components/table/tables/ApprovalPackageTable", () => ({
   ),
 }));
 
-vi.mock("util/formatDate", () => ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  formatDate: (date: string | Date) => "FormattedDate",
-}));
-
 const mockCompletePhase = vi.fn();
 vi.mock("components/application/phase-status/phaseCompletionQueries", () => ({
   useCompletePhase: () => ({
@@ -140,7 +135,12 @@ describe("getApprovalPackagePhaseFromApplication", () => {
     const application = {
       ...baseDemonstration,
       phases: [
-        { phaseName: "Completeness" as const, phaseStatus: "Completed" as const, phaseDates: [], phaseNotes: [] },
+        {
+          phaseName: "Completeness" as const,
+          phaseStatus: "Completed" as const,
+          phaseDates: [],
+          phaseNotes: [],
+        },
       ],
     };
 
@@ -160,7 +160,11 @@ describe("getApprovalPackagePhaseFromApplication", () => {
       ...baseDemonstration,
       documents: [
         doc({ documentType: "Q&A", name: "Q&A Doc", phaseName: "Approval Package" }),
-        doc({ documentType: "Approval Letter", name: "Approval Doc", phaseName: "Approval Package" }),
+        doc({
+          documentType: "Approval Letter",
+          name: "Approval Doc",
+          phaseName: "Approval Package",
+        }),
         doc({ documentType: "Special Terms & Conditions", name: "STCs", phaseName: "Concept" }), // wrong phase
       ],
     };
@@ -180,9 +184,7 @@ describe("getApprovalPackagePhaseFromApplication", () => {
     const application = {
       ...baseDemonstration,
       phases: baseDemonstration.phases.map((p) =>
-        p.phaseName === "Approval Package"
-          ? { ...p, phaseStatus: "Completed" as const }
-          : p
+        p.phaseName === "Approval Package" ? { ...p, phaseStatus: "Completed" as const } : p
       ),
       documents: REQUIRED_DOCUMENT_TYPES.map((type) => doc({ documentType: type })),
     };
@@ -207,9 +209,7 @@ describe("getApprovalPackagePhaseFromApplication", () => {
     const application = {
       ...baseDemonstration,
       phases: baseDemonstration.phases.map((p) =>
-        p.phaseName === "Review"
-          ? { ...p, phaseStatus: "Started" as const }
-          : p
+        p.phaseName === "Review" ? { ...p, phaseStatus: "Started" as const } : p
       ),
       documents: REQUIRED_DOCUMENT_TYPES.map((type) => doc({ documentType: type })),
     };
@@ -222,7 +222,12 @@ describe("getApprovalPackagePhaseFromApplication", () => {
     const application = {
       ...baseDemonstration,
       phases: [
-        { phaseName: "Concept" as const, phaseStatus: "Started" as const, phaseDates: [], phaseNotes: [] },
+        {
+          phaseName: "Concept" as const,
+          phaseStatus: "Started" as const,
+          phaseDates: [],
+          phaseNotes: [],
+        },
         ...baseDemonstration.phases.filter((p) => p.phaseName !== "Concept"),
       ],
       documents: REQUIRED_DOCUMENT_TYPES.map((type) => doc({ documentType: type })),
@@ -238,9 +243,7 @@ describe("getApprovalPackagePhaseFromApplication", () => {
     const application = {
       ...baseDemonstration,
       phases: baseDemonstration.phases.map((p) =>
-        p.phaseName === "Application Intake"
-          ? { ...p, phaseStatus: "Skipped" as const }
-          : p
+        p.phaseName === "Application Intake" ? { ...p, phaseStatus: "Skipped" as const } : p
       ),
       documents: REQUIRED_DOCUMENT_TYPES.map((type) => doc({ documentType: type })),
     };

--- a/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.tsx
+++ b/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.tsx
@@ -189,25 +189,25 @@ export const getApprovalSummaryPhaseFromApplication = (
     workflowApplicationType === "demonstration"
       ? application.id
       : (application as ApplicationWorkflowAmendment | ApplicationWorkflowExtension).demonstration
-          .id;
+        .id;
 
   const demonstrationTypes =
     workflowApplicationType === "demonstration"
       ? (application as ApplicationWorkflowDemonstration).demonstrationTypes
       : (application as ApplicationWorkflowAmendment | ApplicationWorkflowExtension).demonstration
-          .demonstrationTypes;
+        .demonstrationTypes;
 
   const demonstrationStatus =
     workflowApplicationType === "demonstration"
       ? (application as ApplicationWorkflowDemonstration).status
       : (application as ApplicationWorkflowAmendment | ApplicationWorkflowExtension).demonstration
-          .status;
+        .status;
 
   const medicaidId =
     workflowApplicationType === "demonstration"
       ? (application as ApplicationWorkflowDemonstration).medicaidId
       : (application as ApplicationWorkflowAmendment | ApplicationWorkflowExtension).demonstration
-          .medicaidId;
+        .medicaidId;
 
   return (
     <ApprovalSummaryPhase

--- a/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.tsx
+++ b/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useMutation, gql } from "@apollo/client";
-import { formatDate, formatDateForServer, getTodayEst } from "util/formatDate";
+import { formatDateForDisplay, formatDateForServer, getTodayEst } from "util/formatDate";
 import { ApplicationStatus, DateType, UpdateDemonstrationInput } from "demos-server";
 import {
   ApplicationWorkflowAmendment,
@@ -103,10 +103,10 @@ export const getDemonstrationApprovalSummaryFormData = (
     projectOfficerName: demonstration.primaryProjectOfficer?.fullName ?? "",
     status: demonstration.status,
     effectiveDate: demonstration.effectiveDate
-      ? formatDate(demonstration.effectiveDate)
+      ? formatDateForDisplay(demonstration.effectiveDate)
       : undefined,
     expirationDate: demonstration.expirationDate
-      ? formatDate(demonstration.expirationDate)
+      ? formatDateForDisplay(demonstration.expirationDate)
       : undefined,
     description: demonstration.description,
     sdgDivision: demonstration.sdgDivision,
@@ -137,7 +137,7 @@ export const getModificationApprovalSummaryFormData = (
     applicationType: modificationType,
     name: modification.name,
     effectiveDate: modification.effectiveDate
-      ? formatDate(modification.effectiveDate)
+      ? formatDateForDisplay(modification.effectiveDate)
       : undefined,
     description: modification.description,
     signatureLevel: modification.signatureLevel,
@@ -182,28 +182,32 @@ export const getApprovalSummaryPhaseFromApplication = (
   )?.dateValue;
 
   const allPreviousPhasesDone = application.phases
-    .filter(
-      (p) =>
-        p.phaseName !== "Concept" &&
-        p.phaseName !== "Approval Summary"
-    )
+    .filter((p) => p.phaseName !== "Concept" && p.phaseName !== "Approval Summary")
     .every((phase) => phase.phaseStatus === "Completed" || phase.phaseStatus === "Skipped");
 
-  const demonstrationId = workflowApplicationType === "demonstration" ?
-    application.id :
-    (application as ApplicationWorkflowAmendment | ApplicationWorkflowExtension).demonstration.id;
+  const demonstrationId =
+    workflowApplicationType === "demonstration"
+      ? application.id
+      : (application as ApplicationWorkflowAmendment | ApplicationWorkflowExtension).demonstration
+          .id;
 
-  const demonstrationTypes = workflowApplicationType === "demonstration" ?
-    (application as ApplicationWorkflowDemonstration).demonstrationTypes :
-    (application as ApplicationWorkflowAmendment | ApplicationWorkflowExtension).demonstration.demonstrationTypes;
+  const demonstrationTypes =
+    workflowApplicationType === "demonstration"
+      ? (application as ApplicationWorkflowDemonstration).demonstrationTypes
+      : (application as ApplicationWorkflowAmendment | ApplicationWorkflowExtension).demonstration
+          .demonstrationTypes;
 
-  const demonstrationStatus = workflowApplicationType === "demonstration" ?
-    (application as ApplicationWorkflowDemonstration).status :
-    (application as ApplicationWorkflowAmendment | ApplicationWorkflowExtension).demonstration.status;
+  const demonstrationStatus =
+    workflowApplicationType === "demonstration"
+      ? (application as ApplicationWorkflowDemonstration).status
+      : (application as ApplicationWorkflowAmendment | ApplicationWorkflowExtension).demonstration
+          .status;
 
-  const medicaidId = workflowApplicationType === "demonstration" ?
-    (application as ApplicationWorkflowDemonstration).medicaidId :
-    (application as ApplicationWorkflowAmendment | ApplicationWorkflowExtension).demonstration.medicaidId;
+  const medicaidId =
+    workflowApplicationType === "demonstration"
+      ? (application as ApplicationWorkflowDemonstration).medicaidId
+      : (application as ApplicationWorkflowAmendment | ApplicationWorkflowExtension).demonstration
+          .medicaidId;
 
   return (
     <ApprovalSummaryPhase
@@ -231,7 +235,9 @@ export const ApprovalSummaryPhase = ({
   allPreviousPhasesDone,
   demonstrationStatus,
 }: ApprovalSummaryPhaseProps) => {
-  const capitalizedType = initialFormData.applicationType.charAt(0).toUpperCase() + initialFormData.applicationType.slice(1);
+  const capitalizedType =
+    initialFormData.applicationType.charAt(0).toUpperCase() +
+    initialFormData.applicationType.slice(1);
   const [approvalSummaryFormData, setApprovalSummaryFormData] =
     useState<ApplicationDetailsFormData>(initialFormData);
 
@@ -254,7 +260,11 @@ export const ApprovalSummaryPhase = ({
   // Initialize completion date from backend if available
   const [applicationDetailsCompletionDate, setApplicationDetailsCompletionDate] = useState<
     string | undefined
-  >(applicationDetailsCompleteDate ? formatDate(applicationDetailsCompleteDate) : undefined);
+  >(
+    applicationDetailsCompleteDate
+      ? formatDateForDisplay(applicationDetailsCompleteDate)
+      : undefined
+  );
 
   // Find Approval Summary phase completion date (if backend has stored it)
   const approvalSummaryCompletionDateValue = approvalSummaryPhase?.phaseDates?.find(
@@ -264,7 +274,9 @@ export const ApprovalSummaryPhase = ({
   const [approvalSummaryCompletionDate, setApprovalSummaryCompletionDate] = useState<
     string | undefined
   >(
-    approvalSummaryCompletionDateValue ? formatDate(approvalSummaryCompletionDateValue) : undefined
+    approvalSummaryCompletionDateValue
+      ? formatDateForDisplay(approvalSummaryCompletionDateValue)
+      : undefined
   );
 
   const [updateDemonstrationTrigger] = useMutation(UPDATE_DEMONSTRATION_MUTATION);
@@ -358,16 +370,13 @@ export const ApprovalSummaryPhase = ({
         approvalSummaryFormData.signatureLevel
       );
     } else {
-      return !!(
-        approvalSummaryFormData.effectiveDate &&
-        approvalSummaryFormData.signatureLevel
-      );
+      return !!(approvalSummaryFormData.effectiveDate && approvalSummaryFormData.signatureLevel);
     }
   })();
 
   const setApplicationDetailsUIState = (complete: boolean) => {
     setIsApplicationDetailsComplete(complete);
-    setApplicationDetailsCompletionDate(complete ? formatDate(getTodayEst()) : undefined);
+    setApplicationDetailsCompletionDate(complete ? formatDateForDisplay(getTodayEst()) : undefined);
   };
 
   const handleMarkComplete = async () => {
@@ -448,7 +457,7 @@ export const ApprovalSummaryPhase = ({
         ) as typeof previousFormData.readonlyFields,
       }));
 
-      setApprovalSummaryCompletionDate(formatDate(today));
+      setApprovalSummaryCompletionDate(formatDateForDisplay(today));
 
       showSuccess(getPhaseCompletedMessage("Approval Summary"));
     } catch (error) {
@@ -460,7 +469,10 @@ export const ApprovalSummaryPhase = ({
   return (
     <div>
       <h3 className="text-brand text-[22px] font-bold tracking-wide mb-1">APPROVAL SUMMARY</h3>
-      <p className="text-sm text-text-placeholder mb-1">Review and verify {capitalizedType} Details and Performance Periods for Demonstration Types before approving this application.</p>
+      <p className="text-sm text-text-placeholder mb-1">
+        Review and verify {capitalizedType} Details and Performance Periods for Demonstration Types
+        before approving this application.
+      </p>
 
       <section className="bg-white pt-2 flex flex-col gap-2">
         <ApplicationDetailsSection
@@ -479,7 +491,7 @@ export const ApprovalSummaryPhase = ({
           isComplete={isDemonstrationTypesComplete}
           completionDate={
             demonstrationTypeCompletionDate
-              ? formatDate(demonstrationTypeCompletionDate)
+              ? formatDateForDisplay(demonstrationTypeCompletionDate)
               : undefined
           }
           isReadonly={isDemonstrationApproved}
@@ -495,9 +507,11 @@ export const ApprovalSummaryPhase = ({
           name="button-approve-application"
           size="small"
           disabled={!canApproveApplication}
-          onClick={() => showConfirmApproveDialog(handleApproveApplication, initialFormData.applicationType)}
+          onClick={() =>
+            showConfirmApproveDialog(handleApproveApplication, initialFormData.applicationType)
+          }
         >
-          Approve { capitalizedType }
+          Approve {capitalizedType}
         </Button>
       </div>
     </div>

--- a/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
+++ b/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
@@ -8,7 +8,7 @@ import { SelectSdgDivision } from "components/input/select/SelectSdgDivision";
 import { SelectSignatureLevel } from "components/input/select/SelectSignatureLevel";
 import { DatePicker } from "components/input/date/DatePicker";
 import { tw } from "tags/tw";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 
 const LABEL_CLASSES = tw`text-text-font font-bold text-sm tracking-wide h-[14px] flex items-center`;
 const VALUE_CLASSES = tw`text-text-font text-base leading-relaxed h-[40px] flex items-start mt-1`;
@@ -202,7 +202,9 @@ export const ApplicationDetailsSection = ({
                 Effective Date
               </div>
               <div className={VALUE_CLASSES}>
-                {sectionFormData.effectiveDate ? formatDate(sectionFormData.effectiveDate) : "-"}
+                {sectionFormData.effectiveDate
+                  ? formatDateForDisplay(sectionFormData.effectiveDate)
+                  : "-"}
               </div>
             </div>
           ) : (
@@ -237,7 +239,9 @@ export const ApplicationDetailsSection = ({
                   Expiration Date
                 </div>
                 <div className={VALUE_CLASSES}>
-                  {sectionFormData.expirationDate ? formatDate(sectionFormData.expirationDate) : ""}
+                  {sectionFormData.expirationDate
+                    ? formatDateForDisplay(sectionFormData.expirationDate)
+                    : ""}
                 </div>
               </div>
             ) : (

--- a/client/src/components/dialog/DemonstrationTypes/DemonstrationTypesList.tsx
+++ b/client/src/components/dialog/DemonstrationTypes/DemonstrationTypesList.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DeleteIcon } from "components/icons";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 import { TagName } from "demos-server";
 import { DemonstrationType } from "./ApplyDemonstrationTypesDialog";
 import { parseISO } from "date-fns";
@@ -28,8 +28,8 @@ export const DemonstrationTypesList = ({
                   {demonstrationType.approvalStatus === "Unapproved" && " (Unapproved)"}
                 </p>
                 <span>
-                  Effective: {formatDate(parseISO(demonstrationType.effectiveDate))} &bull; Expires:{" "}
-                  {formatDate(parseISO(demonstrationType.expirationDate))}
+                  Effective: {formatDateForDisplay(parseISO(demonstrationType.effectiveDate))}{" "}
+                  &bull; Expires: {formatDateForDisplay(parseISO(demonstrationType.expirationDate))}
                 </span>
               </div>
               <div className="flex items-center">

--- a/client/src/components/dialog/deliverable/ReviewExtensionDeliverableDialog.tsx
+++ b/client/src/components/dialog/deliverable/ReviewExtensionDeliverableDialog.tsx
@@ -11,7 +11,7 @@ import { Notice } from "components/notice/Notice";
 import { useToast } from "components/toast";
 import { DeliverableExtensionReasonCode } from "demos-server";
 import { DELIVERABLE_DETAILS_QUERY } from "pages/deliverables/DeliverableDetailsManagementPage";
-import { formatDate, formatDateForServer } from "util/formatDate";
+import { formatDateForDisplay, formatDateForServer } from "util/formatDate";
 import { DELIVERABLE_EXTENSION_REVIEW_SUBMITTED_MESSAGE } from "util/messages";
 
 export const APPROVE_DELIVERABLE_EXTENSION_MUTATION = gql`
@@ -28,10 +28,7 @@ export const APPROVE_DELIVERABLE_EXTENSION_MUTATION = gql`
 `;
 
 export const DENY_DELIVERABLE_EXTENSION_MUTATION = gql`
-  mutation DenyDeliverableExtension(
-    $deliverableId: ID!
-    $input: DenyDeliverableExtensionInput!
-  ) {
+  mutation DenyDeliverableExtension($deliverableId: ID!, $input: DenyDeliverableExtensionInput!) {
     denyDeliverableExtension(deliverableId: $deliverableId, input: $input) {
       id
       status
@@ -124,9 +121,10 @@ export interface ReviewExtensionDeliverableDialogProps {
   deliverable: ReviewExtensionDeliverableDialogDeliverable;
 }
 
-export const ReviewExtensionDeliverableDialog: React.FC<
-  ReviewExtensionDeliverableDialogProps
-> = ({ onClose, deliverable }) => {
+export const ReviewExtensionDeliverableDialog: React.FC<ReviewExtensionDeliverableDialogProps> = ({
+  onClose,
+  deliverable,
+}) => {
   const { showSuccess, showError } = useToast();
 
   const [formData, setFormData] = useState<ReviewExtensionFormData>(INITIAL_FORM_DATA);
@@ -142,8 +140,8 @@ export const ReviewExtensionDeliverableDialog: React.FC<
   const hasChanges = formHasChanges(formData);
 
   const requestedDateDisplay = expired
-    ? `${formatDate(extensionRequest.originalDateRequested)} (Expired)`
-    : formatDate(extensionRequest.originalDateRequested);
+    ? `${formatDateForDisplay(extensionRequest.originalDateRequested)} (Expired)`
+    : formatDateForDisplay(extensionRequest.originalDateRequested);
 
   const handleSubmit = async () => {
     setAttemptedSubmit(true);
@@ -208,7 +206,7 @@ export const ReviewExtensionDeliverableDialog: React.FC<
         <div className="bg-surface-secondary p-sm rounded grid grid-cols-2 gap-sm">
           <Field
             label="Initial Due Date"
-            value={formatDate(extensionRequest.initialDueDateAtRequest)}
+            value={formatDateForDisplay(extensionRequest.initialDueDateAtRequest)}
           />
           <Field label="State Requested New Date" value={requestedDateDisplay} />
           <div className="col-span-2">
@@ -252,9 +250,7 @@ export const ReviewExtensionDeliverableDialog: React.FC<
               value={formData.newDate}
               onChange={(newDate) => setFormData((prev) => ({ ...prev, newDate }))}
               getValidationMessage={() =>
-                attemptedSubmit && formData.newDate === ""
-                  ? "New Date is required."
-                  : newDateError
+                attemptedSubmit && formData.newDate === "" ? "New Date is required." : newDateError
               }
             />
           )}

--- a/client/src/components/dialog/deliverable/fields/schedule-type/SingleDeliverableScheduleType.tsx
+++ b/client/src/components/dialog/deliverable/fields/schedule-type/SingleDeliverableScheduleType.tsx
@@ -1,7 +1,7 @@
 import { DatePicker } from "components/input/date/DatePicker";
 import React from "react";
 import { isBefore, parseISO } from "date-fns";
-import { formatDate, getTodayEst } from "util/formatDate";
+import { formatDateForDisplay, getTodayEst } from "util/formatDate";
 
 export const SINGLE_DELIVERABLE_DUE_DATE_NAME = "single-deliverable-due-date";
 
@@ -25,7 +25,7 @@ export const SingleDeliverableScheduleType = ({
           minDate={today}
           getValidationMessage={() =>
             value && isBefore(value, today)
-              ? `Date must be on or after ${formatDate(parseISO(today))}.`
+              ? `Date must be on or after ${formatDateForDisplay(parseISO(today))}.`
               : ""
           }
         />

--- a/client/src/components/dialog/referenceAgreement/ReferenceAgreementDocument.tsx
+++ b/client/src/components/dialog/referenceAgreement/ReferenceAgreementDocument.tsx
@@ -3,7 +3,7 @@ import { ReferenceAgreement } from "demos-server";
 import { useDownloadReference } from "hooks/useDownloadReference";
 import React from "react";
 import { tw } from "tags/tw";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 
 const STYLES = {
   fileRow: tw`cursor-pointer bg-surface-secondary border border-border-fields border-l-3 px-2 py-1 flex items-center justify-between`,
@@ -24,7 +24,7 @@ export const ReferenceAgreementDocument: React.FC<{
       <div className="flex items-center gap-1">
         <PDFIcon className="h-2 w-2 text-red-600" />
         <div className="font-medium">{agreement.name}</div>
-        <div className={STYLES.fileMeta}>{formatDate(agreement.createdAt)}</div>
+        <div className={STYLES.fileMeta}>{formatDateForDisplay(agreement.createdAt)}</div>
       </div>
     </button>
   );

--- a/client/src/components/document/documentChip.tsx
+++ b/client/src/components/document/documentChip.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ExitIcon, FileIcon } from "components/icons";
 import { tw } from "tags/tw";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 import { DocumentType } from "demos-server-constants";
 
 const abbreviateLongFilename = (str: string): string => {
@@ -43,7 +43,7 @@ export const DocumentChip: React.FC<{
         </span>
         {document.createdAt && document.documentType && (
           <span className={STYLES.subtext}>
-            {formatDate(document.createdAt)}
+            {formatDateForDisplay(document.createdAt)}
             {` • ${document.documentType}`}
           </span>
         )}

--- a/client/src/components/input/date/DatePicker.tsx
+++ b/client/src/components/input/date/DatePicker.tsx
@@ -6,7 +6,7 @@ import {
   VALIDATION_MESSAGE_CLASSES,
 } from "components/input/Input";
 import { parseISO } from "date-fns";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 
 const DEFAULT_MIN_DATE = "1900-01-01";
 const DEFAULT_MAX_DATE = "2099-12-31";
@@ -67,9 +67,9 @@ export const DatePicker = ({
 
     // Check for the date to be in range
     if (displayedDate < minDate)
-      return `Date must be on or after ${formatDate(parseISO(minDate))}.`;
+      return `Date must be on or after ${formatDateForDisplay(parseISO(minDate))}.`;
     if (displayedDate > maxDate)
-      return `Date must be on or before ${formatDate(parseISO(maxDate))}.`;
+      return `Date must be on or before ${formatDateForDisplay(parseISO(maxDate))}.`;
     return "";
   };
 

--- a/client/src/components/table/ColumnFilter.test.tsx
+++ b/client/src/components/table/ColumnFilter.test.tsx
@@ -9,7 +9,7 @@ import { testTableData, TestType } from "./Table.test";
 import { createColumnHelper } from "@tanstack/react-table";
 import { ColumnFilter } from "./ColumnFilter";
 import { isAfter, isBefore, isSameDay } from "date-fns";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 
 const columnHelper = createColumnHelper<TestType>();
 
@@ -40,7 +40,7 @@ export const testColumns = [
     id: "date",
     header: "Date",
     cell: ({ getValue }) => {
-      return formatDate(getValue());
+      return formatDateForDisplay(getValue());
     },
     meta: {
       filterConfig: {

--- a/client/src/components/table/columns/ReferencesColumns.tsx
+++ b/client/src/components/table/columns/ReferencesColumns.tsx
@@ -6,7 +6,7 @@ import { SecondaryButton } from "components/button";
 import { useDialog } from "components/dialog/DialogContext";
 import { useDownloadReference } from "hooks/useDownloadReference";
 import { Reference, ReferenceAgreement, Tag } from "demos-server";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 
 export function ReferencesColumns() {
   const { showReferenceAgreementDialog } = useDialog();
@@ -43,7 +43,7 @@ export function ReferencesColumns() {
     }),
     columnHelper.accessor("updatedAt", {
       header: "Last Updated",
-      cell: (cell) => formatDate(cell.getValue()),
+      cell: (cell) => formatDateForDisplay(cell.getValue()),
       enableColumnFilter: false,
     }),
     columnHelper.display({

--- a/client/src/components/table/columns/TypesColumns.tsx
+++ b/client/src/components/table/columns/TypesColumns.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { createColumnHelper } from "@tanstack/react-table";
 
 import { highlightCell } from "../KeywordSearch";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 import { createSelectColumnDef } from "./selectColumn";
 import { TypeTableRow } from "../tables/TypesTable";
 
@@ -41,7 +41,7 @@ export function TypesColumns() {
       header: "Effective Date",
       cell: ({ getValue }) => {
         const dateValue = getValue();
-        return dateValue ? formatDate(dateValue) : "—";
+        return dateValue ? formatDateForDisplay(dateValue) : "—";
       },
       meta: {
         filterConfig: {
@@ -53,7 +53,7 @@ export function TypesColumns() {
       header: "Expiration Date",
       cell: ({ getValue }) => {
         const dateValue = getValue();
-        return dateValue ? formatDate(dateValue) : "—";
+        return dateValue ? formatDateForDisplay(dateValue) : "—";
       },
       meta: {
         filterConfig: {

--- a/client/src/components/table/columns/dateColumn.tsx
+++ b/client/src/components/table/columns/dateColumn.tsx
@@ -1,59 +1,53 @@
 import { ColumnHelper } from "@tanstack/react-table";
 import { isAfter, isBefore, isSameDay } from "date-fns";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 
 type DateFilterValue = {
   start?: Date;
   end?: Date;
 };
 
-export function createDateColumnDef<
-  RowData,
-  FieldName extends keyof RowData & string
->(
+export function createDateColumnDef<RowData, FieldName extends keyof RowData & string>(
   columnHelper: ColumnHelper<RowData>,
   fieldName: FieldName,
   header: string
 ) {
-  return columnHelper.accessor(
-    (row: RowData) => row[fieldName],
-    {
-      id: fieldName,
-      header,
-      cell: ({ getValue }) => {
-        const value = getValue() as string | undefined;
-        return value ? formatDate(value) : "";
+  return columnHelper.accessor((row: RowData) => row[fieldName], {
+    id: fieldName,
+    header,
+    cell: ({ getValue }) => {
+      const value = getValue() as string | undefined;
+      return value ? formatDateForDisplay(value) : "";
+    },
+    filterFn: (row, columnId, filterValue: DateFilterValue) => {
+      const value = row.getValue(columnId) as string | undefined;
+      if (!value) return false;
+
+      const date = new Date(value);
+      const { start, end } = filterValue || {};
+
+      if (start && end) {
+        return (
+          isSameDay(date, start) ||
+          isSameDay(date, end) ||
+          (isAfter(date, start) && isBefore(date, end))
+        );
+      }
+
+      if (start) {
+        return isSameDay(date, start) || isAfter(date, start);
+      }
+
+      if (end) {
+        return isSameDay(date, end) || isBefore(date, end);
+      }
+
+      return true;
+    },
+    meta: {
+      filterConfig: {
+        filterType: "date",
       },
-      filterFn: (row, columnId, filterValue: DateFilterValue) => {
-        const value = row.getValue(columnId) as string | undefined;
-        if (!value) return false;
-
-        const date = new Date(value);
-        const { start, end } = filterValue || {};
-
-        if (start && end) {
-          return (
-            isSameDay(date, start) ||
-            isSameDay(date, end) ||
-            (isAfter(date, start) && isBefore(date, end))
-          );
-        }
-
-        if (start) {
-          return isSameDay(date, start) || isAfter(date, start);
-        }
-
-        if (end) {
-          return isSameDay(date, end) || isBefore(date, end);
-        }
-
-        return true;
-      },
-      meta: {
-        filterConfig: {
-          filterType: "date",
-        },
-      },
-    }
-  );
+    },
+  });
 }

--- a/client/src/components/table/tables/SummaryDetailsTable.test.tsx
+++ b/client/src/components/table/tables/SummaryDetailsTable.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { MOCK_DEMONSTRATION } from "mock-data/demonstrationMocks";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 import { beforeEach, describe, expect, it } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { DEMONSTRATION_SUMMARY_DETAILS_QUERY, SummaryDetailsTable } from "./SummaryDetailsTable";
@@ -59,8 +59,8 @@ describe("SummaryDetailsTable", () => {
   describe("Date Formatting", () => {
     it("formats effective and expiration dates correctly", () => {
       // Check that dates are rendered (format will depend on locale)
-      const effectiveDate = formatDate(testDemo.effectiveDate);
-      const expirationDate = formatDate(testDemo.expirationDate);
+      const effectiveDate = formatDateForDisplay(testDemo.effectiveDate);
+      const expirationDate = formatDateForDisplay(testDemo.expirationDate);
 
       expect(screen.getByText(effectiveDate)).toBeInTheDocument();
       expect(screen.getByText(expirationDate)).toBeInTheDocument();

--- a/client/src/components/table/tables/SummaryDetailsTable.tsx
+++ b/client/src/components/table/tables/SummaryDetailsTable.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Demonstration as ServerDemonstration, Person, State } from "demos-server";
 import { gql } from "graphql-tag";
 import { tw } from "tags/tw";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 
 import { useQuery } from "@apollo/client";
 
@@ -117,14 +117,14 @@ export const SummaryDetailsTable: React.FC<{ demonstrationId: string }> = ({ dem
       <div className={FIELD_CONTAINER_CLASSES}>
         <div className={LABEL_CLASSES}>Effective Date</div>
         <div className={VALUE_CLASSES}>
-          {demonstration.effectiveDate ? formatDate(demonstration.effectiveDate) : "-"}
+          {demonstration.effectiveDate ? formatDateForDisplay(demonstration.effectiveDate) : "-"}
         </div>
       </div>
 
       <div className={FIELD_CONTAINER_CLASSES}>
         <div className={LABEL_CLASSES}>Expiration Date</div>
         <div className={VALUE_CLASSES}>
-          {demonstration.expirationDate ? formatDate(demonstration.expirationDate) : "-"}
+          {demonstration.expirationDate ? formatDateForDisplay(demonstration.expirationDate) : "-"}
         </div>
       </div>
 

--- a/client/src/pages/DemonstrationDetail/DemonstrationDetailHeader.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetailHeader.tsx
@@ -4,7 +4,7 @@ import { CircleButton } from "components/button";
 import { BaseButton } from "components/button/BaseButton";
 import { AddNewIcon, ChevronLeftIcon, EditIcon, EllipsisIcon } from "components/icons";
 import { Demonstration, Person, PersonType, State } from "demos-server";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 import { gql, useQuery } from "@apollo/client";
 import { useDialog } from "components/dialog/DialogContext";
 import { useNavigate } from "react-router-dom";
@@ -96,11 +96,15 @@ export const DemonstrationDetailHeader: React.FC<DemonstrationDetailHeaderProps>
     { label: "Status", value: demonstration.status },
     {
       label: "Effective",
-      value: demonstration.effectiveDate ? formatDate(demonstration.effectiveDate) : "--/--/----",
+      value: demonstration.effectiveDate
+        ? formatDateForDisplay(demonstration.effectiveDate)
+        : "--/--/----",
     },
     {
       label: "Expiration",
-      value: demonstration.expirationDate ? formatDate(demonstration.expirationDate) : "--/--/----",
+      value: demonstration.expirationDate
+        ? formatDateForDisplay(demonstration.expirationDate)
+        : "--/--/----",
     },
   ];
   const canManageDemonstration = HEADER_ACTION_PERSON_TYPES.has(currentUser.person.personType);

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ModificationItem } from "./ModificationTabs";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 import { IconButton } from "components/button";
 import { EditIcon } from "components/icons";
 import { useDialog } from "components/dialog/DialogContext";
@@ -21,7 +21,7 @@ const ModificationDetailsFields = ({
   modificationItem: ModificationItem;
 }) => {
   const effectiveDateValue = modificationItem.effectiveDate
-    ? formatDate(modificationItem.effectiveDate)
+    ? formatDateForDisplay(modificationItem.effectiveDate)
     : "--/--/----";
 
   const labelPrefix = modificationItem.modificationType === "amendment" ? "Amendment" : "Extension";

--- a/client/src/pages/DocumentDetails/DocumentDetail.tsx
+++ b/client/src/pages/DocumentDetails/DocumentDetail.tsx
@@ -9,7 +9,7 @@ import {
   Person as ServerPerson,
 } from "demos-server";
 import { useParams } from "react-router-dom";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 import { tw } from "tags/tw";
 import { DocumentPreview } from "./DocumentPreview";
 
@@ -122,7 +122,7 @@ export const DocumentDetail: React.FC<{ documentId: string }> = ({ documentId })
           <span className="font-bold">Uploader:</span> {document.owner.person.fullName}
         </p>
         <p>
-          <span className="font-bold">Uploaded on:</span> {formatDate(document.createdAt)}
+          <span className="font-bold">Uploaded on:</span> {formatDateForDisplay(document.createdAt)}
         </p>
       </div>
       <div className="mt-2 flex-1 min-h-0">

--- a/client/src/pages/deliverables/sections/DeliverableInfoFields.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableInfoFields.tsx
@@ -3,7 +3,7 @@ import { compareDesc } from "date-fns";
 import { BaseButton } from "components/button/BaseButton";
 import { ChevronDownIcon, ChevronLeftIcon } from "components/icons";
 import type { DeliverableDetailsManagementDeliverable } from "../DeliverableDetailsManagementPage";
-import { formatDate } from "util/formatDate";
+import { formatDateForDisplay } from "util/formatDate";
 
 export const DELIVERABLE_INFO_FIELDS_NAME = "deliverable-info-fields";
 export const BACK_TO_DELIVERABLES_BUTTON_NAME = "button-back-to-deliverables";
@@ -48,7 +48,7 @@ export const DeliverableInfoFields = ({
 
   const baseFields: DeliverableInfoField[] = [
     { label: "Deliverable Type", value: deliverable.deliverableType },
-    { label: "Due Date", value: formatDate(deliverable.dueDate) },
+    { label: "Due Date", value: formatDateForDisplay(deliverable.dueDate) },
     { label: "Submission Date", value: "—" },
     { label: "Status", value: deliverable.status },
   ];
@@ -63,7 +63,9 @@ export const DeliverableInfoFields = ({
       : baseFields;
 
   const VerticalRule = () => (
-    <div className="text-[18px] mt-0.5 font-title font-normal opacity-70" aria-hidden="true">|</div>
+    <div className="text-[18px] mt-0.5 font-title font-normal opacity-70" aria-hidden="true">
+      |
+    </div>
   );
 
   return (

--- a/client/src/util/formatDate.test.ts
+++ b/client/src/util/formatDate.test.ts
@@ -1,7 +1,7 @@
 import { UTCDate } from "@date-fns/utc";
 import { TZDate } from "@date-fns/tz";
 
-import { formatDate, formatDateForServer, getTodayEst, getDateEst } from "./formatDate";
+import { formatDateForDisplay, formatDateForServer, getTodayEst, getDateEst } from "./formatDate";
 
 const TEST_DATE_ISO = "2023-04-15T13:45:30.000Z";
 const LEAP_YEAR_DATE_ISO = "2024-02-29T23:59:59.000Z";
@@ -20,12 +20,12 @@ describe("formatDate utilities", () => {
   const midnight = new UTCDate(MIDNIGHT_ISO);
 
   it("formats date as MM/dd/yyyy", () => {
-    expect(formatDate(testDate)).toBe("04/15/2023");
-    expect(formatDate(leapYearDate)).toBe("02/29/2024");
-    expect(formatDate(startOfYear)).toBe("01/01/2022");
-    expect(formatDate(endOfYear)).toBe("12/31/2022");
-    expect(formatDate(noon)).toBe("07/04/2023");
-    expect(formatDate(midnight)).toBe("07/04/2023");
+    expect(formatDateForDisplay(testDate)).toBe("04/15/2023");
+    expect(formatDateForDisplay(leapYearDate)).toBe("02/29/2024");
+    expect(formatDateForDisplay(startOfYear)).toBe("01/01/2022");
+    expect(formatDateForDisplay(endOfYear)).toBe("12/31/2022");
+    expect(formatDateForDisplay(noon)).toBe("07/04/2023");
+    expect(formatDateForDisplay(midnight)).toBe("07/04/2023");
   });
 
   it("formats date as yyyy-MM-dd", () => {

--- a/client/src/util/formatDate.ts
+++ b/client/src/util/formatDate.ts
@@ -11,7 +11,7 @@ export const EST_TIMEZONE = "America/New_York";
 /**
  * Formats a date to MM/DD/YYYY
  */
-export const formatDate = (date: DateArgument): string => {
+export const formatDateForDisplay = (date: DateArgument): string => {
   return format(date, US_DATE_FORMAT);
 };
 


### PR DESCRIPTION
Renames our `util` function `formatDate` to `formatDateForDisplay` which is a bit more explicit and should help communicate when this function should be used and avoid clashing with the `date-fns` function of the same name