### PR TITLE
DEMOS-2257: added a 25 min height to review phase notes

### DIFF
--- a/client/src/components/application/phases/review/cmsOsoraClearanceSection.tsx
+++ b/client/src/components/application/phases/review/cmsOsoraClearanceSection.tsx
@@ -123,7 +123,7 @@ export const CmsOsoraClearanceSection = ({
                 },
               })
             }
-            className="border rounded p-1 min-h-[40px] resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="border rounded p-1 min-h-25 resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
             rows={1}
             disabled={isReadonly}
           />

--- a/client/src/components/application/phases/review/commsClearanceSection.tsx
+++ b/client/src/components/application/phases/review/commsClearanceSection.tsx
@@ -79,7 +79,7 @@ export const CommsClearanceSection = ({
                 },
               })
             }
-            className="border rounded p-1 min-h-[40px] resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="border rounded p-1 min-h-25 resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
             rows={1}
             disabled={isReadonly}
           />

--- a/client/src/components/application/phases/review/ogcAndOmbSection.tsx
+++ b/client/src/components/application/phases/review/ogcAndOmbSection.tsx
@@ -113,7 +113,7 @@ export const OgcAndOmbSection = ({
                 },
               })
             }
-            className="border rounded p-1 min-h-[40px] resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="border rounded p-1 min-h-25 resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
             rows={1}
             disabled={isReadonly}
           />

--- a/client/src/components/application/phases/review/poAndOgdSection.tsx
+++ b/client/src/components/application/phases/review/poAndOgdSection.tsx
@@ -117,7 +117,7 @@ export const PoAndOgdSection = ({
                 },
               })
             }
-            className="border rounded p-1 min-h-[40px] resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="border rounded p-1 min-h-25 resize-y focus:outline-none focus:ring-2 focus:ring-blue-500"
             rows={1}
             disabled={isReadonly}
           />


### PR DESCRIPTION
Super simple: 
<img width="auto" height="900" alt="Screenshot 2026-06-11 at 13 56 01" src="https://github.com/user-attachments/assets/743ad756-8210-4502-a1ab-adcfb4ca1899" />


Just added a min height of just a bit larger for the textareas

<img width="900" height="auto" alt="Screenshot 2026-06-11 at 14 08 39" src="https://github.com/user-attachments/assets/c0fc990d-6e4d-411f-af5f-936b8625a27c" />

