### PR TITLE
DEMOS-2270: made fields required when approved, allowed unsetting sdg

### DIFF
--- a/client/src/components/dialog/demonstration/DemonstrationDialog.test.tsx
+++ b/client/src/components/dialog/demonstration/DemonstrationDialog.test.tsx
@@ -62,10 +62,10 @@ describe("DemonstrationDialog", () => {
     },
   };
 
-  const getDemonstrationDialog = (mode: "create" | "edit" = "create") => {
+  const getDemonstrationDialog = (mode: "create" | "edit" = "create", isApproved?: boolean) => {
     return (
       <TestProvider mocks={[GET_USER_SELECT_OPTIONS_MOCK]}>
-        <DemonstrationDialog {...DEFAULT_PROPS} mode={mode} />
+        <DemonstrationDialog {...DEFAULT_PROPS} mode={mode} isApproved={isApproved} />
       </TestProvider>
     );
   };
@@ -129,9 +129,30 @@ describe("DemonstrationDialog", () => {
     expect(screen.getByTestId(EFFECTIVE_DATE_INPUT_TEST_ID)).toBeInTheDocument();
   });
 
+  it("renders effective date field in edit mode as required when approved", () => {
+    render(getDemonstrationDialog("edit", true));
+    const effectiveDateInput = screen.getByTestId(EFFECTIVE_DATE_INPUT_TEST_ID);
+    expect(effectiveDateInput).toBeInTheDocument();
+    expect(effectiveDateInput).toHaveAttribute("required");
+  });
+
   it("renders expiration date field in edit mode", () => {
     render(getDemonstrationDialog("edit"));
     expect(screen.getByTestId(EXPIRATION_DATE_INPUT_TEST_ID)).toBeInTheDocument();
+  });
+
+  it("renders expiration date field as required in edit mode and approved", () => {
+    render(getDemonstrationDialog("edit", true));
+    const expirationDateInput = screen.getByTestId(EXPIRATION_DATE_INPUT_TEST_ID);
+    expect(expirationDateInput).toBeInTheDocument();
+    expect(expirationDateInput).toHaveAttribute("required");
+  });
+
+  it("renders SDG division select field as required when in edit mode and approved", () => {
+    render(getDemonstrationDialog("edit", true));
+    const sdgSelect = screen.getByTestId(SDG_DIVISION_SELECT_TEST_ID);
+    expect(sdgSelect).toBeInTheDocument();
+    expect(sdgSelect).toHaveAttribute("required");
   });
 
   it("shows error when expiration date is before effective date", async () => {
@@ -265,17 +286,17 @@ describe("DemonstrationDialog", () => {
   describe("checkFormIsValid", () => {
     it("returns false if state is not selected", () => {
       const invalidForm = { ...DEFAULT_DEMONSTRATION, stateId: "" };
-      expect(checkFormIsValid(invalidForm)).toBe(false);
+      expect(checkFormIsValid(invalidForm, false)).toBe(false);
     });
 
     it("returns false if name is empty", () => {
       const invalidForm = { ...DEFAULT_DEMONSTRATION, name: "" };
-      expect(checkFormIsValid(invalidForm)).toBe(false);
+      expect(checkFormIsValid(invalidForm, false)).toBe(false);
     });
 
     it("returns false if project officer is not selected", () => {
       const invalidForm = { ...DEFAULT_DEMONSTRATION, projectOfficerId: "" };
-      expect(checkFormIsValid(invalidForm)).toBe(false);
+      expect(checkFormIsValid(invalidForm, false)).toBe(false);
     });
 
     it("returns false if expiration date is before effective date", () => {
@@ -284,7 +305,35 @@ describe("DemonstrationDialog", () => {
         effectiveDate: "2024-12-01",
         expirationDate: "2024-11-01",
       };
-      expect(checkFormIsValid(invalidForm)).toBe(false);
+      expect(checkFormIsValid(invalidForm, false)).toBe(false);
+    });
+
+    it("returns false if expiration date is missing when approved", () => {
+      const invalidForm = {
+        ...DEFAULT_DEMONSTRATION,
+        effectiveDate: "2024-11-01",
+        expirationDate: "",
+      };
+      expect(checkFormIsValid(invalidForm, true)).toBe(false);
+    });
+
+    it("returns false if effective date is missing when approved", () => {
+      const invalidForm = {
+        ...DEFAULT_DEMONSTRATION,
+        effectiveDate: "",
+        expirationDate: "2024-12-01",
+      };
+      expect(checkFormIsValid(invalidForm, true)).toBe(false);
+    });
+
+    it("returns false if SDG division is missing when approved", () => {
+      const invalidForm = {
+        ...DEFAULT_DEMONSTRATION,
+        effectiveDate: "2024-11-01",
+        expirationDate: "2024-12-01",
+        sdgDivision: undefined,
+      };
+      expect(checkFormIsValid(invalidForm, true)).toBe(false);
     });
 
     it("returns true for a valid form", () => {
@@ -295,8 +344,9 @@ describe("DemonstrationDialog", () => {
         projectOfficerId: "officer-123",
         effectiveDate: "2024-11-01",
         expirationDate: "2024-12-01",
+        sdgDivision: "Division of System Reform Demonstrations" as SdgDivision,
       };
-      expect(checkFormIsValid(validForm)).toBe(true);
+      expect(checkFormIsValid(validForm, true)).toBe(true);
     });
   });
 

--- a/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import { BaseDialog } from "components/dialog/BaseDialog";
 import { Textarea } from "components/input";
@@ -9,7 +9,7 @@ import { SelectUsers } from "components/input/select/SelectUsers";
 import { TextInput } from "components/input/TextInput";
 import { Demonstration, SignatureLevel } from "demos-server";
 import { DatePicker } from "components/input/date/DatePicker";
-import { EXPIRATION_DATE_ERROR_MESSAGE } from "util/messages";
+import { EXPIRATION_DATE_ERROR_MESSAGE, getRequiredFieldWhenApprovedMessage } from "util/messages";
 import { SubmitButton } from "components/button/SubmitButton";
 import { isBefore } from "date-fns";
 import { Input } from "components/input/Input";
@@ -54,44 +54,43 @@ const DemonstrationDescriptionTextArea: React.FC<{
 };
 
 const DateInputs: React.FC<{
+  isApproved: boolean;
   effectiveDate: string;
   expirationDate: string;
   setEffectiveDate: (date: string) => void;
   setExpirationDate: (date: string) => void;
-}> = ({ effectiveDate, expirationDate, setEffectiveDate, setExpirationDate }) => {
-  const [errorMessage, setErrorMessage] = useState<string>("");
-
-  // Validate expiration date is after effective date
-  useEffect(() => {
-    if (expirationDate && effectiveDate && isBefore(expirationDate, effectiveDate)) {
-      setErrorMessage(EXPIRATION_DATE_ERROR_MESSAGE);
-    } else {
-      setErrorMessage("");
-    }
-  }, [effectiveDate, expirationDate]);
-
-  return (
-    <>
-      <div className="flex flex-col gap-xs">
-        <DatePicker
-          name="datepicker-effective-date"
-          label="Effective Date"
-          value={effectiveDate}
-          onChange={(newDate) => setEffectiveDate(newDate)}
-        />
-      </div>
-      <div className="flex flex-col gap-xs">
-        <DatePicker
-          name="datepicker-expiration-date"
-          label="Expiration Date"
-          value={expirationDate}
-          onChange={(newDate) => setExpirationDate(newDate)}
-          getValidationMessage={() => errorMessage}
-        />
-      </div>
-    </>
-  );
-};
+}> = ({ isApproved, effectiveDate, expirationDate, setEffectiveDate, setExpirationDate }) => (
+  <>
+    <div className="flex flex-col gap-xs">
+      <DatePicker
+        isRequired={isApproved}
+        name="datepicker-effective-date"
+        label="Effective Date"
+        value={effectiveDate}
+        onChange={(newDate) => setEffectiveDate(newDate)}
+        getValidationMessage={() =>
+          isApproved && !effectiveDate ? getRequiredFieldWhenApprovedMessage("Effective Date") : ""
+        }
+      />
+    </div>
+    <div className="flex flex-col gap-xs">
+      <DatePicker
+        isRequired={isApproved}
+        name="datepicker-expiration-date"
+        label="Expiration Date"
+        value={expirationDate}
+        onChange={(newDate) => setExpirationDate(newDate)}
+        getValidationMessage={() =>
+          isApproved && !expirationDate
+            ? getRequiredFieldWhenApprovedMessage("Expiration Date")
+            : expirationDate && effectiveDate && isBefore(expirationDate, effectiveDate)
+              ? EXPIRATION_DATE_ERROR_MESSAGE
+              : ""
+        }
+      />
+    </div>
+  </>
+);
 
 export const checkFormHasChanges = (
   initialDemonstration: DemonstrationDialogFields,
@@ -109,7 +108,7 @@ export const checkFormHasChanges = (
   );
 };
 
-export const checkFormIsValid = (demonstration: DemonstrationDialogFields) => {
+export const checkFormIsValid = (demonstration: DemonstrationDialogFields, isApproved: boolean) => {
   if (!demonstration.name) {
     return false;
   }
@@ -117,6 +116,12 @@ export const checkFormIsValid = (demonstration: DemonstrationDialogFields) => {
     return false;
   }
   if (!demonstration.projectOfficerId) {
+    return false;
+  }
+  if (
+    isApproved &&
+    (!demonstration.effectiveDate || !demonstration.expirationDate || !demonstration.sdgDivision)
+  ) {
     return false;
   }
   if (
@@ -132,13 +137,12 @@ export const checkFormIsValid = (demonstration: DemonstrationDialogFields) => {
 export const DemonstrationDialog: React.FC<{
   onClose: () => void;
   mode: DemonstrationDialogMode;
+  isApproved?: boolean;
   initialDemonstration: DemonstrationDialogFields;
   onSubmit: (demonstration: DemonstrationDialogFields) => Promise<void>;
-}> = ({ onClose, mode, initialDemonstration, onSubmit }) => {
+}> = ({ onClose, mode, isApproved = false, initialDemonstration, onSubmit }) => {
   const [activeDemonstration, setActiveDemonstration] = useState(initialDemonstration);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-  const [formHasChanges, setFormHasChanges] = useState<boolean>(false);
-  const [formIsValid, setFormIsValid] = useState<boolean>(false);
 
   const handleSubmit = async () => {
     setIsSubmitting(true);
@@ -146,11 +150,7 @@ export const DemonstrationDialog: React.FC<{
     setIsSubmitting(false);
   };
 
-  const handleChange = (updatedDemonstration: DemonstrationDialogFields) => {
-    setActiveDemonstration(updatedDemonstration);
-    setFormHasChanges(checkFormHasChanges(initialDemonstration, updatedDemonstration));
-    setFormIsValid(checkFormIsValid(updatedDemonstration));
-  };
+  const formHasChanges = checkFormHasChanges(initialDemonstration, activeDemonstration);
 
   return (
     <BaseDialog
@@ -161,7 +161,7 @@ export const DemonstrationDialog: React.FC<{
       actionButton={
         <SubmitButton
           name={"button-submit-demonstration-dialog"}
-          disabled={!formHasChanges || !formIsValid}
+          disabled={!formHasChanges || !checkFormIsValid(activeDemonstration, isApproved)}
           isSubmitting={isSubmitting}
           onClick={handleSubmit}
         />
@@ -174,7 +174,7 @@ export const DemonstrationDialog: React.FC<{
               label="State/Territory"
               value={activeDemonstration.stateId}
               isRequired
-              onSelect={(stateId) => handleChange({ ...activeDemonstration, stateId })}
+              onSelect={(stateId) => setActiveDemonstration({ ...activeDemonstration, stateId })}
             />
           ) : (
             <Input
@@ -195,7 +195,9 @@ export const DemonstrationDialog: React.FC<{
               isRequired
               placeholder="Enter title"
               value={activeDemonstration.name}
-              onChange={(e) => handleChange({ ...activeDemonstration, name: e.target.value })}
+              onChange={(e) =>
+                setActiveDemonstration({ ...activeDemonstration, name: e.target.value })
+              }
             />
           </div>
         </div>
@@ -207,20 +209,21 @@ export const DemonstrationDialog: React.FC<{
               isRequired={true}
               value={activeDemonstration.projectOfficerId}
               onSelect={(projectOfficerId) =>
-                handleChange({ ...activeDemonstration, projectOfficerId })
+                setActiveDemonstration({ ...activeDemonstration, projectOfficerId })
               }
               personTypes={["demos-admin", "demos-cms-user"]}
             />
           </div>
           {mode === "edit" && (
             <DateInputs
+              isApproved={isApproved}
               effectiveDate={activeDemonstration.effectiveDate}
               expirationDate={activeDemonstration.expirationDate}
               setEffectiveDate={(effectiveDate) =>
-                handleChange({ ...activeDemonstration, effectiveDate })
+                setActiveDemonstration({ ...activeDemonstration, effectiveDate })
               }
               setExpirationDate={(expirationDate) =>
-                handleChange({ ...activeDemonstration, expirationDate })
+                setActiveDemonstration({ ...activeDemonstration, expirationDate })
               }
             />
           )}
@@ -229,20 +232,34 @@ export const DemonstrationDialog: React.FC<{
         <div className="flex flex-col gap-xs">
           <DemonstrationDescriptionTextArea
             description={activeDemonstration.description}
-            setDescription={(description) => handleChange({ ...activeDemonstration, description })}
+            setDescription={(description) =>
+              setActiveDemonstration({ ...activeDemonstration, description })
+            }
           />
         </div>
 
         <div className="grid grid-cols-2 gap-2">
-          <SelectSdgDivision
-            initialValue={activeDemonstration.sdgDivision}
-            onSelect={(sdgDivision) => handleChange({ ...activeDemonstration, sdgDivision })}
-          />
+          <div className="flex flex-col gap-xs">
+            <SelectSdgDivision
+              isRequired={isApproved}
+              initialValue={activeDemonstration.sdgDivision}
+              onSelect={(sdgDivision) =>
+                setActiveDemonstration({ ...activeDemonstration, sdgDivision })
+              }
+            />
+            {isApproved && !activeDemonstration.sdgDivision && (
+              <span className="text-text-warn text-sm">
+                {getRequiredFieldWhenApprovedMessage("SDG Division")}
+              </span>
+            )}
+          </div>
           <SelectSignatureLevel
             initialValue={DEFAULT_DEMONSTRATION_SIGNATURE_LEVEL}
             allowedSignatureLevels={["OA"]}
             isDisabled
-            onSelect={(signatureLevel) => handleChange({ ...activeDemonstration, signatureLevel })}
+            onSelect={(signatureLevel) =>
+              setActiveDemonstration({ ...activeDemonstration, signatureLevel })
+            }
           />
         </div>
       </form>

--- a/client/src/components/dialog/demonstration/EditDemonstrationDialog.test.tsx
+++ b/client/src/components/dialog/demonstration/EditDemonstrationDialog.test.tsx
@@ -292,6 +292,11 @@ describe("getUpdateDemonstrationInput", () => {
     expect(result.expirationDate).toBeNull();
   });
 
+  it("passes null for sdgDivision when not provided", () => {
+    const result = getUpdateDemonstrationInput(BASE_DEMONSTRATION);
+    expect(result.sdgDivision).toBeNull();
+  });
+
   it("trims whitespace from description", () => {
     const result = getUpdateDemonstrationInput({
       ...BASE_DEMONSTRATION,

--- a/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
@@ -2,46 +2,94 @@ import React from "react";
 
 import { Loading } from "components/loading/Loading";
 import { useToast } from "components/toast";
-import { Demonstration, LocalDate, UpdateDemonstrationInput } from "demos-server";
+import {
+  Demonstration as ServerDemonstration,
+  LocalDate,
+  UpdateDemonstrationInput,
+  State as ServerState,
+  Person as ServerPerson,
+  DemonstrationRoleAssignment as ServerDemonstrationRoleAssignment,
+} from "demos-server";
 import { DEMONSTRATION_DETAIL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
 import { formatDateForServer } from "util/formatDate";
 
-import { gql, useMutation, useQuery } from "@apollo/client";
+import { gql, TypedDocumentNode, useMutation, useQuery } from "@apollo/client";
 
 import { DemonstrationDialog, DemonstrationDialogFields } from "./DemonstrationDialog";
 
 const SUCCESS_MESSAGE = "Your demonstration has been updated.";
 const ERROR_MESSAGE = "Your demonstration was not updated because of an unknown problem.";
 
-export const GET_DEMONSTRATION_BY_ID_QUERY = gql`
-  query GetDemonstrationById($id: ID!) {
+type Demonstration = Pick<
+  ServerDemonstration,
+  | "id"
+  | "name"
+  | "description"
+  | "status"
+  | "sdgDivision"
+  | "signatureLevel"
+  | "effectiveDate"
+  | "expirationDate"
+> & {
+  state: Pick<ServerState, "id">;
+  primaryProjectOfficer: Pick<ServerPerson, "id">;
+};
+
+export const GET_DEMONSTRATION_BY_ID_QUERY: TypedDocumentNode<
+  {
+    demonstration: Demonstration;
+  },
+  {
+    id: string;
+  }
+> = gql`
+  query EditDemonstrationDialog($id: ID!) {
     demonstration(id: $id) {
       id
       name
       description
+      status
       sdgDivision
       signatureLevel
+      effectiveDate
+      expirationDate
       state {
         id
       }
       primaryProjectOfficer {
         id
       }
-      effectiveDate
-      expirationDate
     }
   }
 `;
 
-export const UPDATE_DEMONSTRATION_MUTATION = gql`
+export const UPDATE_DEMONSTRATION_MUTATION: TypedDocumentNode<
+  {
+    demonstration: Demonstration & {
+      roles: (Pick<ServerDemonstrationRoleAssignment, "isPrimary" | "role"> & {
+        person: Pick<ServerPerson, "id">;
+      })[];
+    };
+  },
+  {
+    id: string;
+    input: UpdateDemonstrationInput;
+  }
+> = gql`
   mutation UpdateDemonstration($id: ID!, $input: UpdateDemonstrationInput!) {
     updateDemonstration(id: $id, input: $input) {
       id
       name
       description
+      status
       sdgDivision
       signatureLevel
+      effectiveDate
+      expirationDate
       state {
+        id
+      }
+      primaryProjectOfficer {
         id
       }
       roles {
@@ -51,11 +99,6 @@ export const UPDATE_DEMONSTRATION_MUTATION = gql`
           id
         }
       }
-      primaryProjectOfficer {
-        id
-      }
-      effectiveDate
-      expirationDate
     }
   }
 `;
@@ -71,7 +114,7 @@ export const getUpdateDemonstrationInput = (
     description: demonstration.description?.trim(),
     effectiveDate: (demonstration.effectiveDate as LocalDate) || null,
     expirationDate: (demonstration.expirationDate as LocalDate) || null,
-    sdgDivision: demonstration.sdgDivision,
+    sdgDivision: demonstration.sdgDivision || null,
   };
 };
 
@@ -142,6 +185,7 @@ export const EditDemonstrationDialog: React.FC<{
         <DemonstrationDialog
           onClose={onClose}
           mode="edit"
+          isApproved={data.demonstration.status === "Approved"}
           onSubmit={onSubmit}
           initialDemonstration={getDemonstrationDialogFields(data.demonstration)}
         />

--- a/client/src/util/messages.ts
+++ b/client/src/util/messages.ts
@@ -2,6 +2,8 @@ import { PhaseName } from "demos-server";
 
 // Demonstration
 export const EXPIRATION_DATE_ERROR_MESSAGE = "Expiration Date cannot be before Effective Date.";
+export const getRequiredFieldWhenApprovedMessage = (fieldName: string) =>
+  `${fieldName} is required when the application is approved.`;
 
 // Document Messages
 export const DOCUMENT_UPLOADED_MESSAGE = "Your document has been added.";

--- a/server/src/model/demonstration/demonstrationSchema.ts
+++ b/server/src/model/demonstration/demonstrationSchema.ts
@@ -121,6 +121,6 @@ export interface UpdateDemonstrationInput {
   description?: string;
   effectiveDate?: DateTimeOrLocalDate | null;
   expirationDate?: DateTimeOrLocalDate | null;
-  sdgDivision?: SdgDivision;
+  sdgDivision?: SdgDivision | null;
   projectOfficerUserId?: string;
 }


### PR DESCRIPTION
part 1 of 2.  This covers the demonstration edit modal; the same changes will need to be done to the edit modifications modal. 

Two main changes: 
1) when a demonstration is not approved, the user should be allowed to update the sdg division, effective date, and expiration date freely. This includes unsetting those fields. Support only needed to be added for unsetting the sdg division. 
2) when a demonstration _is_ approved, the sdg division, expiration date, and effective dates should be considered required fields, disallowing their unsetting. 

small cleanups as well. I tried looking at a larger refactor here, cause the create and edit modals have diverged and the introduction of a isApproved variable just adds another dimension to it. But it ended up looking like a rabbithole, so while i definitely think we need a refactor here (separate out create/edit, purge unneeded state variables, control flow concerns), it can probably wait till post mvp. 


https://github.com/user-attachments/assets/09cb374b-f9a7-4a4d-928a-1c532bb66691

