### PR TITLE
Upgrade client npm packages

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,11 +10,11 @@
       "dependencies": {
         "@tanstack/react-table": "^8.21.3",
         "@testing-library/user-event": "^14.6.1",
-        "date-fns": "^4.3.0",
+        "date-fns": "^4.4.0",
         "demos-shared-library": "file:../shared_library",
         "file-type": "^21.3.4",
         "react-oidc-context": "^3.3.1",
-        "react-router-dom": "^7.15.1",
+        "react-router-dom": "^7.17.0",
         "react-switch": "^7.1.0"
       },
       "devDependencies": {
@@ -28,32 +28,32 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/jest": "^29.5.14",
-        "@types/react": "^19.2.15",
+        "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.7.0",
-        "@vitest/coverage-v8": "^4.1.7",
+        "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.5.0",
         "jsdom": "^26.1.0",
         "prettier": "^3.8.3",
-        "react": "^19.2.6",
-        "react-dom": "^19.2.6",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "react-idle-timer": "^5.7.3",
         "tailwindcss": "^4.3.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.59.4",
-        "vite": "^6.4.2",
+        "typescript-eslint": "^8.60.1",
+        "vite": "^6.4.3",
         "vite-bundle-visualizer": "^1.2.1",
         "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "^4.1.7",
+        "vitest": "^4.1.8",
         "vitest-sonar-reporter": "^3.0.0"
       },
       "optionalDependencies": {
-        "@emnapi/core": "^1.10.0",
-        "@rollup/rollup-linux-x64-musl": "^4.60.4"
+        "@emnapi/core": "^1.11.0",
+        "@rollup/rollup-linux-x64-musl": "^4.61.1"
       }
     },
     "../shared_library": {
@@ -603,20 +603,20 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2440,9 +2440,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.16",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
-      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -14,27 +14,27 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^29.5.14",
-    "@types/react": "^19.2.15",
+    "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.7.0",
-    "@vitest/coverage-v8": "^4.1.7",
+    "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.5.0",
     "jsdom": "^26.1.0",
     "prettier": "^3.8.3",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "react-idle-timer": "^5.7.3",
     "tailwindcss": "^4.3.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.59.4",
-    "vite": "^6.4.2",
+    "typescript-eslint": "^8.60.1",
+    "vite": "^6.4.3",
     "vite-bundle-visualizer": "^1.2.1",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^4.1.7",
+    "vitest": "^4.1.8",
     "vitest-sonar-reporter": "^3.0.0"
   },
   "browserslist": {
@@ -81,15 +81,15 @@
   "dependencies": {
     "@tanstack/react-table": "^8.21.3",
     "@testing-library/user-event": "^14.6.1",
-    "date-fns": "^4.3.0",
+    "date-fns": "^4.4.0",
     "demos-shared-library": "file:../shared_library",
     "file-type": "^21.3.4",
     "react-oidc-context": "^3.3.1",
-    "react-router-dom": "^7.15.1",
+    "react-router-dom": "^7.17.0",
     "react-switch": "^7.1.0"
   },
   "optionalDependencies": {
-    "@emnapi/core": "^1.10.0",
-    "@rollup/rollup-linux-x64-musl": "^4.60.4"
+    "@emnapi/core": "^1.11.0",
+    "@rollup/rollup-linux-x64-musl": "^4.61.1"
   }
 }


### PR DESCRIPTION
## Minor and patch updates

All available *minor* and *patch* updates have been installed. See diff for details.

## Major updates are available

The following packages were not updated, but have major version updates available: 
```Checking /home/jenkins/agent/workspace/npm-updates/client/package.json

Major   Potentially breaking API changes
 @apollo/client         ^3.14.1  →   ^4.2.2  [cooldown] 4.2.3
 @eslint/js             ^9.39.4  →  ^10.0.1
 @faker-js/faker         ^9.9.0  →  ^10.4.0
 @types/jest           ^29.5.14  →  ^30.0.0
 @vitejs/plugin-react    ^4.7.0  →   ^6.0.2
 eslint                 ^9.39.4  →  ^10.4.1  [cooldown] 10.5.0
 file-type              ^21.3.4  →  ^22.0.1
 globals                ^16.5.0  →  ^17.6.0
 jsdom                  ^26.1.0  →  ^29.1.1
 typescript              ^5.9.3  →   ^6.0.3
 vite                    ^6.4.3  →  ^8.0.16
 vite-tsconfig-paths     ^5.1.4  →   ^6.1.1

```