### PR TITLE
Upgrade lambdas/authorizer npm packages

### DIFF
--- a/lambdas/authorizer/package-lock.json
+++ b/lambdas/authorizer/package-lock.json
@@ -13,11 +13,11 @@
         "pino": "^10.3.1"
       },
       "devDependencies": {
-        "@types/aws-lambda": "^8.10.161",
-        "@vitest/coverage-v8": "^4.1.7",
+        "@types/aws-lambda": "^8.10.162",
+        "@vitest/coverage-v8": "^4.1.8",
         "esbuild": "^0.28.0",
         "typescript": "^5.9.3",
-        "vitest": "^4.1.7"
+        "vitest": "^4.1.8"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -920,9 +920,9 @@
       }
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.161",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
-      "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
+      "version": "8.10.162",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.162.tgz",
+      "integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==",
       "dev": true,
       "license": "MIT"
     },

--- a/lambdas/authorizer/package.json
+++ b/lambdas/authorizer/package.json
@@ -11,10 +11,10 @@
     "pino": "^10.3.1"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.161",
-    "@vitest/coverage-v8": "^4.1.7",
+    "@types/aws-lambda": "^8.10.162",
+    "@vitest/coverage-v8": "^4.1.8",
     "esbuild": "^0.28.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.8"
   }
 }


### PR DESCRIPTION
## Minor and patch updates

All available *minor* and *patch* updates have been installed. See diff for details.

## Major updates are available

The following packages were not updated, but have major version updates available: 
```Checking /home/jenkins/agent/workspace/npm-updates/lambdas/authorizer/package.json

Major   Potentially breaking API changes
 jwks-rsa    ^3.2.2  →  ^4.0.1
 typescript  ^5.9.3  →  ^6.0.3

```