### PR TITLE
DEMOS-2271: made tab selection default from query param

### DIFF
--- a/client/src/pages/DemonstrationDetail/DemonstrationDetail.test.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetail.test.tsx
@@ -113,6 +113,7 @@ describe("DemonstrationDetail", () => {
     expect(AmendmentsTab).toHaveBeenCalledWith(
       expect.objectContaining({
         demonstrationId: "1",
+        selectedAmendmentId: "amendment-1",
       }),
       undefined
     );
@@ -130,6 +131,7 @@ describe("DemonstrationDetail", () => {
     expect(ExtensionsTab).toHaveBeenCalledWith(
       expect.objectContaining({
         demonstrationId: "1",
+        selectedExtensionId: "extension-1",
       }),
       undefined
     );

--- a/client/src/pages/DemonstrationDetail/DemonstrationDetail.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetail.tsx
@@ -217,6 +217,7 @@ export const DemonstrationDetail: React.FC = () => {
                 demonstrationId={demonstration.id}
                 medicaidId={demonstration.medicaidId}
                 amendments={demonstration.amendments}
+                selectedAmendmentId={amendmentParam || undefined}
               />
             </Tab>
 
@@ -229,6 +230,7 @@ export const DemonstrationDetail: React.FC = () => {
                 demonstrationId={demonstration.id}
                 medicaidId={demonstration.medicaidId}
                 extensions={demonstration.extensions}
+                selectedExtensionId={extensionParam || undefined}
               />
             </Tab>
           </Tabs>

--- a/client/src/pages/DemonstrationDetail/modifications/AmendmentsTab.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/AmendmentsTab.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { AmendmentsTab } from "./AmendmentsTab";
+import { ModificationTabs } from "./ModificationTabs";
 
 const showCreateAmendmentDialog = vi.fn();
 vi.mock("components/dialog/DialogContext", () => ({
@@ -10,13 +11,24 @@ vi.mock("components/dialog/DialogContext", () => ({
   }),
 }));
 
+vi.mock("./ModificationTabs", () => ({
+  ModificationTabs: vi.fn(() => <div data-testid="modification-tabs">Modification Tabs</div>),
+}));
+
 describe("AmendmentsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   const renderAmendmentsTab = () => {
-    return render(<AmendmentsTab demonstrationId="mock-demonstration-id" medicaidId="mock-medicaid-id" amendments={[]} />);
+    return render(
+      <AmendmentsTab
+        demonstrationId="mock-demonstration-id"
+        medicaidId="mock-medicaid-id"
+        amendments={[]}
+        selectedAmendmentId="mock-amendment-id"
+      />
+    );
   };
 
   it("shows amendments tab title", async () => {
@@ -40,5 +52,19 @@ describe("AmendmentsTab", () => {
     await fireEvent.click(addButton);
 
     expect(showCreateAmendmentDialog).toHaveBeenCalledWith("mock-demonstration-id");
+  });
+
+  it("passes the selected amendment to ModificationTabs", async () => {
+    renderAmendmentsTab();
+
+    expect(ModificationTabs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [],
+        selectedItemId: "mock-amendment-id",
+      }),
+      undefined
+    );
+
+    expect(screen.getByTestId("modification-tabs")).toBeInTheDocument();
   });
 });

--- a/client/src/pages/DemonstrationDetail/modifications/AmendmentsTab.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/AmendmentsTab.tsx
@@ -9,7 +9,8 @@ export const AmendmentsTab: React.FC<{
   demonstrationId: string;
   medicaidId: string;
   amendments: DemonstrationDetailModification[];
-}> = ({ demonstrationId, medicaidId, amendments }) => {
+  selectedAmendmentId?: string;
+}> = ({ demonstrationId, medicaidId, amendments, selectedAmendmentId }) => {
   const { showCreateAmendmentDialog } = useDialog();
 
   const amendmentsWithType = amendments.map((amendment) => ({
@@ -31,7 +32,7 @@ export const AmendmentsTab: React.FC<{
           Add Amendment
         </IconButton>
       </div>
-      <ModificationTabs items={amendmentsWithType} />
+      <ModificationTabs items={amendmentsWithType} selectedItemId={selectedAmendmentId} />
     </div>
   );
 };

--- a/client/src/pages/DemonstrationDetail/modifications/ExtensionsTab.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ExtensionsTab.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { ExtensionsTab } from "./ExtensionsTab";
+import { ModificationTabs } from "./ModificationTabs";
 
 const showCreateExtensionDialog = vi.fn();
 vi.mock("components/dialog/DialogContext", () => ({
@@ -10,13 +11,24 @@ vi.mock("components/dialog/DialogContext", () => ({
   }),
 }));
 
+vi.mock("./ModificationTabs", () => ({
+  ModificationTabs: vi.fn(() => <div data-testid="modification-tabs">Modification Tabs</div>),
+}));
+
 describe("ExtensionsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   const renderExtensionsTab = () => {
-    return render(<ExtensionsTab demonstrationId="mock-demonstration-id" medicaidId="mock-medicaid-id" extensions={[]} />);
+    return render(
+      <ExtensionsTab
+        demonstrationId="mock-demonstration-id"
+        medicaidId="mock-medicaid-id"
+        extensions={[]}
+        selectedExtensionId="mock-extension-id"
+      />
+    );
   };
 
   it("shows extensions tab title", async () => {
@@ -40,5 +52,19 @@ describe("ExtensionsTab", () => {
     await fireEvent.click(addButton);
 
     expect(showCreateExtensionDialog).toHaveBeenCalledWith("mock-demonstration-id");
+  });
+
+  it("passes the selected extension to ModificationTabs", async () => {
+    renderExtensionsTab();
+
+    expect(ModificationTabs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [],
+        selectedItemId: "mock-extension-id",
+      }),
+      undefined
+    );
+
+    expect(screen.getByTestId("modification-tabs")).toBeInTheDocument();
   });
 });

--- a/client/src/pages/DemonstrationDetail/modifications/ExtensionsTab.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ExtensionsTab.tsx
@@ -9,7 +9,8 @@ export const ExtensionsTab: React.FC<{
   demonstrationId: string;
   medicaidId: string;
   extensions: DemonstrationDetailModification[];
-}> = ({ demonstrationId, medicaidId, extensions }) => {
+  selectedExtensionId?: string;
+}> = ({ demonstrationId, medicaidId, extensions, selectedExtensionId }) => {
   const extensionsWithType = extensions.map((extension) => ({
     ...extension,
     modificationType: "extension" as const,
@@ -30,7 +31,7 @@ export const ExtensionsTab: React.FC<{
           Add Extension
         </IconButton>
       </div>
-      <ModificationTabs items={extensionsWithType} />
+      <ModificationTabs items={extensionsWithType} selectedItemId={selectedExtensionId} />
     </div>
   );
 };

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.test.tsx
@@ -70,6 +70,22 @@ describe("ModificationTabs Component", () => {
     expect(tab2Button).toHaveAttribute("aria-selected", "true");
   });
 
+  it("sets the selected tab based on selectedItemId prop on initial render", () => {
+    render(
+      <DialogProvider>
+        <TestProvider>
+          <ModificationTabs items={mockItems} selectedItemId="2" />
+        </TestProvider>
+      </DialogProvider>
+    );
+
+    const tab1Button = screen.getByTestId("modification-tab-1");
+    const tab2Button = screen.getByTestId("modification-tab-2");
+
+    expect(tab1Button).toHaveAttribute("aria-selected", "false");
+    expect(tab2Button).toHaveAttribute("aria-selected", "true");
+  });
+
   it("renders nothing when items array is empty", () => {
     const { container } = render(
       <DialogProvider>
@@ -129,5 +145,21 @@ describe("ModificationTabs Component", () => {
     expect(tabButtons[0]).toHaveTextContent("Second");
     expect(tabButtons[1]).toHaveTextContent("First");
     expect(tabButtons[2]).toHaveTextContent("Third");
+  });
+
+  it("initially selects the tab based on selectedItemId prop", () => {
+    render(
+      <DialogProvider>
+        <TestProvider>
+          <ModificationTabs items={mockItems} selectedItemId="2" />
+        </TestProvider>
+      </DialogProvider>
+    );
+
+    const tab1Button = screen.getByTestId("modification-tab-1");
+    const tab2Button = screen.getByTestId("modification-tab-2");
+
+    expect(tab1Button).toHaveAttribute("aria-selected", "false");
+    expect(tab2Button).toHaveAttribute("aria-selected", "true");
   });
 });

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.tsx
@@ -45,13 +45,24 @@ const sortTabsNewestFirst = (items: ModificationItem[]): ModificationItem[] => {
   });
 };
 
-export const ModificationTabs = ({ items }: { items: ModificationItem[] }) => {
+export const ModificationTabs = ({
+  items,
+  selectedItemId,
+}: {
+  items: ModificationItem[];
+  selectedItemId?: string;
+}) => {
   if (items.length === 0) {
     return null;
   }
 
   const sortedItems = sortTabsNewestFirst(items);
-  const [selectedId, setSelectedId] = useState<string>(sortedItems[0]?.id ?? "");
+  const [selectedId, setSelectedId] = useState<string>(() => {
+    if (selectedItemId && sortedItems.map((item) => item.id).includes(selectedItemId)) {
+      return selectedItemId;
+    }
+    return sortedItems[0]?.id || "";
+  });
   const [selectedItem, setSelectedItem] = useState<ModificationItem>(sortedItems[0]);
 
   useEffect(() => {


### PR DESCRIPTION
This change makes it so the demonstration details page loads with the amendment/extension preselected that has been passed in as a query param. if its not found, or otherwise doesnt exist on the list of amendments or extensions, it defaults to the first item. Just passes along the query param it gets at the base load of the details page. 

https://github.com/user-attachments/assets/8f2528ff-60f3-4fef-874f-e23b1e25797c

