### PR TITLE
DEMOS-2221 — Comments panel spacing/alignment

### DIFF
--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -328,7 +328,7 @@ export const DeliverableDetailsManagementPage: React.FC<{
           <div className="flex-1">
             <FileAndHistoryTabs deliverable={data.deliverable} />
           </div>
-          <div>
+          <div className="self-start">
             <CommentBox deliverableId={data.deliverable.id} />
           </div>
         </div>

--- a/client/src/pages/deliverables/sections/comment_box/CommentBox.tsx
+++ b/client/src/pages/deliverables/sections/comment_box/CommentBox.tsx
@@ -71,7 +71,7 @@ export const CommentBox = ({ deliverableId }: { deliverableId: string }) => {
 
   return (
     <div
-      className="flex flex-col gap-1 bg-gray-primary-layout p-1 min-h-full min-w-87.5 max-w-87.5"
+      className="flex flex-col gap-1 bg-gray-primary-layout p-1 min-w-87.5 max-w-87.5"
       data-testid={COMMENT_BOX_NAME}
     >
       <CommentBoxHeader onCollapse={() => setIsCollapsed(true)} />

--- a/client/src/pages/deliverables/sections/comment_box/CommentBoxTextArea.tsx
+++ b/client/src/pages/deliverables/sections/comment_box/CommentBoxTextArea.tsx
@@ -29,7 +29,7 @@ export const CommentBoxTextArea = ({
   const textareaLabel = commentVisibility === "public" ? "Comments" : "CMS Internal Comments";
 
   return (
-    <div className="flex-1 flex flex-col gap-1">
+    <div className="flex flex-col gap-1">
       <Textarea
         label={textareaLabel}
         value={currentComment}


### PR DESCRIPTION
The Comments panel stretched to fill the full parent height, and the textarea section absorbed the leftover space — leaving a large gap between the **Add Comment** button and **Comment History**.

## Fix
- Removed `min-h-full` from the panel container → panel is now auto-height and wraps its content.
- Removed `flex-1` from the textarea wrapper → input section sizes to its content instead of expanding.
- Added `self-start` to the panel's wrapper `<div>` so it hugs content height instead of being stretched by the flex row.


<img width="343" height="459" alt="image" src="https://github.com/user-attachments/assets/3b0707d3-1ccf-474e-aa71-30412ba432e0" />
