### PR TITLE
DEMOS-2244 — Disable dialog 'X' button while upload is in progress

### DIFF
--- a/client/src/components/dialog/BaseDialog.test.tsx
+++ b/client/src/components/dialog/BaseDialog.test.tsx
@@ -74,6 +74,18 @@ describe("BaseDialog", () => {
     expect(screen.queryByText("Cancel")).not.toBeInTheDocument();
   });
 
+  it("disables the close button and does not close when cancelButtonIsDisabled is true", () => {
+    const onClose = vi.fn();
+    render(<BaseDialog {...defaultProps} onClose={onClose} cancelButtonIsDisabled={true} />);
+    const closeBtn = screen.getByLabelText("Close dialog");
+    expect(closeBtn).toBeDisabled();
+    fireEvent.click(closeBtn);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText("You will lose any unsaved changes in this view.")
+    ).not.toBeInTheDocument();
+  });
+
   it("hides header when hideHeader is true", () => {
     render(<BaseDialog {...defaultProps} hideHeader={true} />);
     expect(screen.queryByText("Test Dialog")).not.toBeInTheDocument();

--- a/client/src/components/dialog/BaseDialog.tsx
+++ b/client/src/components/dialog/BaseDialog.tsx
@@ -20,6 +20,7 @@ interface BaseDialogProps {
 
 const DIALOG = tw`bg-surface-white text-text-font w-full rounded shadow-md p-md relative max-h-[85vh] overflow-y-auto space-y-sm backdrop:bg-black/40`;
 const CLOSE_BUTTON = tw`absolute top-xs right-sm text-[22px] text-text-placeholder hover:text-text-font cursor-pointer`;
+const CLOSE_BUTTON_DISABLED = tw`absolute top-xs right-sm text-[22px] text-text-placeholder/50 cursor-not-allowed`;
 const TITLE = tw`text-[18px] font-bold mb-xs`;
 const HR = tw`border-border-rules my-sm`;
 
@@ -89,7 +90,8 @@ export const BaseDialog: React.FC<BaseDialogProps> = ({
               data-testid="button-dialog-close"
               type="button"
               onClick={onCloseClicked}
-              className={CLOSE_BUTTON}
+              disabled={cancelButtonIsDisabled}
+              className={cancelButtonIsDisabled ? CLOSE_BUTTON_DISABLED : CLOSE_BUTTON}
               aria-label="Close dialog"
             >
               ×


### PR DESCRIPTION
During a document upload (progress-bar period), the Upload and Cancel buttons were disabled to prevent re-submitting, but the dialog's `X` close button stayed clickable — letting the user close the window mid-upload.

## Fix

The `X` button in `BaseDialog` now respects the existing `cancelButtonIsDisabled` prop, so it disables alongside the Cancel button. `DocumentDialog` already sets this prop to `documentDialogState === "uploading"`, so no caller changes were needed.


https://github.com/user-attachments/assets/cd007660-6959-460e-9738-d555883246cc