### PR TITLE
Update CSP to allow read-excel-file

### DIFF
--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -266,7 +266,7 @@ export class UiStack extends Stack {
             override: true,
           },
           contentSecurityPolicy: {
-            contentSecurityPolicy: `default-src 'self'; form-action 'self'; img-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; connect-src 'self' https://cognito-idp.${Aws.REGION}.amazonaws.com ${cognitoDomain} https://${uploadBucketName}.s3.us-east-1.amazonaws.com https://${cleanBucketName}.s3.us-east-1.amazonaws.com; frame-ancestors 'none'; object-src 'self' blob:; frame-src 'self' blob: ${cognitoDomain}`,
+            contentSecurityPolicy: `default-src 'self'; form-action 'self'; img-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; connect-src 'self' https://cognito-idp.${Aws.REGION}.amazonaws.com ${cognitoDomain} https://${uploadBucketName}.s3.us-east-1.amazonaws.com https://${cleanBucketName}.s3.us-east-1.amazonaws.com; frame-ancestors 'none'; object-src 'self' blob:; frame-src 'self' blob: ${cognitoDomain}; worker-src 'self' blob:;`,
             override: true,
           },
         },


### PR DESCRIPTION
Adds `worker-src 'self' blob:;` to the CSP to unblock `read-excel-file` during BN validation