### PR TITLE
DEMOS-1852-demo-type-report

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -528,5 +528,6 @@ export const ON_DEMAND_REPORT_TYPES = [
   "Deliverable Status Report",
   "Application Details Report",
   "Demonstration Overview Report",
+  "Demonstration Types Report",
 ] as const;
 export const ON_DEMAND_REPORT_STATUSES = ["Available"] as const;

--- a/server/src/model/migrations/20260616212836_add_demo_type_report/migration.sql
+++ b/server/src/model/migrations/20260616212836_add_demo_type_report/migration.sql
@@ -1,0 +1,4 @@
+INSERT INTO
+    demos_app.on_demand_report_type
+VALUES
+    ('Demonstration Types Report');

--- a/server/src/onDemandReports/configs/demonstrationOverviewReportConfig.ts
+++ b/server/src/onDemandReports/configs/demonstrationOverviewReportConfig.ts
@@ -13,7 +13,7 @@ import {
 } from "../../constants";
 import { usDateString, usDateStringOrDash } from "./onDemandReportCustomSchemaTypes";
 
-type demonstrationOverviewReportColumn =
+type DemonstrationOverviewReportColumn =
   | "state_territory"
   | "demonstration_title"
   | "demonstration_number"
@@ -59,7 +59,7 @@ export const demonstrationOverviewReportSchema = z
     state_pocs: z.string(),
     primary_monitoring_evaluation_tech_director: z.string(),
     application_approval_date: usDateStringOrDash,
-  } satisfies OnDemandReportColumnSchema<demonstrationOverviewReportColumn>)
+  } satisfies OnDemandReportColumnSchema<DemonstrationOverviewReportColumn>)
   .strict();
 
 export const demonstrationOverviewReportColumnHeaders = {
@@ -84,7 +84,7 @@ export const demonstrationOverviewReportColumnHeaders = {
   state_pocs: "State POCs",
   primary_monitoring_evaluation_tech_director: "Primary Monitoring & Evaluation Technical Director",
   application_approval_date: "Application Approval Date",
-} satisfies OnDemandReportColumnHeader<demonstrationOverviewReportColumn>;
+} satisfies OnDemandReportColumnHeader<DemonstrationOverviewReportColumn>;
 
 export const demonstrationOverviewReportConfiguration = {
   sqlQueries: demonstrationOverviewReportQueries,

--- a/server/src/onDemandReports/configs/demonstrationTypesReportConfig.ts
+++ b/server/src/onDemandReports/configs/demonstrationTypesReportConfig.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { APPLICATION_STATUS, STATES_AND_TERRITORIES } from "../../constants";
+import {
+  OnDemandReportColumnHeader,
+  OnDemandReportColumnSchema,
+  OnDemandReportConfiguration,
+} from "./onDemandReportConfigTypes";
+import { demonstrationTypesReportQueries } from "./demonstrationTypesReportQueries";
+import { usDateString, usDateStringOrDash } from "./onDemandReportCustomSchemaTypes";
+
+type DemonstrationTypesReportColumn =
+  | "state_territory"
+  | "demonstration_title"
+  | "demonstration_number"
+  | "chip_id"
+  | "status"
+  | "status_update_date"
+  | "demonstration_effective_date"
+  | "demonstration_expiration_date"
+  | "primary_project_officer"
+  | "primary_state_poc"
+  | "application_approval_date"
+  | "demonstration_type"
+  | "demonstration_type_effective_date"
+  | "demonstration_type_expiration_date";
+
+const demonstrationTypesReportSchema = z
+  .object({
+    state_territory: z.enum(STATES_AND_TERRITORIES.map((state) => state.id)),
+    demonstration_title: z.string(),
+    demonstration_number: z.string(),
+    chip_id: z.string(),
+    status: z.enum(APPLICATION_STATUS),
+    status_update_date: usDateString,
+    demonstration_effective_date: usDateString,
+    demonstration_expiration_date: usDateString,
+    primary_project_officer: z.string(),
+    primary_state_poc: z.string(),
+    application_approval_date: usDateStringOrDash,
+    demonstration_type: z.string(),
+    demonstration_type_effective_date: usDateString,
+    demonstration_type_expiration_date: usDateString,
+  } satisfies OnDemandReportColumnSchema<DemonstrationTypesReportColumn>)
+  .strict();
+
+const demonstrationTypesReportColumnHeaders = {
+  state_territory: "State/Territory",
+  demonstration_title: "Demonstration Title",
+  demonstration_number: "Demonstration Number",
+  chip_id: "CHIP ID",
+  status: "Status",
+  status_update_date: "Status Update Date",
+  demonstration_effective_date: "Demonstration Effective Date",
+  demonstration_expiration_date: "Demonstration Expiration Date",
+  primary_project_officer: "Primary Project Officer",
+  primary_state_poc: "Primary State POC",
+  application_approval_date: "Application Approval Date",
+  demonstration_type: "Demonstration Type",
+  demonstration_type_effective_date: "Demonstration Type Effective Date",
+  demonstration_type_expiration_date: "Demonstration Type Expiration Date",
+} satisfies OnDemandReportColumnHeader<DemonstrationTypesReportColumn>;
+
+export const demonstrationTypesReportConfiguration = {
+  sqlQueries: demonstrationTypesReportQueries,
+  reportRowSchema: demonstrationTypesReportSchema,
+  excelConfiguration: { columnNames: demonstrationTypesReportColumnHeaders },
+} satisfies OnDemandReportConfiguration;

--- a/server/src/onDemandReports/configs/demonstrationTypesReportQueries.ts
+++ b/server/src/onDemandReports/configs/demonstrationTypesReportQueries.ts
@@ -1,0 +1,68 @@
+const dataFetchQuery = `
+WITH primary_roles AS (
+    SELECT
+        p.first_name || ' ' || p.last_name AS full_name,
+        pdra.demonstration_id,
+        pdra.role_id
+    FROM
+        demos_app.primary_demonstration_role_assignment AS pdra
+    INNER JOIN
+        demos_app.person AS p
+        ON
+            pdra.person_id = p.id
+)
+
+SELECT
+    demo.state_id AS state_territory,
+    demo.name AS demonstration_title,
+    demo.medicaid_id AS demonstration_number,
+    coalesce(
+        max(CASE WHEN demo_type.tag_name_id = 'Children''s Health Insurance Program (CHIP)' THEN demo.chip_id END)
+            OVER (PARTITION BY demo_type.demonstration_id),
+        '-'
+    ) AS chip_id,
+    demo.status_id AS status,
+    to_char(demo.status_updated_at AT TIME ZONE 'America/New_York', 'MM/DD/YYYY') AS status_update_date,
+    to_char(demo.effective_date AT TIME ZONE 'America/New_York', 'MM/DD/YYYY') AS demonstration_effective_date,
+    to_char(demo.expiration_date AT TIME ZONE 'America/New_York', 'MM/DD/YYYY') AS demonstration_expiration_date,
+    primary_project_officer.full_name AS primary_project_officer,
+    coalesce(primary_state_poc.full_name, '-') AS primary_state_poc,
+    coalesce(to_char(app_date.date_value AT TIME ZONE 'America/New_York', 'MM/DD/YYYY'), '-')
+        AS application_approval_date,
+    demo_type.tag_name_id AS demonstration_type,
+    to_char(demo_type.effective_date AT TIME ZONE 'America/New_York', 'MM/DD/YYYY')
+        AS demonstration_type_effective_date,
+    to_char(demo_type.expiration_date AT TIME ZONE 'America/New_York', 'MM/DD/YYYY')
+        AS demonstration_type_expiration_date
+FROM
+    demos_app.demonstration_type_tag_assignment AS demo_type
+
+-- Almost by definition, demonstration types have demonstrations
+INNER JOIN
+    demos_app.demonstration AS demo
+    ON
+        demo_type.demonstration_id = demo.id
+
+-- Every demonstration has a primary project officer
+INNER JOIN
+    primary_roles AS primary_project_officer
+    ON
+        demo_type.demonstration_id = primary_project_officer.demonstration_id
+        AND primary_project_officer.role_id = 'Project Officer'
+
+-- Every demonstration not guaranteed to have state POC
+LEFT JOIN
+    primary_roles AS primary_state_poc
+    ON
+        demo_type.demonstration_id = primary_state_poc.demonstration_id
+        AND primary_state_poc.role_id = 'State Point of Contact'
+
+-- Not all demonstrations have an approval date
+LEFT JOIN
+    demos_app.application_date AS app_date
+    ON
+        demo_type.demonstration_id = app_date.application_id
+        AND app_date.date_type_id = 'Approval Summary Completion Date';
+`;
+
+export const demonstrationTypesReportQueries = [dataFetchQuery];

--- a/server/src/onDemandReports/configs/index.ts
+++ b/server/src/onDemandReports/configs/index.ts
@@ -5,12 +5,14 @@ import { basicTestReportConfiguration } from "./basicTestReportConfig";
 import { deliverableStatusReportConfiguration } from "./deliverableStatusReportConfig";
 import { applicationDetailsReportConfiguration } from "./applicationDetailsReportConfig";
 import { demonstrationOverviewReportConfiguration } from "./demonstrationOverviewReportConfig";
+import { demonstrationTypesReportConfiguration } from "./demonstrationTypesReportConfig";
 
 export const ON_DEMAND_REPORT_CONFIGURATIONS = {
   "Basic Test Report": basicTestReportConfiguration,
   "Deliverable Status Report": deliverableStatusReportConfiguration,
   "Application Details Report": applicationDetailsReportConfiguration,
   "Demonstration Overview Report": demonstrationOverviewReportConfiguration,
+  "Demonstration Types Report": demonstrationTypesReportConfiguration,
 } satisfies Record<OnDemandReportType, OnDemandReportConfiguration>;
 
 export function getOnDemandReportConfiguration<T extends OnDemandReportType>(


### PR DESCRIPTION
Implements the fourth of the major reports, the Demonstration Types Report. A minor typo is also corrected in the Demonstration Overview Report code (no actual report changes, just casing correctly on a type).

Like the report for #1459, we'll need to refactor ever so slightly once "Application Approval Date" is a supported date type; for now, this just reports the completion of Phase 8.