### PR TITLE
DEMOS-2318: prevented uploads and edits to finalized deliverable docu…

### DIFF
--- a/server/src/model/document/documentData.test.ts
+++ b/server/src/model/document/documentData.test.ts
@@ -289,12 +289,6 @@ describe("documentData", () => {
       vi.mocked(selectDocument).mockResolvedValueOnce(document);
 
       await editDocument(where, { name: "Updated Name" }, user);
-      expect(selectDocument).toHaveBeenCalledExactlyOnceWith(
-        {
-          AND: [where, authFilter],
-        },
-        undefined
-      );
       expect(validateDocumentCanBeUpdated).toHaveBeenCalledExactlyOnceWith(document.id);
     });
 

--- a/server/src/model/document/documentData.test.ts
+++ b/server/src/model/document/documentData.test.ts
@@ -8,6 +8,7 @@ import { PrismaTransactionClient } from "../../prismaClient";
 import { handleDeleteDocument } from "./handleDeleteDocument";
 import { validateDocumentCanBeDeleted } from "./validateDocumentCanBeDeleted";
 import { selectDeliverableOrThrow } from "../deliverable/queries/selectDeliverableOrThrow";
+import { validateDocumentCanBeUpdated } from "./validateDocumentCanBeUpdated";
 
 vi.mock("../../auth", () => ({
   buildAuthorizationFilter: vi.fn(),
@@ -35,6 +36,10 @@ vi.mock("./handleDeleteDocument", () => ({
 
 vi.mock("./validateDocumentCanBeDeleted", () => ({
   validateDocumentCanBeDeleted: vi.fn(),
+}));
+
+vi.mock("./validateDocumentCanBeUpdated", () => ({
+  validateDocumentCanBeUpdated: vi.fn(),
 }));
 
 describe("documentData", () => {
@@ -276,6 +281,21 @@ describe("documentData", () => {
         undefined
       );
       expect(result).toStrictEqual({ ...document, name: "Updated Name" });
+    });
+
+    it("validates that the document can be updated before updating", async () => {
+      const document = { id: "document-1" } as PrismaDocument;
+      vi.mocked(buildAuthorizationFilter).mockReturnValueOnce(authFilter);
+      vi.mocked(selectDocument).mockResolvedValueOnce(document);
+
+      await editDocument(where, { name: "Updated Name" }, user);
+      expect(selectDocument).toHaveBeenCalledExactlyOnceWith(
+        {
+          AND: [where, authFilter],
+        },
+        undefined
+      );
+      expect(validateDocumentCanBeUpdated).toHaveBeenCalledExactlyOnceWith(document.id);
     });
 
     it("passes transaction client to updateDocument if provided", async () => {

--- a/server/src/model/document/documentData.ts
+++ b/server/src/model/document/documentData.ts
@@ -8,6 +8,7 @@ import { selectDeliverableOrThrow } from "../deliverable/queries/selectDeliverab
 import { DeliverableStatus } from "../../constants";
 import { handleDeleteDocument } from "./handleDeleteDocument";
 import { validateDocumentCanBeDeleted } from "./validateDocumentCanBeDeleted";
+import { validateDocumentCanBeUpdated } from "./validateDocumentCanBeUpdated";
 
 const getViewPermissionFilters = (userId: string) =>
   ({
@@ -127,6 +128,7 @@ export async function editDocument(
     );
 
     if (authorizedDocument) {
+      await validateDocumentCanBeUpdated(authorizedDocument.id);
       return await updateDocument(where, data, tx);
     }
   }

--- a/server/src/model/document/validateDocumentCanBeUpdated.test.ts
+++ b/server/src/model/document/validateDocumentCanBeUpdated.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { validateDocumentCanBeUpdated } from "./validateDocumentCanBeUpdated";
+import { prisma } from "../../prismaClient";
+
+const mockDocumentId = "doc1";
+
+vi.mock("../../prismaClient", () => ({
+  prisma: vi.fn(),
+}));
+
+describe("validateDocumentCanBeUpdated", () => {
+  it("should throw an error if the document is part of a finalized deliverable", async () => {
+    vi.mocked(prisma).mockReturnValue({
+      document: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: mockDocumentId,
+          deliverable: {
+            statusId: "Accepted",
+          },
+        }),
+      },
+    } as never);
+
+    await expect(validateDocumentCanBeUpdated(mockDocumentId)).rejects.toThrow(
+      `Document with ID doc1 cannot be updated because its deliverable is in a finalized status of Accepted.`
+    );
+  });
+
+  it("should not throw an error if the document is not part of a finalized deliverable", async () => {
+    vi.mocked(prisma).mockReturnValue({
+      document: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: mockDocumentId,
+          deliverable: {
+            statusId: "Upcoming",
+          },
+        }),
+      },
+    } as never);
+
+    await expect(validateDocumentCanBeUpdated(mockDocumentId)).resolves.toBeUndefined();
+  });
+
+  it("should not throw an error when the document is not attached to a deliverable", async () => {
+    vi.mocked(prisma).mockReturnValue({
+      document: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: mockDocumentId,
+          deliverable: null,
+        }),
+      },
+    } as never);
+
+    await expect(validateDocumentCanBeUpdated(mockDocumentId)).resolves.toBeUndefined();
+  });
+});

--- a/server/src/model/document/validateDocumentCanBeUpdated.ts
+++ b/server/src/model/document/validateDocumentCanBeUpdated.ts
@@ -1,0 +1,21 @@
+import { FINAL_DELIVERABLE_STATUSES, FinalDeliverableStatus } from "../../constants";
+import { prisma } from "../../prismaClient";
+
+export async function validateDocumentCanBeUpdated(documentId: string) {
+  const document = await prisma().document.findUniqueOrThrow({
+    where: { id: documentId },
+    select: {
+      deliverable: true,
+    },
+  });
+
+  if (document.deliverable) {
+    if (
+      FINAL_DELIVERABLE_STATUSES.includes(document.deliverable.statusId as FinalDeliverableStatus)
+    ) {
+      throw new Error(
+        `Document with ID ${documentId} cannot be updated because its deliverable is in a finalized status of ${document.deliverable.statusId}.`
+      );
+    }
+  }
+}

--- a/server/src/model/documentPendingUpload/handleUploadDocumentToDeliverable.test.ts
+++ b/server/src/model/documentPendingUpload/handleUploadDocumentToDeliverable.test.ts
@@ -3,6 +3,7 @@ import { handleUploadDocumentToDeliverable } from "./handleUploadDocumentToDeliv
 import { UploadDocumentToDeliverableInput } from "./documentPendingUploadSchema";
 import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
 import { selectDeliverableOrThrow } from "../deliverable";
+import { FINAL_DELIVERABLE_STATUSES } from "../../constants";
 
 const testInput: UploadDocumentToDeliverableInput = {
   applicationId: "app-123",
@@ -47,6 +48,18 @@ describe("handleUploadDocumentToDeliverable", () => {
     expect(selectDeliverableOrThrow).toHaveBeenCalledExactlyOnceWith({
       id: testInput.deliverableId,
     });
+  });
+
+  it("throws an error if the deliverable is in a finalized status", async () => {
+    vi.mocked(selectDeliverableOrThrow).mockResolvedValue({
+      statusId: FINAL_DELIVERABLE_STATUSES[0],
+    } as any);
+
+    await expect(
+      handleUploadDocumentToDeliverable(testInput, testOwnerUserId, false)
+    ).rejects.toThrow(
+      `Document cannot be uploaded to Deliverable with ID ${testInput.deliverableId} because its in a finalized status of ${FINAL_DELIVERABLE_STATUSES[0]}.`
+    );
   });
 
   it("calls uploadDocument with appropriate cms-file configuration", async () => {

--- a/server/src/model/documentPendingUpload/handleUploadDocumentToDeliverable.ts
+++ b/server/src/model/documentPendingUpload/handleUploadDocumentToDeliverable.ts
@@ -1,4 +1,8 @@
 import { getS3Adapter } from "../../adapters";
+import {
+  FINAL_DELIVERABLE_STATUSES,
+  FinalDeliverableStatus,
+} from "../../constants";
 import { checkOptionalNotNullFields } from "../../errors/checkOptionalNotNullFields";
 import { handlePrismaError } from "../../errors/handlePrismaError";
 import { selectDeliverableOrThrow } from "../deliverable";
@@ -13,6 +17,11 @@ export async function handleUploadDocumentToDeliverable(
 
   try {
     const deliverable = await selectDeliverableOrThrow({ id: input.deliverableId });
+    if (FINAL_DELIVERABLE_STATUSES.includes(deliverable.statusId as FinalDeliverableStatus)) {
+      throw new Error(
+        `Document cannot be uploaded to Deliverable with ID ${input.deliverableId} because its in a finalized status of ${deliverable.statusId}.`
+      );
+    }
     return await getS3Adapter().uploadDocument({
       name: input.name,
       description: input.description,


### PR DESCRIPTION
This ticket does two things: 
* prevent new documents from being uploaded to deliverables when the deliverable is in one of the Finalized statuses
* prevent the edit of a document which belongs to a deliverable in one of the finalized statuses.

Note that this DOES allow for the editing of a document which has been submitted if the deliverable has not yet been finalized. 