### PR TITLE
DEMOS-2286: componentized the "create new menu" and moved it to only the demos table 

### DIFF
--- a/client/src/components/header/CreateNewButton.test.tsx
+++ b/client/src/components/header/CreateNewButton.test.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+
+import * as UserContext from "components/user/UserContext";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { mockUsers } from "mock-data/userMocks";
+import { vi } from "vitest";
+
+import { CreateNewButton } from "./CreateNewButton";
+
+const showCreateDemonstrationDialog = vi.fn();
+const showCreateAmendmentDialog = vi.fn();
+const showCreateExtensionDialog = vi.fn();
+
+vi.mock("components/dialog/DialogContext", () => ({
+  useDialog: () => ({
+    showCreateDemonstrationDialog,
+    showCreateAmendmentDialog,
+    showCreateExtensionDialog,
+  }),
+}));
+
+vi.mock("components/user/UserContext", async (importOriginal) => {
+  const actual = await importOriginal<typeof UserContext>();
+  return {
+    ...actual,
+    getCurrentUser: vi.fn(),
+  };
+});
+
+describe("CreateNewButton", () => {
+  const mockGetCurrentUser = vi.mocked(UserContext.getCurrentUser);
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("opens and closes the dropdown", () => {
+    mockGetCurrentUser.mockReturnValue({
+      currentUser: mockUsers[0],
+    });
+
+    render(<CreateNewButton />);
+
+    fireEvent.click(screen.getByText("Create New"));
+    expect(screen.getByText("Demonstration")).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText("Demonstration")).not.toBeInTheDocument();
+  });
+
+  it("does not show the menu for state users", () => {
+    mockGetCurrentUser.mockReturnValue({
+      currentUser: {
+        ...mockUsers[0],
+        person: {
+          ...mockUsers[0].person,
+          personType: "demos-state-user",
+        },
+      },
+    });
+
+    render(<CreateNewButton />);
+
+    expect(screen.queryByText("Create New")).not.toBeInTheDocument();
+  });
+
+  it("opens CreateDemonstrationDialog when demonstration is clicked", () => {
+    mockGetCurrentUser.mockReturnValue({
+      currentUser: mockUsers[0],
+    });
+
+    render(<CreateNewButton />);
+
+    fireEvent.click(screen.getByText("Create New"));
+    fireEvent.click(screen.getByText("Demonstration"));
+
+    expect(showCreateDemonstrationDialog).toHaveBeenCalledWith();
+  });
+
+  it("opens CreateAmendmentDialog when amendment is clicked", () => {
+    mockGetCurrentUser.mockReturnValue({
+      currentUser: mockUsers[0],
+    });
+
+    render(<CreateNewButton />);
+
+    fireEvent.click(screen.getByText("Create New"));
+    fireEvent.click(screen.getByText("Amendment"));
+
+    expect(showCreateAmendmentDialog).toHaveBeenCalledWith();
+  });
+
+  it("opens CreateExtensionDialog when extension is clicked", () => {
+    mockGetCurrentUser.mockReturnValue({
+      currentUser: mockUsers[0],
+    });
+
+    render(<CreateNewButton />);
+
+    fireEvent.click(screen.getByText("Create New"));
+    fireEvent.click(screen.getByText("Extension"));
+
+    expect(showCreateExtensionDialog).toHaveBeenCalledWith();
+  });
+});

--- a/client/src/components/header/CreateNewButton.tsx
+++ b/client/src/components/header/CreateNewButton.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useRef, useState } from "react";
+
+import { IconButton } from "components/button";
+import { AddNewIcon } from "components/icons";
+import { PersonType } from "demos-server";
+import { getCurrentUser } from "components/user/UserContext";
+import { useDialog } from "components/dialog/DialogContext";
+
+const CREATE_PERSON_TYPES: ReadonlySet<PersonType> = new Set(["demos-admin", "demos-cms-user"]);
+
+export const CreateNewButton: React.FC = () => {
+  const [showDropdown, setShowDropdown] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const { currentUser } = getCurrentUser();
+  const { showCreateDemonstrationDialog, showCreateAmendmentDialog, showCreateExtensionDialog } =
+    useDialog();
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setShowDropdown(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  if (!CREATE_PERSON_TYPES.has(currentUser.person.personType)) {
+    return null;
+  }
+
+  return (
+    <div ref={dropdownRef} className="relative">
+      <IconButton
+        icon={<AddNewIcon />}
+        name="create-new"
+        onClick={() => setShowDropdown((prev) => !prev)}
+      >
+        Create New
+      </IconButton>
+
+      {showDropdown && (
+        <div className="absolute right-0 mt-1 w-[160px] bg-white text-black rounded-[6px] shadow-lg border z-20">
+          <button
+            data-testid="button-create-new-demonstration"
+            onClick={() => {
+              setShowDropdown(false);
+              showCreateDemonstrationDialog();
+            }}
+            className="w-full text-left px-1 py-[10px] hover:bg-gray-100"
+          >
+            Demonstration
+          </button>
+          <button
+            data-testid="button-create-new-amendment"
+            onClick={() => {
+              setShowDropdown(false);
+              showCreateAmendmentDialog();
+            }}
+            className="w-full text-left px-1 py-[10px] hover:bg-gray-100"
+          >
+            Amendment
+          </button>
+          <button
+            data-testid="button-create-new-extension"
+            onClick={() => {
+              setShowDropdown(false);
+              showCreateExtensionDialog();
+            }}
+            className="w-full text-left px-1 py-[10px] hover:bg-gray-100"
+          >
+            Extension
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/client/src/components/header/DefaultHeaderLower.test.tsx
+++ b/client/src/components/header/DefaultHeaderLower.test.tsx
@@ -1,27 +1,13 @@
-// src/components/DefaultHeaderLower.test.tsx
 import React from "react";
 
 import * as UserContext from "components/user/UserContext";
-import { DemosApolloProvider } from "router/DemosApolloProvider";
 import { vi } from "vitest";
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 import { DefaultHeaderLower } from "./DefaultHeaderLower";
 import { mockUsers } from "mock-data/userMocks";
 
-const showCreateDemonstrationDialog = vi.fn();
-const showCreateAmendmentDialog = vi.fn();
-const showCreateExtensionDialog = vi.fn();
-vi.mock("components/dialog/DialogContext", () => ({
-  useDialog: () => ({
-    showCreateDemonstrationDialog,
-    showCreateAmendmentDialog,
-    showCreateExtensionDialog,
-  }),
-}));
-
-// Mock UserContext
 vi.mock("components/user/UserContext", async (importOriginal) => {
   const actual = await importOriginal<typeof UserContext>();
   return {
@@ -29,28 +15,6 @@ vi.mock("components/user/UserContext", async (importOriginal) => {
     getCurrentUser: vi.fn(),
   };
 });
-
-// Stub modals
-vi.mock("components/dialog", () => ({
-  EditDemonstrationDialog: () => <div>EditDemonstrationDialog</div>,
-  CreateDemonstrationDialog: () => <div>CreateDemonstrationDialog</div>,
-}));
-
-vi.mock("components/dialog/AmendmentDialog", () => ({
-  AmendmentDialog: ({ mode, onClose }: { mode: string; onClose: () => void }) => (
-    <div>
-      AmendmentDialog ({mode})<button onClick={onClose}>Close</button>
-    </div>
-  ),
-}));
-
-vi.mock("components/dialog/ExtensionDialog", () => ({
-  ExtensionDialog: ({ mode, onClose }: { mode: string; onClose: () => void }) => (
-    <div>
-      ExtensionDialog ({mode})<button onClick={onClose}>Close</button>
-    </div>
-  ),
-}));
 
 describe("DefaultHeaderLower", () => {
   const mockGetCurrentUser = vi.mocked(UserContext.getCurrentUser);
@@ -67,66 +31,13 @@ describe("DefaultHeaderLower", () => {
     expect(screen.getByText("Hello John Doe")).toBeInTheDocument();
   });
 
-  it("opens and closes the dropdown", () => {
+  it("does not render the Create New menu", () => {
     mockGetCurrentUser.mockReturnValue({
       currentUser: mockUsers[0],
-    });
-    render(<DefaultHeaderLower />);
-    const button = screen.getByText("Create New");
-    fireEvent.click(button);
-    expect(screen.getByText("Demonstration")).toBeInTheDocument();
-    fireEvent.mouseDown(document.body);
-    expect(screen.queryByText("Demonstration")).not.toBeInTheDocument();
-  });
-
-  it("does not show the Create New menu for state users", () => {
-    mockGetCurrentUser.mockReturnValue({
-      currentUser: {
-        ...mockUsers[0],
-        person: {
-          ...mockUsers[0].person,
-          personType: "demos-state-user",
-        },
-      },
     });
 
     render(<DefaultHeaderLower />);
 
     expect(screen.queryByText("Create New")).not.toBeInTheDocument();
-  });
-
-  it("opens CreateDemonstrationDialog when demonstration modal is clicked", () => {
-    mockGetCurrentUser.mockReturnValue({
-      currentUser: mockUsers[0],
-    });
-
-    render(
-      <DemosApolloProvider>
-        <DefaultHeaderLower />
-      </DemosApolloProvider>
-    );
-    fireEvent.click(screen.getByText("Create New"));
-    fireEvent.click(screen.getByText("Demonstration"));
-    expect(showCreateDemonstrationDialog).toHaveBeenCalledWith();
-  });
-
-  it("opens AmendmentDialog for amendment", () => {
-    mockGetCurrentUser.mockReturnValue({
-      currentUser: mockUsers[0],
-    });
-    render(<DefaultHeaderLower />);
-    fireEvent.click(screen.getByText("Create New"));
-    fireEvent.click(screen.getByText("Amendment"));
-    expect(showCreateAmendmentDialog).toHaveBeenCalledWith();
-  });
-
-  it("opens ExtensionDialog for extension", () => {
-    mockGetCurrentUser.mockReturnValue({
-      currentUser: mockUsers[0],
-    });
-    render(<DefaultHeaderLower />);
-    fireEvent.click(screen.getByText("Create New"));
-    fireEvent.click(screen.getByText("Extension"));
-    expect(showCreateExtensionDialog).toHaveBeenCalledWith();
   });
 });

--- a/client/src/components/header/DefaultHeaderLower.tsx
+++ b/client/src/components/header/DefaultHeaderLower.tsx
@@ -1,9 +1,6 @@
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 
-import { IconButton } from "components/button";
-import { AddNewIcon } from "components/icons";
 import { getCurrentUser } from "components/user/UserContext";
-import { useDialog } from "components/dialog/DialogContext";
 
 const UserGreeting = () => {
   const { currentUser } = getCurrentUser();
@@ -17,77 +14,5 @@ const UserGreeting = () => {
 };
 
 export const DefaultHeaderLower: React.FC = () => {
-  const [showDropdown, setShowDropdown] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const { currentUser } = getCurrentUser();
-  const { showCreateDemonstrationDialog, showCreateAmendmentDialog, showCreateExtensionDialog } =
-    useDialog();
-  const canCreate =
-    currentUser.person.personType === "demos-admin" ||
-    currentUser.person.personType === "demos-cms-user";
-
-  useEffect(() => {
-    // Close dropdown on outside click
-    const handleClickOutside = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setShowDropdown(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  return (
-    <>
-      <UserGreeting />
-
-      {canCreate && (
-        <div ref={dropdownRef}>
-          <IconButton
-            icon={<AddNewIcon />}
-            name="create-new"
-            data-testid="create-new"
-            onClick={() => setShowDropdown((prev) => !prev)}
-          >
-            Create New
-          </IconButton>
-
-          {showDropdown && (
-            <div className="absolute w-[160px] bg-white text-black rounded-[6px] shadow-lg border z-20">
-              <button
-                data-testid="button-create-new-demonstration"
-                onClick={() => {
-                  setShowDropdown(false);
-                  showCreateDemonstrationDialog();
-                }}
-                className="w-full text-left px-1 py-[10px] hover:bg-gray-100"
-              >
-                Demonstration
-              </button>
-              <button
-                data-testid="button-create-new-amendment"
-                onClick={() => {
-                  setShowDropdown(false);
-                  showCreateAmendmentDialog();
-                }}
-                className="w-full text-left px-1 py-[10px] hover:bg-gray-100"
-              >
-                Amendment
-              </button>
-              <button
-                data-testid="button-create-new-extension"
-                onClick={() => {
-                  setShowDropdown(false);
-                  showCreateExtensionDialog();
-                }}
-                className="w-full text-left px-1 py-[10px] hover:bg-gray-100"
-              >
-                Extension
-              </button>
-            </div>
-          )}
-        </div>
-      )}
-    </>
-  );
+  return <UserGreeting />;
 };

--- a/client/src/components/header/Header.test.tsx
+++ b/client/src/components/header/Header.test.tsx
@@ -4,7 +4,6 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { DialogProvider } from "components/dialog/DialogContext";
 import { TestProvider } from "test-utils/TestProvider";
 import { Route, Routes } from "react-router-dom";
-import { DefaultHeaderLower } from "./DefaultHeaderLower";
 import { Header } from "./Header";
 import { PROFILE_BUTTON_TEST_ID, ProfileBlock, SIGNOUT_LINK_TEST_ID } from "./ProfileBlock";
 import { QUICK_LINKS_TEST_ID } from "./QuickLinks";
@@ -37,11 +36,6 @@ describe("Header", () => {
   it("renders the QuickLinks", async () => {
     renderWithProviders(<Header />);
     expect(await screen.findByTestId(QUICK_LINKS_TEST_ID)).toBeInTheDocument();
-  });
-
-  it("renders the Create New button", async () => {
-    renderWithProviders(<DefaultHeaderLower />);
-    expect(await screen.findByTestId("create-new")).toBeInTheDocument();
   });
 
   it("opens and closes the ProfileBlock menu when toggled by clicking the name", async () => {

--- a/client/src/pages/DemonstrationsPage.test.tsx
+++ b/client/src/pages/DemonstrationsPage.test.tsx
@@ -11,6 +11,10 @@ vi.mock("@apollo/client", () => ({
   useQuery: (...args: unknown[]) => mockUseQuery(...args),
 }));
 
+vi.mock("components/header/CreateNewButton", () => ({
+  CreateNewButton: () => <div data-testid="create-new-button" />,
+}));
+
 const baseData = {
   demonstrations: [
     {
@@ -46,6 +50,7 @@ describe("DemonstrationsPage tab persistence", () => {
   it("defaults to My Demonstrations when no tab is stored", () => {
     render(<DemonstrationsPage />);
 
+    expect(screen.getByTestId("create-new-button")).toBeInTheDocument();
     expect(screen.getByTestId("button-my-demonstrations")).toHaveAttribute("aria-selected", "true");
     expect(sessionStorage.getItem("selectedDemonstrationTab")).toBe("my-demonstrations");
   });

--- a/client/src/pages/DemonstrationsPage.tsx
+++ b/client/src/pages/DemonstrationsPage.tsx
@@ -11,6 +11,7 @@ import {
 } from "demos-server";
 import { Tab, HorizontalSectionTabs } from "layout/Tabs";
 import { useSessionTab } from "hooks/useSessionTab";
+import { CreateNewButton } from "components/header/CreateNewButton";
 
 export const DEMONSTRATIONS_PAGE_QUERY = gql`
   query GetDemonstrationsPage {
@@ -65,9 +66,8 @@ export type DemonstrationsPageQueryResult = {
 };
 
 export const DemonstrationsPage: React.FC = () => {
-  const { data, loading, error } = useQuery<DemonstrationsPageQueryResult>(
-    DEMONSTRATIONS_PAGE_QUERY
-  );
+  const { data, loading, error } =
+    useQuery<DemonstrationsPageQueryResult>(DEMONSTRATIONS_PAGE_QUERY);
 
   const demonstrations = data?.demonstrations || [];
   const myDemonstrations = demonstrations.filter(
@@ -82,16 +82,14 @@ export const DemonstrationsPage: React.FC = () => {
 
   return (
     <div className="shadow-md bg-white p-[16px]">
-      <h1 className="text-[20px] font-bold mb-[24px] text-brand uppercase border-b-1 pb-[8px]">
-        Demonstrations
-      </h1>
+      <div className="flex items-center justify-between mb-[24px] border-b-1 pb-[8px]">
+        <h1 className="text-[20px] font-bold text-brand uppercase">Demonstrations</h1>
+        <CreateNewButton />
+      </div>
       {loading && <div className="p-4">Loading demonstrations...</div>}
       {error && <div className="p-4 text-red-500">Error loading demonstrations.</div>}
       {data && (
-        <HorizontalSectionTabs
-          defaultValue={tabValue}
-          onSelect={onTabSelect}
-        >
+        <HorizontalSectionTabs defaultValue={tabValue} onSelect={onTabSelect}>
           <Tab label={`My Demonstrations (${myDemonstrations.length})`} value="my-demonstrations">
             <DemonstrationTable
               demonstrations={myDemonstrations}


### PR DESCRIPTION
In DefaultHeaderLower there's the createNew buttons. They inc the create demo ext and amendment buttons, but this is on the wrong line in the header. Was able to reduce the header lower page and moved to Header file

<img width="2000" height="auto" alt="Screenshot 2026-06-18 at 14 22 51" src="https://github.com/user-attachments/assets/ddded4ca-5730-4980-9d62-bf899c2793c2" />
