### PR TITLE
DEMOS-2285: made deleting BN workbook also delete associated bn data

### DIFF
--- a/client/src/components/dialog/document/AddDocumentToDeliverableDialog.tsx
+++ b/client/src/components/dialog/document/AddDocumentToDeliverableDialog.tsx
@@ -16,8 +16,7 @@ import { tryUploadingFileToS3 } from "./tryUploadingFileToS3";
 import { useBNValidationStatus } from "./useBNValidationStatus";
 import { useDocumentPassedVirusScan } from "./useDocumentPassedVirusScan";
 import { useUploadDocument } from "./useUploadDocument";
-
-const BN_WORKBOOK_DOCUMENT_TYPE: DocumentType = "BN Workbook";
+import { BN_WORKBOOK_DOCUMENT_TYPE } from "demos-server-constants";
 
 export const UPLOAD_DOCUMENT_TO_DELIVERABLE_STATE_FILES_MUTATION: TypedDocumentNode<
   {

--- a/client/src/components/dialog/document/DocumentDialog.test.tsx
+++ b/client/src/components/dialog/document/DocumentDialog.test.tsx
@@ -13,6 +13,7 @@ import {
   DocumentDialog,
 } from "./DocumentDialog";
 import type { DocumentDialogFields, DocumentUploadResult } from "./DocumentDialog";
+import { BN_WORKBOOK_DOCUMENT_TYPE } from "demos-server-constants";
 
 const parseBNFile = vi.fn();
 const rule = vi.fn();
@@ -61,7 +62,7 @@ describe("checkFormHasChanges", () => {
 
 describe("documentTypeRequiresAttestation", () => {
   it("requires attestation for the BN Workbook document type", () => {
-    expect(documentTypeRequiresAttestation("BN Workbook")).toBe(true);
+    expect(documentTypeRequiresAttestation(BN_WORKBOOK_DOCUMENT_TYPE)).toBe(true);
   });
 
   it("does not require attestation for other document types", () => {
@@ -114,7 +115,7 @@ describe("DocumentDialog attestation gating", () => {
 
   it("shows the attestation dialog and defers upload for a BN Workbook", async () => {
     const onSubmit = vi.fn(() => Promise.resolve<DocumentUploadResult>("succeeded"));
-    renderAddDialog("BN Workbook", onSubmit);
+    renderAddDialog(BN_WORKBOOK_DOCUMENT_TYPE, onSubmit);
 
     selectWorkbook();
     await waitForUploadEnabled();
@@ -128,7 +129,7 @@ describe("DocumentDialog attestation gating", () => {
 
   it("proceeds with the upload after the attestation is confirmed", async () => {
     const onSubmit = vi.fn(() => Promise.resolve<DocumentUploadResult>("succeeded"));
-    renderAddDialog("BN Workbook", onSubmit);
+    renderAddDialog(BN_WORKBOOK_DOCUMENT_TYPE, onSubmit);
 
     selectWorkbook();
     await waitForUploadEnabled();
@@ -143,7 +144,7 @@ describe("DocumentDialog attestation gating", () => {
   it("confirms before cancelling the upload when the attestation is dismissed", async () => {
     const onSubmit = vi.fn(() => Promise.resolve<DocumentUploadResult>("succeeded"));
     const onClose = vi.fn();
-    renderAddDialog("BN Workbook", onSubmit, onClose);
+    renderAddDialog(BN_WORKBOOK_DOCUMENT_TYPE, onSubmit, onClose);
 
     selectWorkbook();
     await waitForUploadEnabled();
@@ -196,7 +197,7 @@ describe("DocumentDialog BN Workbook pre-validation", () => {
     parseBNFile.mockResolvedValue([{ sheet: "Sheet1", data: [] }]);
     rule.mockReturnValue({ code: "1", message: "Error: C Report Tab - missing data." });
 
-    renderAddDialog("BN Workbook", onSubmit);
+    renderAddDialog(BN_WORKBOOK_DOCUMENT_TYPE, onSubmit);
     selectWorkbook();
 
     await waitFor(() => {
@@ -214,7 +215,7 @@ describe("DocumentDialog BN Workbook pre-validation", () => {
     parseBNFile.mockResolvedValue([{ sheet: "Sheet1", data: [] }]);
     rule.mockReturnValue(null);
 
-    renderAddDialog("BN Workbook", onSubmit);
+    renderAddDialog(BN_WORKBOOK_DOCUMENT_TYPE, onSubmit);
     selectWorkbook();
 
     await waitFor(() => {

--- a/client/src/components/dialog/document/DocumentDialog.tsx
+++ b/client/src/components/dialog/document/DocumentDialog.tsx
@@ -16,9 +16,10 @@ import { AttestationDialog } from "components/dialog/AttestationDialog";
 import { UploadButton } from "./UploadButton";
 import { BNPreValidationState, useBNWorkbookPreValidation } from "./useBNWorkbookPreValidation";
 import { DocumentChip } from "components/document/documentChip";
+import { BN_WORKBOOK_DOCUMENT_TYPE } from "demos-server-constants";
 
 // BN Workbook uploads require the user to attest to the content before submitting.
-const ATTESTATION_DOCUMENT_TYPES: DocumentType[] = ["BN Workbook"];
+const ATTESTATION_DOCUMENT_TYPES: DocumentType[] = [BN_WORKBOOK_DOCUMENT_TYPE];
 
 export const documentTypeRequiresAttestation = (documentType: DocumentType): boolean =>
   ATTESTATION_DOCUMENT_TYPES.includes(documentType);

--- a/client/src/components/dialog/document/useBNWorkbookPreValidation.test.tsx
+++ b/client/src/components/dialog/document/useBNWorkbookPreValidation.test.tsx
@@ -8,6 +8,7 @@ import {
   BNPreValidationState,
   useBNWorkbookPreValidation,
 } from "./useBNWorkbookPreValidation";
+import { BN_WORKBOOK_DOCUMENT_TYPE } from "demos-server-constants";
 
 const parseBNFile = vi.fn();
 const rule1 = vi.fn();
@@ -48,7 +49,7 @@ afterEach(() => {
 
 describe("useBNWorkbookPreValidation", () => {
   it("stays idle when no file is selected", () => {
-    render(<Probe file={null} documentType="BN Workbook" />);
+    render(<Probe file={null} documentType={BN_WORKBOOK_DOCUMENT_TYPE} />);
     expect(readState().status).toBe("idle");
     expect(parseBNFile).not.toHaveBeenCalled();
   });
@@ -64,7 +65,7 @@ describe("useBNWorkbookPreValidation", () => {
     rule1.mockReturnValue(null);
     rule2.mockReturnValue(null);
 
-    render(<Probe file={makeFile()} documentType="BN Workbook" />);
+    render(<Probe file={makeFile()} documentType={BN_WORKBOOK_DOCUMENT_TYPE} />);
 
     await waitFor(() => expect(readState().status).toBe("valid"));
   });
@@ -77,7 +78,7 @@ describe("useBNWorkbookPreValidation", () => {
       message: "Error: C Report - 'Data Pulled On' field is blank.",
     });
 
-    render(<Probe file={makeFile()} documentType="BN Workbook" />);
+    render(<Probe file={makeFile()} documentType={BN_WORKBOOK_DOCUMENT_TYPE} />);
 
     await waitFor(() => {
       const state = readState();
@@ -94,7 +95,7 @@ describe("useBNWorkbookPreValidation", () => {
   it("returns invalid with a PARSE_ERROR when the file cannot be parsed", async () => {
     parseBNFile.mockRejectedValue(new Error("bad xlsx"));
 
-    render(<Probe file={makeFile("not-really.xlsx")} documentType="BN Workbook" />);
+    render(<Probe file={makeFile("not-really.xlsx")} documentType={BN_WORKBOOK_DOCUMENT_TYPE} />);
 
     await waitFor(() => {
       const state = readState();
@@ -112,7 +113,7 @@ describe("useBNWorkbookPreValidation", () => {
     });
     rule2.mockReturnValue({ code: "2", message: "Error: Reporting Year missing." });
 
-    render(<Probe file={makeFile()} documentType="BN Workbook" />);
+    render(<Probe file={makeFile()} documentType={BN_WORKBOOK_DOCUMENT_TYPE} />);
 
     await waitFor(() => {
       const state = readState();

--- a/client/src/components/dialog/document/useBNWorkbookPreValidation.ts
+++ b/client/src/components/dialog/document/useBNWorkbookPreValidation.ts
@@ -1,8 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { BudgetNeutralityValidationError, DocumentType } from "demos-server";
-
-const BN_WORKBOOK_DOCUMENT_TYPE: DocumentType = "BN Workbook";
+import { BN_WORKBOOK_DOCUMENT_TYPE } from "demos-server-constants";
 
 const PARSE_ERROR: BudgetNeutralityValidationError = {
   code: "PARSE_ERROR",

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -185,6 +185,8 @@ export const DOCUMENT_TYPES = [
 ] as const;
 export type DocumentType = (typeof DOCUMENT_TYPES)[number];
 
+export const BN_WORKBOOK_DOCUMENT_TYPE = 'BN Workbook' as const satisfies DocumentType;
+
 export const NON_DELIVERABLE_DOCUMENT_TYPES: DocumentType[] = [
   "Application Completeness Letter",
   "Approval Letter",

--- a/server/src/model/budgetNeutralityWorkbook/queries/deleteBudgetNeutralityWorkbook.test.ts
+++ b/server/src/model/budgetNeutralityWorkbook/queries/deleteBudgetNeutralityWorkbook.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { deleteBudgetNeutralityWorkbook } from "./deleteBudgetNeutralityWorkbook";
+
+describe("deleteBudgetNeutralityWorkbook", () => {
+  const transactionMocks = {
+    budgetNeutralityWorkbook: {
+      delete: vi.fn(),
+    },
+  };
+  const mockTransaction = {
+    budgetNeutralityWorkbook: {
+      delete: transactionMocks.budgetNeutralityWorkbook.delete,
+    },
+  } as any;
+  const testBudgetNeutralityWorkbookId = "doc-123-456";
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("should delete budgetNeutralityWorkbook from the database", async () => {
+    const where = { id: testBudgetNeutralityWorkbookId };
+
+    await deleteBudgetNeutralityWorkbook(where, mockTransaction);
+    expect(transactionMocks.budgetNeutralityWorkbook.delete).toHaveBeenCalledExactlyOnceWith({ where });
+  });
+
+  it("should throw an error if the budgetNeutralityWorkbook cannot be deleted", async () => {
+    const where = { id: testBudgetNeutralityWorkbookId };
+    transactionMocks.budgetNeutralityWorkbook.delete.mockRejectedValueOnce("Prisma error :(");
+
+    await expect(deleteBudgetNeutralityWorkbook(where, mockTransaction)).rejects.toThrow("Prisma error :(");
+    expect(transactionMocks.budgetNeutralityWorkbook.delete).toHaveBeenCalledExactlyOnceWith({ where });
+  });
+});

--- a/server/src/model/budgetNeutralityWorkbook/queries/deleteBudgetNeutralityWorkbook.ts
+++ b/server/src/model/budgetNeutralityWorkbook/queries/deleteBudgetNeutralityWorkbook.ts
@@ -1,0 +1,9 @@
+import { BudgetNeutralityWorkbook as PrismaBudgetNeutralityWorkbook, Prisma } from "@prisma/client";
+import { PrismaTransactionClient } from "../../../prismaClient";
+
+export async function deleteBudgetNeutralityWorkbook(
+  where: Prisma.BudgetNeutralityWorkbookWhereUniqueInput,
+  tx: PrismaTransactionClient
+): Promise<PrismaBudgetNeutralityWorkbook> {
+  return tx.budgetNeutralityWorkbook.delete({ where });
+}

--- a/server/src/model/budgetNeutralityWorkbook/queries/index.ts
+++ b/server/src/model/budgetNeutralityWorkbook/queries/index.ts
@@ -1,0 +1,1 @@
+export { deleteBudgetNeutralityWorkbook } from "./deleteBudgetNeutralityWorkbook";

--- a/server/src/model/document/handleDeleteDocument.test.ts
+++ b/server/src/model/document/handleDeleteDocument.test.ts
@@ -3,9 +3,16 @@ import { Document as PrismaDocument } from "@prisma/client";
 import { getS3Adapter, S3Adapter } from "../../adapters/s3/S3Adapter";
 import { handleDeleteDocument } from ".";
 import { deleteDocument } from "./queries/deleteDocument";
+import { BN_WORKBOOK_DOCUMENT_TYPE } from "../../constants";
+import { deleteBudgetNeutralityWorkbook } from "../budgetNeutralityWorkbook/queries";
+import { PrismaTransactionClient } from "../../prismaClient";
 
 vi.mock("./queries/deleteDocument", () => ({
   deleteDocument: vi.fn(),
+}));
+
+vi.mock("../budgetNeutralityWorkbook/queries", () => ({
+  deleteBudgetNeutralityWorkbook: vi.fn(),
 }));
 
 vi.mock("../../adapters/s3/S3Adapter", () => ({
@@ -13,17 +20,7 @@ vi.mock("../../adapters/s3/S3Adapter", () => ({
 }));
 
 describe("handleDeleteDocument", () => {
-  const transactionMocks = {
-    document: {
-      delete: vi.fn(),
-    },
-  };
-  const mockTransaction = {
-    document: {
-      delete: transactionMocks.document.delete,
-    },
-  } as any;
-
+  const mockTransaction = {} as PrismaTransactionClient;
   const testDocumentId = "doc-123-456";
   const testApplicationId = "app-123-456";
   const mockMoveDocumentFromCleanToDeleted = vi.fn();
@@ -74,20 +71,36 @@ describe("handleDeleteDocument", () => {
     );
   });
 
-  it("should construct S3 key from applicationId and document id", async () => {
-    vi.mocked(deleteDocument).mockResolvedValue(mockDeletedDocument as PrismaDocument);
-    const expectedKey = `${testApplicationId}/${testDocumentId}`;
-
-    await handleDeleteDocument({ id: testDocumentId }, mockTransaction);
-
-    expect(mockMoveDocumentFromCleanToDeleted).toHaveBeenCalledWith(expectedKey);
-  });
-
   it("should return the deleted document", async () => {
     vi.mocked(deleteDocument).mockResolvedValue(mockDeletedDocument as PrismaDocument);
 
     const result = await handleDeleteDocument({ id: testDocumentId }, mockTransaction);
 
     expect(result).toEqual(mockDeletedDocument);
+  });
+
+  describe("BN Workbook", () => {
+    it("should also delete the associated budget neutrality workbook if it is of type BN Workbook", async () => {
+      const mockBNWorkbookDocument = {
+        ...mockDeletedDocument,
+        documentTypeId: BN_WORKBOOK_DOCUMENT_TYPE,
+      } as PrismaDocument;
+      vi.mocked(deleteDocument).mockResolvedValue(mockBNWorkbookDocument);
+      await handleDeleteDocument({ id: testDocumentId }, mockTransaction);
+      expect(deleteBudgetNeutralityWorkbook).toHaveBeenCalledExactlyOnceWith(
+        { id: testDocumentId },
+        mockTransaction
+      );
+    });
+
+    it("should not attempt to delete a budget neutrality workbook if the document is not of type BN Workbook", async () => {
+      const mockNonBNWorkbookDocument = {
+        ...mockDeletedDocument,
+        documentTypeId: "State Application",
+      } as PrismaDocument;
+      vi.mocked(deleteDocument).mockResolvedValue(mockNonBNWorkbookDocument);
+      await handleDeleteDocument({ id: testDocumentId }, mockTransaction);
+      expect(deleteBudgetNeutralityWorkbook).not.toHaveBeenCalled();
+    });
   });
 });

--- a/server/src/model/document/handleDeleteDocument.ts
+++ b/server/src/model/document/handleDeleteDocument.ts
@@ -2,12 +2,17 @@ import { Prisma, Document as PrismaDocument } from "@prisma/client";
 import { PrismaTransactionClient } from "../../prismaClient";
 import { getS3Adapter } from "../../adapters/s3/S3Adapter";
 import { deleteDocument } from "./queries/deleteDocument";
+import { BN_WORKBOOK_DOCUMENT_TYPE } from "../../constants";
+import { deleteBudgetNeutralityWorkbook } from "../budgetNeutralityWorkbook/queries";
 
 export async function handleDeleteDocument(
   where: Prisma.DocumentWhereUniqueInput,
   tx: PrismaTransactionClient
 ): Promise<PrismaDocument> {
   const document = await deleteDocument(where, tx);
+  if (document.documentTypeId === BN_WORKBOOK_DOCUMENT_TYPE) {
+    await deleteBudgetNeutralityWorkbook({ id: document.id }, tx);
+  }
   const key = `${document.applicationId}/${document.id}`;
 
   const s3Adapter = getS3Adapter();


### PR DESCRIPTION
A good be simpler than i was worrying about. Just need to check the document type and if its a BN workbook, also delete the BN data within the same transaction. Because deleting a document is only happening via one spot thats already validated, just needed to add on the delete. Went ahead and built out with the common pattern of utilizing a query, then made the frontend use the same const we're using in backend where applicable. 

https://github.com/user-attachments/assets/09aae059-8316-40e9-b912-9b47aa126095

