### PR TITLE
Remove  `addTypename` on MockedProvider

### DIFF
--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -106,9 +106,3 @@ vi.mock("@apollo/client", async () => {
 - `src/router/`: app-level providers and routing
 - `src/layout/`: layout and navigation shells
 - `src/mock-data/`: Apollo `MockedResponse` fixtures
-
-## Outdated Patterns
-
-Patterns that exist now that will likely be replaced in the future. Try not entrench these patterns further if avoidable and if not then implement them consistently with other usages to make for a simpler refactor.
-
-- `addTypename` on `<MockedProvider>` is deprecated and should be removed.

--- a/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.test.tsx
+++ b/client/src/components/application/phases/approval-summary/ApprovalSummaryPhase.test.tsx
@@ -5,7 +5,10 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { ApprovalSummaryPhase } from "./ApprovalSummaryPhase";
-import { ApplicationDetailsFormData, ModificationDetailsFormData } from "./applicationDetailsSection";
+import {
+  ApplicationDetailsFormData,
+  ModificationDetailsFormData,
+} from "./applicationDetailsSection";
 import { TestProvider } from "test-utils/TestProvider";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { UPDATE_DEMONSTRATION_MUTATION } from "components/dialog/demonstration/EditDemonstrationDialog";
@@ -180,7 +183,7 @@ describe("ApprovalSummaryPhase", () => {
     initialTypes: DemonstrationDetailDemonstrationType[] = []
   ) => {
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <TestProvider>
           <ApprovalSummaryPhase
             applicationId="demo-123"
@@ -204,9 +207,7 @@ describe("ApprovalSummaryPhase", () => {
     setup();
 
     expect(screen.getByText("APPROVAL SUMMARY")).toBeInTheDocument();
-    expect(
-      screen.getByText(/Review and verify Demonstration Details/i)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Review and verify Demonstration Details/i)).toBeInTheDocument();
   });
 
   it("renders Application Details section", () => {
@@ -316,9 +317,7 @@ describe("ApprovalSummaryPhase", () => {
   it("shows 'Verify Amendment' for amendment", () => {
     setup(buildAmendmentFormData(), [mockUpdateAmendment]);
 
-    expect(
-      screen.getByText(/verify amendment/i)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/verify amendment/i)).toBeInTheDocument();
   });
 
   it("calls updateAmendment for amendment", async () => {
@@ -356,16 +355,21 @@ describe("ApprovalSummaryPhase", () => {
 
   it("covers amendment mark incomplete path", async () => {
     render(
-      <MockedProvider addTypename={false}>
+      <MockedProvider>
         <TestProvider>
           <ApprovalSummaryPhase
             applicationId="demo-123"
             initialFormData={buildAmendmentFormData()}
             initialTypes={[]}
-            approvalSummaryPhase={{ phaseStatus: "Started", phaseDates: [{
-              dateType: "Application Details Marked Complete Date",
-              dateValue: new Date("2025-01-01"),
-            }]}}
+            approvalSummaryPhase={{
+              phaseStatus: "Started",
+              phaseDates: [
+                {
+                  dateType: "Application Details Marked Complete Date",
+                  dateValue: new Date("2025-01-01"),
+                },
+              ],
+            }}
             allPreviousPhasesDone={true}
             demonstrationId="demo-123"
             demonstrationStatus="Approved"
@@ -388,16 +392,21 @@ describe("ApprovalSummaryPhase", () => {
 
   it("covers extension mark incomplete path", async () => {
     render(
-      <MockedProvider addTypename={false}>
+      <MockedProvider>
         <TestProvider>
           <ApprovalSummaryPhase
             applicationId="demo-123"
             initialFormData={buildExtensionFormData()}
             initialTypes={[]}
-            approvalSummaryPhase={{ phaseStatus: "Started", phaseDates: [{
-              dateType: "Application Details Marked Complete Date",
-              dateValue: new Date("2025-01-01"),
-            }]}}
+            approvalSummaryPhase={{
+              phaseStatus: "Started",
+              phaseDates: [
+                {
+                  dateType: "Application Details Marked Complete Date",
+                  dateValue: new Date("2025-01-01"),
+                },
+              ],
+            }}
             allPreviousPhasesDone={true}
             demonstrationId="demo-123"
             demonstrationStatus="Approved"

--- a/client/src/components/dialog/DemonstrationTypes/EditDemonstrationTypeDialog.test.tsx
+++ b/client/src/components/dialog/DemonstrationTypes/EditDemonstrationTypeDialog.test.tsx
@@ -73,7 +73,7 @@ describe("EditDemonstrationTypeDialog", () => {
 
     const user = userEvent.setup();
     render(
-      <MockedProvider mocks={[errorMock]} addTypename={false}>
+      <MockedProvider mocks={[errorMock]}>
         <EditDemonstrationTypeDialog
           demonstrationId={MOCK_DEMONSTRATION_ID}
           initialDemonstrationType={MOCK_INITIAL_TYPE}

--- a/client/src/components/dialog/ManageContactsDialog.test.tsx
+++ b/client/src/components/dialog/ManageContactsDialog.test.tsx
@@ -79,7 +79,7 @@ const defaultProps: ManageContactsDialogProps = {
 
 const renderWithProviders = (props = defaultProps, mocks: MockedResponse[] = []) => {
   return render(
-    <MockedProvider mocks={mocks} addTypename={false}>
+    <MockedProvider mocks={mocks}>
       <ToastProvider>
         <ManageContactsDialog {...props} />
       </ToastProvider>

--- a/client/src/components/input/select/SelectDemonstration.test.tsx
+++ b/client/src/components/input/select/SelectDemonstration.test.tsx
@@ -79,7 +79,7 @@ describe("SelectDemonstration", () => {
 
   it("shows loading state initially", () => {
     render(
-      <MockedProvider mocks={successMock} addTypename={false}>
+      <MockedProvider mocks={successMock}>
         <SelectDemonstration value="" onSelect={mockOnSelect} />
       </MockedProvider>
     );
@@ -89,7 +89,7 @@ describe("SelectDemonstration", () => {
 
   it("renders AutoCompleteSelect with demonstrations after loading", async () => {
     render(
-      <MockedProvider mocks={successMock} addTypename={false}>
+      <MockedProvider mocks={successMock}>
         <SelectDemonstration value="" onSelect={mockOnSelect} />
       </MockedProvider>
     );
@@ -104,7 +104,7 @@ describe("SelectDemonstration", () => {
 
   it("passes correct options to AutoCompleteSelect", async () => {
     render(
-      <MockedProvider mocks={successMock} addTypename={false}>
+      <MockedProvider mocks={successMock}>
         <SelectDemonstration value="" onSelect={mockOnSelect} />
       </MockedProvider>
     );
@@ -122,7 +122,7 @@ describe("SelectDemonstration", () => {
     const user = userEvent.setup();
 
     render(
-      <MockedProvider mocks={successMock} addTypename={false}>
+      <MockedProvider mocks={successMock}>
         <SelectDemonstration value="" onSelect={mockOnSelect} />
       </MockedProvider>
     );
@@ -139,7 +139,7 @@ describe("SelectDemonstration", () => {
 
   it("shows error message when query fails", async () => {
     render(
-      <MockedProvider mocks={errorMock} addTypename={false}>
+      <MockedProvider mocks={errorMock}>
         <SelectDemonstration value="" onSelect={mockOnSelect} />
       </MockedProvider>
     );
@@ -151,7 +151,7 @@ describe("SelectDemonstration", () => {
 
   it("shows no demonstrations message when list is empty", async () => {
     render(
-      <MockedProvider mocks={emptyMock} addTypename={false}>
+      <MockedProvider mocks={emptyMock}>
         <SelectDemonstration value="" onSelect={mockOnSelect} />
       </MockedProvider>
     );
@@ -163,7 +163,7 @@ describe("SelectDemonstration", () => {
 
   it("passes isRequired prop to AutoCompleteSelect", async () => {
     render(
-      <MockedProvider mocks={successMock} addTypename={false}>
+      <MockedProvider mocks={successMock}>
         <SelectDemonstration value="" onSelect={mockOnSelect} isRequired />
       </MockedProvider>
     );
@@ -177,7 +177,7 @@ describe("SelectDemonstration", () => {
 
   it("passes isDisabled prop to AutoCompleteSelect", async () => {
     render(
-      <MockedProvider mocks={successMock} addTypename={false}>
+      <MockedProvider mocks={successMock}>
         <SelectDemonstration value="" onSelect={mockOnSelect} isDisabled />
       </MockedProvider>
     );
@@ -192,7 +192,7 @@ describe("SelectDemonstration", () => {
 
   it("passes value prop to AutoCompleteSelect", async () => {
     render(
-      <MockedProvider mocks={successMock} addTypename={false}>
+      <MockedProvider mocks={successMock}>
         <SelectDemonstration onSelect={mockOnSelect} value="demo-2" />
       </MockedProvider>
     );
@@ -207,7 +207,7 @@ describe("SelectDemonstration", () => {
 
   it("renders with correct placeholder text", async () => {
     render(
-      <MockedProvider mocks={successMock} addTypename={false}>
+      <MockedProvider mocks={successMock}>
         <SelectDemonstration value="" onSelect={mockOnSelect} />
       </MockedProvider>
     );

--- a/client/src/components/table/tables/ApprovalPackageTable.test.tsx
+++ b/client/src/components/table/tables/ApprovalPackageTable.test.tsx
@@ -63,7 +63,7 @@ describe("ApprovalPackageTable", () => {
 
   const setup = () =>
     render(
-      <MockedProvider mocks={[]} addTypename={false}>
+      <MockedProvider mocks={[]}>
         <ApprovalPackageTable demonstrationId="demo-123" rows={rows} />
       </MockedProvider>
     );

--- a/client/src/components/table/tables/ContactsTable.test.tsx
+++ b/client/src/components/table/tables/ContactsTable.test.tsx
@@ -85,7 +85,7 @@ describe("ContactsTable", () => {
     beforeEach(async () => {
       vi.clearAllMocks();
       render(
-        <MockedProvider mocks={[contactsTableQueryMock]} addTypename={false}>
+        <MockedProvider mocks={[contactsTableQueryMock]}>
           <ContactsTable demonstrationId={"demo-123"} />
         </MockedProvider>
       );
@@ -154,7 +154,7 @@ describe("ContactsTable", () => {
     beforeEach(async () => {
       vi.clearAllMocks();
       render(
-        <MockedProvider mocks={[contactsTableQuery25Mock]} addTypename={false}>
+        <MockedProvider mocks={[contactsTableQuery25Mock]}>
           <ContactsTable demonstrationId="demo-123" />
         </MockedProvider>
       );
@@ -186,7 +186,7 @@ describe("ContactsTable", () => {
     beforeEach(async () => {
       vi.clearAllMocks();
       render(
-        <MockedProvider mocks={[contactsTableQueryEmptyMock]} addTypename={false}>
+        <MockedProvider mocks={[contactsTableQueryEmptyMock]}>
           <ContactsTable demonstrationId="demo-123" />
         </MockedProvider>
       );

--- a/client/src/components/table/tables/DocumentTable.test.tsx
+++ b/client/src/components/table/tables/DocumentTable.test.tsx
@@ -24,7 +24,7 @@ vi.mock("components/dialog/DialogContext", () => ({
 describe("DocumentTable", () => {
   beforeEach(() => {
     render(
-      <MockedProvider mocks={ALL_MOCKS} addTypename={false}>
+      <MockedProvider mocks={ALL_MOCKS}>
         <DocumentTable documents={mockDocuments} />
       </MockedProvider>
     );

--- a/client/src/components/table/tables/SummaryDetailsTable.test.tsx
+++ b/client/src/components/table/tables/SummaryDetailsTable.test.tsx
@@ -86,7 +86,7 @@ describe("Error States", () => {
     };
 
     render(
-      <MockedProvider mocks={[errorMock]} addTypename={false}>
+      <MockedProvider mocks={[errorMock]}>
         <SummaryDetailsTable demonstrationId="1" />
       </MockedProvider>
     );

--- a/client/src/pages/DemonstrationDetail/DemonstrationDetail.test.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetail.test.tsx
@@ -72,7 +72,7 @@ describe("DemonstrationDetail", () => {
     mock = buildDemonstrationDetailMock()
   ) => {
     return render(
-      <MockedProvider mocks={[mock]} addTypename={false}>
+      <MockedProvider mocks={[mock]}>
         <MemoryRouter initialEntries={[initialEntry]}>
           <Routes>
             <Route path="/demonstrations/:id" element={<DemonstrationDetail />} />

--- a/client/src/pages/DemonstrationDetail/DemonstrationDetailHeader.test.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetailHeader.test.tsx
@@ -113,7 +113,7 @@ const renderHeader = (
 ) =>
   render(
     <MemoryRouter>
-      <MockedProvider mocks={mocks} addTypename={false}>
+      <MockedProvider mocks={mocks}>
         <TestUserProvider currentUser={currentUser}>
           <DemonstrationDetailHeader demonstrationId="1" />
         </TestUserProvider>

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.test.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.test.tsx
@@ -63,7 +63,7 @@ const mockDemonstration: DemonstrationTabDemonstration = {
 
 const renderWithProvider = (component: React.ReactElement) => {
   return render(
-    <TestProvider mocks={deliverableMocks} addTypename={false}>
+    <TestProvider mocks={deliverableMocks}>
       <DialogProvider>{component}</DialogProvider>
     </TestProvider>
   );

--- a/client/src/router/DemosApolloProvider.tsx
+++ b/client/src/router/DemosApolloProvider.tsx
@@ -36,7 +36,7 @@ export const DemosApolloProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
   if (shouldUseMocks()) {
     return (
-      <MockedProvider mocks={ALL_MOCKS} addTypename={false}>
+      <MockedProvider mocks={ALL_MOCKS}>
         {children}
       </MockedProvider>
     );

--- a/client/src/router/DemosRouter.test.tsx
+++ b/client/src/router/DemosRouter.test.tsx
@@ -85,7 +85,7 @@ vi.mock("./DemosApolloProvider", async () => {
   const React = (await import("react")).default;
   const { MockedProvider } = await import("@apollo/client/testing");
   const DemosApolloProvider = ({ children }: { children: React.ReactNode }) => (
-    <MockedProvider mocks={[]} addTypename={false}>
+    <MockedProvider mocks={[]}>
       {children}
     </MockedProvider>
   );

--- a/client/src/test-utils/TestProvider.tsx
+++ b/client/src/test-utils/TestProvider.tsx
@@ -12,7 +12,6 @@ import { developmentMockUser } from "mock-data/userMocks";
 interface TestProviderProps {
   children: ReactNode;
   mocks?: MockedProviderProps["mocks"];
-  addTypename?: boolean;
   routerEntries?: MemoryRouterProps["initialEntries"];
   currentUser?: CurrentUser;
 }
@@ -38,14 +37,13 @@ interface TestProviderProps {
 export const TestProvider: React.FC<TestProviderProps> = ({
   children,
   mocks = ALL_MOCKS,
-  addTypename = false,
   routerEntries = ["/"],
   currentUser = developmentMockUser,
 }) => {
   return (
     <MemoryRouter initialEntries={routerEntries}>
       <ToastProvider>
-        <MockedProvider mocks={mocks} addTypename={addTypename}>
+        <MockedProvider mocks={mocks}>
           <TestUserProvider currentUser={currentUser}>{children}</TestUserProvider>
         </MockedProvider>
       </ToastProvider>


### PR DESCRIPTION
Apollo has deprecated `addTypename` on MockedProvider, this defaults to `true` if it's not included, but it never needs to be `false` since apollo will always return the `_typename` field