### PR TITLE
Demos 2329 prevent finalization when unsubmitted docs

### DIFF
--- a/client/src/components/table/columns/dateColumn.tsx
+++ b/client/src/components/table/columns/dateColumn.tsx
@@ -1,4 +1,4 @@
-import { ColumnHelper } from "@tanstack/react-table";
+import { CellContext, ColumnHelper, DeepKeys, DeepValue, Row } from "@tanstack/react-table";
 import { isAfter, isBefore, isSameDay } from "date-fns";
 import { formatDateForDisplay } from "util/formatDate";
 
@@ -13,21 +13,21 @@ type DateColumnMeta = {
   cellClassName?: string;
 };
 
-export function createDateColumnDef<RowData, FieldName extends keyof RowData & string>(
+export function createDateColumnDef<RowData, FieldName extends DeepKeys<RowData>>(
   columnHelper: ColumnHelper<RowData>,
   fieldName: FieldName,
   header: string,
   defaultValue: string = "",
   meta?: DateColumnMeta
 ) {
-  return columnHelper.accessor((row: RowData) => row[fieldName], {
-    id: fieldName,
+  return columnHelper.accessor(fieldName, {
+    id: String(fieldName),
     header,
-    cell: ({ getValue }) => {
+    cell: ({ getValue }: CellContext<RowData, DeepValue<RowData, FieldName>>) => {
       const value = getValue() as string | undefined;
       return value ? formatDateForDisplay(value) : defaultValue;
     },
-    filterFn: (row, columnId, filterValue: DateFilterValue) => {
+    filterFn: (row: Row<RowData>, columnId: string, filterValue: DateFilterValue) => {
       const value = row.getValue(columnId) as string | undefined;
       if (!value) return false;
 

--- a/client/src/components/table/columns/deliverableFileColumns.tsx
+++ b/client/src/components/table/columns/deliverableFileColumns.tsx
@@ -7,7 +7,7 @@ import { createDateColumnDef } from "components/table/columns/dateColumn";
 import { createSelectColumnDef } from "components/table/columns/selectColumn";
 import { highlightCell } from "components/table/KeywordSearch";
 
-import type { DeliverableFileRow } from "./DeliverableFileTypes";
+import type { DeliverableFileRow } from "../../../pages/deliverables/sections/DeliverableFileTypes";
 
 const DOCUMENT_TYPE_OPTIONS = DOCUMENT_TYPES.map((type) => ({ label: type, value: type }));
 
@@ -47,6 +47,13 @@ const uploadedByColumn = columnHelper.accessor("owner.person.fullName", {
 
 const uploadedDateColumn = createDateColumnDef(columnHelper, "createdAt", "Uploaded Date");
 
+const submittedDateColumn = createDateColumnDef(
+  columnHelper,
+  "deliverableSubmissionAction.actionTimestamp",
+  "Submitted Date",
+  "-"
+);
+
 // Opens the document in a new tab, where PDFs/images preview inline and other
 // formats download. Shared by the State Files and CMS Files tables.
 const viewColumn = columnHelper.display({
@@ -72,6 +79,7 @@ export function makeStateFileColumns() {
     descriptionColumn,
     uploadedByColumn,
     uploadedDateColumn,
+    submittedDateColumn,
     viewColumn,
   ];
 }

--- a/client/src/mock-data/deliverableMocks.ts
+++ b/client/src/mock-data/deliverableMocks.ts
@@ -67,7 +67,9 @@ export const MOCK_DELIVERABLE_1: DeliverableDetailsManagementDeliverable = {
       documentType: "General File",
       createdAt: new Date("2026-03-23"),
       owner: { person: { fullName: "Florida State" } },
-      isPartOfDeliverableSubmission: false,
+      deliverableSubmissionAction: {
+        actionTimestamp: new Date("2026-03-23"),
+      },
     },
   ],
   cmsDocuments: [
@@ -78,8 +80,9 @@ export const MOCK_DELIVERABLE_1: DeliverableDetailsManagementDeliverable = {
       documentType: "General File",
       createdAt: new Date("2026-03-24"),
       owner: { person: { fullName: "Tess Davenport" } },
-      isPartOfDeliverableSubmission: false,
-    },
+      deliverableSubmissionAction: {
+        actionTimestamp: new Date("2026-03-24"),
+      }    },
   ],
   deliverableActions: [
     {

--- a/client/src/mock-data/deliverableMocks.ts
+++ b/client/src/mock-data/deliverableMocks.ts
@@ -82,7 +82,8 @@ export const MOCK_DELIVERABLE_1: DeliverableDetailsManagementDeliverable = {
       owner: { person: { fullName: "Tess Davenport" } },
       deliverableSubmissionAction: {
         actionTimestamp: new Date("2026-03-24"),
-      }    },
+      },
+    },
   ],
   deliverableActions: [
     {

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -99,7 +99,9 @@ export const DELIVERABLE_DETAILS_QUERY = gql`
             fullName
           }
         }
-        isPartOfDeliverableSubmission
+        deliverableSubmissionAction {
+          actionTimestamp
+        }
       }
       cmsDocuments {
         id
@@ -112,7 +114,9 @@ export const DELIVERABLE_DETAILS_QUERY = gql`
             fullName
           }
         }
-        isPartOfDeliverableSubmission
+        deliverableSubmissionAction {
+          actionTimestamp
+        }
       }
       deliverableActions {
         id

--- a/client/src/pages/deliverables/sections/CmsFilesTab.test.tsx
+++ b/client/src/pages/deliverables/sections/CmsFilesTab.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -53,6 +53,35 @@ const renderTab = (overrides: Partial<React.ComponentProps<typeof CmsFilesTab>> 
 };
 
 describe("CmsFilesTab", () => {
+  describe("row data", () => {
+    it("renders the expected columns", () => {
+      renderTab();
+
+      expect(screen.getByRole("columnheader", { name: /Type/i })).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: /File Name/i })).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: /Description/i })).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: /Uploaded By/i })).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: /Uploaded Date/i })).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: /View/i })).toBeInTheDocument();
+    });
+
+    it("renders the expected data in each row", () => {
+      renderTab();
+
+      const row = screen.getByText("CmsAlpha.pdf").closest("tr");
+      expect(row).not.toBeNull();
+
+      const cells = within(row as HTMLTableRowElement).getAllByRole("cell");
+      expect(within(cells[0]).getByTestId("select-row-cms-a")).toBeInTheDocument();
+      expect(cells[1]).toHaveTextContent("General File");
+      expect(cells[2]).toHaveTextContent("CmsAlpha.pdf");
+      expect(cells[3]).toHaveTextContent("CMS Alpha description");
+      expect(cells[4]).toHaveTextContent("Tess Davenport");
+      expect(cells[5]).toHaveTextContent("03/10/2026");
+      expect(within(cells[6]).getByTestId("view-file-cms-a")).toBeInTheDocument();
+    });
+  });
+
   it("renders one row per CMS file", () => {
     renderTab();
 
@@ -154,7 +183,10 @@ describe("CmsFilesTab", () => {
 
       const addButton = screen.getByTestId(CMS_FILES_ADD_BUTTON_NAME);
       expect(addButton).toBeDisabled();
-      expect(addButton).toHaveAttribute("title", "Files cannot be added to a Finalized deliverable.");
+      expect(addButton).toHaveAttribute(
+        "title",
+        "Files cannot be added to a Finalized deliverable."
+      );
     });
 
     it("keeps Edit disabled even when a row is selected", async () => {
@@ -167,10 +199,12 @@ describe("CmsFilesTab", () => {
       await user.click(screen.getByTestId("select-row-cms-a"));
 
       expect(editButton).toBeDisabled();
-      expect(editButton).toHaveAttribute("title", "Documents on Finalized deliverables cannot be edited.");
+      expect(editButton).toHaveAttribute(
+        "title",
+        "Documents on Finalized deliverables cannot be edited."
+      );
     });
   });
-
 
   describe("when file is part of a deliverable submission", () => {
     it("disables Delete for files that are part of a submission", async () => {

--- a/client/src/pages/deliverables/sections/CmsFilesTab.test.tsx
+++ b/client/src/pages/deliverables/sections/CmsFilesTab.test.tsx
@@ -21,7 +21,7 @@ const MOCK_FILES: DeliverableFileRow[] = [
     documentType: "General File",
     createdAt: new Date("2026-03-10"),
     owner: { person: { fullName: "Tess Davenport" } },
-    isPartOfDeliverableSubmission: false,
+    deliverableSubmissionAction: null,
   },
   {
     id: "cms-b",
@@ -30,7 +30,9 @@ const MOCK_FILES: DeliverableFileRow[] = [
     documentType: "Monitoring Report",
     createdAt: new Date("2026-04-15"),
     owner: { person: { fullName: "Sam Smith" } },
-    isPartOfDeliverableSubmission: true,
+    deliverableSubmissionAction: {
+      actionTimestamp: new Date("2026-04-15"),
+    },
   },
 ];
 

--- a/client/src/pages/deliverables/sections/CmsFilesTab.tsx
+++ b/client/src/pages/deliverables/sections/CmsFilesTab.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import type { DeliverableFileRow } from "./DeliverableFileTypes";
 import { DeliverableFileTable } from "./DeliverableFileTable";
-import { makeCmsFileColumns } from "./fileColumns";
+import { makeCmsFileColumns } from "components/table/columns/deliverableFileColumns";
 
 export const CMS_FILES_TAB_NAME = "cms-files-tab";
 export const CMS_FILES_ADD_BUTTON_NAME = "button-add-cms-file";

--- a/client/src/pages/deliverables/sections/DeliverableFileTable.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableFileTable.tsx
@@ -81,7 +81,7 @@ export const DeliverableFileTable: React.FC<DeliverableFileTableProps> = ({
             const selectedCount = selectedRows.length;
 
             const hasSubmittedFile = selectedRows.some(
-              (row) => row.isPartOfDeliverableSubmission
+              (row) => row.deliverableSubmissionAction
             );
 
             return (

--- a/client/src/pages/deliverables/sections/DeliverableFileTypes.ts
+++ b/client/src/pages/deliverables/sections/DeliverableFileTypes.ts
@@ -1,9 +1,10 @@
-import { Document, Person } from "demos-server";
+import { DeliverableAction, Document, Person } from "demos-server";
 
 export type DeliverableFileRow = Pick<
   Document,
-  "id" | "name" | "description" | "createdAt" | "isPartOfDeliverableSubmission" | "documentType"
+  "id" | "name" | "description" | "createdAt" | "documentType"
 > & {
+  deliverableSubmissionAction: Pick<DeliverableAction, "actionTimestamp"> | null;
   owner: { person: Pick<Person, "fullName"> };
 };
 

--- a/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
+++ b/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
@@ -21,7 +21,7 @@ const MOCK_FILES: DeliverableFileRow[] = [
     documentType: "General File",
     createdAt: new Date("2026-01-15"),
     owner: { person: { fullName: "Alpha Owner" } },
-    isPartOfDeliverableSubmission: false,
+    deliverableSubmissionAction: null,
   },
   {
     id: "file-b",
@@ -30,7 +30,7 @@ const MOCK_FILES: DeliverableFileRow[] = [
     documentType: "Monitoring Report",
     createdAt: new Date("2026-02-20"),
     owner: { person: { fullName: "Bravo Owner" } },
-    isPartOfDeliverableSubmission: false,
+    deliverableSubmissionAction: null,
   },
   {
     id: "file-c",
@@ -39,7 +39,9 @@ const MOCK_FILES: DeliverableFileRow[] = [
     documentType: "General File",
     createdAt: new Date("2026-03-25"),
     owner: { person: { fullName: "Charlie Owner" } },
-    isPartOfDeliverableSubmission: true,
+    deliverableSubmissionAction: {
+      actionTimestamp: new Date("2026-03-25"),
+    },
   },
 ];
 

--- a/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
+++ b/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -40,7 +40,7 @@ const MOCK_FILES: DeliverableFileRow[] = [
     createdAt: new Date("2026-03-25"),
     owner: { person: { fullName: "Charlie Owner" } },
     deliverableSubmissionAction: {
-      actionTimestamp: new Date("2026-03-25"),
+      actionTimestamp: new Date("2026-06-25"),
     },
   },
 ];
@@ -61,19 +61,17 @@ const renderTab = (overrides: Partial<React.ComponentProps<typeof StateFilesTab>
   );
 };
 
-
 describe("StateFilesTab", () => {
   describe("empty state", () => {
-
     it("renders the table header and shows the empty-rows message", () => {
-      renderTab({files: []});
+      renderTab({ files: [] });
 
       expect(screen.getByRole("table")).toBeInTheDocument();
       expect(screen.getByText(/No files have been added yet\./i)).toBeInTheDocument();
     });
 
     it("renders the header Add File(s) button", () => {
-      renderTab({files: []});
+      renderTab({ files: [] });
 
       expect(screen.getByTestId(STATE_FILES_ADD_BUTTON_NAME)).toBeInTheDocument();
     });
@@ -81,7 +79,7 @@ describe("StateFilesTab", () => {
     it("invokes onAdd when the header Add File(s) button is clicked", async () => {
       const user = userEvent.setup();
       const onAdd = vi.fn();
-      renderTab({files: [], onAdd});
+      renderTab({ files: [], onAdd });
 
       await user.click(screen.getByTestId(STATE_FILES_ADD_BUTTON_NAME));
 
@@ -95,6 +93,35 @@ describe("StateFilesTab", () => {
 
       expect(screen.getByText("Alpha.pdf")).toBeInTheDocument();
       expect(screen.getByText("Bravo.pdf")).toBeInTheDocument();
+    });
+
+    it("renders the expected columns", () => {
+      renderTab();
+
+      expect(screen.getByRole("columnheader", { name: /Type/i })).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: /File Name/i })).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: /Description/i })).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: /Uploaded By/i })).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: /Uploaded Date/i })).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: /Submitted Date/i })).toBeInTheDocument();
+      expect(screen.getByRole("columnheader", { name: /View/i })).toBeInTheDocument();
+    });
+
+    it("renders the expected data in each row", () => {
+      renderTab();
+
+      const row = screen.getByText("Charlie.pdf").closest("tr");
+      expect(row).not.toBeNull();
+
+      const cells = within(row as HTMLTableRowElement).getAllByRole("cell");
+      expect(within(cells[0]).getByTestId("select-row-file-c")).toBeInTheDocument();
+      expect(cells[1]).toHaveTextContent("General File");
+      expect(cells[2]).toHaveTextContent("Charlie.pdf");
+      expect(cells[3]).toHaveTextContent("Charlie description");
+      expect(cells[4]).toHaveTextContent("Charlie Owner");
+      expect(cells[5]).toHaveTextContent("03/25/2026");
+      expect(cells[6]).toHaveTextContent("06/25/2026");
+      expect(within(cells[7]).getByTestId("view-file-file-c")).toBeInTheDocument();
     });
 
     it("disables Edit until exactly one file is selected", async () => {
@@ -182,7 +209,10 @@ describe("StateFilesTab", () => {
 
       const addButton = screen.getByTestId(STATE_FILES_ADD_BUTTON_NAME);
       expect(addButton).toBeDisabled();
-      expect(addButton).toHaveAttribute("title", "Files cannot be added to a Finalized deliverable.");
+      expect(addButton).toHaveAttribute(
+        "title",
+        "Files cannot be added to a Finalized deliverable."
+      );
     });
 
     it("keeps Edit disabled even when a row is selected", async () => {
@@ -195,7 +225,10 @@ describe("StateFilesTab", () => {
       await user.click(screen.getByTestId("select-row-file-a"));
 
       expect(editButton).toBeDisabled();
-      expect(editButton).toHaveAttribute("title", "Documents on Finalized deliverables cannot be edited.");
+      expect(editButton).toHaveAttribute(
+        "title",
+        "Documents on Finalized deliverables cannot be edited."
+      );
     });
   });
   describe("when file is part of a deliverable submission", () => {

--- a/client/src/pages/deliverables/sections/StateFilesTab.tsx
+++ b/client/src/pages/deliverables/sections/StateFilesTab.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import type { DeliverableFileRow } from "./DeliverableFileTypes";
 import { DeliverableFileTable } from "./DeliverableFileTable";
-import { makeStateFileColumns } from "./fileColumns";
+import { makeStateFileColumns } from "components/table/columns/deliverableFileColumns";
 
 export const STATE_FILES_TAB_NAME = "state-files-tab";
 export const STATE_FILES_ADD_BUTTON_NAME = "button-add-state-files";

--- a/server/src/model/deliverableAction/deliverableActionFormattingFunctions.test.ts
+++ b/server/src/model/deliverableAction/deliverableActionFormattingFunctions.test.ts
@@ -3,11 +3,11 @@ import { describe, it, expect } from "vitest";
 import { DeepPartial } from "../../testUtilities";
 
 // Types
-import { SelectManyDeliverableActionsRowResult } from "./queries";
 import { DeliverableActionType, DeliverableExtensionReasonCode, PersonType } from "../../types";
 
 // Functions under test
 import { formatFullUserName, formatDetailsMessage } from "./deliverableActionFormattingFunctions";
+import { SelectDeliverableActionRowResult } from "./queries";
 
 // Mock imports
 
@@ -16,16 +16,16 @@ describe("deliverableActionFormattingFunctions", () => {
 
   describe("formatFullUserName", () => {
     it("should return System Update if no user is present", () => {
-      const testInput: DeepPartial<SelectManyDeliverableActionsRowResult> = {
+      const testInput: DeepPartial<SelectDeliverableActionRowResult> = {
         deliverableId: testDeliverableId,
       };
 
-      const result = formatFullUserName(testInput as SelectManyDeliverableActionsRowResult);
+      const result = formatFullUserName(testInput as SelectDeliverableActionRowResult);
       expect(result).toBe("System Update");
     });
 
     it("should use the user.personTypeId (these should never be different anyway)", () => {
-      const testInput: DeepPartial<SelectManyDeliverableActionsRowResult> = {
+      const testInput: DeepPartial<SelectDeliverableActionRowResult> = {
         deliverableId: testDeliverableId,
         user: {
           personTypeId: "demos-admin" satisfies PersonType,
@@ -37,12 +37,12 @@ describe("deliverableActionFormattingFunctions", () => {
         },
       };
 
-      const result = formatFullUserName(testInput as SelectManyDeliverableActionsRowResult);
+      const result = formatFullUserName(testInput as SelectDeliverableActionRowResult);
       expect(result).toBe("Jane Smith (Admin User)");
     });
 
     it("should return a formatted admin user if present", () => {
-      const testInput: DeepPartial<SelectManyDeliverableActionsRowResult> = {
+      const testInput: DeepPartial<SelectDeliverableActionRowResult> = {
         deliverableId: testDeliverableId,
         user: {
           personTypeId: "demos-admin" satisfies PersonType,
@@ -54,12 +54,12 @@ describe("deliverableActionFormattingFunctions", () => {
         },
       };
 
-      const result = formatFullUserName(testInput as SelectManyDeliverableActionsRowResult);
+      const result = formatFullUserName(testInput as SelectDeliverableActionRowResult);
       expect(result).toBe("Jane Smith (Admin User)");
     });
 
     it("should return a formatted CMS user if present", () => {
-      const testInput: DeepPartial<SelectManyDeliverableActionsRowResult> = {
+      const testInput: DeepPartial<SelectDeliverableActionRowResult> = {
         deliverableId: testDeliverableId,
         user: {
           personTypeId: "demos-cms-user" satisfies PersonType,
@@ -71,12 +71,12 @@ describe("deliverableActionFormattingFunctions", () => {
         },
       };
 
-      const result = formatFullUserName(testInput as SelectManyDeliverableActionsRowResult);
+      const result = formatFullUserName(testInput as SelectDeliverableActionRowResult);
       expect(result).toBe("Billy Smith (CMS User)");
     });
 
     it("should return a formatted state user if present", () => {
-      const testInput: DeepPartial<SelectManyDeliverableActionsRowResult> = {
+      const testInput: DeepPartial<SelectDeliverableActionRowResult> = {
         deliverableId: testDeliverableId,
         user: {
           personTypeId: "demos-state-user" satisfies PersonType,
@@ -88,24 +88,24 @@ describe("deliverableActionFormattingFunctions", () => {
         },
       };
 
-      const result = formatFullUserName(testInput as SelectManyDeliverableActionsRowResult);
+      const result = formatFullUserName(testInput as SelectDeliverableActionRowResult);
       expect(result).toBe("Jackson Smith (State User)");
     });
   });
 
   describe("formatDetailsMessage", () => {
     it("should return the proper message for marking a deliverable past due", () => {
-      const testInput: DeepPartial<SelectManyDeliverableActionsRowResult> = {
+      const testInput: DeepPartial<SelectDeliverableActionRowResult> = {
         deliverableId: testDeliverableId,
         actionTypeId: "Marked as Past Due" satisfies DeliverableActionType,
       };
 
-      const result = formatDetailsMessage(testInput as SelectManyDeliverableActionsRowResult);
+      const result = formatDetailsMessage(testInput as SelectDeliverableActionRowResult);
       expect(result).toBe("The deliverable is past its due date");
     });
 
     it("should return the proper message for requesting an extension", () => {
-      const testInput: DeepPartial<SelectManyDeliverableActionsRowResult> = {
+      const testInput: DeepPartial<SelectDeliverableActionRowResult> = {
         deliverableId: testDeliverableId,
         actionTypeId: "Requested Extension" satisfies DeliverableActionType,
         oldDueDate: new Date(2026, 10, 13, 4, 59, 59, 999),
@@ -116,7 +116,7 @@ describe("deliverableActionFormattingFunctions", () => {
         note: "COVID-19 is causing major delays in processing of paperwork.",
       };
 
-      const result = formatDetailsMessage(testInput as SelectManyDeliverableActionsRowResult);
+      const result = formatDetailsMessage(testInput as SelectDeliverableActionRowResult);
       expect(result).toBe(
         "Current Due Date: 11/12/2026\n" +
           "New Due Date Requested: 01/11/2027\n" +
@@ -126,31 +126,31 @@ describe("deliverableActionFormattingFunctions", () => {
     });
 
     it("should return the proper message for approving an extension", () => {
-      const testInput: DeepPartial<SelectManyDeliverableActionsRowResult> = {
+      const testInput: DeepPartial<SelectDeliverableActionRowResult> = {
         deliverableId: testDeliverableId,
         actionTypeId: "Approved Extension Request" satisfies DeliverableActionType,
         newDueDate: new Date(2026, 10, 13, 4, 59, 59, 999),
       };
 
-      const result = formatDetailsMessage(testInput as SelectManyDeliverableActionsRowResult);
+      const result = formatDetailsMessage(testInput as SelectDeliverableActionRowResult);
       expect(result).toBe("Approved Due Date: 11/12/2026");
     });
 
     it("should return the proper message for denying an extension", () => {
-      const testInput: DeepPartial<SelectManyDeliverableActionsRowResult> = {
+      const testInput: DeepPartial<SelectDeliverableActionRowResult> = {
         deliverableId: testDeliverableId,
         actionTypeId: "Denied Extension Request" satisfies DeliverableActionType,
         note: "Your request for an extension is denied on the grounds of technical merit",
       };
 
-      const result = formatDetailsMessage(testInput as SelectManyDeliverableActionsRowResult);
+      const result = formatDetailsMessage(testInput as SelectDeliverableActionRowResult);
       expect(result).toBe(
         "Denial Reason: Your request for an extension is denied on the grounds of technical merit"
       );
     });
 
     it("should return the proper message for requesting resubmission", () => {
-      const testInput: DeepPartial<SelectManyDeliverableActionsRowResult> = {
+      const testInput: DeepPartial<SelectDeliverableActionRowResult> = {
         deliverableId: testDeliverableId,
         actionTypeId: "Requested Resubmission" satisfies DeliverableActionType,
         oldDueDate: new Date(2026, 10, 13, 4, 59, 59, 999),
@@ -158,7 +158,7 @@ describe("deliverableActionFormattingFunctions", () => {
         note: "Please resubmit with form J-127 attached! Thanks.",
       };
 
-      const result = formatDetailsMessage(testInput as SelectManyDeliverableActionsRowResult);
+      const result = formatDetailsMessage(testInput as SelectDeliverableActionRowResult);
       expect(result).toBe(
         "Old Due Date: 11/12/2026\n" +
           "New Due Date: 01/11/2027\n" +
@@ -167,7 +167,7 @@ describe("deliverableActionFormattingFunctions", () => {
     });
 
     it("should return the proper message for a manual date change", () => {
-      const testInput: DeepPartial<SelectManyDeliverableActionsRowResult> = {
+      const testInput: DeepPartial<SelectDeliverableActionRowResult> = {
         deliverableId: testDeliverableId,
         actionTypeId: "Manually Changed Due Date" satisfies DeliverableActionType,
         oldDueDate: new Date(2026, 10, 13, 4, 59, 59, 999),
@@ -175,7 +175,7 @@ describe("deliverableActionFormattingFunctions", () => {
         note: "Changed per request of PO",
       };
 
-      const result = formatDetailsMessage(testInput as SelectManyDeliverableActionsRowResult);
+      const result = formatDetailsMessage(testInput as SelectDeliverableActionRowResult);
       expect(result).toBe(
         "Old Due Date: 11/12/2026\n" +
           "New Due Date: 01/11/2027\n" +
@@ -184,12 +184,12 @@ describe("deliverableActionFormattingFunctions", () => {
     });
 
     it("should return nothing if none of the special cases are encountered", () => {
-      const testInput: DeepPartial<SelectManyDeliverableActionsRowResult> = {
+      const testInput: DeepPartial<SelectDeliverableActionRowResult> = {
         deliverableId: testDeliverableId,
         actionTypeId: "Submitted Deliverable" satisfies DeliverableActionType,
       };
 
-      const result = formatDetailsMessage(testInput as SelectManyDeliverableActionsRowResult);
+      const result = formatDetailsMessage(testInput as SelectDeliverableActionRowResult);
       expect(result).toBe("");
     });
   });

--- a/server/src/model/deliverableAction/deliverableActionFormattingFunctions.ts
+++ b/server/src/model/deliverableAction/deliverableActionFormattingFunctions.ts
@@ -1,4 +1,3 @@
-import { SelectManyDeliverableActionsRowResult } from "./queries";
 import {
   formatEasternTZDateToMMDDYYYY,
   parseJSDateToEasternTZDate,
@@ -10,6 +9,7 @@ import {
   NonEmptyString,
   PersonType,
 } from "../../types";
+import { SelectDeliverableActionRowResult } from "./queries";
 
 const PERSON_TYPE_DISPLAY_MAP = new Map<PersonType, string>([
   ["demos-admin", "Admin User"],
@@ -18,7 +18,7 @@ const PERSON_TYPE_DISPLAY_MAP = new Map<PersonType, string>([
 ]);
 
 // Note: casts below are enforced by the database
-export function formatFullUserName(input: SelectManyDeliverableActionsRowResult): NonEmptyString {
+export function formatFullUserName(input: SelectDeliverableActionRowResult): NonEmptyString {
   if (input.user) {
     const firstName = input.user.person.firstName;
     const lastName = input.user.person.lastName;
@@ -63,7 +63,7 @@ function makeResubmissionRequestedOrDateChangedMessage(
   return `Old Due Date: ${formattedOldDue}\nNew Due Date: ${formattedNewDue}\nReason Details: ${reason}`;
 }
 
-export function formatDetailsMessage(input: SelectManyDeliverableActionsRowResult): string {
+export function formatDetailsMessage(input: SelectDeliverableActionRowResult): string {
   // Field existence enforced by database for all objects below
   switch (input.actionTypeId as DeliverableActionType) {
     case "Marked as Past Due":

--- a/server/src/model/deliverableAction/getFormattedDeliverableActions.test.ts
+++ b/server/src/model/deliverableAction/getFormattedDeliverableActions.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DeepPartial } from "../../testUtilities";
 
 // Types
-import { SelectManyDeliverableActionsRowResult } from "./queries";
 import { DeliverableActionType } from "../../types";
 
 // Functions under test
@@ -25,7 +24,7 @@ vi.mock("./queries", () => ({
 
 import { prisma } from "../../prismaClient";
 import { formatDetailsMessage, formatFullUserName } from ".";
-import { selectManyDeliverableActions } from "./queries";
+import { SelectDeliverableActionRowResult, selectManyDeliverableActions } from "./queries";
 
 describe("selectManyDeliverableActions", () => {
   // Test inputs
@@ -34,7 +33,7 @@ describe("selectManyDeliverableActions", () => {
   // Mock return values
   const mockPrismaClient = "I'm a returned client!" as any;
   const mockTransaction = "I'm a transaction!" as any;
-  const mockQueryResults: DeepPartial<SelectManyDeliverableActionsRowResult>[] = [
+  const mockQueryResults: DeepPartial<SelectDeliverableActionRowResult>[] = [
     {
       id: "eafccca7-9b92-435d-8069-d065dbc52d0a",
       actionTimestamp: new Date(2026, 3, 23, 20, 20, 39, 131),
@@ -57,7 +56,7 @@ describe("selectManyDeliverableActions", () => {
     vi.mocked(formatFullUserName).mockReturnValueOnce(mockFullName[0]);
     vi.mocked(formatFullUserName).mockReturnValueOnce(mockFullName[1]);
     vi.mocked(selectManyDeliverableActions).mockResolvedValue(
-      mockQueryResults as SelectManyDeliverableActionsRowResult[]
+      mockQueryResults as SelectDeliverableActionRowResult[]
     );
   });
 

--- a/server/src/model/deliverableAction/queries/index.ts
+++ b/server/src/model/deliverableAction/queries/index.ts
@@ -1,6 +1,18 @@
+import { 
+  DeliverableAction as PrismaDeliverableAction, 
+  DeliverableExtension as PrismaDeliverableExtension, 
+  Person as PrismaPerson, 
+  User as PrismaUser 
+} from "@prisma/client";
+
 export { insertDeliverableAction } from "./insertDeliverableAction";
 export { selectDeliverableAction } from "./selectDeliverableAction";
 export { selectManyDeliverableActions } from "./selectManyDeliverableActions";
 
 export type { InsertDeliverableActionInput } from "./insertDeliverableAction";
-export type { SelectManyDeliverableActionsRowResult } from "./selectManyDeliverableActions";
+
+export type SelectDeliverableActionRowResult = PrismaDeliverableAction & {
+  user: (PrismaUser & { person: PrismaPerson }) | null;
+} & {
+  activeExtension: PrismaDeliverableExtension | null;
+};

--- a/server/src/model/deliverableAction/queries/selectDeliverableAction.test.ts
+++ b/server/src/model/deliverableAction/queries/selectDeliverableAction.test.ts
@@ -38,6 +38,14 @@ describe("selectDeliverableAction", () => {
 
   const expectedCall = {
     where: testInput,
+    include: {
+      user: {
+        include: {
+          person: true,
+        },
+      },
+      activeExtension: true,
+    }, 
   };
 
   beforeEach(() => {

--- a/server/src/model/deliverableAction/queries/selectDeliverableAction.ts
+++ b/server/src/model/deliverableAction/queries/selectDeliverableAction.ts
@@ -1,25 +1,36 @@
-import { DeliverableAction as PrismaDeliverableAction, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { prisma, PrismaTransactionClient } from "../../../prismaClient";
+import { SelectDeliverableActionRowResult } from ".";
 
 export async function selectDeliverableAction(
   where: Prisma.DeliverableActionWhereInput,
   shouldAlwaysReturn: true,
   tx?: PrismaTransactionClient
-): Promise<PrismaDeliverableAction>;
+): Promise<SelectDeliverableActionRowResult>;
 
 export async function selectDeliverableAction(
   where: Prisma.DeliverableActionWhereInput,
   shouldAlwaysReturn: false,
   tx?: PrismaTransactionClient
-): Promise<PrismaDeliverableAction | null>;
+): Promise<SelectDeliverableActionRowResult | null>;
 
 export async function selectDeliverableAction(
   where: Prisma.DeliverableActionWhereInput,
   shouldAlwaysReturn: boolean,
   tx?: PrismaTransactionClient
-): Promise<PrismaDeliverableAction | null> {
+): Promise<SelectDeliverableActionRowResult | null> {
   const prismaClient = tx ?? prisma();
-  const result = await prismaClient.deliverableAction.findAtMostOne({ where });
+  const result = await prismaClient.deliverableAction.findAtMostOne({ 
+    where,     
+    include: {
+      user: {
+        include: {
+          person: true,
+        },
+      },
+      activeExtension: true,
+    }, 
+  });
   if (shouldAlwaysReturn && !result) {
     throw new Error(
       `Expected selectDeliverableAction to return a record but it did not! Where clause: ${JSON.stringify(where)}`

--- a/server/src/model/deliverableAction/queries/selectManyDeliverableActions.ts
+++ b/server/src/model/deliverableAction/queries/selectManyDeliverableActions.ts
@@ -1,22 +1,13 @@
 import {
   Prisma,
-  DeliverableAction as PrismaDeliverableAction,
-  DeliverableExtension as PrismaDeliverableExtension,
-  Person as PrismaPerson,
-  User as PrismaUser,
 } from "@prisma/client";
 import { prisma, PrismaTransactionClient } from "../../../prismaClient";
-
-export type SelectManyDeliverableActionsRowResult = PrismaDeliverableAction & {
-  user: (PrismaUser & { person: PrismaPerson }) | null;
-} & {
-  activeExtension: PrismaDeliverableExtension | null;
-};
+import { SelectDeliverableActionRowResult } from ".";
 
 export async function selectManyDeliverableActions(
   where: Prisma.DeliverableActionWhereInput = {},
   tx?: PrismaTransactionClient
-): Promise<SelectManyDeliverableActionsRowResult[]> {
+): Promise<SelectDeliverableActionRowResult[]> {
   const prismaClient = tx ?? prisma();
   const deliverableActions = await prismaClient.deliverableAction.findMany({
     where: where,

--- a/server/src/model/deliverableExtension/deliverableExtensionResolvers.test.ts
+++ b/server/src/model/deliverableExtension/deliverableExtensionResolvers.test.ts
@@ -16,7 +16,7 @@ vi.mock("../deliverableAction/queries", () => ({
   selectDeliverableAction: vi.fn(),
 }));
 
-import { selectDeliverableAction } from "../deliverableAction/queries";
+import { selectDeliverableAction, SelectDeliverableActionRowResult } from "../deliverableAction/queries";
 
 describe("deliverableExtensionResolvers", () => {
   const testDeliverableExtension: Partial<PrismaDeliverableExtension> = {
@@ -32,7 +32,7 @@ describe("deliverableExtensionResolvers", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(selectDeliverableAction).mockResolvedValue(
-      mockDeliverableAction as PrismaDeliverableAction
+      mockDeliverableAction as SelectDeliverableActionRowResult
     );
   });
 

--- a/server/src/model/document/documentResolvers.test.ts
+++ b/server/src/model/document/documentResolvers.test.ts
@@ -15,6 +15,7 @@ import {
   resolveHasPendingUIPathResult,
 } from "./documentResolvers";
 import { editDocument, getDocument, removeDocument } from "./documentData";
+import { selectDeliverableAction, SelectDeliverableActionRowResult } from "../deliverableAction/queries";
 
 // Mock dependencies
 vi.mock("../../prismaClient", () => ({
@@ -61,6 +62,10 @@ vi.mock("../../services/uipathQueue", () => ({
 
 vi.mock("../user/queries", () => ({
   selectUserOrThrow: vi.fn(),
+}));
+
+vi.mock("../deliverableAction/queries", () => ({
+  selectDeliverableAction: vi.fn(),
 }));
 
 describe("documentResolvers", () => {
@@ -175,23 +180,49 @@ describe("documentResolvers", () => {
     });
   });
 
-  describe("Document.isPartOfDeliverableSubmission", () => {
-    it("returns true when deliverableSubmissionActionId is not null", () => {
-      const document = {
-        deliverableSubmissionActionId: "action-123",
-      } as PrismaDocument;
-
-      const result = documentResolvers.Document.isPartOfDeliverableSubmission(document);
-      expect(result).toBe(true);
-    });
-
-    it("returns false when deliverableSubmissionActionId is null", () => {
+  describe("Document.deliverableSubmissionAction", () => {
+    it("returns null when deliverableSubmissionActionId is null ", async () => {
       const document = {
         deliverableSubmissionActionId: null,
       } as PrismaDocument;
 
-      const result = documentResolvers.Document.isPartOfDeliverableSubmission(document);
-      expect(result).toBe(false);
+      const result = await documentResolvers.Document.deliverableSubmissionAction(document);
+      expect(result).toBeNull();
+    });
+
+    it("finds and maps the delierableSubmissionAction based on the deliverableSubmissionActionId", async () => {
+      const document = {
+        deliverableSubmissionActionId: "action-123",
+      } as PrismaDocument;
+
+      const now = new Date("2025-01-01T00:00:00.000Z");
+      vi.mocked(selectDeliverableAction).mockResolvedValue({
+        id: "action-123",
+        actionTimestamp: now,
+        actionTypeId: "Submitted Deliverable",
+        user: {
+          personTypeId: "demos-cms-user",
+          person: {
+            firstName: "John",
+            lastName: "Doe",
+          },
+        },
+      } as SelectDeliverableActionRowResult);
+         
+      const result = await documentResolvers.Document.deliverableSubmissionAction(document);
+      expect(selectDeliverableAction).toHaveBeenCalledExactlyOnceWith(
+        {
+          id: document.deliverableSubmissionActionId,
+        },
+        true
+      );
+      expect(result).toEqual({
+        id: "action-123",
+        actionTimestamp: now,
+        actionType: "Submitted Deliverable",
+        details: "",
+        userFullName: "John Doe (CMS User)",
+      });
     });
   });
   describe("Document.phaseName", () => {

--- a/server/src/model/document/documentResolvers.ts
+++ b/server/src/model/document/documentResolvers.ts
@@ -5,6 +5,8 @@ import { handlePrismaError } from "../../errors/handlePrismaError";
 import { prisma } from "../../prismaClient";
 import type {
   BudgetNeutralityValidationStatus,
+  DeliverableAction,
+  DeliverableActionType,
   DocumentType,
   PhaseName,
   UpdateDocumentInput,
@@ -19,6 +21,8 @@ import type {
   BudgetNeutralityValidationError,
   BudgetNeutralityValidationResult,
 } from "./documentSchema";
+import { selectDeliverableAction } from "../deliverableAction/queries";
+import { formatDetailsMessage, formatFullUserName } from "../deliverableAction";
 
 export async function triggerUiPath(
   parent: unknown,
@@ -156,8 +160,24 @@ export const documentResolvers = {
     application: (parent: PrismaDocument): Promise<PrismaApplication> =>
       getApplication(parent.applicationId),
     deliverable: resolveDeliverable,
-    isPartOfDeliverableSubmission: (parent: PrismaDocument): boolean =>
-      !!parent.deliverableSubmissionActionId,
+    deliverableSubmissionAction: async (parent: PrismaDocument): Promise<DeliverableAction | null> => {
+      if (!parent.deliverableSubmissionActionId) {
+        return null;
+      }
+      const deliverableAction = await selectDeliverableAction(
+        {
+          id: parent.deliverableSubmissionActionId,
+        },
+        true
+      );
+      return {
+        id: deliverableAction.id,
+        actionTimestamp: deliverableAction.actionTimestamp,
+        actionType: deliverableAction.actionTypeId as DeliverableActionType,
+        details: formatDetailsMessage(deliverableAction),
+        userFullName: formatFullUserName(deliverableAction),
+      };
+    },
     phaseName: (parent: PrismaDocument): PhaseName => parent.phaseId as PhaseName,
     hasPendingUIPathResult: resolveHasPendingUIPathResult,
     budgetNeutralityValidation: resolveBudgetNeutralityValidation,

--- a/server/src/model/document/documentSchema.ts
+++ b/server/src/model/document/documentSchema.ts
@@ -4,6 +4,7 @@ import {
   Application,
   BudgetNeutralityValidationStatus,
   Deliverable,
+  DeliverableAction,
   DocumentType,
   NonEmptyString,
   PhaseName,
@@ -32,7 +33,7 @@ export const documentSchema = gql`
     phaseName: PhaseName @auth(requires: ["Access CMS Field"])
     presignedDownloadUrl: String! @auth(requires: ["Access CMS Field"])
     deliverable: Deliverable @auth(requires: ["Access CMS Field"])
-    isPartOfDeliverableSubmission: Boolean!
+    deliverableSubmissionAction: DeliverableAction
     hasPendingUIPathResult: Boolean! @auth(requires: ["Access CMS Field"])
     budgetNeutralityValidation: BudgetNeutralityValidationResult
     createdAt: DateTime!
@@ -80,7 +81,7 @@ export interface Document {
   application: Application;
   phaseName?: PhaseName;
   deliverable?: Deliverable;
-  isPartOfDeliverableSubmission: boolean;
+  deliverableSubmissionAction?: DeliverableAction;
   createdAt: Date;
   updatedAt: Date;
   presignedDownloadUrl: string;


### PR DESCRIPTION
part 1 of 2 for https://jiraent.cms.gov/browse/DEMOS-2329. This covers the secondary requirement of "show the document's submission date, should it exist, in the state files tab". Realized we werent actually returning this from the server, just a boolean of "is in a submission". So i went ahead and fleshed it out to return a full gql type, the same one used on the deliverable actions table. Now, to display the date on frontend we can just ask the server for it on the document.deliverableSubmissionAction. Once the server was set up, i did the frontend to insert the new column. 

https://github.com/user-attachments/assets/d875be74-e011-4fd2-897d-05153a20369d

