### PR TITLE
DEMOS-2218: AutoCompleteSelects don't get cut off by dialog

### DIFF
--- a/client/src/components/dialog/BaseDialog.tsx
+++ b/client/src/components/dialog/BaseDialog.tsx
@@ -6,7 +6,7 @@ import { ConfirmCancellationDialog } from "./ConfirmCancellationDialog";
 
 export const DIALOG_CANCEL_BUTTON_NAME = "button-dialog-cancel";
 
-const DIALOG = tw`bg-surface-white text-text-font w-full rounded shadow-md p-md relative max-h-[85vh] overflow-y-auto space-y-sm backdrop:bg-black/40`;
+const DIALOG = tw`bg-surface-white text-text-font w-full rounded shadow-md p-md relative flex flex-col space-y-sm overflow-visible backdrop:bg-black/40`;
 const CLOSE_BUTTON = tw`absolute top-xs right-sm text-[22px] text-text-placeholder hover:text-text-font cursor-pointer`;
 const CLOSE_BUTTON_DISABLED = tw`absolute top-xs right-sm text-[22px] text-text-placeholder/50 cursor-not-allowed`;
 const TITLE = tw`text-[18px] font-bold mb-xs`;


### PR DESCRIPTION
per DEMOS-2218, this fixes the problem of dialogs cutting off the text in our custom combo box implementations. Took a while to come to this solution, a lot of editing but it's looking good now

## Problem
<img width="1789" height="1164" alt="image" src="https://github.com/user-attachments/assets/a707623c-5060-4055-b4a2-8d8ec10e2afe" />


## Fixed

<img width="1946" height="1385" alt="firefox_14_00_04" src="https://github.com/user-attachments/assets/e1e4b53a-22a3-4325-a0a0-a2b6b1bf568c" />
<img width="1834" height="1239" alt="firefox_14_00_11" src="https://github.com/user-attachments/assets/b458a6cb-5054-4ac0-a821-0f640a302a6d" />
