### PR TITLE
Demos 2334 -  BN Workbook validation updates

### DIFF
--- a/shared_library/src/BN/index.test.ts
+++ b/shared_library/src/BN/index.test.ts
@@ -87,10 +87,8 @@ describe("excelColumnRow", () => {
     );
   });
 
-  it("throws when row is out of range", () => {
-    expect(() => excelColumnRow("A99", "Sheet1", workbookData)).toThrow(
-      "Row 99 not found",
-    );
+  it("returns null when row is out of range", () => {
+    expect(excelColumnRow("A99", "Sheet1", workbookData)).toBeNull();
   });
 
   it("numberToExcelColumn converts numbers to Excel column letters correctly", () => {

--- a/shared_library/src/BN/index.ts
+++ b/shared_library/src/BN/index.ts
@@ -64,10 +64,10 @@ export function excelColumnRow(
 
   const columnLetters = match[1]!;
   const rowNumber = parseInt(match[2]!, 10) - 1;
-  
+
   const row = sheetData.data[rowNumber];
   if (!row) {
-    throw new Error(`Row ${rowNumber + 1} not found`);
+    return null;
   }
 
   return row[excelColumnToNumber(columnLetters)] as CellValue;

--- a/shared_library/src/BN/rulesets/v1/index.ts
+++ b/shared_library/src/BN/rulesets/v1/index.ts
@@ -65,10 +65,21 @@ export const validations: ValidationFunction[] = [
         row += 1;
         continue;
       }
-      for (let colNumber =  excelColumnToNumber(columnStart); colNumber <= excelColumnToNumber(columnEnd); colNumber++) {
+      for (
+        let colNumber = excelColumnToNumber(columnStart);
+        colNumber <= excelColumnToNumber(columnEnd);
+        colNumber++
+      ) {
         const col = numberToExcelColumn(colNumber);
         const cellValue = excelColumnRow(`${col}${row}`, "C Report", data);
-        if (cellValue !== "" && cellValue !== null) {
+        if (
+          cellValue !== "" &&
+          cellValue !== null &&
+          cellValue !== 0 &&
+          cellValue !== "Federal Share" &&
+          cellValue !== "ADM Waivers" &&
+          cellValue !== "Total Computable"
+        ) {
           return {
             code: "4",
             message:
@@ -106,8 +117,8 @@ export const validations: ValidationFunction[] = [
   },
 
   function error7(data: ExcelData) {
-    const k3 = Number(excelColumnRow("K3", "C Report", data));
-    if (isNaN(k3) || k3 < 1 || k3 > 4) {
+    const F3 = Number(excelColumnRow("F3", "C Report", data));
+    if (isNaN(F3) || F3 < 1 || F3 > 4) {
       return {
         code: "7",
         message:
@@ -124,8 +135,13 @@ export const validations: ValidationFunction[] = [
     const columnEnd = "AH";
 
     for (let row = rowStart; row <= rowEnd; row++) {
-      for (let colNumber = excelColumnToNumber(columnStart); colNumber <= excelColumnToNumber(columnEnd); colNumber++) {
+      for (
+        let colNumber = excelColumnToNumber(columnStart);
+        colNumber <= excelColumnToNumber(columnEnd);
+        colNumber++
+      ) {
         const col = numberToExcelColumn(colNumber);
+
         const cellValue = excelColumnRow(`${col}${row}`, "MemMon Actual", data);
         if (
           cellValue !== "" &&
@@ -151,8 +167,13 @@ export const validations: ValidationFunction[] = [
     const columnEnd = "AH";
 
     for (let row = rowStart; row <= rowEnd; row++) {
-      for (let colNumber = excelColumnToNumber(columnStart); colNumber <= excelColumnToNumber(columnEnd); colNumber++) {
+      for (
+        let colNumber = excelColumnToNumber(columnStart);
+        colNumber <= excelColumnToNumber(columnEnd);
+        colNumber++
+      ) {
         const col = numberToExcelColumn(colNumber);
+
         const cellValue = excelColumnRow(
           `${col}${row}`,
           "MemMon Projected",
@@ -183,7 +204,11 @@ export const validations: ValidationFunction[] = [
     const skipColumns = ["AR", "AS"];
 
     for (let row = rowStart; row <= rowEnd; row++) {
-      for (let colNumber = excelColumnToNumber(columnStart); colNumber <= excelColumnToNumber(columnEnd); colNumber++) {
+      for (
+        let colNumber = excelColumnToNumber(columnStart);
+        colNumber <= excelColumnToNumber(columnEnd);
+        colNumber++
+      ) {
         const col = numberToExcelColumn(colNumber);
         if (skipColumns.includes(col)) {
           continue;
@@ -214,10 +239,14 @@ export const validations: ValidationFunction[] = [
     const rowStart = 68;
     const rowEnd = 467;
     const columnStart = "D";
-    const columnEnd = "BV";  
+    const columnEnd = "BV";
 
     for (let row = rowStart; row <= rowEnd; row++) {
-      for (let colNumber = excelColumnToNumber(columnStart); colNumber <= excelColumnToNumber(columnEnd); colNumber++) {
+      for (
+        let colNumber = excelColumnToNumber(columnStart);
+        colNumber <= excelColumnToNumber(columnEnd);
+        colNumber++
+      ) {
         const col = numberToExcelColumn(colNumber);
         const cellValue = excelColumnRow(
           `${col}${row}`,

--- a/shared_library/src/BN/validation.test.ts
+++ b/shared_library/src/BN/validation.test.ts
@@ -1,9 +1,21 @@
 import { describe, it, expect, vi } from "vitest";
 
 import type { ExcelData } from "./index.js";
+import * as BN from "./index.js";
 import { validateBNWorkbook, type ValidationError } from "./validation.js";
+import { validations as v1Validations } from "./rulesets/v1/index.js";
+import { extractorFunctions } from "./extractors/index.js";
 
 describe("validateBNWorkbook", () => {
+  it("should validate a real file", async() => {
+    const data = await BN.parseBNFileFromPath("test/fixtures/test-bn.xlsm");
+    const result = await validateBNWorkbook(data, v1Validations, extractorFunctions);    
+    expect(result.isValid).toBe(true);
+    expect(result.extractedValues?.get("netVariance")).toBe(46848737436.56)
+    expect(result.extractedValues?.get("actuals")).toBe("Actuals + Projected");
+    console.log(result);
+  });
+
   it("returns a valid result with empty errors when no validations are provided", async () => {
     const data: ExcelData = [];
 


### PR DESCRIPTION
Vivian and team created a realistic example BN workbook which is now included.  The new file exposed some issues that required some code changes.  

The changes:
- Excel doesn't always save empty rows, so if a row is empty treat the value as null (before we would throw an out of index error)
- On the C report page, The rows that say:  "Federal Share" "ADM Waivers" "Total Computable" have these values in all cells, but they look blank on the screen.  We ignore them now.
- Validation Error 7 had a typo where it was looking at k3 when it should have been f3
