### PR TITLE
DEMOS-2270: format date before sending to date picker

### DIFF
--- a/client/src/components/dialog/modification/ModificationForm.test.tsx
+++ b/client/src/components/dialog/modification/ModificationForm.test.tsx
@@ -323,16 +323,16 @@ describe("ModificationForm", () => {
     describe("hasChanges", () => {
       it("returns false when no fields have changed", () => {
         const formData: ModificationFormData = {
-          demonstrationId: "demo-1",
           name: "Test",
           description: "Description",
           signatureLevel: "OA",
+          effectiveDate: "2024-02-01" as LocalDate,
         };
         const original: Partial<Modification> = {
-          demonstration: { id: "demo-1" },
           name: "Test",
           description: "Description",
           signatureLevel: "OA",
+          effectiveDate: "2024-02-01T04:00:00.000Z",
         };
         expect(hasChanges(formData, original)).toBe(false);
       });
@@ -398,7 +398,7 @@ describe("ModificationForm", () => {
           name: "Test",
           description: "Description",
           signatureLevel: "OA",
-          effectiveDate: "2024-01-01" as LocalDate,
+          effectiveDate: "2024-06-01T04:00:00.000Z",
         };
         expect(hasChanges(formData, original)).toBe(true);
       });

--- a/client/src/components/dialog/modification/ModificationForm.tsx
+++ b/client/src/components/dialog/modification/ModificationForm.tsx
@@ -5,6 +5,7 @@ import { SelectSignatureLevel } from "components/input/select/SelectSignatureLev
 import { SelectDemonstration } from "components/input/select/SelectDemonstration";
 import { DatePicker } from "components/input/date/DatePicker";
 import { getRequiredFieldWhenApprovedMessage } from "util/messages";
+import { formatDateForServer } from "util/formatDate";
 
 export type Modification = {
   id: string;
@@ -49,13 +50,13 @@ export const hasChanges = (
   createModificationFormData: ModificationFormData,
   initialModification: Partial<Modification>
 ): boolean => {
-  const initialEffectiveDate = initialModification.effectiveDate ?? undefined;
+  const initialModifiactionFormData = getFormDataFromModification(initialModification);
 
   return !!(
-    createModificationFormData.name != initialModification.name ||
-    createModificationFormData.description != initialModification.description ||
-    createModificationFormData.signatureLevel != initialModification.signatureLevel ||
-    createModificationFormData.effectiveDate != initialEffectiveDate
+    createModificationFormData.name != initialModifiactionFormData.name ||
+    createModificationFormData.description != initialModifiactionFormData.description ||
+    createModificationFormData.signatureLevel != initialModifiactionFormData.signatureLevel ||
+    createModificationFormData.effectiveDate != initialModifiactionFormData.effectiveDate
   );
 };
 
@@ -64,7 +65,9 @@ export const getFormDataFromModification = (
 ): ModificationFormData => ({
   name: modification.name,
   description: modification.description ?? undefined,
-  effectiveDate: modification.effectiveDate ?? undefined,
+  effectiveDate: modification.effectiveDate
+    ? formatDateForServer(modification.effectiveDate)
+    : undefined,
   signatureLevel: modification.signatureLevel ?? undefined,
   demonstrationId: modification.demonstration?.id,
 });


### PR DESCRIPTION
issue here was that we were passing the full ISO string into the datepicker, rather than the YYYY-mm-dd date, so nothing would display. Made it format when it generates the form data, and made the hasChanges pass the original modification through that same formatter. 