### PR TITLE
QOL: More concise messages for `getBy` and `findBy` errors

### DIFF
--- a/client/vitest.setup.ts
+++ b/client/vitest.setup.ts
@@ -1,5 +1,6 @@
 // Import DOM testing library for Jest, to be used by all test files
 import "@testing-library/jest-dom";
+import { configure } from "@testing-library/dom";
 
 import React from "react";
 
@@ -26,6 +27,20 @@ Object.defineProperty(HTMLDialogElement.prototype, "close", {
     this.open = false;
   }),
   writable: true,
+});
+
+// Better error messages for Testing Library DOM queries
+configure({
+  getElementError: (message) => {
+    const cleaned = message?.replace(/\.\. This could be because.*$/s, ".") ?? undefined;
+    const error = new Error(cleaned);
+    error.name = "TestingLibraryElementError";
+    error.stack = error.stack
+      ?.split("\n")
+      .filter((line) => !line.includes("node_modules") && !line.includes("vitest.setup.ts"))
+      .join("\n");
+    return error;
+  },
 });
 
 Object.defineProperty(HTMLDialogElement.prototype, "open", {


### PR DESCRIPTION
A small change I made for another piece of work that I figured I'd break out into its own piece, the error messages before would dump a pretty large DOM tree so I this just helps scroll through the errors a bit easier


https://github.com/user-attachments/assets/e46e6bd8-5b13-4b73-afdf-2cd3b0fab3c6

