### PR TITLE
Demos 2345: added caped an "I" in "Federal Comment Internal Analysis Document" and make the file type default

### DIFF
--- a/client/src/components/application/phases/FederalCommentPhase.tsx
+++ b/client/src/components/application/phases/FederalCommentPhase.tsx
@@ -30,7 +30,7 @@ export const FEDERAL_COMMENT_PHASE_STEP_ONE_DESCRIPTION = {
   testId: "federal-comment-phase-step-one-description",
 };
 export const FEDERAL_COMMENT_PHASE_STEP_TWO_DESCRIPTION = {
-  text: "Upload the internal Analysis Document (Optional).",
+  text: "Upload the Internal Analysis Document (Optional).",
 };
 
 export const getFederalCommentPhaseFromApplication = (application: WorkflowApplication) => {

--- a/client/src/components/dialog/document/phases/FederalCommentUploadDialog.test.tsx
+++ b/client/src/components/dialog/document/phases/FederalCommentUploadDialog.test.tsx
@@ -97,9 +97,11 @@ describe("FederalCommentUploadDialog", () => {
   });
 
   describe("Federal Comment Configuration", () => {
-    it("defaults document type to 'General File'", () => {
+    it("defaults document type to 'Federal Comment Internal Analysis Document'", () => {
       setup();
-      expect(screen.getByDisplayValue("General File")).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue("Federal Comment Internal Analysis Document")
+      ).toBeInTheDocument();
     });
 
     it("shows Federal Comment specific dialog title", () => {

--- a/client/src/components/dialog/document/phases/FederalCommentUploadDialog.tsx
+++ b/client/src/components/dialog/document/phases/FederalCommentUploadDialog.tsx
@@ -9,8 +9,8 @@ import {
 } from "components/application";
 
 const FEDERAL_COMMENT_DOCUMENT_TYPES: DocumentType[] = [
-  "General File",
   "Federal Comment Internal Analysis Document",
+  "General File",
 ];
 
 export const FederalCommentUploadDialog = ({

--- a/client/src/components/dialog/document/phases/FederalCommentUploadDialog.tsx
+++ b/client/src/components/dialog/document/phases/FederalCommentUploadDialog.tsx
@@ -8,6 +8,7 @@ import {
   GET_WORKFLOW_DEMONSTRATION_QUERY,
 } from "components/application";
 
+// The top item is the default for doc dialog
 const FEDERAL_COMMENT_DOCUMENT_TYPES: DocumentType[] = [
   "Federal Comment Internal Analysis Document",
   "General File",


### PR DESCRIPTION
Federal Comment Internal Analysis Document is now the default file type for Phase 4
Replacing 🫡 General File. And capped an "I" (eye)

<img width="1955" height="1289" alt="Screenshot 2026-06-26 at 09 59 50" src="https://github.com/user-attachments/assets/919dcd21-2016-488a-9f80-31563e7685e1" />
