### PR TITLE
DEMOS-2332: added relative to layout content

### DIFF
--- a/client/src/layout/PrimaryLayout.tsx
+++ b/client/src/layout/PrimaryLayout.tsx
@@ -29,7 +29,7 @@ export const PrimaryLayout = ({ children }: { children: React.ReactNode }) => {
           <Header />
           <div className="flex flex-1 overflow-hidden bg-gray-primary-layout min-h-0">
             {!hideSideNav && <SideNav />}
-            <div className="flex-1 overflow-auto min-h-0 flex flex-col">
+            <div className="relative flex-1 overflow-auto min-h-0 flex flex-col">
               <div className="p-[16px] flex-1">{children}</div>
             </div>
           </div>


### PR DESCRIPTION
this was a beast of a layout/css issue that just kept going and going. funny, given the size of the fix. my _adventure_:

SO main issue is when the demo details section is expanded, an additional scrollbar is put on the page and the user can scroll down past the footer. Looked to see what was causing this by iteratively commenting out different sections of the html until it seemed to work correctly. Oddly, it led me all the way down to the `<span className="sr-only">Select</span>` span in the checkbox. This was very strange, since the sr-only makes the element 1px tall and wide, so nowhere near the amount of extra content being generated. 

Dug deeper, and found that this issue was also reproducing on the Approval Package phase. So i suspect it was coming from something in the table layout; but this theory didnt work because other tables in other places seemed to work fine; the documents table had no issue. So needed to dig deeper. 

Eventually i found that this issue could be reproduced on other pages if there is enough content on the page; it would push the absolutely positioned span down enough to be below the footer and expand the page height. I then made a test page to really get to the bottom of this, and found that it wouldnt reproduce on a completely blank page, but could reproduce on a blank page within our primary layout. Something about the combination of containers, content on the page, and an absolutely positioned span causes the span to render way below the rest of the content. 

By switching the "sr-only" to just "absolute", its clear whats happening:
<img width="1597" height="1584" alt="image" src="https://github.com/user-attachments/assets/9fbbdba0-1d9b-4fa9-aede-0fb7cfa6fec9" />

So, because this bug was reproducible everywhere within our primary layout, given the right circumstances, the fix was just to make sure we had a position: relative at the start of our main content window. Im guessing this is one of the first times we have actually had an absolutely positioned element on the site, so it just never occurred before. That all being said, i feel like something is off in the layout in general for this to be an issue. We should probably take a cleanup pass to this section of the code as well. 

Quick runthrough of the site, since the change is really high level; validates that things are still looking fine.  Checked demo details, application phases, dialogs, deliverables, document preview (though that doesnt use the layout), etc. 

https://github.com/user-attachments/assets/6b40e941-0fb8-48b1-86d3-10f600736e83


