### PR TITLE
DEMOS-2357: changed up some triggers/behaviors

### DIFF
--- a/client/src/components/input/select/AutoCompleteSelect.test.tsx
+++ b/client/src/components/input/select/AutoCompleteSelect.test.tsx
@@ -80,6 +80,50 @@ describe("AutoCompleteSelect", () => {
     expect(onSelect).toHaveBeenCalledWith("cherry");
   });
 
+  it("closes the dropdown when reselecting the current value", async () => {
+    render(<AutoCompleteSelect value="banana" options={options} onSelect={onSelect} />);
+    const input = screen.getByTestId(AUTOCOMPLETE_SELECT_TEST_ID);
+
+    await userEvent.click(input);
+    expect(screen.getByText("Apple")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("Banana"));
+
+    expect(screen.queryByText("Apple")).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue("Banana")).toBeInTheDocument();
+  });
+
+  it("reopens dropdown when clicking the already-focused input after selection", async () => {
+    render(<AutoCompleteSelect value="" options={options} onSelect={onSelect} />);
+    const input = screen.getByTestId(AUTOCOMPLETE_SELECT_TEST_ID);
+
+    await userEvent.click(input);
+    await userEvent.click(screen.getByText("Cherry"));
+
+    expect(screen.queryByText("Apple")).not.toBeInTheDocument();
+
+    await userEvent.click(input);
+
+    expect(screen.getByText("Apple")).toBeInTheDocument();
+    expect(screen.getByText("Banana")).toBeInTheDocument();
+  });
+
+  it("starts a new search when typing after selection without requiring blur", async () => {
+    const user = userEvent.setup();
+
+    render(<AutoCompleteSelect value="" options={options} onSelect={onSelect} />);
+    const input = screen.getByTestId(AUTOCOMPLETE_SELECT_TEST_ID);
+
+    await user.click(input);
+    await user.click(screen.getByText("Cherry"));
+
+    await user.keyboard("B");
+
+    expect(input).toHaveValue("B");
+    expect(screen.getByText("Banana")).toBeInTheDocument();
+    expect(screen.queryByText("Apple")).not.toBeInTheDocument();
+  });
+
   it("calls onSelect and closes dropdown on keyboard selection", async () => {
     render(<AutoCompleteSelect value="" options={options} onSelect={onSelect} />);
     const input = screen.getByTestId(AUTOCOMPLETE_SELECT_TEST_ID);

--- a/client/src/components/input/select/AutoCompleteSelect.tsx
+++ b/client/src/components/input/select/AutoCompleteSelect.tsx
@@ -82,7 +82,14 @@ export const AutoCompleteSelect = ({
     setIsOpen(true);
   };
 
+  const activateSelect = () => {
+    if (!isDisabled) {
+      openSelect();
+    }
+  };
+
   const handleFilterChange = (newFilterValue: string) => {
+    activateSelect();
     setFilterValue(newFilterValue);
     setActiveIndex(-1);
     const matches = filterOptions(options, newFilterValue);
@@ -95,7 +102,7 @@ export const AutoCompleteSelect = ({
     setFilterValue("");
     onFilterChangeProp?.("", true);
     closeSelect();
-    inputRef.current?.focus();
+    inputRef.current?.select();
   };
 
   const listboxId = `${id || dataTestId || "autocomplete"}-listbox`;
@@ -105,6 +112,11 @@ export const AutoCompleteSelect = ({
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!isOpen && e.key === "ArrowDown") {
       openSelect();
+      return;
+    }
+    if (!isOpen && e.key.length === 1 && !e.altKey && !e.ctrlKey && !e.metaKey) {
+      e.preventDefault();
+      handleFilterChange(e.key);
       return;
     }
     if (e.key === "ArrowDown") {
@@ -127,6 +139,7 @@ export const AutoCompleteSelect = ({
             <button
               type="button"
               className={`${ITEM_CLASSES} ${isActive ? ITEM_ACTIVE_CLASSES : ""} w-full text-left`}
+              onMouseDown={(e) => e.preventDefault()}
               onClick={() => handleSelectOption(option)}
               onMouseEnter={() => setActiveIndex(i)}
             >
@@ -163,7 +176,8 @@ export const AutoCompleteSelect = ({
           aria-controls={listboxId}
           placeholder={placeholder}
           value={isOpen ? filterValue : selectedOption?.label || ""}
-          onFocus={() => !isDisabled && setIsOpen(true)}
+          onFocus={activateSelect}
+          onClick={activateSelect}
           onChange={(e) => handleFilterChange(e.target.value)}
           onKeyDown={onKeyDown}
           required={isRequired}


### PR DESCRIPTION
we were seeing some weird edge case behavior in the autocomplete selects, mainly that when you selected an option you had to defocus then refocus to open the menu again. This stops that from happening. In addition, i found that selecting the same already-selected option didnt close the menu, so made it do that while i was at it. 


https://github.com/user-attachments/assets/9b65565c-722e-41f6-82e3-e31653e14716

