### PR TITLE
DEMOS-2342 update submission enabled logic for deliverables

### DIFF
--- a/client/src/pages/deliverables/fileAndHistoryTabs/FileAndHistoryTabs.test.tsx
+++ b/client/src/pages/deliverables/fileAndHistoryTabs/FileAndHistoryTabs.test.tsx
@@ -164,12 +164,6 @@ describe("FileAndHistoryTabs", () => {
       expect(mockShowRequestResubmissionDeliverableDialog).not.toHaveBeenCalled();
     });
 
-    it("enables Submit Deliverable when state files exist", () => {
-      setup();
-
-      expect(screen.getByTestId(STATE_FILES_SUBMIT_BUTTON_NAME)).not.toBeDisabled();
-    });
-
     it("disables Submit Deliverable when no state files have been uploaded", () => {
       setup({ stateDocuments: [] });
 
@@ -273,6 +267,69 @@ describe("FileAndHistoryTabs", () => {
       setup({ status: "Submitted" });
 
       expect(screen.getByTestId(STATE_FILES_ADD_BUTTON_NAME)).not.toBeDisabled();
+    });
+
+    describe("Submit Deliverable button", () => {
+      it.each(["Upcoming", "Past Due"] as const)(
+        "enables Submit Deliverable for %s even when all files have already been submitted",
+        (status) => {
+          setup({
+            status,
+            stateDocuments: [
+              {
+                ...MOCK_DELIVERABLE_1.stateDocuments[0],
+                deliverableSubmissionAction: {
+                  actionTimestamp: new Date("2026-06-26T19:32:52.932Z"),
+                },
+              },
+            ],
+          });
+
+          expect(screen.getByTestId(STATE_FILES_SUBMIT_BUTTON_NAME)).not.toBeDisabled();
+        }
+      );
+
+      it.each(["Submitted", "Under CMS Review"] as const)(
+        "disables Submit Deliverable for %s when there are no unsubmitted files",
+        (status) => {
+          setup({
+            status,
+            stateDocuments: [
+              {
+                ...MOCK_DELIVERABLE_1.stateDocuments[0],
+                deliverableSubmissionAction: {
+                  actionTimestamp: new Date("2026-06-26T19:32:52.932Z"),
+                },
+              },
+            ],
+          });
+
+          expect(screen.getByTestId(STATE_FILES_SUBMIT_BUTTON_NAME)).toBeDisabled();
+        }
+      );
+
+      it.each(["Submitted", "Under CMS Review"] as const)(
+        "enables Submit Deliverable for %s when an unsubmitted file exists",
+        (status) => {
+          setup({
+            status,
+            stateDocuments: [
+              {
+                ...MOCK_DELIVERABLE_1.stateDocuments[0],
+                deliverableSubmissionAction: null,
+              },
+            ],
+          });
+
+          expect(screen.getByTestId(STATE_FILES_SUBMIT_BUTTON_NAME)).not.toBeDisabled();
+        }
+      );
+
+      it("disables Submit Deliverable when no state files have been uploaded", () => {
+        setup({ stateDocuments: [] });
+
+        expect(screen.getByTestId(STATE_FILES_SUBMIT_BUTTON_NAME)).toBeDisabled();
+      });
     });
   });
 });

--- a/client/src/pages/deliverables/fileAndHistoryTabs/FileAndHistoryTabs.tsx
+++ b/client/src/pages/deliverables/fileAndHistoryTabs/FileAndHistoryTabs.tsx
@@ -41,6 +41,11 @@ export const SUBMIT_DELIVERABLE_MUTATION = gql`
   }
 `;
 
+export const SUBMISSION_ALWAYS_ENABLED_STATUSES: ReadonlySet<DeliverableStatus> = new Set([
+  "Upcoming",
+  "Past Due",
+]);
+
 export const RESUBMISSION_DISABLED_STATUSES: ReadonlySet<DeliverableStatus> = new Set([
   "Upcoming",
   "Past Due",
@@ -100,6 +105,13 @@ export const FileAndHistoryTabs: React.FC<{
   const isCmsStaffUser = CMS_STAFF_PERSON_TYPES.has(userPersonType);
   const canManageCmsFiles = isCmsStaffUser;
 
+  const canSubmitWithoutUnsubmittedFiles =
+    SUBMISSION_ALWAYS_ENABLED_STATUSES.has(deliverable.status);
+
+  const hasUnsubmittedFiles = stateFiles.some(
+    file => file.deliverableSubmissionAction == null
+  );
+
   const handleRequestResubmission = () => {
     showRequestResubmissionDeliverableDialog({
       id: deliverable.id,
@@ -149,7 +161,11 @@ export const FileAndHistoryTabs: React.FC<{
     }
   };
 
-  const isSubmitDisabled = isFinalized || stateFiles.length === 0 || submitLoading;
+  const isSubmitDisabled =
+    isFinalized
+    || stateFiles.length === 0
+    || submitLoading
+    || (!hasUnsubmittedFiles && !canSubmitWithoutUnsubmittedFiles);
 
   return (
     <div data-testid={FILE_AND_HISTORY_TABS_NAME}>

--- a/client/src/pages/deliverables/fileAndHistoryTabs/FileAndHistoryTabs.tsx
+++ b/client/src/pages/deliverables/fileAndHistoryTabs/FileAndHistoryTabs.tsx
@@ -167,6 +167,10 @@ export const FileAndHistoryTabs: React.FC<{
     || submitLoading
     || (!hasUnsubmittedFiles && !canSubmitWithoutUnsubmittedFiles);
 
+  const submitTooltip = isSubmitDisabled && !hasUnsubmittedFiles && !isFinalized
+    ? "No Unsubmitted Files"
+    : undefined;
+
   return (
     <div data-testid={FILE_AND_HISTORY_TABS_NAME}>
       <HorizontalSectionTabs defaultValue={TABS.STATE_FILES} variant="bordered">
@@ -209,6 +213,7 @@ export const FileAndHistoryTabs: React.FC<{
           onClick={handleSubmitDeliverable}
           size="large"
           name={STATE_FILES_SUBMIT_BUTTON_NAME}
+          tooltip={submitTooltip}
         >
           Submit Deliverable
         </Button>


### PR DESCRIPTION
This updates the submission enabled logic for deliverables.

- When status is in Past Due or Upcoming, submission is enabled (unless no state files exist)
- When status is in Submitted or Under Review:
- - If there are unsubmitted files, submission is enabled
- - If there are no unsubmitted files, submission is disabled
- When status is in Accepted, Approved, or Received and filed, submission is disabled

