### PR TITLE
DEMOS-2019: defaulted to current user from context

### DIFF
--- a/client/src/components/dialog/deliverable/AddDeliverableSlotDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/AddDeliverableSlotDialog.test.tsx
@@ -24,6 +24,7 @@ import {
 import { TestProvider } from "test-utils/TestProvider";
 import { DELIVERABLE_SLOTS_CREATED_MESSAGE } from "util/messages";
 import { formatDateForServer } from "util/formatDate";
+import { CurrentUser } from "components/user/UserContext";
 
 const mockMutate = vi.fn(() => Promise.resolve({ data: {} }));
 vi.mock("@apollo/client", async () => {
@@ -66,7 +67,7 @@ describe("AddDeliverableSlotDialog", () => {
     };
 
     render(
-      <TestProvider mocks={personMocks}>
+      <TestProvider mocks={personMocks} currentUser={{ id: "3" } as CurrentUser}>
         <AddDeliverableSlotDialog onClose={onClose} demonstration={demonstrationWithOverrides} />
       </TestProvider>
     );
@@ -199,6 +200,12 @@ describe("AddDeliverableSlotDialog", () => {
 
     expect(mockShowSuccess).toHaveBeenCalledWith(DELIVERABLE_SLOTS_CREATED_MESSAGE);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("is pre-populated with the current user", async () => {
+    setup();
+
+    await waitFor(() => expect(screen.getByTestId("select-users")).toHaveValue("Jim Smith"));
   });
 });
 

--- a/client/src/components/dialog/deliverable/AddDeliverableSlotDialog.tsx
+++ b/client/src/components/dialog/deliverable/AddDeliverableSlotDialog.tsx
@@ -10,12 +10,19 @@ import { DemonstrationTypeField } from "./fields/DemonstrationTypeField";
 import { ScheduleType, ScheduleTypeField } from "./fields/schedule-type/ScheduleTypeField";
 import { SingleDeliverableScheduleType } from "./fields/schedule-type/SingleDeliverableScheduleType";
 import { QuarterlyDeliverableSchedule } from "./fields/schedule-type/QuarterlyDeliverableSchedule";
-import { CreateDeliverableInput, DeliverableType, Demonstration, LocalDate, Tag } from "demos-server";
+import {
+  CreateDeliverableInput,
+  DeliverableType,
+  Demonstration,
+  LocalDate,
+  Tag,
+} from "demos-server";
 import { useToast } from "components/toast";
 import { DELIVERABLE_SLOTS_CREATED_MESSAGE } from "util/messages";
 import { DELIVERABLES_PAGE_QUERY } from "components/table/tables/DeliverableTable";
 import { getTodayEst } from "util/formatDate";
 import { isBefore } from "date-fns";
+import { getCurrentUser } from "components/user/UserContext";
 
 export const CREATE_DELIVERABLE_MUTATION = gql`
   mutation CreateDeliverable($input: CreateDeliverableInput!) {
@@ -32,9 +39,7 @@ export const useCreateDeliverable = () => {
   });
 
   const createDeliverables = async (inputs: CreateDeliverableInput[]) => {
-    await Promise.all(
-      inputs.map((input) => createDeliverable({ variables: { input } }))
-    );
+    await Promise.all(inputs.map((input) => createDeliverable({ variables: { input } })));
   };
 
   return { createDeliverables, loading };
@@ -66,16 +71,6 @@ export type AddDeliverableSlotPayload = Omit<
   "quarterlyDueDates" | "scheduleType"
 > & { demonstrationId: string };
 
-const INITIAL_FORM_DATA: AddDeliverableSlotFormData = {
-  deliverableName: "",
-  cmsOwnerUserId: "",
-  deliverableType: "" as DeliverableType,
-  scheduleType: "Single",
-  dueDate: "",
-  quarterlyDueDates: ALL_QUARTERS.map(() => ""),
-  demonstrationTypes: [],
-};
-
 export const getQuarterlyDeliverableSlotName = (
   demonstrationYear: number,
   quarter: Quarter,
@@ -88,7 +83,12 @@ export const buildAddDeliverableSlotPayloads = (
   formData: AddDeliverableSlotFormData
 ): CreateDeliverableInput[] => {
   const { quarterlyDueDates, scheduleType, deliverableName, ...rest } = formData;
-  const payloadBase = { ...rest, name: deliverableName, demonstrationId, dueDate: formData.dueDate as LocalDate };
+  const payloadBase = {
+    ...rest,
+    name: deliverableName,
+    demonstrationId,
+    dueDate: formData.dueDate as LocalDate,
+  };
 
   if (scheduleType === "Single") {
     return [payloadBase];
@@ -96,11 +96,7 @@ export const buildAddDeliverableSlotPayloads = (
 
   return ALL_QUARTERS.map((quarter, quarterIndex) => ({
     ...payloadBase,
-    name: getQuarterlyDeliverableSlotName(
-      demonstrationYear,
-      quarter,
-      formData.deliverableName
-    ),
+    name: getQuarterlyDeliverableSlotName(demonstrationYear, quarter, formData.deliverableName),
     dueDate: quarterlyDueDates[quarterIndex] as LocalDate,
   }));
 };
@@ -110,9 +106,7 @@ const hasValidDueDateForScheduleType = (data: AddDeliverableSlotFormData): boole
   if (data.scheduleType === "Single") {
     return data.dueDate.length > 0 && !isBefore(data.dueDate, today);
   }
-  return data.quarterlyDueDates.every(
-    (dueDate) => dueDate.length > 0 && !isBefore(dueDate, today)
-  );
+  return data.quarterlyDueDates.every((dueDate) => dueDate.length > 0 && !isBefore(dueDate, today));
 };
 
 const formIsValid = (data: AddDeliverableSlotFormData): boolean =>
@@ -123,12 +117,15 @@ const formIsValid = (data: AddDeliverableSlotFormData): boolean =>
   hasValidDueDateForScheduleType(data) &&
   (!requiresDemonstrationTypes(data.deliverableType) || data.demonstrationTypes.length > 0);
 
-const formHasChanges = (data: AddDeliverableSlotFormData): boolean =>
-  data.deliverableName !== INITIAL_FORM_DATA.deliverableName ||
-  data.cmsOwnerUserId !== INITIAL_FORM_DATA.cmsOwnerUserId ||
-  data.deliverableType !== INITIAL_FORM_DATA.deliverableType ||
-  data.scheduleType !== INITIAL_FORM_DATA.scheduleType ||
-  data.dueDate !== INITIAL_FORM_DATA.dueDate ||
+const formHasChanges = (
+  data: AddDeliverableSlotFormData,
+  initialFormData: AddDeliverableSlotFormData
+): boolean =>
+  data.deliverableName !== initialFormData.deliverableName ||
+  data.cmsOwnerUserId !== initialFormData.cmsOwnerUserId ||
+  data.deliverableType !== initialFormData.deliverableType ||
+  data.scheduleType !== initialFormData.scheduleType ||
+  data.dueDate !== initialFormData.dueDate ||
   data.quarterlyDueDates.some((dueDate) => dueDate.length > 0) ||
   data.demonstrationTypes.length !== 0;
 
@@ -149,11 +146,26 @@ export const AddDeliverableSlotDialog = ({
   const { showSuccess } = useToast();
   const { createDeliverables, loading } = useCreateDeliverable();
 
-  const [formData, setFormData] = useState<AddDeliverableSlotFormData>(INITIAL_FORM_DATA);
+  const contextUser = getCurrentUser();
+  if (!contextUser) {
+    throw new Error("User context is not available.");
+  }
+
+  const initialFormData: AddDeliverableSlotFormData = {
+    deliverableName: "",
+    deliverableType: "" as DeliverableType,
+    scheduleType: "Single",
+    dueDate: "",
+    quarterlyDueDates: ALL_QUARTERS.map(() => ""),
+    demonstrationTypes: [],
+    cmsOwnerUserId: contextUser.currentUser.id,
+  };
+
+  const [formData, setFormData] = useState<AddDeliverableSlotFormData>(initialFormData);
   const [demonstrationYear, setDemonstrationYear] = useState<number>(1);
 
   const isFormValid = formIsValid(formData);
-  const hasFormChanges = formHasChanges(formData);
+  const hasFormChanges = formHasChanges(formData, initialFormData);
 
   return (
     <BaseDialog
@@ -185,7 +197,12 @@ export const AddDeliverableSlotDialog = ({
         <div className="grid grid-cols-2 gap-sm">
           <DeliverableTypeField
             value={formData.deliverableType}
-            onSelect={(deliverableType) => setFormData((prev) => ({ ...prev, deliverableType: deliverableType as DeliverableType }))}
+            onSelect={(deliverableType) =>
+              setFormData((prev) => ({
+                ...prev,
+                deliverableType: deliverableType as DeliverableType,
+              }))
+            }
           />
           <ScheduleTypeField
             value={formData.scheduleType}
@@ -224,7 +241,9 @@ export const AddDeliverableSlotDialog = ({
         <div className="grid grid-cols-2 gap-sm">
           <CMSOwnerField
             value={formData.cmsOwnerUserId}
-            onSelect={(cmsOwnerId) => setFormData((prev) => ({ ...prev, cmsOwnerUserId: cmsOwnerId }))}
+            onSelect={(cmsOwnerId) =>
+              setFormData((prev) => ({ ...prev, cmsOwnerUserId: cmsOwnerId }))
+            }
           />
           <DemonstrationTypeField
             demonstrationTypeTags={demonstration.demonstrationTypes}


### PR DESCRIPTION
Similar to creating a new demonstration, the CMS Owner should be defaulted to the current user. Because CMS users are the only ones who can create a new deliverable anyway, we can safely error if something happens when fetching the current user. 

https://github.com/user-attachments/assets/446bd754-7508-4c99-a8af-ea4161e13b68

