### PR TITLE
(1/2) DEMOS-2358: Break components out in `CompletenessPhase`

### DIFF
--- a/client/src/components/application/phases/completeness/CompletenessNotice.test.tsx
+++ b/client/src/components/application/phases/completeness/CompletenessNotice.test.tsx
@@ -1,0 +1,49 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { TestProvider } from "test-utils/TestProvider";
+import { CompletenessNotice } from "./CompletenessNotice";
+import { TZDate } from "@date-fns/tz";
+import { EST_TIMEZONE } from "util/formatDate";
+
+describe("CompletenessNotice", () => {
+  it("renders the banner with correct content and dismisses on click", async () => {
+    const today = new TZDate("2026-02-08T00:00:00Z", EST_TIMEZONE);
+    vi.setSystemTime(today);
+
+    render(
+      <TestProvider>
+        <CompletenessNotice completenessReviewDate="2026-02-10" completenessComplete={false} />
+      </TestProvider>
+    );
+
+    const title = screen.getByText("2 days left");
+    const description = screen.getByText(/This Demonstration must be declared complete by/);
+    expect(title).toBeInTheDocument();
+    expect(description).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+
+    expect(title).not.toBeInTheDocument();
+  });
+
+  it("does not render the banner if completenessReviewDate is missing", () => {
+    render(
+      <TestProvider>
+        <CompletenessNotice completenessReviewDate={undefined} completenessComplete={false} />
+      </TestProvider>
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("does not render the banner if phase is complete", () => {
+    render(
+      <TestProvider>
+        <CompletenessNotice completenessReviewDate="2026-02-10" completenessComplete={true} />
+      </TestProvider>
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/application/phases/completeness/CompletenessNotice.tsx
+++ b/client/src/components/application/phases/completeness/CompletenessNotice.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo, useState } from "react";
+
+import { Notice, NoticeVariant } from "components/notice/Notice";
+import { formatDateForDisplay } from "util/formatDate";
+import { differenceInCalendarDays, parseISO } from "date-fns";
+
+export const CompletenessNotice = ({
+  completenessReviewDate,
+  completenessComplete,
+}: {
+  completenessReviewDate?: string;
+  completenessComplete: boolean;
+}) => {
+  const [isNoticeDismissed, setNoticeDismissed] = useState(
+    !(completenessReviewDate && !completenessComplete)
+  );
+
+  const noticeContent = useMemo(() => {
+    if (!completenessReviewDate) return null;
+    const noticeDueDateValue = parseISO(completenessReviewDate ?? "");
+    const daysLeft = differenceInCalendarDays(noticeDueDateValue, new Date());
+    if (daysLeft > 1) {
+      return {
+        title: `${daysLeft} days left`,
+        description: `This Demonstration must be declared complete by ${formatDateForDisplay(noticeDueDateValue)}`,
+        variant: "warning" as NoticeVariant,
+      };
+    }
+    if (daysLeft === 1) {
+      return {
+        title: "1 day left in Completion Period",
+        description: `This Demonstration must be declared complete by ${formatDateForDisplay(noticeDueDateValue)}`,
+        variant: "error" as NoticeVariant,
+      };
+    } else {
+      return {
+        title: `${Math.abs(daysLeft)} days past due`,
+        description: `This Demonstration completeness was due on ${formatDateForDisplay(noticeDueDateValue)}`,
+        variant: "error" as NoticeVariant,
+      };
+    }
+  }, [completenessReviewDate]);
+
+  if (isNoticeDismissed || !noticeContent) return null;
+
+  return (
+    <Notice
+      title={noticeContent.title}
+      description={noticeContent.description}
+      variant={noticeContent.variant}
+      onDismiss={() => setNoticeDismissed(true)}
+    />
+  );
+};

--- a/client/src/components/application/phases/completeness/CompletenessPhase.test.tsx
+++ b/client/src/components/application/phases/completeness/CompletenessPhase.test.tsx
@@ -7,7 +7,6 @@ import { TestProvider } from "test-utils/TestProvider";
 import {
   CompletenessPhase,
   CompletenessPhaseProps,
-  COMPLETENESS_UPLOAD_BUTTON_NAME,
   COMPLETENESS_FINISH_BUTTON_NAME,
   COMPLETENESS_DECLARE_INCOMPLETE_BUTTON_NAME,
   STATE_DEEMED_COMPLETE_DATEPICKER_NAME,
@@ -15,8 +14,6 @@ import {
   FEDERAL_COMMENT_END_DATEPICKER_NAME,
   getApplicationCompletenessFromApplication,
   COMPLETENESS_PHASE_DESCRIPTION,
-  COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION,
-  COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION,
 } from "./CompletenessPhase";
 import { ApplicationWorkflowDocument, WorkflowApplication } from "components/application";
 import { TZDate } from "@date-fns/tz";
@@ -121,47 +118,6 @@ describe("CompletenessPhase", () => {
       expect(screen.getByTestId(COMPLETENESS_PHASE_DESCRIPTION.testId)).toHaveTextContent(
         COMPLETENESS_PHASE_DESCRIPTION.text
       );
-    });
-  });
-
-  describe("Step 1 - Upload Section", () => {
-    it("renders upload button and helper text", () => {
-      setup();
-      expect(screen.getByText("Step 1 - Upload")).toBeInTheDocument();
-      expect(screen.getByTestId(COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.testId)).toHaveTextContent(
-        COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.text
-      );
-      expect(screen.getByTestId(COMPLETENESS_UPLOAD_BUTTON_NAME)).toBeInTheDocument();
-    });
-
-    it("renders uploaded documents", () => {
-      setup({ completenessDocuments: [mockCompletenessDoc, mockInternalDoc] });
-      expect(screen.getByText("Completeness Letter")).toBeInTheDocument();
-      expect(screen.getByText("Internal Form")).toBeInTheDocument();
-    });
-  });
-
-  describe("Step 2 - Verify/Complete Section", () => {
-    it("renders section title and description", () => {
-      setup();
-      expect(screen.getByText("Step 2 - Verify/Complete")).toBeInTheDocument();
-      expect(screen.getByTestId(COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.testId)).toHaveTextContent(
-        COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.text
-      );
-    });
-    it("renders date picker for State Application Deemed Complete", () => {
-      setup();
-      const dateInput = screen.getByTestId(STATE_DEEMED_COMPLETE_DATEPICKER_NAME);
-      expect(dateInput).toBeInTheDocument();
-      expect(dateInput).toHaveAttribute("type", "date");
-    });
-
-    it("renders disabled date pickers for Federal Comment Period", () => {
-      setup();
-      const startInput = screen.getByTestId(FEDERAL_COMMENT_START_DATEPICKER_NAME);
-      const endInput = screen.getByTestId(FEDERAL_COMMENT_END_DATEPICKER_NAME);
-      expect(startInput).toBeDisabled();
-      expect(endInput).toBeDisabled();
     });
   });
 
@@ -326,17 +282,6 @@ describe("CompletenessPhase", () => {
     });
   });
 
-  describe("Upload Modal", () => {
-    it("calls dialog function when upload clicked", async () => {
-      setup();
-
-      const uploadButton = screen.getByTestId(COMPLETENESS_UPLOAD_BUTTON_NAME);
-      await userEvent.click(uploadButton);
-
-      expect(showCompletenessDocumentUploadDialog).toHaveBeenCalledWith("app-123");
-    });
-  });
-
   describe("Document Reactivity", () => {
     it("reflects updated documents when props change (no refresh needed)", () => {
       const { rerender } = render(
@@ -407,59 +352,6 @@ describe("CompletenessPhase", () => {
       expect(screen.getByTestId(COMPLETENESS_FINISH_BUTTON_NAME)).toBeEnabled();
     });
   });
-
-  describe("Completeness Notice Banner", () => {
-    it("renders the banner with correct content and dismisses on click", async () => {
-      const today = new TZDate("2026-02-08T00:00:00Z", EST_TIMEZONE);
-      vi.setSystemTime(today);
-
-      const reviewDate = "2026-02-10"; // 2 days from today
-
-      render(
-        <TestProvider>
-          <CompletenessPhase
-            applicationId="app-123"
-            applicationIntakeComplete={true}
-            completenessReviewDate={reviewDate}
-            completenessPhaseStatus="Started"
-            stateDeemedCompleteDate=""
-            completenessDocuments={[]}
-            setSelectedPhase={mockSetSelectedPhase}
-          />
-        </TestProvider>
-      );
-
-      // banner shows 2 days left
-      const title = screen.getByText("2 days left");
-      const description = screen.getByText(/This Demonstration must be declared complete by/);
-      expect(title).toBeInTheDocument();
-      expect(description).toBeInTheDocument();
-
-      // dismiss the banner
-      const dismissButton = screen.getByRole("button", { name: /dismiss/i });
-      await userEvent.click(dismissButton);
-
-      expect(title).not.toBeInTheDocument();
-    });
-
-    it("does not render the banner if completenessReviewDate is missing or phase is complete", () => {
-      render(
-        <TestProvider>
-          <CompletenessPhase
-            applicationId="app-123"
-            applicationIntakeComplete={true}
-            completenessReviewDate={undefined}
-            completenessPhaseStatus="Completed"
-            stateDeemedCompleteDate=""
-            completenessDocuments={[]}
-            setSelectedPhase={mockSetSelectedPhase}
-          />
-        </TestProvider>
-      );
-
-      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    });
-  });
 });
 
 describe("getApplicationCompletenessFromApplication", () => {
@@ -494,15 +386,15 @@ describe("getApplicationCompletenessFromApplication", () => {
           phaseDates: [
             {
               dateType: "State Application Deemed Complete",
-              dateValue: new TZDate("2026-03-01", EST_TIMEZONE),
+              dateValue: new TZDate("2026-03-01T05:00:00.000Z", EST_TIMEZONE),
             },
             {
               dateType: "Federal Comment Period Start Date",
-              dateValue: new TZDate("2026-03-02", EST_TIMEZONE),
+              dateValue: new TZDate("2026-03-02T05:00:00.000Z", EST_TIMEZONE),
             },
             {
               dateType: "Federal Comment Period End Date",
-              dateValue: new TZDate("2026-04-01", EST_TIMEZONE),
+              dateValue: new TZDate("2026-04-01T04:00:00.000Z", EST_TIMEZONE),
             },
           ],
           phaseNotes: [],

--- a/client/src/components/application/phases/completeness/CompletenessPhase.test.tsx
+++ b/client/src/components/application/phases/completeness/CompletenessPhase.test.tsx
@@ -43,7 +43,7 @@ vi.mock("components/application/date/dateQueries", () => ({
 
 const mockCompletePhase = vi.fn();
 const mockDeclareCompletenessPhaseIncomplete = vi.fn();
-vi.mock("../phase-status/phaseCompletionQueries", () => ({
+vi.mock("../../phase-status/phaseCompletionQueries", () => ({
   useCompletePhase: vi.fn(() => ({
     completePhase: mockCompletePhase,
   })),

--- a/client/src/components/application/phases/completeness/CompletenessPhase.tsx
+++ b/client/src/components/application/phases/completeness/CompletenessPhase.tsx
@@ -1,23 +1,23 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 
 import { Button, SecondaryButton } from "components/button";
 import { ExportIcon } from "components/icons";
 import { tw } from "tags/tw";
-import { formatDateForDisplay, formatDateForServer, getDateEst } from "util/formatDate";
-import { addDays, differenceInCalendarDays, parseISO } from "date-fns";
+import { formatDateForServer, getDateEst } from "util/formatDate";
+import { addDays, parseISO } from "date-fns";
 import { WorkflowApplication, ApplicationWorkflowDocument } from "components/application";
 import { useToast } from "components/toast";
-import { DocumentList } from "./sections";
+import { DocumentList } from "../sections";
 import { ApplicationDateInput, DateType, LocalDate, PhaseName, PhaseStatus } from "demos-server";
 import { useDialog } from "components/dialog/DialogContext";
 import { useSetApplicationDates } from "components/application/date/dateQueries";
 import { getPhaseCompletedMessage, SAVE_FOR_LATER_MESSAGE } from "util/messages";
 import { DatePicker } from "components/input/date/DatePicker";
-import { Notice, NoticeVariant } from "components/notice/Notice";
 import {
   useCompletePhase,
   useDeclareCompletenessPhaseIncomplete,
 } from "components/application/phase-status/phaseCompletionQueries";
+import { CompletenessNotice } from "./CompletenessNotice";
 
 const STYLES = {
   pane: tw`bg-white`,
@@ -43,55 +43,6 @@ export const COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION = {
 export const COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION = {
   text: "Verify that the document is uploaded/accurate and that all required fields are filled. Review the file and fix the Submitted Date if needed. Hitting Finish sets the Due Date.",
   testId: "completeness-phase-step-two-description",
-};
-
-const CompletenessNotice = ({
-  completenessReviewDate,
-  completenessComplete,
-}: {
-  completenessReviewDate?: string;
-  completenessComplete: boolean;
-}) => {
-  const [isNoticeDismissed, setNoticeDismissed] = useState(
-    !(completenessReviewDate && !completenessComplete)
-  );
-
-  const noticeContent = useMemo(() => {
-    if (!completenessReviewDate) return null;
-    const noticeDueDateValue = parseISO(completenessReviewDate ?? "");
-    const daysLeft = differenceInCalendarDays(noticeDueDateValue, new Date());
-    if (daysLeft > 1) {
-      return {
-        title: `${daysLeft} days left`,
-        description: `This Demonstration must be declared complete by ${formatDateForDisplay(noticeDueDateValue)}`,
-        variant: "warning" as NoticeVariant,
-      };
-    }
-    if (daysLeft === 1) {
-      return {
-        title: "1 day left in Completion Period",
-        description: `This Demonstration must be declared complete by ${formatDateForDisplay(noticeDueDateValue)}`,
-        variant: "error" as NoticeVariant,
-      };
-    } else {
-      return {
-        title: `${Math.abs(daysLeft)} days past due`,
-        description: `This Demonstration completeness was due on ${formatDateForDisplay(noticeDueDateValue)}`,
-        variant: "error" as NoticeVariant,
-      };
-    }
-  }, [completenessReviewDate]);
-
-  if (isNoticeDismissed || !noticeContent) return null;
-
-  return (
-    <Notice
-      title={noticeContent.title}
-      description={noticeContent.description}
-      variant={noticeContent.variant}
-      onDismiss={() => setNoticeDismissed(true)}
-    />
-  );
 };
 
 const THIS_PHASE_NAME: PhaseName = "Completeness";

--- a/client/src/components/application/phases/completeness/CompletenessPhase.tsx
+++ b/client/src/components/application/phases/completeness/CompletenessPhase.tsx
@@ -1,23 +1,21 @@
 import React, { useState } from "react";
 
-import { Button, SecondaryButton } from "components/button";
-import { ExportIcon } from "components/icons";
 import { tw } from "tags/tw";
 import { formatDateForServer, getDateEst } from "util/formatDate";
 import { addDays, parseISO } from "date-fns";
 import { WorkflowApplication, ApplicationWorkflowDocument } from "components/application";
 import { useToast } from "components/toast";
-import { DocumentList } from "../sections";
 import { ApplicationDateInput, DateType, LocalDate, PhaseName, PhaseStatus } from "demos-server";
 import { useDialog } from "components/dialog/DialogContext";
 import { useSetApplicationDates } from "components/application/date/dateQueries";
 import { getPhaseCompletedMessage, SAVE_FOR_LATER_MESSAGE } from "util/messages";
-import { DatePicker } from "components/input/date/DatePicker";
 import {
   useCompletePhase,
   useDeclareCompletenessPhaseIncomplete,
 } from "components/application/phase-status/phaseCompletionQueries";
 import { CompletenessNotice } from "./CompletenessNotice";
+import { UploadSection } from "./UploadSection";
+import { VerifyCompleteSection } from "./VerifyCompleteSection";
 
 const STYLES = {
   pane: tw`bg-white`,
@@ -237,88 +235,6 @@ export const CompletenessPhase = ({
     }
   };
 
-  const UploadSection = () => (
-    <div aria-labelledby="completeness-upload-title">
-      <h4 id="completeness-upload-title" className={STYLES.title}>
-        Step 1 - Upload
-      </h4>
-      <p className={STYLES.helper} data-testId={COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.testId}>
-        {COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.text}
-      </p>
-      <SecondaryButton
-        onClick={() => showCompletenessDocumentUploadDialog(applicationId)}
-        size="small"
-        name={COMPLETENESS_UPLOAD_BUTTON_NAME}
-      >
-        Upload
-        <ExportIcon />
-      </SecondaryButton>
-      <DocumentList documents={completenessDocuments} />
-    </div>
-  );
-
-  const VerifyCompleteSection = () => (
-    <div aria-labelledby="completeness-verify-title">
-      <h4 id="completeness-verify-title" className={STYLES.title}>
-        Step 2 - Verify/Complete
-      </h4>
-      <p className={STYLES.helper} data-testId={COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.testId}>
-        {COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.text}
-      </p>
-
-      <div className="grid grid-cols-2 gap-4">
-        <div className="col-span-2">
-          <DatePicker
-            name={STATE_DEEMED_COMPLETE_DATEPICKER_NAME}
-            label={"State Application Deemed Complete" satisfies DateType}
-            value={stateDeemedComplete}
-            onChange={(date) => {
-              setUserSelectedStateDeemedCompleteDate(date);
-            }}
-            isDisabled={completenessComplete}
-          />
-        </div>
-
-        <div>
-          <DatePicker
-            name={FEDERAL_COMMENT_START_DATEPICKER_NAME}
-            label={"Federal Comment Period Start Date" satisfies DateType}
-            value={federalStartDate}
-            isDisabled
-          />
-        </div>
-
-        <div>
-          <DatePicker
-            name={FEDERAL_COMMENT_END_DATEPICKER_NAME}
-            label={"Federal Comment Period End Date" satisfies DateType}
-            value={federalEndDate}
-            isDisabled
-          />
-        </div>
-      </div>
-
-      <div className={STYLES.actions}>
-        <SecondaryButton
-          name={COMPLETENESS_DECLARE_INCOMPLETE_BUTTON_NAME}
-          size="small"
-          onClick={handleDeclareIncomplete}
-          disabled={completenessComplete}
-        >
-          Declare Incomplete
-        </SecondaryButton>
-        <Button
-          name={COMPLETENESS_FINISH_BUTTON_NAME}
-          size="small"
-          disabled={!finishIsEnabled()}
-          onClick={handleFinishCompleteness}
-        >
-          Finish
-        </Button>
-      </div>
-    </div>
-  );
-
   return (
     <div>
       <div className="flex flex-col gap-6">
@@ -339,8 +255,21 @@ export const CompletenessPhase = ({
         <section className={STYLES.pane}>
           <div className={STYLES.grid}>
             <span aria-hidden className={STYLES.divider} />
-            <UploadSection />
-            <VerifyCompleteSection />
+            <UploadSection
+              applicationId={applicationId}
+              completenessDocuments={completenessDocuments}
+              onUploadClick={showCompletenessDocumentUploadDialog}
+            />
+            <VerifyCompleteSection
+              stateDeemedComplete={stateDeemedComplete}
+              federalStartDate={federalStartDate}
+              federalEndDate={federalEndDate}
+              completenessComplete={completenessComplete}
+              finishIsEnabled={!!finishIsEnabled()}
+              onDateChange={setUserSelectedStateDeemedCompleteDate}
+              onDeclareIncomplete={handleDeclareIncomplete}
+              onFinish={handleFinishCompleteness}
+            />
           </div>
         </section>
       </div>

--- a/client/src/components/application/phases/completeness/UploadSection.test.tsx
+++ b/client/src/components/application/phases/completeness/UploadSection.test.tsx
@@ -1,0 +1,74 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { TestProvider } from "test-utils/TestProvider";
+import { DialogProvider } from "components/dialog/DialogContext";
+import { UploadSection } from "./UploadSection";
+import { ApplicationWorkflowDocument } from "components/application";
+import { TZDate } from "@date-fns/tz";
+import { EST_TIMEZONE } from "util/formatDate";
+import {
+  COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION,
+  COMPLETENESS_UPLOAD_BUTTON_NAME,
+} from "./CompletenessPhase";
+
+const mockCompletenessDoc: ApplicationWorkflowDocument = {
+  id: "doc-1",
+  name: "Completeness Letter",
+  description: "Test letter",
+  documentType: "Application Completeness Letter",
+  phaseName: "Completeness",
+  owner: { person: { fullName: "Jane Doe" } },
+  createdAt: new TZDate("2026-02-01", EST_TIMEZONE),
+};
+
+const mockInternalDoc: ApplicationWorkflowDocument = {
+  id: "doc-2",
+  name: "Internal Form",
+  description: "Internal form",
+  documentType: "Internal Completeness Review Form",
+  phaseName: "Completeness",
+  owner: { person: { fullName: "John Smith" } },
+  createdAt: new TZDate("2026-02-02", EST_TIMEZONE),
+};
+
+describe("UploadSection", () => {
+  const onUploadClick = vi.fn();
+
+  const setup = (completenessDocuments: ApplicationWorkflowDocument[] = []) => {
+    render(
+      <TestProvider>
+        <DialogProvider>
+          <UploadSection
+            applicationId="app-123"
+            completenessDocuments={completenessDocuments}
+            onUploadClick={onUploadClick}
+          />
+        </DialogProvider>
+      </TestProvider>
+    );
+  };
+
+  it("renders upload button and helper text", () => {
+    setup();
+    expect(screen.getByText("Step 1 - Upload")).toBeInTheDocument();
+    expect(screen.getByTestId(COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.testId)).toHaveTextContent(
+      COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.text
+    );
+    expect(screen.getByTestId(COMPLETENESS_UPLOAD_BUTTON_NAME)).toBeInTheDocument();
+  });
+
+  it("renders uploaded documents", () => {
+    setup([mockCompletenessDoc, mockInternalDoc]);
+    expect(screen.getByText("Completeness Letter")).toBeInTheDocument();
+    expect(screen.getByText("Internal Form")).toBeInTheDocument();
+  });
+
+  it("calls onUploadClick with applicationId when upload button is clicked", async () => {
+    setup();
+    await userEvent.click(screen.getByTestId(COMPLETENESS_UPLOAD_BUTTON_NAME));
+    expect(onUploadClick).toHaveBeenCalledWith("app-123");
+  });
+});

--- a/client/src/components/application/phases/completeness/UploadSection.tsx
+++ b/client/src/components/application/phases/completeness/UploadSection.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import { SecondaryButton } from "components/button";
 import { ExportIcon } from "components/icons";
-import { tw } from "tags/tw";
 import { ApplicationWorkflowDocument } from "components/application";
 import { DocumentList } from "../sections";
 import {
@@ -10,27 +9,23 @@ import {
   COMPLETENESS_UPLOAD_BUTTON_NAME,
 } from "./CompletenessPhase";
 
-const STYLES = {
-  title: tw`text-xl font-semibold mb-2 uppercase`,
-  helper: tw`text-sm text-text-placeholder mb-2`,
-};
-
-interface UploadSectionProps {
-  applicationId: string;
-  completenessDocuments: ApplicationWorkflowDocument[];
-  onUploadClick: (applicationId: string) => void;
-}
-
 export const UploadSection = ({
   applicationId,
   completenessDocuments,
   onUploadClick,
-}: UploadSectionProps) => (
+}: {
+  applicationId: string;
+  completenessDocuments: ApplicationWorkflowDocument[];
+  onUploadClick: (applicationId: string) => void;
+}) => (
   <div aria-labelledby="completeness-upload-title">
-    <h4 id="completeness-upload-title" className={STYLES.title}>
+    <h4 id="completeness-upload-title" className="text-xl font-semibold mb-2 uppercase">
       Step 1 - Upload
     </h4>
-    <p className={STYLES.helper} data-testId={COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.testId}>
+    <p
+      className={"text-sm text-text-placeholder mb-2"}
+      data-testId={COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.testId}
+    >
       {COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.text}
     </p>
     <SecondaryButton

--- a/client/src/components/application/phases/completeness/UploadSection.tsx
+++ b/client/src/components/application/phases/completeness/UploadSection.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+import { SecondaryButton } from "components/button";
+import { ExportIcon } from "components/icons";
+import { tw } from "tags/tw";
+import { ApplicationWorkflowDocument } from "components/application";
+import { DocumentList } from "../sections";
+import {
+  COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION,
+  COMPLETENESS_UPLOAD_BUTTON_NAME,
+} from "./CompletenessPhase";
+
+const STYLES = {
+  title: tw`text-xl font-semibold mb-2 uppercase`,
+  helper: tw`text-sm text-text-placeholder mb-2`,
+};
+
+interface UploadSectionProps {
+  applicationId: string;
+  completenessDocuments: ApplicationWorkflowDocument[];
+  onUploadClick: (applicationId: string) => void;
+}
+
+export const UploadSection = ({
+  applicationId,
+  completenessDocuments,
+  onUploadClick,
+}: UploadSectionProps) => (
+  <div aria-labelledby="completeness-upload-title">
+    <h4 id="completeness-upload-title" className={STYLES.title}>
+      Step 1 - Upload
+    </h4>
+    <p className={STYLES.helper} data-testId={COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.testId}>
+      {COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.text}
+    </p>
+    <SecondaryButton
+      onClick={() => onUploadClick(applicationId)}
+      size="small"
+      name={COMPLETENESS_UPLOAD_BUTTON_NAME}
+    >
+      Upload
+      <ExportIcon />
+    </SecondaryButton>
+    <DocumentList documents={completenessDocuments} />
+  </div>
+);

--- a/client/src/components/application/phases/completeness/VerifyCompleteSection.test.tsx
+++ b/client/src/components/application/phases/completeness/VerifyCompleteSection.test.tsx
@@ -1,0 +1,71 @@
+import "@testing-library/jest-dom";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { TestProvider } from "test-utils/TestProvider";
+import { VerifyCompleteSection } from "./VerifyCompleteSection";
+import {
+  COMPLETENESS_DECLARE_INCOMPLETE_BUTTON_NAME,
+  COMPLETENESS_FINISH_BUTTON_NAME,
+  COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION,
+  FEDERAL_COMMENT_END_DATEPICKER_NAME,
+  FEDERAL_COMMENT_START_DATEPICKER_NAME,
+  STATE_DEEMED_COMPLETE_DATEPICKER_NAME,
+} from "./CompletenessPhase";
+
+describe("VerifyCompleteSection", () => {
+  const defaultProps = {
+    stateDeemedComplete: "",
+    federalStartDate: "",
+    federalEndDate: "",
+    completenessComplete: false,
+    finishIsEnabled: false,
+    onDateChange: vi.fn(),
+    onDeclareIncomplete: vi.fn(),
+    onFinish: vi.fn(),
+  };
+
+  const setup = (props: Partial<typeof defaultProps> = {}) => {
+    render(
+      <TestProvider>
+        <VerifyCompleteSection {...defaultProps} {...props} />
+      </TestProvider>
+    );
+  };
+
+  it("renders section title and description", () => {
+    setup();
+    expect(screen.getByText("Step 2 - Verify/Complete")).toBeInTheDocument();
+    expect(screen.getByTestId(COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.testId)).toHaveTextContent(
+      COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.text
+    );
+  });
+
+  it("renders date picker for State Application Deemed Complete", () => {
+    setup();
+    const dateInput = screen.getByTestId(STATE_DEEMED_COMPLETE_DATEPICKER_NAME);
+    expect(dateInput).toBeInTheDocument();
+    expect(dateInput).toHaveAttribute("type", "date");
+  });
+
+  it("renders disabled date pickers for Federal Comment Period", () => {
+    setup();
+    expect(screen.getByTestId(FEDERAL_COMMENT_START_DATEPICKER_NAME)).toBeDisabled();
+    expect(screen.getByTestId(FEDERAL_COMMENT_END_DATEPICKER_NAME)).toBeDisabled();
+  });
+
+  it("disables Declare Incomplete button when completenessComplete is true", () => {
+    setup({ completenessComplete: true });
+    expect(screen.getByTestId(COMPLETENESS_DECLARE_INCOMPLETE_BUTTON_NAME)).toBeDisabled();
+  });
+
+  it("disables Finish button when finishIsEnabled is false", () => {
+    setup({ finishIsEnabled: false });
+    expect(screen.getByTestId(COMPLETENESS_FINISH_BUTTON_NAME)).toBeDisabled();
+  });
+
+  it("enables Finish button when finishIsEnabled is true", () => {
+    setup({ finishIsEnabled: true });
+    expect(screen.getByTestId(COMPLETENESS_FINISH_BUTTON_NAME)).toBeEnabled();
+  });
+});

--- a/client/src/components/application/phases/completeness/VerifyCompleteSection.tsx
+++ b/client/src/components/application/phases/completeness/VerifyCompleteSection.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import { Button, SecondaryButton } from "components/button";
-import { tw } from "tags/tw";
 import { DateType } from "demos-server";
 import { DatePicker } from "components/input/date/DatePicker";
 import {
@@ -13,23 +12,6 @@ import {
   STATE_DEEMED_COMPLETE_DATEPICKER_NAME,
 } from "./CompletenessPhase";
 
-const STYLES = {
-  title: tw`text-xl font-semibold mb-2 uppercase`,
-  helper: tw`text-sm text-text-placeholder mb-2`,
-  actions: tw`mt-8 flex justify-end gap-2`,
-};
-
-interface VerifyCompleteSectionProps {
-  stateDeemedComplete: string;
-  federalStartDate: string;
-  federalEndDate: string;
-  completenessComplete: boolean;
-  finishIsEnabled: boolean;
-  onDateChange: (date: string) => void;
-  onDeclareIncomplete: () => void;
-  onFinish: () => void;
-}
-
 export const VerifyCompleteSection = ({
   stateDeemedComplete,
   federalStartDate,
@@ -39,12 +21,24 @@ export const VerifyCompleteSection = ({
   onDateChange,
   onDeclareIncomplete,
   onFinish,
-}: VerifyCompleteSectionProps) => (
+}: {
+  stateDeemedComplete: string;
+  federalStartDate: string;
+  federalEndDate: string;
+  completenessComplete: boolean;
+  finishIsEnabled: boolean;
+  onDateChange: (date: string) => void;
+  onDeclareIncomplete: () => void;
+  onFinish: () => void;
+}) => (
   <div aria-labelledby="completeness-verify-title">
-    <h4 id="completeness-verify-title" className={STYLES.title}>
+    <h4 id="completeness-verify-title" className="text-xl font-semibold mb-2 uppercase">
       Step 2 - Verify/Complete
     </h4>
-    <p className={STYLES.helper} data-testId={COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.testId}>
+    <p
+      className={"text-sm text-text-placeholder mb-2"}
+      data-testId={COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.testId}
+    >
       {COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.text}
     </p>
 
@@ -78,7 +72,7 @@ export const VerifyCompleteSection = ({
       </div>
     </div>
 
-    <div className={STYLES.actions}>
+    <div className={"mt-8 flex justify-end gap-2"}>
       <SecondaryButton
         name={COMPLETENESS_DECLARE_INCOMPLETE_BUTTON_NAME}
         size="small"

--- a/client/src/components/application/phases/completeness/VerifyCompleteSection.tsx
+++ b/client/src/components/application/phases/completeness/VerifyCompleteSection.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+
+import { Button, SecondaryButton } from "components/button";
+import { tw } from "tags/tw";
+import { DateType } from "demos-server";
+import { DatePicker } from "components/input/date/DatePicker";
+import {
+  COMPLETENESS_DECLARE_INCOMPLETE_BUTTON_NAME,
+  COMPLETENESS_FINISH_BUTTON_NAME,
+  COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION,
+  FEDERAL_COMMENT_END_DATEPICKER_NAME,
+  FEDERAL_COMMENT_START_DATEPICKER_NAME,
+  STATE_DEEMED_COMPLETE_DATEPICKER_NAME,
+} from "./CompletenessPhase";
+
+const STYLES = {
+  title: tw`text-xl font-semibold mb-2 uppercase`,
+  helper: tw`text-sm text-text-placeholder mb-2`,
+  actions: tw`mt-8 flex justify-end gap-2`,
+};
+
+interface VerifyCompleteSectionProps {
+  stateDeemedComplete: string;
+  federalStartDate: string;
+  federalEndDate: string;
+  completenessComplete: boolean;
+  finishIsEnabled: boolean;
+  onDateChange: (date: string) => void;
+  onDeclareIncomplete: () => void;
+  onFinish: () => void;
+}
+
+export const VerifyCompleteSection = ({
+  stateDeemedComplete,
+  federalStartDate,
+  federalEndDate,
+  completenessComplete,
+  finishIsEnabled,
+  onDateChange,
+  onDeclareIncomplete,
+  onFinish,
+}: VerifyCompleteSectionProps) => (
+  <div aria-labelledby="completeness-verify-title">
+    <h4 id="completeness-verify-title" className={STYLES.title}>
+      Step 2 - Verify/Complete
+    </h4>
+    <p className={STYLES.helper} data-testId={COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.testId}>
+      {COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.text}
+    </p>
+
+    <div className="grid grid-cols-2 gap-4">
+      <div className="col-span-2">
+        <DatePicker
+          name={STATE_DEEMED_COMPLETE_DATEPICKER_NAME}
+          label={"State Application Deemed Complete" satisfies DateType}
+          value={stateDeemedComplete}
+          onChange={onDateChange}
+          isDisabled={completenessComplete}
+        />
+      </div>
+
+      <div>
+        <DatePicker
+          name={FEDERAL_COMMENT_START_DATEPICKER_NAME}
+          label={"Federal Comment Period Start Date" satisfies DateType}
+          value={federalStartDate}
+          isDisabled
+        />
+      </div>
+
+      <div>
+        <DatePicker
+          name={FEDERAL_COMMENT_END_DATEPICKER_NAME}
+          label={"Federal Comment Period End Date" satisfies DateType}
+          value={federalEndDate}
+          isDisabled
+        />
+      </div>
+    </div>
+
+    <div className={STYLES.actions}>
+      <SecondaryButton
+        name={COMPLETENESS_DECLARE_INCOMPLETE_BUTTON_NAME}
+        size="small"
+        onClick={onDeclareIncomplete}
+        disabled={completenessComplete}
+      >
+        Declare Incomplete
+      </SecondaryButton>
+      <Button
+        name={COMPLETENESS_FINISH_BUTTON_NAME}
+        size="small"
+        disabled={!finishIsEnabled}
+        onClick={onFinish}
+      >
+        Finish
+      </Button>
+    </div>
+  </div>
+);

--- a/client/src/components/application/phases/completeness/index.ts
+++ b/client/src/components/application/phases/completeness/index.ts
@@ -1,0 +1,1 @@
+export * from "./CompletenessPhase";

--- a/client/src/components/application/phases/index.ts
+++ b/client/src/components/application/phases/index.ts
@@ -1,6 +1,6 @@
 export * from "./ConceptPhase";
 export * from "./ApplicationIntakePhase";
-export * from "./CompletenessPhase";
+export * from "./completeness";
 export * from "./FederalCommentPhase";
 export * from "./SdgPreparationPhase";
 export * from "./review/";


### PR DESCRIPTION
While working on DEMOS-2358 I noticed this component could use some modernization of the sub-components. Broke these out into their own components and made them a bit more pure regarding taking parameters rather than using implicit values in scope - this should benefit both the reliability and maintainability of the component.