### PR TITLE
Demos 2369 aria label and testid

### DIFF
--- a/client/src/components/application/phases/ApplicationIntakePhase.tsx
+++ b/client/src/components/application/phases/ApplicationIntakePhase.tsx
@@ -136,7 +136,7 @@ const UploadSection = ({
       </h4>
       <p
         className={STYLES.helper}
-        data-testId={APPLICATION_INTAKE_PHASE_STEP_ONE_DESCRIPTION.testId}
+        data-testid={APPLICATION_INTAKE_PHASE_STEP_ONE_DESCRIPTION.testId}
       >
         {APPLICATION_INTAKE_PHASE_STEP_ONE_DESCRIPTION.text}
       </p>
@@ -207,7 +207,7 @@ const VerifyCompleteSection = ({
       </h4>
       <p
         className={STYLES.helper}
-        data-testId={APPLICATION_INTAKE_PHASE_STEP_TWO_DESCRIPTION.testId}
+        data-testid={APPLICATION_INTAKE_PHASE_STEP_TWO_DESCRIPTION.testId}
       >
         {APPLICATION_INTAKE_PHASE_STEP_TWO_DESCRIPTION.text}
       </p>
@@ -429,7 +429,7 @@ export const ApplicationIntakePhase = ({
       <h3 className="text-brand text-[22px] font-bold">APPLICATION INTAKE</h3>
       <p
         className="text-sm text-text-placeholder mb-4"
-        data-testId={APPLICATION_INTAKE_PHASE_DESCRIPTION.testId}
+        data-testid={APPLICATION_INTAKE_PHASE_DESCRIPTION.testId}
       >
         {APPLICATION_INTAKE_PHASE_DESCRIPTION.text}
       </p>
@@ -451,7 +451,7 @@ export const ApplicationIntakePhase = ({
           </h4>
           <p
             className={STYLES.helper}
-            data-testId={APPLICATION_INTAKE_PHASE_STEP_THREE_DESCRIPTION.testId}
+            data-testid={APPLICATION_INTAKE_PHASE_STEP_THREE_DESCRIPTION.testId}
           >
             {APPLICATION_INTAKE_PHASE_STEP_THREE_DESCRIPTION.text}
           </p>

--- a/client/src/components/application/phases/CompletenessPhase.tsx
+++ b/client/src/components/application/phases/CompletenessPhase.tsx
@@ -291,7 +291,7 @@ export const CompletenessPhase = ({
       <h4 id="completeness-upload-title" className={STYLES.title}>
         Step 1 - Upload
       </h4>
-      <p className={STYLES.helper} data-testId={COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.testId}>
+      <p className={STYLES.helper} data-testid={COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.testId}>
         {COMPLETENESS_PHASE_STEP_ONE_DESCRIPTION.text}
       </p>
       <SecondaryButton
@@ -311,7 +311,7 @@ export const CompletenessPhase = ({
       <h4 id="completeness-verify-title" className={STYLES.title}>
         Step 2 - Verify/Complete
       </h4>
-      <p className={STYLES.helper} data-testId={COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.testId}>
+      <p className={STYLES.helper} data-testid={COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.testId}>
         {COMPLETENESS_PHASE_STEP_TWO_DESCRIPTION.text}
       </p>
 
@@ -380,7 +380,7 @@ export const CompletenessPhase = ({
       <div id="completeness-phase-content">
         <p
           className="text-sm text-text-placeholder mb-4"
-          data-testId={COMPLETENESS_PHASE_DESCRIPTION.testId}
+          data-testid={COMPLETENESS_PHASE_DESCRIPTION.testId}
         >
           {COMPLETENESS_PHASE_DESCRIPTION.text}
         </p>

--- a/client/src/components/application/phases/ConceptPhase.tsx
+++ b/client/src/components/application/phases/ConceptPhase.tsx
@@ -220,7 +220,7 @@ export const ConceptPhase = ({
       <h4 id="state-application-upload-title" className={STYLES.title}>
         Step 1 - Upload
       </h4>
-      <p data-testId={CONCEPT_PHASE_STEP_ONE_DESCRIPTION.testId} className={STYLES.helper}>
+      <p data-testid={CONCEPT_PHASE_STEP_ONE_DESCRIPTION.testId} className={STYLES.helper}>
         {CONCEPT_PHASE_STEP_ONE_DESCRIPTION.text}
       </p>
 
@@ -242,7 +242,7 @@ export const ConceptPhase = ({
       <h4 id="concept-verify-title" className={STYLES.title}>
         Step 2 - Verify/Complete
       </h4>
-      <p data-testId={CONCEPT_PHASE_STEP_TWO_DESCRIPTION.testId} className={STYLES.helper}>
+      <p data-testid={CONCEPT_PHASE_STEP_TWO_DESCRIPTION.testId} className={STYLES.helper}>
         {CONCEPT_PHASE_STEP_TWO_DESCRIPTION.text}
       </p>
 
@@ -287,7 +287,7 @@ export const ConceptPhase = ({
   return (
     <div className="p-1">
       <h3 className="text-brand text-[22px] font-bold tracking-wide mb-1">CONCEPT</h3>
-      <p data-testId={CONCEPT_PHASE_DESCRIPTION.testId} className={STYLES.helper}>
+      <p data-testid={CONCEPT_PHASE_DESCRIPTION.testId} className={STYLES.helper}>
         {CONCEPT_PHASE_DESCRIPTION.text}
       </p>
 

--- a/client/src/components/application/phases/ConceptPhase.tsx
+++ b/client/src/components/application/phases/ConceptPhase.tsx
@@ -265,7 +265,7 @@ export const ConceptPhase = ({
       <div className={STYLES.actions}>
         <SecondaryButton
           name={SKIP_BUTTON_NAME}
-          ariaLabel="Skip this section"
+          aria-label="Skip this section"
           onClick={onSkip}
           disabled={!isSkipEnabled}
         >
@@ -274,7 +274,7 @@ export const ConceptPhase = ({
         </SecondaryButton>
         <Button
           name={FINISH_BUTTON_NAME}
-          ariaLabel="Finish this section"
+          aria-label="Finish this section"
           onClick={onFinish}
           disabled={!isFinishEnabled}
         >

--- a/client/src/components/application/phases/sections/ApplicationUploadSection.tsx
+++ b/client/src/components/application/phases/sections/ApplicationUploadSection.tsx
@@ -37,7 +37,7 @@ export const ApplicationUploadSection: React.FC<Props> = ({
         onClick={onUploadClick}
         size="small"
         name="button-open-upload-modal"
-        ariaLabel="Upload"
+        aria-label="Upload"
       >
         Upload
         <ExportIcon />

--- a/client/src/components/button/BaseButton.tsx
+++ b/client/src/components/button/BaseButton.tsx
@@ -45,7 +45,7 @@ export interface ButtonProps {
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   children: React.ReactNode;
   className: string;
-  ariaLabel?: string;
+  "aria-label"?: string;
   type?: ButtonType;
   form?: string;
   size?: ButtonSize;
@@ -60,7 +60,7 @@ export const BaseButton: React.FC<ButtonProps> = ({
   children,
   form,
   className,
-  ariaLabel,
+  "aria-label": ariaLabel,
   type = "button",
   size = "standard",
   disabled = false,

--- a/client/src/components/dialog/ApplyTagsDialog.tsx
+++ b/client/src/components/dialog/ApplyTagsDialog.tsx
@@ -279,7 +279,7 @@ export const ApplyTagsDialog: React.FC<ApplyTagsDialogProps> = ({
       onClose={onClose}
       dialogHasChanges={hasChanges}
       actionButton={
-        <Button onClick={handleApply} name="button-confirm-apply-tags" ariaLabel="Apply tags">
+        <Button onClick={handleApply} name="button-confirm-apply-tags" aria-label="Apply tags">
           Apply Tag(s)
         </Button>
       }

--- a/client/src/components/dialog/BaseDialog.tsx
+++ b/client/src/components/dialog/BaseDialog.tsx
@@ -109,7 +109,7 @@ export const BaseDialog = ({
                 name={DIALOG_CANCEL_BUTTON_NAME}
                 onClick={onCloseClicked}
                 disabled={cancelButtonIsDisabled}
-                ariaLabel="Cancel and close dialog"
+                aria-label="Cancel and close dialog"
               >
                 Cancel
               </SecondaryButton>

--- a/client/src/components/dialog/ConfirmApproveDialog.tsx
+++ b/client/src/components/dialog/ConfirmApproveDialog.tsx
@@ -31,7 +31,7 @@ export const ConfirmApproveDialog: React.FC<ConfirmApproveDialogProps> = ({
       actionButton={
         <Button
           name="button-ca-dialog-approve"
-          ariaLabel={`Submit approved ${applicationType}`}
+          aria-label={`Submit approved ${applicationType}`}
           onClick={handleSubmitClicked}
         >
           Submit Approved {applicationType.charAt(0).toUpperCase() + applicationType.slice(1)}

--- a/client/src/components/dialog/ConfirmCancellationDialog.tsx
+++ b/client/src/components/dialog/ConfirmCancellationDialog.tsx
@@ -50,14 +50,14 @@ export const ConfirmCancellationDialog: React.FC<ConfirmCancellationDialogProps>
         <div className={STYLES.BUTTONS}>
           <SecondaryButton
             name="button-cc-dialog-cancel"
-            ariaLabel="Keep editing"
+            aria-label="Keep editing"
             onClick={onClose}
           >
             Cancel
           </SecondaryButton>
           <ErrorButton
             name="button-cc-dialog-discard"
-            ariaLabel="Discard changes"
+            aria-label="Discard changes"
             onClick={onConfirm}
           >
             Discard Changes

--- a/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/DemonstrationDialog.tsx
@@ -68,7 +68,7 @@ const SubmitButton = ({
     <Button
       name={SUBMIT_BUTTON_NAME}
       onClick={onClick}
-      ariaLabel={"Create New Demonstration"}
+      aria-label={"Create New Demonstration"}
       disabled={disabled || isSubmitting}
     >
       {isSubmitting && <Spinner />}

--- a/client/src/components/dialog/document/UploadButton.tsx
+++ b/client/src/components/dialog/document/UploadButton.tsx
@@ -8,7 +8,7 @@ interface UploadButtonProps {
   isUploading: boolean;
   label?: string;
   loadingLabel?: string;
-  ariaLabel?: string;
+  "aria-label"?: string;
 }
 
 const ButtonText = ({
@@ -39,14 +39,14 @@ export const UploadButton: React.FC<UploadButtonProps> = ({
   isUploading,
   label = "Upload",
   loadingLabel = "Uploading",
-  ariaLabel,
+  "aria-label": ariaLabel,
 }) => {
   const resolvedAriaLabel = ariaLabel ?? `${label} Document`;
   return (
     <Button
       name="button-confirm-upload-document"
       onClick={onClick}
-      ariaLabel={resolvedAriaLabel}
+      aria-label={resolvedAriaLabel}
       aria-disabled={disabled || isUploading ? "true" : "false"}
       disabled={disabled || isUploading}
     >

--- a/client/src/components/input/select/SelectSignatureLevel.tsx
+++ b/client/src/components/input/select/SelectSignatureLevel.tsx
@@ -48,7 +48,7 @@ export const SelectSignatureLevel = ({
         setSignatureLevel(selectedValue);
         onSelect(selectedValue);
       }}
-      data-testId="signature-level-select"
+      data-testid="signature-level-select"
       id="signature-level-select"
       label="Signature Level"
       isDisabled={isDisabled}

--- a/client/src/components/notice/Notice.test.tsx
+++ b/client/src/components/notice/Notice.test.tsx
@@ -22,7 +22,7 @@ describe("Notice", () => {
         title="Heads up"
         description="Details about the notice"
         variant="warning"
-        testId="custom-notice-id"
+        data-testid="custom-notice-id"
       />
     );
 

--- a/client/src/components/notice/Notice.tsx
+++ b/client/src/components/notice/Notice.tsx
@@ -31,14 +31,14 @@ export const Notice = ({
   title,
   description,
   variant = "info",
-  testId,
+  "data-testid": testId,
   onDismiss,
 }: {
   title: string;
   description?: React.ReactNode;
   variant?: NoticeVariant;
   onDismiss?: () => void;
-  testId?: string;
+  "data-testid"?: string;
 }) => {
   const variantClasses = VARIANT_TO_CLASSNAME[variant];
   const icon = VARIANT_TO_ICON[variant];

--- a/client/src/components/table/PaginationControls.test.tsx
+++ b/client/src/components/table/PaginationControls.test.tsx
@@ -159,7 +159,7 @@ describe("PaginationControls", () => {
       const data = createTestData(100);
       render(<TestWrapper data={data} />);
 
-      const prevButton = screen.getByRole("button", { name: /Go to previous page/i });
+      const prevButton = screen.getByRole("button", { name: /No previous page/i });
       expect(prevButton).toBeDisabled();
     });
 
@@ -244,7 +244,7 @@ describe("PaginationControls", () => {
       const data = createTestData(100);
       render(<TestWrapper data={data} />);
 
-      const currentPageButton = screen.getByRole("button", { name: "Go to page 1" });
+      const currentPageButton = screen.getByRole("button", { name: "Page 1, current page" });
       expect(currentPageButton).toBeInTheDocument();
       expect(currentPageButton).toHaveClass("bg-action");
     });

--- a/client/src/components/table/columns/ApprovalPackageColumns.tsx
+++ b/client/src/components/table/columns/ApprovalPackageColumns.tsx
@@ -54,7 +54,7 @@ export function ApprovalPackageColumns(demonstrationId: string) {
             {!doc ? (
               <SecondaryButton
                 name={`upload-${row.original.documentType}`}
-                ariaLabel={`Upload ${row.original.documentType}`}
+                aria-label={`Upload ${row.original.documentType}`}
                 onClick={() =>
                   showApprovalPackageDocumentUploadDialog(
                     demonstrationId,
@@ -68,7 +68,7 @@ export function ApprovalPackageColumns(demonstrationId: string) {
               <>
                 <TertiaryButton
                   name={`edit-${doc.documentType}`}
-                  ariaLabel={`Edit ${doc.documentType}`}
+                  aria-label={`Edit ${doc.documentType}`}
                   onClick={() =>
                     showEditDocumentDialog({
                       id: doc.id,
@@ -81,7 +81,7 @@ export function ApprovalPackageColumns(demonstrationId: string) {
                 </TertiaryButton>
                 <TertiaryButton
                   name={`delete-${doc.documentType}`}
-                  ariaLabel={`Delete ${doc.documentType}`}
+                  aria-label={`Delete ${doc.documentType}`}
                   onClick={() => showRemoveDocumentDialog([doc.id])}
                 >
                   <DeleteIcon />

--- a/client/src/components/table/columns/ContactColumns.tsx
+++ b/client/src/components/table/columns/ContactColumns.tsx
@@ -130,7 +130,7 @@ export function ContactColumns({
           <div className="text-center">
             <CircleButton
               name="delete-contact"
-              ariaLabel="Delete Contact"
+              aria-label="Delete Contact"
               tooltip={deleteTooltip}
               size="small"
               onClick={() => onRemoveContact(contact.id)}

--- a/client/src/components/table/columns/DeliverableColumns.tsx
+++ b/client/src/components/table/columns/DeliverableColumns.tsx
@@ -139,7 +139,7 @@ export function DeliverableColumns({
           size={isDemonstrationDetail ? "small" : undefined}
           onClick={handleClick}
           name={isDemonstrationDetail ? `view-deliverable-${deliverableId}` : "view-deliverable"}
-          ariaLabel={`View ${row.original.name}`}
+          aria-label={`View ${row.original.name}`}
         >
           View
         </SecondaryButton>

--- a/client/src/components/table/columns/DocumentColumns.tsx
+++ b/client/src/components/table/columns/DocumentColumns.tsx
@@ -57,7 +57,7 @@ export function DocumentColumns() {
           <SecondaryButton
             onClick={handleClick}
             name="view-document"
-            ariaLabel={`View ${row.original.name}`}
+            aria-label={`View ${row.original.name}`}
           >
             View
           </SecondaryButton>

--- a/client/src/components/table/columns/ReferencesColumns.tsx
+++ b/client/src/components/table/columns/ReferencesColumns.tsx
@@ -54,7 +54,7 @@ export function ReferencesColumns() {
           <div className="flex gap-2 justify-center">
             <SecondaryButton
               name={`download-${row.original.id}`}
-              ariaLabel={
+              aria-label={
                 row.original.agreement
                   ? `Open ${row.original.id} agreement`
                   : `Download ${row.original.id}`

--- a/client/src/components/table/columns/ReportsColumns.tsx
+++ b/client/src/components/table/columns/ReportsColumns.tsx
@@ -24,7 +24,7 @@ export function ReportsColumns(
           <div className="flex gap-2 justify-center">
             <SecondaryButton
               name={`download-${row.original.id}`}
-              ariaLabel={`Download ${row.original.id}`}
+              aria-label={`Download ${row.original.id}`}
               onClick={() => onDownload(row.original.id)}
             >
               Download

--- a/client/src/components/table/tables/DeliverableActionButtons.tsx
+++ b/client/src/components/table/tables/DeliverableActionButtons.tsx
@@ -72,7 +72,7 @@ export const DeliverableActionButtons: React.FC<{
     <div className="flex gap-1 ml-4">
       <CircleButton
         name="edit-deliverable"
-        ariaLabel="Edit Deliverable"
+        aria-label="Edit Deliverable"
         tooltip={editTooltip}
         disabled={!editEnabled}
         onClick={() => {
@@ -86,7 +86,7 @@ export const DeliverableActionButtons: React.FC<{
 
       <CircleButton
         name="remove-deliverable"
-        ariaLabel="Remove Deliverable"
+        aria-label="Remove Deliverable"
         tooltip={deleteTooltip}
         disabled={!deleteEnabled}
         onClick={() => {

--- a/client/src/components/table/tables/DocumentTable.tsx
+++ b/client/src/components/table/tables/DocumentTable.tsx
@@ -63,7 +63,7 @@ export const DocumentTable = ({ documents }: { documents: DocumentTableDocument[
               <div className="flex gap-1 ml-4">
                 <CircleButton
                   name="edit-document"
-                  ariaLabel="Edit Document"
+                  aria-label="Edit Document"
                   tooltip={editTooltip}
                   disabled={!editEnabled}
                   onClick={() =>
@@ -79,7 +79,7 @@ export const DocumentTable = ({ documents }: { documents: DocumentTableDocument[
 
                 <CircleButton
                   name="remove-document"
-                  ariaLabel="Remove Document"
+                  aria-label="Remove Document"
                   tooltip={deleteTooltip}
                   disabled={!deleteEnabled}
                   onClick={() => showRemoveDocumentDialog(selectedDocs.map((doc) => doc.id))}

--- a/client/src/components/table/tables/TypesTable.tsx
+++ b/client/src/components/table/tables/TypesTable.tsx
@@ -121,7 +121,7 @@ export const TypesTable: React.FC<TypesTableProps> = ({
               <div className="flex gap-1 ml-4">
                 <CircleButton
                   name="edit-type"
-                  ariaLabel="Edit Type"
+                  aria-label="Edit Type"
                   tooltip={editTooltip}
                   disabled={editDisabled || inputDisabled}
                   onClick={() =>
@@ -140,7 +140,7 @@ export const TypesTable: React.FC<TypesTableProps> = ({
 
                 <CircleButton
                   name="delete-type"
-                  ariaLabel="Delete Type"
+                  aria-label="Delete Type"
                   tooltip={removeTooltip}
                   disabled={removeDisabled}
                   onClick={() =>

--- a/client/src/components/tags/SparklyUIPathTags.tsx
+++ b/client/src/components/tags/SparklyUIPathTags.tsx
@@ -40,7 +40,7 @@ export const SparklyUIPathTags = ({
             variant="suggestion"
             icon={<SparklyIcon label="Suggested by DEMOS AI" className="shrink-0" />}
             onClick={() => onAcceptSuggestion(tagName)}
-            ariaLabel={`Apply suggested tag ${tagName}`}
+            aria-label={`Apply suggested tag ${tagName}`}
             disabled={isApplyingSuggestion}
           />
         ))}

--- a/client/src/components/tags/TagChip.test.tsx
+++ b/client/src/components/tags/TagChip.test.tsx
@@ -55,7 +55,7 @@ describe("Approval status", () => {
         tag={{ tagName: "Health Equity", approvalStatus: "Approved" }}
         variant="suggestion"
         onClick={() => {}}
-        ariaLabel="Apply suggested tag Health Equity"
+        aria-label="Apply suggested tag Health Equity"
       />
     );
 

--- a/client/src/components/tags/TagChip.tsx
+++ b/client/src/components/tags/TagChip.tsx
@@ -20,7 +20,7 @@ export const TagChip = ({
   variant = "default",
   icon,
   onClick,
-  ariaLabel,
+  "aria-label": ariaLabel,
   disabled = false,
 }: {
   tag: Tag;
@@ -28,7 +28,7 @@ export const TagChip = ({
   variant?: TagChipVariant;
   icon?: React.ReactNode;
   onClick?: () => void;
-  ariaLabel?: string;
+  "aria-label"?: string;
   disabled?: boolean;
 }) => {
   const tagName = tag.tagName;

--- a/client/src/components/toast/ConfirmationToast.tsx
+++ b/client/src/components/toast/ConfirmationToast.tsx
@@ -31,7 +31,7 @@ export const ConfirmationToast: React.FC<ConfirmationToastProps> = ({
       <div className="flex justify-center gap-6">
         <SecondaryButton
           name="confirmation-cancel"
-          ariaLabel={cancelText}
+          aria-label={cancelText}
           size="small"
           onClick={onCancel}
         >
@@ -39,7 +39,7 @@ export const ConfirmationToast: React.FC<ConfirmationToastProps> = ({
         </SecondaryButton>
         <ErrorButton
           name="confirmation-confirm"
-          ariaLabel={confirmText}
+          aria-label={confirmText}
           isOutlined={true}
           size="small"
           onClick={onConfirm}

--- a/client/src/pages/DemonstrationDetail/modifications/AmendmentsTab.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/AmendmentsTab.tsx
@@ -21,7 +21,7 @@ export const AmendmentsTab: React.FC<{
       <div className="flex min-h-70 flex-col items-center justify-center gap-4 p-2">
         <p className="text-sm text-text-primary">{EMPTY_AMENDMENTS_MESSAGE}</p>
         <IconButton
-          ariaLabel="Create Amendment"
+          aria-label="Create Amendment"
           icon={<AddNewIcon />}
           name="create-new-amendment"
           size="small"

--- a/client/src/pages/DemonstrationDetail/modifications/ExtensionsTab.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ExtensionsTab.tsx
@@ -21,7 +21,7 @@ export const ExtensionsTab: React.FC<{
       <div className="flex min-h-90 flex-col items-center justify-center gap-4 p-2">
         <p className="text-sm text-text-primary">{EMPTY_EXTENSIONS_MESSAGE}</p>
         <IconButton
-          ariaLabel="Create Extension"
+          aria-label="Create Extension"
           icon={<AddNewIcon />}
           name="create-new-extension"
           size="small"

--- a/client/src/pages/DocumentDetails/DocumentPreview.tsx
+++ b/client/src/pages/DocumentDetails/DocumentPreview.tsx
@@ -18,7 +18,7 @@ const FilePreviewer = ({
     <embed src={blobUrl} className="w-full h-full" />
   ) : (
     <a href={blobUrl} download={filename} rel="noopener noreferrer">
-      <Button size="large" name="button-download-file" ariaLabel="Download file">
+      <Button size="large" name="button-download-file" aria-label="Download file">
         Download File
       </Button>
     </a>

--- a/client/src/pages/deliverables/sections/CmsFilesTab.tsx
+++ b/client/src/pages/deliverables/sections/CmsFilesTab.tsx
@@ -32,7 +32,7 @@ export const CmsFilesTab: React.FC<CmsFilesTabProps> = ({
 
   return (
     <DeliverableFileTable
-      testId={CMS_FILES_TAB_NAME}
+      data-testid={CMS_FILES_TAB_NAME}
       title="CMS Files"
       addButtonName={CMS_FILES_ADD_BUTTON_NAME}
       editButtonName={CMS_FILES_EDIT_BUTTON_NAME}

--- a/client/src/pages/deliverables/sections/DeliverableFileTable.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableFileTable.tsx
@@ -88,7 +88,7 @@ export const DeliverableFileTable: React.FC<DeliverableFileTableProps> = ({
               <div className="flex gap-1 ml-4">
                 <CircleButton
                   name={editButtonName}
-                  ariaLabel={editAriaLabel}
+                  aria-label={editAriaLabel}
                   tooltip={ isFinalized
                     ? "Documents on Finalized deliverables cannot be edited."
                     : selectionTooltip({
@@ -104,7 +104,7 @@ export const DeliverableFileTable: React.FC<DeliverableFileTableProps> = ({
                 </CircleButton>
                 <CircleButton
                   name={deleteButtonName}
-                  ariaLabel={deleteAriaLabel}
+                  aria-label={deleteAriaLabel}
                   tooltip={hasSubmittedFile
                     ? "Selection contains files that have been submitted. Cannot delete submitted files."
                     : selectionTooltip({

--- a/client/src/pages/deliverables/sections/DeliverableFileTable.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableFileTable.tsx
@@ -14,7 +14,7 @@ import type { DeliverableFileRow } from "./DeliverableFileTypes";
 const INITIAL_TABLE_STATE = { sorting: [{ id: "createdAt", desc: true }] };
 
 export type DeliverableFileTableProps = {
-  testId: string;
+  "data-testid": string;
   title: string;
   addButtonName: string;
   editButtonName: string;
@@ -33,7 +33,7 @@ export type DeliverableFileTableProps = {
 };
 
 export const DeliverableFileTable: React.FC<DeliverableFileTableProps> = ({
-  testId,
+  "data-testid": testId,
   title,
   addButtonName,
   editButtonName,

--- a/client/src/pages/deliverables/sections/DeliverableInfoFields.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableInfoFields.tsx
@@ -77,7 +77,7 @@ export const DeliverableInfoFields = ({
         <BaseButton
           type="button"
           name={BACK_TO_DELIVERABLES_BUTTON_NAME}
-          ariaLabel="Back to deliverables"
+          aria-label="Back to deliverables"
           onClick={onBack}
           className="w-[48px] h-[60px] bg-white text-action hover:bg-action hover:text-white border border-action"
         >

--- a/client/src/pages/deliverables/sections/StateFilesTab.tsx
+++ b/client/src/pages/deliverables/sections/StateFilesTab.tsx
@@ -32,7 +32,7 @@ export const StateFilesTab: React.FC<StateFilesTabProps> = ({
 
   return (
     <DeliverableFileTable
-      testId={STATE_FILES_TAB_NAME}
+      data-testid={STATE_FILES_TAB_NAME}
       title="State Files"
       addButtonName={STATE_FILES_ADD_BUTTON_NAME}
       editButtonName={STATE_FILES_EDIT_BUTTON_NAME}


### PR DESCRIPTION
simple cleanup. Replaces instances of ariaLabel or similar spellings in our components' props with aria-label.  Then does similar with data-testId, making it all lowercase and where used in a prop like testId, changed it to data-testid as well. 

Its kinda strange, for most props typescript will throw an error if the prop doesnt exist on the called component. However, these hyphenated props dont flag. This leads to scenarios where we might attempt to pass in a "aria-label" but the prop is dropped without any indication that something is wrong. 

I had tried to figure out if there was a way to make TS be a little more explicit, and perhaps there is, but given the scope of this cleanup id rather just do the string substitution. So looked at wherever i could find we were using these attributes and made them consistent with the aria/html standard. 

the other one, data-testId, had a similar problem, but we were getting console errors because of it. apparently, it needs to be spelled "data-testid", all lowercase, even though the testing framework doesnt care. 

Finally, im not entirely sure if this is the best way to go; personally i kinda like making it explicitly not a hyphenated prop, so that the typechecking is enforced. But without custom linting rules or something, theres no way to enforce "dont use the hyphenated prop here". So rather than go down that rabbithole, lets just make it consistent for now