### PR TITLE
DEMOS-2366 & DEMOS-2372 DatePicker updates and testing datepicker and safari adjustments

### DIFF
--- a/client/src/components/application/phase-selector/PhaseBox.tsx
+++ b/client/src/components/application/phase-selector/PhaseBox.tsx
@@ -6,7 +6,7 @@ import { PhaseDate } from "./PhaseDate";
 import { PhaseName } from "demos-server";
 
 const BASE_STYLES = {
-  PHASE_BOX: tw`relative flex flex-col items-center justify-center rounded-sm hover:cursor-pointer aspect-2/1 p-1`,
+  PHASE_BOX: tw`relative flex flex-col items-center justify-center rounded-sm hover:cursor-pointer aspect-2/1 w-full min-w-0 p-1`,
   PHASE_NUMBER: tw`flex items-center justify-center text-lg w-3 h-3 my-1 rounded-full font-bold`,
   PHASE_NAME: tw`text-[12px] font-bold truncate max-w-full`,
   AI_SUGGESTION_ICON: tw`absolute right-[5px] top-[5px] text-purple-700 size-[1.8em]`,
@@ -57,7 +57,7 @@ export const PhaseBox = (props: PhaseBoxProps) => {
   const showSuccessIcon = isCompletionStatus(props.phaseStatus);
 
   return (
-    <div className="flex flex-col justify-center col-span-1">
+    <div className="flex flex-col justify-center col-span-1 min-w-0">
       <div
         key={props.phaseName}
         className={`${BASE_STYLES.PHASE_BOX} 

--- a/client/src/components/dialog/deliverable/deliverableDueDateValidation.ts
+++ b/client/src/components/dialog/deliverable/deliverableDueDateValidation.ts
@@ -1,12 +1,6 @@
 import { isBefore, parseISO } from "date-fns";
-import { formatDateForDisplay, getTodayEst } from "util/formatDate";
-// Temporary until we get datepicker fix tested. then we'lll use minDate=`{getTodayEst()}`
-// This is just a third location for SingeDueDate and QuarterlyDueDate, will get replaced once datepicker fixed
+
+import { getTodayEst } from "util/formatDate";
 
 export const dueDateIsTodayOrFuture = (dueDate: string): boolean =>
   dueDate.length > 0 && !isBefore(parseISO(dueDate), parseISO(getTodayEst()));
-
-export const getDueDateValidationMessage = (dueDate: string): string =>
-  dueDate.length > 0 && !dueDateIsTodayOrFuture(dueDate)
-    ? `Date must be on or after ${formatDateForDisplay(getTodayEst())}.`
-    : "";

--- a/client/src/components/dialog/deliverable/fields/schedule-type/QuarterlyDeliverableSchedule.test.tsx
+++ b/client/src/components/dialog/deliverable/fields/schedule-type/QuarterlyDeliverableSchedule.test.tsx
@@ -59,6 +59,14 @@ describe("QuarterlyDeliverableSchedule", () => {
     ).toBeInTheDocument();
   });
 
+  it("requires quarterly due dates to be today or later", () => {
+    render(<QuarterlyDeliverableSchedule onSelectYear={vi.fn()} />);
+
+    screen.getAllByLabelText(/Quarter/i).forEach((datePicker) => {
+      expect(datePicker).toHaveAttribute("min", getTodayEst());
+    });
+  });
+
   it("calls onSelectQuarterDate with the correct quarter index and date when a date is changed", () => {
     const onSelectQuarterDate = vi.fn();
     render(

--- a/client/src/components/dialog/deliverable/fields/schedule-type/QuarterlyDeliverableSchedule.tsx
+++ b/client/src/components/dialog/deliverable/fields/schedule-type/QuarterlyDeliverableSchedule.tsx
@@ -3,8 +3,7 @@ import { differenceInCalendarYears } from "date-fns";
 
 import { DatePicker } from "components/input/date/DatePicker";
 import { Select } from "components/input/select/Select";
-// Temporary until we get datepicker fix tested.
-import { getDueDateValidationMessage } from "../../deliverableDueDateValidation";
+import { getTodayEst } from "util/formatDate";
 
 export function getOptionsForYearSelect(
   demonstrationEffectiveDate?: Date,
@@ -38,6 +37,7 @@ export function QuarterlyDeliverableSchedule({
   onSelectQuarterDate?: (quarterIndex: number, dueDate: string) => void;
 }) {
   const [selectedYear, setSelectedYear] = useState(1);
+  const today = getTodayEst();
 
   const getQuarterDueDate = (quarterIndex: number) => quarterlyDueDates?.[quarterIndex] ?? "";
 
@@ -66,8 +66,7 @@ export function QuarterlyDeliverableSchedule({
           value={getQuarterDueDate(0)}
           onChange={(newDate: string) => onSelectQuarterDate?.(0, newDate)}
           isRequired={true}
-          // Temporary until we get datepicker fix tested. then we'lll use minDate=`{getTodayEst()}`
-          getValidationMessage={() => getDueDateValidationMessage(getQuarterDueDate(0))}
+          minDate={today}
         />
       </div>
 
@@ -79,7 +78,7 @@ export function QuarterlyDeliverableSchedule({
           value={getQuarterDueDate(1)}
           onChange={(newDate: string) => onSelectQuarterDate?.(1, newDate)}
           isRequired={true}
-          getValidationMessage={() => getDueDateValidationMessage(getQuarterDueDate(1))}
+          minDate={today}
         />
       </div>
 
@@ -91,7 +90,7 @@ export function QuarterlyDeliverableSchedule({
           value={getQuarterDueDate(2)}
           onChange={(newDate: string) => onSelectQuarterDate?.(2, newDate)}
           isRequired={true}
-          getValidationMessage={() => getDueDateValidationMessage(getQuarterDueDate(2))}
+          minDate={today}
         />
       </div>
 
@@ -103,7 +102,7 @@ export function QuarterlyDeliverableSchedule({
           value={getQuarterDueDate(3)}
           onChange={(newDate: string) => onSelectQuarterDate?.(3, newDate)}
           isRequired={true}
-          getValidationMessage={() => getDueDateValidationMessage(getQuarterDueDate(3))}
+          minDate={today}
         />
       </div>
     </div>

--- a/client/src/components/dialog/deliverable/fields/schedule-type/SingleDeliverableScheduleType.tsx
+++ b/client/src/components/dialog/deliverable/fields/schedule-type/SingleDeliverableScheduleType.tsx
@@ -1,6 +1,6 @@
 import { DatePicker } from "components/input/date/DatePicker";
 import React from "react";
-import { getDueDateValidationMessage } from "../../deliverableDueDateValidation";
+import { getTodayEst } from "util/formatDate";
 
 export const SINGLE_DELIVERABLE_DUE_DATE_NAME = "single-deliverable-due-date";
 
@@ -11,6 +11,7 @@ export const SingleDeliverableScheduleType = ({
   value: string;
   onChange: (dueDate: string) => void;
 }) => {
+  const today = getTodayEst();
   return (
     <div className="grid grid-cols-2">
       <div className="col-span-1">
@@ -20,8 +21,7 @@ export const SingleDeliverableScheduleType = ({
           value={value}
           onChange={onChange}
           isRequired={true}
-          // Temporary until we get datepicker fix tested. then we'lll use minDate=`{getTodayEst()}`
-          getValidationMessage={() => getDueDateValidationMessage(value)}
+          minDate={today}
         />
       </div>
     </div>

--- a/client/src/components/dialog/document/UploadButton.tsx
+++ b/client/src/components/dialog/document/UploadButton.tsx
@@ -27,7 +27,11 @@ const ButtonText = ({
 
   return (
     <>
-      {isUploading && <Spinner />}
+      {isUploading && (
+        <span className="inline-flex size-[20px] shrink-0 items-center justify-center">
+          <Spinner />
+        </span>
+      )}
       {getButtonText()}
     </>
   );

--- a/client/src/components/input/date/DatePicker.test.tsx
+++ b/client/src/components/input/date/DatePicker.test.tsx
@@ -39,8 +39,7 @@ describe("DatePicker component", () => {
   });
 
   // onChange commits immediately when a complete date is selected (calendar pick or keyboard).
-  // Range is enforced by the native (inclusive) min/max attributes and surfaced via the
-  // validation message derived from the parent's value prop.
+  // Range is surfaced through native min/max attributes and the component's validation message.
   describe("onChange commit + range messaging", () => {
     it("does not propagate partial-year dates emitted during year-subfield editing", () => {
       render(<DatePicker {...requiredProps} />);
@@ -60,13 +59,23 @@ describe("DatePicker component", () => {
       expect(mockOnChange).toHaveBeenCalledWith("2025-03-20");
     });
 
-    it("shows an out of range date and message while not propagating it to the caller", () => {
+    it("shows an out of range date and message while propagating it to the caller", () => {
       render(<DatePicker {...requiredProps} />);
       const input = screen.getByTestId("test-date");
 
       fireEvent.change(input, { target: { value: "1899-12-31" } });
-      expect(mockOnChange).not.toHaveBeenCalled();
+      expect(mockOnChange).toHaveBeenCalledWith("1899-12-31");
       expect(screen.getByText("Date must be on or after 01/01/1900.")).toBeInTheDocument();
+    });
+
+    it("propagates complete dates outside a provided minDate", () => {
+      render(<DatePicker {...requiredProps} minDate="2026-04-28" />);
+      const input = screen.getByTestId("test-date");
+
+      fireEvent.change(input, { target: { value: "2026-04-01" } });
+
+      expect(mockOnChange).toHaveBeenCalledWith("2026-04-01");
+      expect(screen.getByText("Date must be on or after 04/28/2026.")).toBeInTheDocument();
     });
 
     it("commits inclusive boundary dates 1900-01-01 and 2099-12-31 on change", () => {

--- a/client/src/components/input/date/DatePicker.tsx
+++ b/client/src/components/input/date/DatePicker.tsx
@@ -33,7 +33,7 @@ export const DatePicker = ({
   maxDate?: string;
   getValidationMessage?: () => string;
 }) => {
-  // Displayed date is needed to show out of range values in the input while not propagating them to the parent component via onChange.
+  // Displayed date is needed to keep partially typed year values visible before committing them.
   const [displayedDate, setDisplayedDate] = React.useState(value ?? "");
 
   // This is needed to update the displayed date when the parent component controls the value (e.g. when resetting the form). Without this, the input would not update to reflect changes to the value prop after the initial render. We want to allow the parent to control the value while still letting the user type out-of-range values without immediately reverting them back to a valid date. This effect ensures that when the parent updates the value prop
@@ -46,9 +46,9 @@ export const DatePicker = ({
     const newDate = e.target.value;
     setDisplayedDate(newDate);
 
-    // Only call onChange if the date is valid (empty or within range).
-    // (newDate === "" || newDate >= FULL_YEAR_DATE) <-- change that fixes min date validation.
-    if (newDate === "" || (newDate >= minDate && newDate <= maxDate)) {
+    // Browser date inputs can emit partial-year values while editing the year subfield.
+    // Complete dates should propagate even when out of range so callers can validate current state.
+    if (newDate === "" || newDate >= FULL_YEAR_DATE) {
       onChange?.(newDate);
     }
   };


### PR DESCRIPTION
I feel very confident about this after a solid 12 hrs of testing. 

But i made the changes to Datapicker and then ran thru this with a few browsers and ran into issues with mostly Safari. So both tickets ran into this. Which is just a consequence of the the first ticket. 

Before: 
<img width="500" height="auto" alt="Screenshot 2026-06-30 at 10 05 59" src="https://github.com/user-attachments/assets/c10e39c1-025c-4af0-8ff6-6b64341131a9" />

After: 
<img width="500" height="auto" alt="Screenshot 2026-06-30 at 11 32 27" src="https://github.com/user-attachments/assets/ff381bdf-641a-4880-9bed-0a1b2649987a" />

Safari datepicker disabled:
<img width="356" height="238" alt="Screenshot 2026-06-30 at 16 54 12" src="https://github.com/user-attachments/assets/b5973bfa-126c-416b-9339-6dec957b5a35" />

Chrome:
<img width="538" height="393" alt="Screenshot 2026-06-30 at 16 55 05" src="https://github.com/user-attachments/assets/f858add4-2b70-4119-ac34-f9f10a2e81ac" />

