### PR TITLE
Upgrade shared_library npm packages

### DIFF
--- a/shared_library/package-lock.json
+++ b/shared_library/package-lock.json
@@ -12,7 +12,7 @@
         "read-excel-file": "^8.0.3"
       },
       "devDependencies": {
-        "@types/node": "^25.9.3",
+        "@types/node": "^25.9.4",
         "typescript": "^5.9.3",
         "vitest": "^4.1.9"
       }
@@ -413,9 +413,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "25.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
+      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/shared_library/package.json
+++ b/shared_library/package.json
@@ -18,7 +18,7 @@
     "test:watch": "vitest --watch"
   },
   "devDependencies": {
-    "@types/node": "^25.9.3",
+    "@types/node": "^25.9.4",
     "typescript": "^5.9.3",
     "vitest": "^4.1.9"
   },


### PR DESCRIPTION
## Minor and patch updates

All available *minor* and *patch* updates have been installed. See diff for details.

## Major updates are available

The following packages were not updated, but have major version updates available: 
```
Major   Potentially breaking API changes
 @types/node      ^25.9.4  →  ^26.1.0
 read-excel-file   ^8.0.3  →   ^9.2.0
 typescript        ^5.9.3  →   ^6.0.3

```