### PR TITLE
DEMOS-2387: modified expected actuals strings

### DIFF
--- a/server/src/onDemandReports/configs/deliverableStatusReportConfig.ts
+++ b/server/src/onDemandReports/configs/deliverableStatusReportConfig.ts
@@ -75,7 +75,7 @@ const deliverableStatusReportSchema = z
     deliverable_reviewer: z.string(),
     deliverable_review_date: usDateStringOrDash,
     budget_neutrality_variance: z.string(),
-    actuals: z.enum(["Actual", "Actual + Projected", "-"]),
+    actuals: z.enum(["Actuals Only", "Actual + Projected", "-"]),
   } satisfies OnDemandReportColumnSchema<DeliverableStatusReportColumn>)
   .strict();
 


### PR DESCRIPTION
Simple change. No test files needed updating because this is largely a configuration and this is the only step in which we're implementing validation.  Locally, uploaded BN workbooks and modified such they would return the expected values and fail if something other than Actuals Only or Actual + Projected was returned. 