### PR TITLE
DEMOS-2158: adding initialization of admin user permissions

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -522,8 +522,11 @@ export const PERMISSIONS = [
   "Delete State Documents on Assigned Deliverables",
 
   // Field Level Permissions
+  "Access Admin Field",
+  "Access Admin Query",
   "Access CMS Field",
   "Access CMS Query",
+  "Perform Admin Action",
   "Perform CMS Action",
   "Perform State Action",
 ] as const;

--- a/server/src/model/migrations/20260706142328_initialize_admin_schema_permissions/migration.sql
+++ b/server/src/model/migrations/20260706142328_initialize_admin_schema_permissions/migration.sql
@@ -1,0 +1,15 @@
+INSERT INTO
+    demos_app.permission
+VALUES
+    ('Access Admin Field', 'System'),
+    ('Access Admin Query', 'System'),
+    ('Perform Admin Action', 'System')
+;
+
+INSERT INTO
+    demos_app.role_permission
+VALUES
+    ('Admin User', 'System', 'Access Admin Field'),
+    ('Admin User', 'System', 'Access Admin Query'),
+    ('Admin User', 'System', 'Perform Admin Action')
+;


### PR DESCRIPTION
This PR is in preparation for 2.0 work, and should unblock any development on admin feature that need to be restricted to only admins. Currently, those permissions do not yet exist but this adds 3: access admin field, access admin query, and perform admin action. 

Here i demonstrate the permission, with a new "users" query (not included in this PR):

https://github.com/user-attachments/assets/5263358b-8e40-41a5-a5aa-579fd07f0c31



