### PR TITLE
DEMOS-2378 Generate sanitized, human-readable download file names

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -28,8 +28,10 @@
         "graphql-tools": "^9.0.28",
         "jsonwebtoken": "^9.0.3",
         "jwks-rsa": "^3.2.2",
+        "mime-types": "^3.0.2",
         "pg": "^8.21.0",
         "pino": "^10.3.1",
+        "sanitize-filename": "^1.6.4",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -40,6 +42,7 @@
         "@faker-js/faker": "^9.9.0",
         "@graphql-tools/merge": "^9.1.9",
         "@parcel/watcher": "^2.5.6",
+        "@types/mime-types": "^3.0.1",
         "@types/node": "^22.19.20",
         "@vitest/coverage-v8": "^4.1.8",
         "@vitest/ui": "^4.1.8",
@@ -66,7 +69,7 @@
         "read-excel-file": "^8.0.3"
       },
       "devDependencies": {
-        "@types/node": "^25.9.3",
+        "@types/node": "^25.9.4",
         "typescript": "^5.9.3",
         "vitest": "^4.1.9"
       }
@@ -3246,6 +3249,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ms": {
@@ -7008,6 +7018,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -7448,6 +7467,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -7628,6 +7656,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/valibot": {
       "version": "1.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -29,8 +29,10 @@
     "graphql-tools": "^9.0.28",
     "jsonwebtoken": "^9.0.3",
     "jwks-rsa": "^3.2.2",
+    "mime-types": "^3.0.2",
     "pg": "^8.21.0",
     "pino": "^10.3.1",
+    "sanitize-filename": "^1.6.4",
     "zod": "^4.4.3"
   },
   "scripts": {
@@ -67,6 +69,7 @@
     "@faker-js/faker": "^9.9.0",
     "@graphql-tools/merge": "^9.1.9",
     "@parcel/watcher": "^2.5.6",
+    "@types/mime-types": "^3.0.1",
     "@types/node": "^22.19.20",
     "@vitest/coverage-v8": "^4.1.8",
     "@vitest/ui": "^4.1.8",

--- a/server/src/adapters/index.ts
+++ b/server/src/adapters/index.ts
@@ -1,2 +1,2 @@
 export { getS3Adapter } from "./s3/S3Adapter";
-export type { S3Adapter } from "./s3/S3Adapter";
+export type { S3Adapter, GetPresignedDownloadUrlOptions } from "./s3/S3Adapter";

--- a/server/src/adapters/s3/AwsS3Adapter.test.ts
+++ b/server/src/adapters/s3/AwsS3Adapter.test.ts
@@ -12,6 +12,7 @@ import {
   S3Client,
   PutObjectCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   CopyObjectCommand,
   DeleteObjectCommand,
 } from "@aws-sdk/client-s3";
@@ -22,6 +23,7 @@ vi.mock("@aws-sdk/client-s3", () => ({
   S3Client: vi.fn(),
   PutObjectCommand: vi.fn(),
   GetObjectCommand: vi.fn(),
+  HeadObjectCommand: vi.fn(),
   CopyObjectCommand: vi.fn(),
   DeleteObjectCommand: vi.fn(),
 }));
@@ -53,6 +55,9 @@ describe("AwsS3Adapter", () => {
   const mockGetObjectCommand: Partial<GetObjectCommand> = {
     input: { Bucket: "test-bucket", Key: "get-object-command" },
   };
+  const mockHeadObjectCommand: Partial<HeadObjectCommand> = {
+    input: { Bucket: "test-bucket", Key: "head-object-command" },
+  };
   const mockCopyObjectCommand: Partial<CopyObjectCommand> = {
     input: { Bucket: "test-bucket", CopySource: "test-source", Key: "copy-object-command" },
   };
@@ -77,6 +82,9 @@ describe("AwsS3Adapter", () => {
     });
     vi.mocked(GetObjectCommand).mockImplementation(function () {
       return mockGetObjectCommand as GetObjectCommand;
+    });
+    vi.mocked(HeadObjectCommand).mockImplementation(function () {
+      return mockHeadObjectCommand as HeadObjectCommand;
     });
     vi.mocked(CopyObjectCommand).mockImplementation(function () {
       return mockCopyObjectCommand as CopyObjectCommand;
@@ -115,21 +123,74 @@ describe("AwsS3Adapter", () => {
         Bucket: testCleanBucket,
         Key: testKey,
       });
+      // No file name means no Content-Type lookup is needed.
+      expect(HeadObjectCommand).not.toHaveBeenCalled();
       expect(getSignedUrl).toHaveBeenCalledExactlyOnceWith(mockS3Client, mockGetObjectCommand, {
         expiresIn: 10,
       });
     });
 
-    it("sets an inline Content-Disposition, safely encoding the file name", async () => {
+    it("appends an extension derived from the object's Content-Type", async () => {
+      mockSend.mockResolvedValueOnce({ ContentType: "application/pdf" });
       const adapter = createAWSS3Adapter();
-      // Name with a quote (escaped) and a non-ASCII char (encoded via filename*)
-      // proves arbitrary document names can't malform or inject the header.
-      await adapter.getPresignedDownloadUrl(testKey, 'Quârterly "Report".pdf');
+      await adapter.getPresignedDownloadUrl(testKey, "Quarterly Report");
+
+      expect(HeadObjectCommand).toHaveBeenCalledExactlyOnceWith({
+        Bucket: testCleanBucket,
+        Key: testKey,
+      });
+      expect(GetObjectCommand).toHaveBeenCalledExactlyOnceWith({
+        Bucket: testCleanBucket,
+        Key: testKey,
+        ResponseContentDisposition: 'inline; filename="Quarterly Report.pdf"',
+      });
+    });
+
+    it("sanitizes the file name and safely encodes the Content-Disposition header", async () => {
+      mockSend.mockResolvedValueOnce({ ContentType: "application/pdf" });
+      const adapter = createAWSS3Adapter();
+      // Quotes are stripped as invalid; the non-ASCII char is percent-encoded via filename*.
+      await adapter.getPresignedDownloadUrl(testKey, 'Quârterly "Report"');
 
       expect(GetObjectCommand).toHaveBeenCalledExactlyOnceWith({
         Bucket: testCleanBucket,
         Key: testKey,
-        ResponseContentDisposition: String.raw`inline; filename="Qu?rterly \"Report\".pdf"; filename*=UTF-8''Qu%C3%A2rterly%20%22Report%22.pdf`,
+        ResponseContentDisposition:
+          String.raw`inline; filename="Qu?rterly Report.pdf"; ` +
+          String.raw`filename*=UTF-8''Qu%C3%A2rterly%20Report.pdf`,
+      });
+    });
+
+    it("falls back to the key when the name is entirely invalid characters", async () => {
+      mockSend.mockResolvedValueOnce({ ContentType: "application/pdf" });
+      const adapter = createAWSS3Adapter();
+      await adapter.getPresignedDownloadUrl("uuid-123", "///");
+
+      expect(GetObjectCommand).toHaveBeenCalledExactlyOnceWith({
+        Bucket: testCleanBucket,
+        Key: "uuid-123",
+        // No spaces/special chars, so content-disposition leaves it unquoted.
+        ResponseContentDisposition: "inline; filename=uuid-123.pdf",
+      });
+    });
+
+    it("forces a download and derives the extension when disposition is attachment", async () => {
+      mockSend.mockResolvedValueOnce({
+        ContentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      });
+      const adapter = createAWSS3Adapter();
+      await adapter.getPresignedDownloadUrl("reports/on-demand/r1.xlsx", "Deliverable Report", {
+        disposition: "attachment",
+      });
+
+      expect(HeadObjectCommand).toHaveBeenCalledExactlyOnceWith({
+        Bucket: testCleanBucket,
+        Key: "reports/on-demand/r1.xlsx",
+      });
+      expect(GetObjectCommand).toHaveBeenCalledExactlyOnceWith({
+        Bucket: testCleanBucket,
+        Key: "reports/on-demand/r1.xlsx",
+        ResponseContentDisposition: 'attachment; filename="Deliverable Report.xlsx"',
       });
     });
   });

--- a/server/src/adapters/s3/AwsS3Adapter.ts
+++ b/server/src/adapters/s3/AwsS3Adapter.ts
@@ -2,13 +2,16 @@ import {
   CopyObjectCommand,
   DeleteObjectCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { create as createContentDisposition } from "content-disposition";
+import { extension as extensionForContentType } from "mime-types";
 import { prisma, PrismaTransactionClient } from "../../prismaClient";
-import { S3Adapter } from "../";
+import { GetPresignedDownloadUrlOptions, S3Adapter } from "../";
+import { sanitizeDownloadFileName } from "./sanitizeDownloadFileName";
 import { Prisma, DocumentPendingUpload as PrismaDocumentPendingUpload } from "@prisma/client";
 
 const EXPIRATION_TIME_SECONDS = 10;
@@ -29,6 +32,33 @@ const createS3Client = () => {
 
   return new S3Client(s3ClientConfig);
 };
+
+/** Maps the object's stored S3 Content-Type to a file extension (e.g. "pdf"), or "" if unknown. */
+async function getExtensionForObject(
+  s3Client: S3Client,
+  bucket: string,
+  key: string
+): Promise<string> {
+  const head = await s3Client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+  const contentType = head.ContentType ?? "";
+  return contentType ? extensionForContentType(contentType) || "" : "";
+}
+
+/** Builds a Content-Disposition with a sanitized name plus the extension derived from Content-Type. */
+async function buildContentDisposition(
+  s3Client: S3Client,
+  bucket: string,
+  key: string,
+  fileName: string,
+  options?: GetPresignedDownloadUrlOptions
+): Promise<string> {
+  const safeName = sanitizeDownloadFileName(fileName, key.split("/").pop() ?? key);
+
+  const extension = await getExtensionForObject(s3Client, bucket, key);
+  const finalName = extension ? `${safeName}.${extension}` : safeName;
+
+  return createContentDisposition(finalName, { type: options?.disposition ?? "inline" });
+}
 
 /**
  * Creates an AWS S3 adapter that uses the AWS SDK to interact with S3 buckets.
@@ -52,12 +82,16 @@ export function createAWSS3Adapter(): S3Adapter {
       });
     },
 
-    async getPresignedDownloadUrl(key: string, fileName?: string): Promise<string> {
+    async getPresignedDownloadUrl(
+      key: string,
+      fileName?: string,
+      options?: GetPresignedDownloadUrlOptions
+    ): Promise<string> {
       const getObjectCommand = new GetObjectCommand({
         Bucket: cleanBucket,
         Key: key,
         ResponseContentDisposition: fileName
-          ? createContentDisposition(fileName, { type: "inline" })
+          ? await buildContentDisposition(s3Client, cleanBucket, key, fileName, options)
           : undefined,
       });
       return await getSignedUrl(s3Client, getObjectCommand, {

--- a/server/src/adapters/s3/LocalS3Adapter.ts
+++ b/server/src/adapters/s3/LocalS3Adapter.ts
@@ -1,5 +1,6 @@
 import { prisma, PrismaTransactionClient } from "../../prismaClient";
-import { S3Adapter } from "../";
+import { GetPresignedDownloadUrlOptions, S3Adapter } from "../";
+import { sanitizeDownloadFileName } from "./sanitizeDownloadFileName";
 import { Prisma, DocumentPendingUpload as PrismaDocumentPendingUpload } from "@prisma/client";
 
 const HOSTNAME = "LocalS3Adapter";
@@ -18,14 +19,25 @@ export function createLocalS3Adapter(): S3Adapter {
       return `${HOSTNAME}/${BUCKET_NAME}/${key}?upload=true&expires=3600`;
     },
 
-    async getPresignedDownloadUrl(key: string): Promise<string> {
+    async getPresignedDownloadUrl(
+      key: string,
+      fileName?: string,
+      options?: GetPresignedDownloadUrlOptions
+    ): Promise<string> {
+      // Fake URLs only — just reflect the sanitized name/disposition for local dev visibility.
+      const fileNameParam = fileName
+        ? `&fileName=${encodeURIComponent(
+            sanitizeDownloadFileName(fileName, key.split("/").pop() ?? key)
+          )}&disposition=${options?.disposition ?? "inline"}`
+        : "";
+
       if (uploadedFiles.has(key)) {
-        return `${HOSTNAME}/${BUCKET_NAME}/${key}?download=true&expires=3600`;
+        return `${HOSTNAME}/${BUCKET_NAME}/${key}?download=true&expires=3600${fileNameParam}`;
       }
 
       const onDemandReport = uploadedOnDemandReports.get(key);
       if (onDemandReport) {
-        return `${HOSTNAME}/${BUCKET_NAME}/${key}?download=true&expires=3600&size=${onDemandReport.byteLength}`;
+        return `${HOSTNAME}/${BUCKET_NAME}/${key}?download=true&expires=3600&size=${onDemandReport.byteLength}${fileNameParam}`;
       }
 
       return `${key} does not exist!`;

--- a/server/src/adapters/s3/S3Adapter.ts
+++ b/server/src/adapters/s3/S3Adapter.ts
@@ -2,9 +2,18 @@ import { PrismaTransactionClient } from "../../prismaClient";
 import { createAWSS3Adapter } from "./AwsS3Adapter";
 import { createLocalS3Adapter } from "./LocalS3Adapter";
 import { Prisma, DocumentPendingUpload as PrismaDocumentPendingUpload } from "@prisma/client";
+export interface GetPresignedDownloadUrlOptions {
+  /** Content-Disposition type. Defaults to "inline" (renders previews); use "attachment" to force download. */
+  disposition?: "inline" | "attachment";
+}
+
 export interface S3Adapter {
   getPresignedUploadUrl(key: string): Promise<string>;
-  getPresignedDownloadUrl(key: string, fileName?: string): Promise<string>;
+  getPresignedDownloadUrl(
+    key: string,
+    fileName?: string,
+    options?: GetPresignedDownloadUrlOptions
+  ): Promise<string>;
   moveDocumentFromCleanToDeleted(key: string): Promise<void>;
   uploadDocument(
     documentData: Prisma.DocumentPendingUploadCreateArgs["data"],

--- a/server/src/adapters/s3/sanitizeDownloadFileName.test.ts
+++ b/server/src/adapters/s3/sanitizeDownloadFileName.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeDownloadFileName } from "./sanitizeDownloadFileName";
+
+describe("sanitizeDownloadFileName", () => {
+  const fallback = "123e4567-e89b-12d3-a456-426614174000";
+
+  it("returns a normal name unchanged", () => {
+    expect(sanitizeDownloadFileName("Quarterly Report", fallback)).toBe("Quarterly Report");
+  });
+
+  it("strips characters that are invalid in file names", () => {
+    expect(sanitizeDownloadFileName('Report: Q1/Q2 "final"', fallback)).toBe("Report Q1Q2 final");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(sanitizeDownloadFileName("  spaced out  ", fallback)).toBe("spaced out");
+  });
+
+  it("falls back to the provided UUID when the name is entirely invalid", () => {
+    expect(sanitizeDownloadFileName("///", fallback)).toBe(fallback);
+  });
+
+  it("falls back when the name is empty", () => {
+    expect(sanitizeDownloadFileName("", fallback)).toBe(fallback);
+  });
+
+  it("sanitizes the fallback itself if it contains separators", () => {
+    expect(sanitizeDownloadFileName("", "reports/on-demand/abc")).toBe("reportson-demandabc");
+  });
+});

--- a/server/src/adapters/s3/sanitizeDownloadFileName.ts
+++ b/server/src/adapters/s3/sanitizeDownloadFileName.ts
@@ -1,0 +1,12 @@
+import sanitize from "sanitize-filename";
+
+/** Cleans a name into a safe download file name (no extension), falling back to the UUID/key if empty. */
+export function sanitizeDownloadFileName(name: string, fallback: string): string {
+  const sanitizedName = sanitize(name).trim();
+  if (sanitizedName.length > 0) {
+    return sanitizedName;
+  }
+
+  // Rare: name was entirely invalid characters — fall back to the UUID/key.
+  return sanitize(fallback).trim();
+}

--- a/server/src/model/onDemandReport/onDemandReportResolvers.test.ts
+++ b/server/src/model/onDemandReport/onDemandReportResolvers.test.ts
@@ -144,7 +144,9 @@ describe("onDemandReportResolvers", () => {
         },
         mockTransaction
       );
-      expect(mockGetPresignedDownloadUrl).toHaveBeenCalledExactlyOnceWith(mockS3Path);
+      expect(mockGetPresignedDownloadUrl).toHaveBeenCalledExactlyOnceWith(mockS3Path, testReportType, {
+        disposition: "attachment",
+      });
       expect(mockDeleteOnDemandReport).not.toHaveBeenCalled();
       expect(result).toBe("https://presigned-download-url");
     });

--- a/server/src/model/onDemandReport/onDemandReportResolvers.ts
+++ b/server/src/model/onDemandReport/onDemandReportResolvers.ts
@@ -62,7 +62,10 @@ export const onDemandReportResolvers = {
           handlePrismaError(error);
         }
       }
-      return await s3Adapter.getPresignedDownloadUrl(uploadedReportS3Path);
+      // Name without extension — `.xlsx` is derived from the object's Content-Type.
+      return await s3Adapter.getPresignedDownloadUrl(uploadedReportS3Path, args.reportType, {
+        disposition: "attachment",
+      });
     },
   },
 };

--- a/server/src/model/reference/getReferenceAgreementDownloadUrl.test.ts
+++ b/server/src/model/reference/getReferenceAgreementDownloadUrl.test.ts
@@ -35,6 +35,7 @@ describe("getReferenceAgreementDownloadUrl", () => {
 
   const mockActiveReferenceAgreement: Partial<SelectReferenceAgreementResult> = {
     id: testReferenceAgreementId,
+    name: "Sample Agreement",
     s3Path: "some/s3/path",
     inActiveUse: true,
   };
@@ -86,7 +87,11 @@ describe("getReferenceAgreementDownloadUrl", () => {
   it("returns a presigned download URL for an active reference agreement", async () => {
     const result = await getReferenceAgreementDownloadUrl({}, { id: testReferenceAgreementId });
     expect(getS3Adapter).toHaveBeenCalledOnce();
-    expect(mockS3Adapter.getPresignedDownloadUrl).toHaveBeenCalledExactlyOnceWith("some/s3/path");
+    expect(mockS3Adapter.getPresignedDownloadUrl).toHaveBeenCalledExactlyOnceWith(
+      "some/s3/path",
+      "Sample Agreement",
+      { disposition: "attachment" }
+    );
     expect(result).toBe("https://example.com/download");
   });
 });

--- a/server/src/model/reference/getReferenceAgreementDownloadUrl.ts
+++ b/server/src/model/reference/getReferenceAgreementDownloadUrl.ts
@@ -32,5 +32,7 @@ export async function getReferenceAgreementDownloadUrl(
     });
   }
 
-  return getS3Adapter().getPresignedDownloadUrl(referenceAgreement.s3Path);
+  return getS3Adapter().getPresignedDownloadUrl(referenceAgreement.s3Path, referenceAgreement.name, {
+    disposition: "attachment",
+  });
 }

--- a/server/src/model/reference/getReferenceDownloadUrl.test.ts
+++ b/server/src/model/reference/getReferenceDownloadUrl.test.ts
@@ -46,9 +46,11 @@ describe("getReferenceDownloadUrl", () => {
     user: { id: testUserId },
   };
 
+  const testReferenceName = "Sample Reference";
   const mockReferenceConfiguration = {
     reference: {
       id: testReferenceId,
+      name: testReferenceName,
       s3Path: testS3Path,
     },
     referenceAgreement: {
@@ -128,7 +130,11 @@ describe("getReferenceDownloadUrl", () => {
       testContext as GraphQLContext
     );
     expect(getS3Adapter).toHaveBeenCalledOnce();
-    expect(mockS3Adapter.getPresignedDownloadUrl).toHaveBeenCalledExactlyOnceWith(testS3Path);
+    expect(mockS3Adapter.getPresignedDownloadUrl).toHaveBeenCalledExactlyOnceWith(
+      testS3Path,
+      testReferenceName,
+      { disposition: "attachment" }
+    );
     expect(result).toBe(testDownloadUrl);
   });
 });

--- a/server/src/model/reference/getReferenceDownloadUrl.ts
+++ b/server/src/model/reference/getReferenceDownloadUrl.ts
@@ -28,5 +28,9 @@ export async function getReferenceDownloadUrl(
     }
     return validatedReferenceConfiguration;
   });
-  return getS3Adapter().getPresignedDownloadUrl(requestedReferenceConfiguration.reference.s3Path);
+  return getS3Adapter().getPresignedDownloadUrl(
+    requestedReferenceConfiguration.reference.s3Path,
+    requestedReferenceConfiguration.reference.name,
+    { disposition: "attachment" }
+  );
 }


### PR DESCRIPTION
Files are stored in S3 under their UUID, but users expect a human-readable name
when downloading. This wires the presigned **download** URL to return a file with
a clean, valid name and the correct extension — for documents, references,
reference agreements, and on-demand reports (not just the document preview page).

## What it does

1. **Human-readable names via Content-Disposition** — `getPresignedDownloadUrl`
   accepts a desired file name and sets `ResponseContentDisposition` so the
   download comes back named, instead of a raw UUID / S3 object key.
2. **Sanitized names** — the name is cleaned with `sanitize-filename` before use.
   If a name is comprised entirely of invalid characters, it falls back to the
   object's UUID/key.
3. **Correct extension** — the extension is derived from the object's stored S3
   `Content-Type` (via `mime-types`) and appended, so names passed in are always
   extension-less and the download still opens correctly.

## Call pattern

Every caller passes a bare, extension-less name; the adapter adds the extension
from Content-Type. The only thing that varies is the disposition:

| Caller | Disposition | Notes |
| --- | --- | --- |
| Documents | `inline` (default) | Keeps the in-page PDF `<embed>` preview working |
| References / agreements / reports | `attachment` | Direct downloads |

## Key changes

- `adapters/s3/sanitizeDownloadFileName.ts` *(new)* — shared sanitize + UUID-fallback helper
- `adapters/s3/AwsS3Adapter.ts` — sanitize → read Content-Type → append extension → Content-Disposition
- `adapters/s3/S3Adapter.ts` — `GetPresignedDownloadUrlOptions` (`disposition`) + updated signature
- `adapters/s3/LocalS3Adapter.ts` — signature kept in sync with the AWS adapter
- `model/reference/getReferenceDownloadUrl.ts`, `getReferenceAgreementDownloadUrl.ts` — pass the reference/agreement name
- `model/onDemandReport/onDemandReportResolvers.ts` — pass the report type as the name

## Notes / edge cases

- **Document preview page** was verified for collisions: it never appends an
  extension, so the new server-side extension logic won't produce `name.pdf.pdf`.
- Document names are stored **without** an extension (the client strips it on
  upload), which is why the extension is derived from Content-Type here.
- A user *could* manually type an extension into a document name (free-text
  field), which would produce `report.pdf.pdf`. This is the rare, accepted edge
  the ticket calls out.

## Dependencies added

- `sanitize-filename`
- `mime-types` + `@types/mime-types`

## Testing

- `tsc --noEmit`, ESLint clean
- Unit tests added/updated for the sanitizer, both S3 adapters, and the
  reference/report resolvers — all passing
