### PR TITLE
DEMOS-2403: Update CSP and embedder policy to allow presigned url embeds

### DIFF
--- a/deployment/package-lock.json
+++ b/deployment/package-lock.json
@@ -14,7 +14,7 @@
         "@aws-sdk/client-s3": "^3.1063.0",
         "@aws-sdk/client-ssm": "^3.1063.0",
         "aws-cdk": "^2.1126.0",
-        "aws-cdk-lib": "^2.258.0",
+        "aws-cdk-lib": "^2.260.0",
         "cdk-nag": "^2.38.2",
         "chalk": "^5.6.2",
         "constructs": "^10.6.0",
@@ -2424,9 +2424,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.258.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.258.0.tgz",
-      "integrity": "sha512-OfFfg30ikBRJ3dimlzsWhPIrj6qug1p2XYsdB38CtMtcur7SufzoUczgI6kWjbQkOVcQgYzhzN29DErV0yZG7A==",
+      "version": "2.260.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.260.0.tgz",
+      "integrity": "sha512-2PPG+hbPDot8+ibkb5Jl9y3OY5rBE6TFwjzOi+yEyU4ZG6u8bM4DDKhhBi/S20NqqSFDso9rH1txVJAdwXNiuQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",

--- a/deployment/package.json
+++ b/deployment/package.json
@@ -47,7 +47,7 @@
     "@aws-sdk/client-s3": "^3.1063.0",
     "@aws-sdk/client-ssm": "^3.1063.0",
     "aws-cdk": "^2.1126.0",
-    "aws-cdk-lib": "^2.258.0",
+    "aws-cdk-lib": "^2.260.0",
     "cdk-nag": "^2.38.2",
     "chalk": "^5.6.2",
     "constructs": "^10.6.0",

--- a/deployment/stacks/ui.ts
+++ b/deployment/stacks/ui.ts
@@ -230,7 +230,7 @@ export class UiStack extends Stack {
             },
             {
               header: "Cross-Origin-Embedder-Policy",
-              value: "require-corp",
+              value: "unsafe-none", // set to allow presigned urls to be used directly in embeds. To be reworked in the future
               override: true,
             },
             {
@@ -266,7 +266,7 @@ export class UiStack extends Stack {
             override: true,
           },
           contentSecurityPolicy: {
-            contentSecurityPolicy: `default-src 'self'; form-action 'self'; img-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; connect-src 'self' https://cognito-idp.${Aws.REGION}.amazonaws.com ${cognitoDomain} https://${uploadBucketName}.s3.us-east-1.amazonaws.com https://${cleanBucketName}.s3.us-east-1.amazonaws.com; frame-ancestors 'none'; object-src 'self' blob: https://${cleanBucketName}.s3.us-east-1.amazonaws.com; frame-src 'self' blob: ${cognitoDomain}; worker-src 'self' blob:;`,
+            contentSecurityPolicy: `default-src 'self'; form-action 'self'; img-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; connect-src 'self' https://cognito-idp.${Aws.REGION}.amazonaws.com ${cognitoDomain} https://${uploadBucketName}.s3.us-east-1.amazonaws.com https://${cleanBucketName}.s3.us-east-1.amazonaws.com; frame-ancestors 'none'; object-src 'self' blob: https://${cleanBucketName}.s3.us-east-1.amazonaws.com; frame-src 'self' blob: ${cognitoDomain} https://${cleanBucketName}.s3.us-east-1.amazonaws.com; worker-src 'self' blob:;`,
             override: true,
           },
         },


### PR DESCRIPTION
This change updates `Cross-Origin-Embedder-Policy` to `unsafe-none` since S3 cannot set the CORP header and we are now directly embedding S3 presigned urls.

This also updates the CSP to allow the embeds.

An additional commit was added to fix the existing snyk vuln in aws-cdk-lib