### PR TITLE
Demos 2412 unselect table option after edit

### DIFF
--- a/client/src/components/dialog/DemonstrationTypes/EditDemonstrationTypeDialog.test.tsx
+++ b/client/src/components/dialog/DemonstrationTypes/EditDemonstrationTypeDialog.test.tsx
@@ -28,6 +28,8 @@ vi.mock("../DialogContext", () => ({
   }),
 }));
 
+const mockOnSubmit = vi.fn();
+
 const SUBMIT_BUTTON_TEST_ID = "button-submit-edit-demonstration-type-dialog";
 const MOCK_DEMONSTRATION_ID = "demo-123";
 const MOCK_INITIAL_TYPE: DemonstrationType = {
@@ -77,6 +79,7 @@ describe("EditDemonstrationTypeDialog", () => {
         <EditDemonstrationTypeDialog
           demonstrationId={MOCK_DEMONSTRATION_ID}
           initialDemonstrationType={MOCK_INITIAL_TYPE}
+          onSubmit={mockOnSubmit}
         />
       </MockedProvider>
     );
@@ -95,6 +98,7 @@ describe("EditDemonstrationTypeDialog", () => {
     await waitFor(() => {
       expect(mockShowError).toHaveBeenCalledWith("Failed to edit demonstration type.");
       expect(mockCloseDialog).toHaveBeenCalledTimes(1);
+      expect(mockOnSubmit).not.toHaveBeenCalled();
     });
   });
 
@@ -342,6 +346,7 @@ describe("EditDemonstrationTypeDialog", () => {
           <EditDemonstrationTypeDialog
             demonstrationId={MOCK_DEMONSTRATION_ID}
             initialDemonstrationType={initialType}
+            onSubmit={mockOnSubmit}
           />
         </MockedProvider>
       );
@@ -366,6 +371,7 @@ describe("EditDemonstrationTypeDialog", () => {
       await waitFor(() => {
         expect(mockShowSuccess).toHaveBeenCalledWith("Demonstration type edited successfully.");
         expect(mockCloseDialog).toHaveBeenCalledTimes(1);
+        expect(mockOnSubmit).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/client/src/components/dialog/DemonstrationTypes/EditDemonstrationTypeDialog.tsx
+++ b/client/src/components/dialog/DemonstrationTypes/EditDemonstrationTypeDialog.tsx
@@ -80,9 +80,11 @@ const isValid = (effectiveDate: LocalDate, expirationDate: LocalDate) => {
 export const EditDemonstrationTypeDialog = ({
   demonstrationId,
   initialDemonstrationType,
+  onSubmit,
 }: {
   demonstrationId: string;
   initialDemonstrationType: DemonstrationType;
+  onSubmit?: () => void;
 }) => {
   const { closeDialog } = useDialog();
   const { showSuccess, showError } = useToast();
@@ -117,6 +119,7 @@ export const EditDemonstrationTypeDialog = ({
       await editDemonstrationType({
         variables: { input: editDemonstrationTypeInput },
       });
+      onSubmit?.();
       showSuccess("Demonstration type edited successfully.");
     } catch (error) {
       console.error("Error editing demonstration type:", error);

--- a/client/src/components/dialog/DialogContext.tsx
+++ b/client/src/components/dialog/DialogContext.tsx
@@ -39,10 +39,7 @@ import {
   RequestExtensionDeliverableDialog,
   RequestExtensionDeliverableDialogDeliverable,
 } from "./deliverable/RequestExtensionDeliverableDialog";
-import type {
-  EditDeliverableDialogDeliverable,
-  EditDeliverableInput,
-} from "./deliverable/EditDeliverableDialog";
+import type { EditDeliverableDialogDeliverable } from "./deliverable/EditDeliverableDialog";
 import { WorkflowApplicationType } from "components/application";
 import { AddDeliverableSlotDemonstration } from "./deliverable/AddDeliverableSlotDialog";
 import type { DeliverableTableRow } from "components/table/tables/DeliverableTable";
@@ -345,7 +342,7 @@ export const useDialog = () => {
 
   const showEditDeliverableDialog = (
     deliverable: EditDeliverableDialogSource,
-    onSave?: (input: EditDeliverableInput, reasonForChange?: string) => Promise<void> | void
+    onSubmit: () => void
   ) => {
     const dialogDeliverable: EditDeliverableDialogDeliverable = {
       id: deliverable.id,
@@ -367,7 +364,7 @@ export const useDialog = () => {
         onClose={context.hideDialog}
         deliverable={dialogDeliverable}
         demonstrationTypeTags={demonstrationTypeTags}
-        onSave={onSave}
+        onSubmit={onSubmit}
       />
     );
   };

--- a/client/src/components/dialog/DialogContext.tsx
+++ b/client/src/components/dialog/DialogContext.tsx
@@ -257,12 +257,14 @@ export const useDialog = () => {
     demonstrationType: Pick<
       DemonstrationTypeAssignment,
       "demonstrationTypeName" | "status" | "effectiveDate" | "expirationDate" | "approvalStatus"
-    >
+    >,
+    onSubmit?: () => void
   ) => {
     context.showDialog(
       <EditDemonstrationTypeDialog
         demonstrationId={demonstrationId}
         initialDemonstrationType={demonstrationType}
+        onSubmit={onSubmit}
       />
     );
   };

--- a/client/src/components/dialog/DialogContext.tsx
+++ b/client/src/components/dialog/DialogContext.tsx
@@ -159,9 +159,12 @@ export const useDialog = () => {
 
   const showEditDocumentDialog = (
     document: Pick<ServerDocument, "id" | "name" | "description">,
-    refetchQueries?: DocumentNode[]
+    refetchQueries?: DocumentNode[],
+    onSubmit?: () => void
   ) => {
-    context.showDialog(<EditDocumentDialog document={document} refetchQueries={refetchQueries} />);
+    context.showDialog(
+      <EditDocumentDialog document={document} refetchQueries={refetchQueries} onSubmit={onSubmit} />
+    );
   };
 
   const showRemoveDocumentDialog = (

--- a/client/src/components/dialog/deliverable/EditDeliverableDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/EditDeliverableDialog.test.tsx
@@ -62,6 +62,7 @@ const setup = (overrides?: {
   mocks?: React.ComponentProps<typeof TestProvider>["mocks"];
 }) => {
   const onClose = vi.fn();
+  const onSubmit = vi.fn();
   const deliverable = { ...TEST_DELIVERABLE, ...overrides?.deliverable };
 
   render(
@@ -70,11 +71,12 @@ const setup = (overrides?: {
         deliverable={deliverable}
         demonstrationTypeTags={MOCK_TAGS}
         onClose={onClose}
+        onSubmit={onSubmit}
       />
     </TestProvider>
   );
 
-  return { onClose };
+  return { onClose, onSubmit };
 };
 
 describe("EditDeliverableDialog", () => {
@@ -157,7 +159,7 @@ describe("EditDeliverableDialog", () => {
 
   it("persists changes with the updateDeliverable mutation", async () => {
     const user = userEvent.setup();
-    const { onClose } = setup();
+    const { onClose, onSubmit } = setup();
 
     await waitFor(() =>
       expect(screen.getByTestId("select-demonstration-type")).toBeInTheDocument()
@@ -182,12 +184,13 @@ describe("EditDeliverableDialog", () => {
     });
     await waitFor(() => expect(mockShowSuccess).toHaveBeenCalledWith(DELIVERABLE_UPDATED_MESSAGE));
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the modal open and shows an error when updateDeliverable fails", async () => {
     const user = userEvent.setup();
     mockMutation.mockRejectedValueOnce(new Error("Update failed"));
-    const { onClose } = setup();
+    const { onClose, onSubmit } = setup();
 
     await waitFor(() =>
       expect(screen.getByTestId("select-demonstration-type")).toBeInTheDocument()
@@ -203,6 +206,7 @@ describe("EditDeliverableDialog", () => {
       expect(mockShowError).toHaveBeenCalledWith(DELIVERABLE_UPDATE_FAILED_MESSAGE)
     );
     expect(onClose).not.toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });
 

--- a/client/src/components/dialog/deliverable/EditDeliverableDialog.test.tsx
+++ b/client/src/components/dialog/deliverable/EditDeliverableDialog.test.tsx
@@ -10,7 +10,6 @@ import {
   EDIT_DELIVERABLE_SAVE_BUTTON_NAME,
   EditDeliverableDialog,
   EditDeliverableDialogDeliverable,
-  EditDeliverableInput,
   buildInitialFormData,
   formHasChanges,
   formIsValid,
@@ -58,15 +57,11 @@ const MOCK_TAGS: Tag[] = [
   { tagName: "Annual Limits", approvalStatus: "Approved" },
 ];
 
-type OnSaveFn = (input: EditDeliverableInput, reasonForChange?: string) => Promise<void> | void;
-
 const setup = (overrides?: {
   deliverable?: Partial<EditDeliverableDialogDeliverable>;
-  onSave?: OnSaveFn;
   mocks?: React.ComponentProps<typeof TestProvider>["mocks"];
 }) => {
   const onClose = vi.fn();
-  const onSave = overrides?.onSave;
   const deliverable = { ...TEST_DELIVERABLE, ...overrides?.deliverable };
 
   render(
@@ -75,12 +70,11 @@ const setup = (overrides?: {
         deliverable={deliverable}
         demonstrationTypeTags={MOCK_TAGS}
         onClose={onClose}
-        onSave={onSave}
       />
     </TestProvider>
   );
 
-  return { onClose, onSave };
+  return { onClose };
 };
 
 describe("EditDeliverableDialog", () => {
@@ -161,38 +155,6 @@ describe("EditDeliverableDialog", () => {
     );
   });
 
-  it("calls onSave with the reason and shows a success toast", async () => {
-    const user = userEvent.setup();
-    const onSave = vi.fn().mockResolvedValue(undefined);
-    const { onClose } = setup({ onSave });
-
-    await waitFor(() =>
-      expect(screen.getByTestId("select-demonstration-type")).toBeInTheDocument()
-    );
-    await user.click(screen.getByTestId("select-demonstration-type"));
-    await user.click(screen.getByText("Aggregate Cap"));
-
-    fireEvent.change(screen.getByTestId(SINGLE_DELIVERABLE_DUE_DATE_NAME), {
-      target: { value: "2026-07-20" },
-    });
-
-    await user.type(screen.getByTestId(EDIT_DELIVERABLE_REASON_FIELD_NAME), "Schedule slip");
-
-    await user.click(screen.getByTestId(EDIT_DELIVERABLE_SAVE_BUTTON_NAME));
-
-    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
-    expect(onSave).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: "deliverable-1",
-        dueDate: "2026-07-20",
-        demonstrationTypes: ["Aggregate Cap"],
-      }),
-      "Schedule slip"
-    );
-    expect(mockShowSuccess).toHaveBeenCalledWith(DELIVERABLE_UPDATED_MESSAGE);
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
   it("persists changes with the updateDeliverable mutation", async () => {
     const user = userEvent.setup();
     const { onClose } = setup();
@@ -218,9 +180,7 @@ describe("EditDeliverableDialog", () => {
         },
       },
     });
-    await waitFor(() =>
-      expect(mockShowSuccess).toHaveBeenCalledWith(DELIVERABLE_UPDATED_MESSAGE)
-    );
+    await waitFor(() => expect(mockShowSuccess).toHaveBeenCalledWith(DELIVERABLE_UPDATED_MESSAGE));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
@@ -243,23 +203,6 @@ describe("EditDeliverableDialog", () => {
       expect(mockShowError).toHaveBeenCalledWith(DELIVERABLE_UPDATE_FAILED_MESSAGE)
     );
     expect(onClose).not.toHaveBeenCalled();
-  });
-
-  it("does not pass a reason to onSave when the due date was not modified", async () => {
-    const user = userEvent.setup();
-    const onSave = vi.fn().mockResolvedValue(undefined);
-    setup({ onSave });
-
-    await waitFor(() =>
-      expect(screen.getByTestId("select-demonstration-type")).toBeInTheDocument()
-    );
-    await user.click(screen.getByTestId("select-demonstration-type"));
-    await user.click(screen.getByText("Aggregate Cap"));
-
-    await user.click(screen.getByTestId(EDIT_DELIVERABLE_SAVE_BUTTON_NAME));
-
-    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
-    expect(onSave).toHaveBeenCalledWith(expect.any(Object), undefined);
   });
 });
 
@@ -304,15 +247,15 @@ describe("formIsValid / formHasChanges / buildInitialFormData", () => {
   });
 
   it("formIsValid is false when demonstration types empty for Implementation Plan / Monitoring Protocol", () => {
-    expect(formIsValid(initial, { ...initial, demonstrationTypes: [] }, TODAY, TYPE_REQUIRES_DEMO)).toBe(
-      false
-    );
+    expect(
+      formIsValid(initial, { ...initial, demonstrationTypes: [] }, TODAY, TYPE_REQUIRES_DEMO)
+    ).toBe(false);
   });
 
   it("formIsValid is true when demonstration types empty for other deliverable types", () => {
-    expect(formIsValid(initial, { ...initial, demonstrationTypes: [] }, TODAY, TYPE_DEMO_OPTIONAL)).toBe(
-      true
-    );
+    expect(
+      formIsValid(initial, { ...initial, demonstrationTypes: [] }, TODAY, TYPE_DEMO_OPTIONAL)
+    ).toBe(true);
   });
 
   it("formIsValid requires reason when due date changes", () => {

--- a/client/src/components/dialog/deliverable/EditDeliverableDialog.tsx
+++ b/client/src/components/dialog/deliverable/EditDeliverableDialog.tsx
@@ -138,7 +138,7 @@ export interface EditDeliverableDialogProps {
   onClose: () => void;
   deliverable: EditDeliverableDialogDeliverable;
   demonstrationTypeTags: Tag[];
-  onSave?: (input: EditDeliverableInput, reasonForChange?: string) => Promise<void> | void;
+  onSubmit?: () => void;
 }
 
 const buildUpdateDeliverableInput = (
@@ -162,7 +162,7 @@ export const EditDeliverableDialog: React.FC<EditDeliverableDialogProps> = ({
   onClose,
   deliverable,
   demonstrationTypeTags,
-  onSave,
+  onSubmit,
 }) => {
   const { showSuccess, showError } = useToast();
   const [updateDeliverable, { loading: isSaving }] = useMutation(UPDATE_DELIVERABLE_MUTATION);
@@ -194,18 +194,15 @@ export const EditDeliverableDialog: React.FC<EditDeliverableDialogProps> = ({
     const reasonForChange = dueDateWasChanged ? formData.reasonForChange.trim() : undefined;
 
     try {
-      if (onSave) {
-        await onSave(input, reasonForChange);
-      } else {
-        await updateDeliverable({
-          variables: {
-            id: input.id,
-            input: buildUpdateDeliverableInput(input, reasonForChange),
-          },
-        });
-      }
+      await updateDeliverable({
+        variables: {
+          id: input.id,
+          input: buildUpdateDeliverableInput(input, reasonForChange),
+        },
+      });
 
       showSuccess(DELIVERABLE_UPDATED_MESSAGE);
+      onSubmit?.();
       onClose();
     } catch {
       showError(DELIVERABLE_UPDATE_FAILED_MESSAGE);

--- a/client/src/components/dialog/document/EditDocumentDialog.test.tsx
+++ b/client/src/components/dialog/document/EditDocumentDialog.test.tsx
@@ -11,6 +11,7 @@ import { EditDocumentDialog } from "./";
 import { Document as ServerDocument } from "demos-server";
 
 const mockQuery = vi.fn();
+const mockOnSubmit = vi.fn();
 
 beforeEach(() => {
   vi.mock("@apollo/client", async () => {
@@ -45,7 +46,7 @@ describe("EditDocumentDialog", () => {
   const setup = () => {
     render(
       <ToastProvider>
-        <EditDocumentDialog document={existingDocument} />
+        <EditDocumentDialog document={existingDocument} onSubmit={mockOnSubmit} />
       </ToastProvider>
     );
   };
@@ -91,6 +92,31 @@ describe("EditDocumentDialog", () => {
     fireEvent.click(screen.getByText("Cancel"));
 
     await waitFor(() => {
+      expect(mockCloseDialog).toHaveBeenCalled();
+    });
+  });
+
+  it("calls onSubmit when document is successfully updated", async () => {
+    setup();
+
+    const titleInput = screen.getByDisplayValue("Existing Document");
+    fireEvent.change(titleInput, { target: { value: "Updated Document" } });
+
+    await fireEvent.click(screen.getByTestId(UPLOAD_DOCUMENT_BUTTON_TEST_ID));
+
+    await waitFor(() => {
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: {
+            id: existingDocument.id,
+            input: {
+              name: "Updated Document",
+              description: existingDocument.description,
+            },
+          },
+        })
+      );
+      expect(mockOnSubmit).toHaveBeenCalled();
       expect(mockCloseDialog).toHaveBeenCalled();
     });
   });

--- a/client/src/components/dialog/document/EditDocumentDialog.tsx
+++ b/client/src/components/dialog/document/EditDocumentDialog.tsx
@@ -37,7 +37,8 @@ export const isValid = (document: Document): boolean => !!document.name.trim();
 export const EditDocumentDialog: React.FC<{
   document: Document;
   refetchQueries?: DocumentNode[];
-}> = ({ document, refetchQueries = [DEMONSTRATION_DETAIL_QUERY] }) => {
+  onSubmit?: () => void;
+}> = ({ document, refetchQueries = [DEMONSTRATION_DETAIL_QUERY], onSubmit }) => {
   const { closeDialog } = useDialog();
   const [activeDocument, setActiveDocument] = React.useState<Document>(document);
   const { showSuccess, showError } = useToast();
@@ -59,6 +60,7 @@ export const EditDocumentDialog: React.FC<{
         refetchQueries,
       });
       showSuccess(UPDATE_SUCCESS_MESSAGE);
+      onSubmit?.();
     } catch (error) {
       console.error("Error updating document:", error);
       showError(UPDATE_FAILURE_MESSAGE);

--- a/client/src/components/table/tables/DeliverableActionButtons.tsx
+++ b/client/src/components/table/tables/DeliverableActionButtons.tsx
@@ -77,7 +77,7 @@ export const DeliverableActionButtons: React.FC<{
         disabled={!editEnabled}
         onClick={() => {
           if (oneSelectedDeliverable) {
-            showEditDeliverableDialog(oneSelectedDeliverable);
+            showEditDeliverableDialog(oneSelectedDeliverable, () => table.resetRowSelection(true));
           }
         }}
       >

--- a/client/src/components/table/tables/DeliverableTable.test.tsx
+++ b/client/src/components/table/tables/DeliverableTable.test.tsx
@@ -1,4 +1,4 @@
-import React, { use } from "react";
+import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/client/src/components/table/tables/DeliverableTable.test.tsx
+++ b/client/src/components/table/tables/DeliverableTable.test.tsx
@@ -1,9 +1,13 @@
-import React from "react";
+import React, { use } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { DeliverableTable, formatDeliverableStatus, getLatestSubmissionDate } from "./DeliverableTable";
+import {
+  DeliverableTable,
+  formatDeliverableStatus,
+  getLatestSubmissionDate,
+} from "./DeliverableTable";
 import { DELIVERABLE_CANT_DELETE_HAS_FILES } from "./DeliverableActionButtons";
 import { sortDeliverablesByDefault } from "util/sortDeliverables";
 import type { DeliverableTableRow } from "./DeliverableTable";
@@ -107,6 +111,21 @@ describe("DeliverableTable", () => {
 
     const editBtn = screen.getByTestId("edit-deliverable");
     expect(editBtn).toBeDisabled();
+  });
+
+  it("deselects rows after Edit dialog is submitted", async () => {
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTestId(`select-row-${sortedFirstPageIds[0]}`));
+    expect(screen.getByTestId(`select-row-${sortedFirstPageIds[0]}`)).toBeChecked();
+
+    await user.click(screen.getByLabelText(/Edit Deliverable/i));
+    const onSubmit = showEditDeliverableDialog.mock.calls[0][1];
+    onSubmit();
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`select-row-${sortedFirstPageIds[0]}`)).not.toBeChecked();
+    });
   });
 
   it("enables Remove when at least one row selected", async () => {
@@ -774,9 +793,7 @@ describe("DeliverableTable Remove action", () => {
       expect(screen.getByRole("table")).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByText(formatDateForDisplay(latestSubmission))
-    ).toBeInTheDocument();
+    expect(screen.getByText(formatDateForDisplay(latestSubmission))).toBeInTheDocument();
   });
 });
 

--- a/client/src/components/table/tables/DemonstrationDeliverableTable.test.tsx
+++ b/client/src/components/table/tables/DemonstrationDeliverableTable.test.tsx
@@ -192,7 +192,35 @@ describe("DemonstrationDeliverableTable", () => {
     expect(screen.getByLabelText(/Remove Deliverable/i)).not.toBeDisabled();
 
     await user.click(screen.getByLabelText(/Edit Deliverable/i));
-    expect(showEditDeliverableDialog).toHaveBeenCalledWith(deliverable);
+    expect(showEditDeliverableDialog).toHaveBeenCalledWith(deliverable, expect.any(Function));
+  });
+
+  it("deselects all rows after editing a deliverable", async () => {
+    const user = userEvent.setup();
+    const deliverable = {
+      id: "row-action",
+      name: "Editable Item",
+      dueDate: new Date("2026-01-01"),
+      status: "Upcoming" as const,
+      combinedStatus: "Upcoming",
+      combinedStatusFilter: "Upcoming",
+      ...baseDeliverable,
+    };
+
+    render(
+      <DemonstrationDeliverableTable viewMode="demos-cms-user" deliverables={[deliverable]} />
+    );
+
+    await user.click(screen.getByTestId("select-row-row-action"));
+    expect(screen.getByTestId("select-row-row-action")).toBeChecked();
+
+    await user.click(screen.getByLabelText(/Edit Deliverable/i));
+    const onSubmit = showEditDeliverableDialog.mock.calls[0][1];
+    onSubmit();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("select-row-row-action")).not.toBeChecked();
+    });
   });
 
   it("uses multiselect filter inputs for configured categorical fields", async () => {

--- a/client/src/components/table/tables/DocumentTable.test.tsx
+++ b/client/src/components/table/tables/DocumentTable.test.tsx
@@ -63,7 +63,33 @@ describe("DocumentTable", () => {
     const editBtn = screen.getByLabelText(/Edit Document/i);
     await user.click(editBtn);
     // Modal should open, assuming it renders 'edit document' text
-    expect(showEditDocumentDialog).toHaveBeenCalled();
+    expect(showEditDocumentDialog).toHaveBeenCalledWith(
+      {
+        id: mockDocuments[0].id,
+        description: mockDocuments[0].description,
+        name: mockDocuments[0].name,
+      },
+      undefined,
+      expect.any(Function)
+    );
+  });
+
+  it("deselects all rows after edit dialog is closed", async () => {
+    const user = userEvent.setup();
+    await waitFor(() => {
+      expect(screen.getByRole("table")).toBeInTheDocument();
+    });
+    // Select a row
+    await user.click(screen.getByTestId(`select-row-${mockDocuments[0].id}`));
+    const editBtn = screen.getByLabelText(/Edit Document/i);
+    await user.click(editBtn);
+
+    const closeDialogCallback = showEditDocumentDialog.mock.lastCall?.[2];
+    closeDialogCallback();
+
+    await waitFor(() =>
+      expect(screen.getByTestId(`select-row-${mockDocuments[0].id}`)).not.toBeChecked()
+    );
   });
 
   it("renders the filter dropdown initially", async () => {

--- a/client/src/components/table/tables/DocumentTable.tsx
+++ b/client/src/components/table/tables/DocumentTable.tsx
@@ -67,11 +67,15 @@ export const DocumentTable = ({ documents }: { documents: DocumentTableDocument[
                   tooltip={editTooltip}
                   disabled={!editEnabled}
                   onClick={() =>
-                    showEditDocumentDialog({
-                      id: selectedDocs[0].id,
-                      name: selectedDocs[0].name,
-                      description: selectedDocs[0].description,
-                    })
+                    showEditDocumentDialog(
+                      {
+                        id: selectedDocs[0].id,
+                        name: selectedDocs[0].name,
+                        description: selectedDocs[0].description,
+                      },
+                      undefined,
+                      () => table.resetRowSelection(true)
+                    )
                   }
                 >
                   <EditIcon />

--- a/client/src/components/table/tables/TypesTable.test.tsx
+++ b/client/src/components/table/tables/TypesTable.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -43,6 +43,10 @@ const MOCK_DEMONSTRATION = {
 };
 
 describe("TypesTable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders required columns", async () => {
     render(<TypesTable demonstration={MOCK_DEMONSTRATION} />);
     await waitFor(() => screen.getByRole("table"));
@@ -189,7 +193,25 @@ describe("TypesTable", () => {
 
       expect(mockShowEditDemonstrationTypeDialog).toHaveBeenCalledWith(
         MOCK_DEMONSTRATION_ID,
-        expectedDemonstrationType
+        expectedDemonstrationType,
+        expect.any(Function)
+      );
+    });
+
+    it("deselects all rows after edit dialog is closed", async () => {
+      render(<TypesTable demonstration={MOCK_DEMONSTRATION} />);
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId(`select-row-${mockTypes[0].demonstrationTypeName}`));
+      const editButton = screen.getByTestId("edit-type");
+      await user.click(editButton);
+
+      const closeDialogCallback = mockShowEditDemonstrationTypeDialog.mock.lastCall?.[2];
+      closeDialogCallback();
+
+      await waitFor(() =>
+        expect(
+          screen.getByTestId(`select-row-${mockTypes[0].demonstrationTypeName}`)
+        ).not.toBeChecked()
       );
     });
 

--- a/client/src/components/table/tables/TypesTable.tsx
+++ b/client/src/components/table/tables/TypesTable.tsx
@@ -126,13 +126,17 @@ export const TypesTable: React.FC<TypesTableProps> = ({
                   disabled={editDisabled || inputDisabled}
                   onClick={() =>
                     !editDisabled &&
-                    showEditDemonstrationTypeDialog(demonstration.id, {
-                      demonstrationTypeName: selected[0].typeLabel,
-                      status: selected[0].status,
-                      approvalStatus: selected[0].approvalStatus,
-                      effectiveDate: selected[0].effectiveDate,
-                      expirationDate: selected[0].expirationDate,
-                    })
+                    showEditDemonstrationTypeDialog(
+                      demonstration.id,
+                      {
+                        demonstrationTypeName: selected[0].typeLabel,
+                        status: selected[0].status,
+                        approvalStatus: selected[0].approvalStatus,
+                        effectiveDate: selected[0].effectiveDate,
+                        expirationDate: selected[0].expirationDate,
+                      },
+                      () => table.resetRowSelection(true)
+                    )
                   }
                 >
                   <EditIcon />

--- a/client/src/pages/deliverables/fileAndHistoryTabs/FileAndHistoryTabs.tsx
+++ b/client/src/pages/deliverables/fileAndHistoryTabs/FileAndHistoryTabs.tsx
@@ -105,12 +105,11 @@ export const FileAndHistoryTabs: React.FC<{
   const isCmsStaffUser = CMS_STAFF_PERSON_TYPES.has(userPersonType);
   const canManageCmsFiles = isCmsStaffUser;
 
-  const canSubmitWithoutUnsubmittedFiles =
-    SUBMISSION_ALWAYS_ENABLED_STATUSES.has(deliverable.status);
-
-  const hasUnsubmittedFiles = stateFiles.some(
-    file => file.deliverableSubmissionAction == null
+  const canSubmitWithoutUnsubmittedFiles = SUBMISSION_ALWAYS_ENABLED_STATUSES.has(
+    deliverable.status
   );
+
+  const hasUnsubmittedFiles = stateFiles.some((file) => file.deliverableSubmissionAction == null);
 
   const handleRequestResubmission = () => {
     showRequestResubmissionDeliverableDialog({
@@ -139,8 +138,8 @@ export const FileAndHistoryTabs: React.FC<{
     });
   };
 
-  const handleEditFile = (file: DeliverableFileRow) => {
-    showEditDocumentDialog(fileRowToDialogFields(file), refetchAfterFileChange);
+  const handleEditFile = (file: DeliverableFileRow, onSubmit: () => void) => {
+    showEditDocumentDialog(fileRowToDialogFields(file), refetchAfterFileChange, onSubmit);
   };
 
   const handleDeleteFiles = (fileIds: string[]) => {
@@ -162,14 +161,13 @@ export const FileAndHistoryTabs: React.FC<{
   };
 
   const isSubmitDisabled =
-    isFinalized
-    || stateFiles.length === 0
-    || submitLoading
-    || (!hasUnsubmittedFiles && !canSubmitWithoutUnsubmittedFiles);
+    isFinalized ||
+    stateFiles.length === 0 ||
+    submitLoading ||
+    (!hasUnsubmittedFiles && !canSubmitWithoutUnsubmittedFiles);
 
-  const submitTooltip = isSubmitDisabled && !hasUnsubmittedFiles && !isFinalized
-    ? "No Unsubmitted Files"
-    : undefined;
+  const submitTooltip =
+    isSubmitDisabled && !hasUnsubmittedFiles && !isFinalized ? "No Unsubmitted Files" : undefined;
 
   return (
     <div data-testid={FILE_AND_HISTORY_TABS_NAME}>

--- a/client/src/pages/deliverables/sections/CmsFilesTab.test.tsx
+++ b/client/src/pages/deliverables/sections/CmsFilesTab.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -131,7 +131,22 @@ describe("CmsFilesTab", () => {
     await user.click(screen.getByTestId("select-row-cms-a"));
     await user.click(screen.getByTestId(CMS_FILES_EDIT_BUTTON_NAME));
 
-    expect(onEdit).toHaveBeenCalledWith(MOCK_FILES[0]);
+    expect(onEdit).toHaveBeenCalledWith(MOCK_FILES[0], expect.any(Function));
+  });
+
+  it("deselects all rows after edit dialog is submitted", async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    renderTab({ onEdit });
+
+    await user.click(screen.getByTestId("select-row-cms-a"));
+    expect(screen.getByTestId("select-row-cms-a")).toBeChecked();
+    await user.click(screen.getByTestId(CMS_FILES_EDIT_BUTTON_NAME));
+
+    const closeDialogCallback = onEdit.mock.lastCall?.[1];
+    closeDialogCallback();
+
+    await waitFor(() => expect(screen.getByTestId("select-row-cms-a")).not.toBeChecked());
   });
 
   it("disables Delete until at least one file is selected", async () => {

--- a/client/src/pages/deliverables/sections/CmsFilesTab.tsx
+++ b/client/src/pages/deliverables/sections/CmsFilesTab.tsx
@@ -14,7 +14,7 @@ const CMS_FILES_EMPTY_MESSAGE = "No files have been added yet.";
 export type CmsFilesTabProps = {
   files: DeliverableFileRow[];
   onAdd: () => void;
-  onEdit: (file: DeliverableFileRow) => void;
+  onEdit: (file: DeliverableFileRow, onSubmit: () => void) => void;
   onDelete: (fileIds: string[]) => void;
   canManage: boolean;
   isFinalized: boolean;

--- a/client/src/pages/deliverables/sections/DeliverableFileTable.tsx
+++ b/client/src/pages/deliverables/sections/DeliverableFileTable.tsx
@@ -25,7 +25,7 @@ export type DeliverableFileTableProps = {
   files: DeliverableFileRow[];
   columns: TableProps<DeliverableFileRow>["columns"];
   onAdd: () => void;
-  onEdit: (file: DeliverableFileRow) => void;
+  onEdit: (file: DeliverableFileRow, onSubmit: () => void) => void;
   onDelete: (fileIds: string[]) => void;
   footer?: React.ReactNode;
   showActions: boolean;
@@ -98,7 +98,7 @@ export const DeliverableFileTable: React.FC<DeliverableFileTableProps> = ({
                       rule: { kind: "exactly", count: 1 },
                     })}
                   disabled={isFinalized || selectedCount !== 1}
-                  onClick={() => onEdit?.(selectedRows[0])}
+                  onClick={() => onEdit?.(selectedRows[0], () => table.resetRowSelection(true))}
                 >
                   <EditIcon />
                 </CircleButton>

--- a/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
+++ b/client/src/pages/deliverables/sections/StateFilesTab.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -157,7 +157,22 @@ describe("StateFilesTab", () => {
       await user.click(screen.getByTestId("select-row-file-a"));
       await user.click(screen.getByTestId(STATE_FILES_EDIT_BUTTON_NAME));
 
-      expect(onEdit).toHaveBeenCalledWith(MOCK_FILES[0]);
+      expect(onEdit).toHaveBeenCalledWith(MOCK_FILES[0], expect.any(Function));
+    });
+
+    it("deselects rows after Edit dialog is submitted", async () => {
+      const user = userEvent.setup();
+      const onEdit = vi.fn();
+      renderTab({ onEdit });
+
+      await user.click(screen.getByTestId("select-row-file-a"));
+      expect(screen.getByTestId("select-row-file-a")).toBeChecked();
+      await user.click(screen.getByTestId(STATE_FILES_EDIT_BUTTON_NAME));
+
+      const closeDialogCallback = onEdit.mock.lastCall?.[1];
+      closeDialogCallback();
+
+      await waitFor(() => expect(screen.getByTestId("select-row-file-a")).not.toBeChecked());
     });
 
     it("invokes onDelete with all selected file ids", async () => {

--- a/client/src/pages/deliverables/sections/StateFilesTab.tsx
+++ b/client/src/pages/deliverables/sections/StateFilesTab.tsx
@@ -16,7 +16,7 @@ const STATE_FILES_EMPTY_MESSAGE =
 export type StateFilesTabProps = {
   files: DeliverableFileRow[];
   onAdd: () => void;
-  onEdit: (file: DeliverableFileRow) => void;
+  onEdit: (file: DeliverableFileRow, onSubmit: () => void) => void;
   onDelete: (fileIds: string[]) => void;
   isFinalized: boolean;
 };


### PR DESCRIPTION
For DEMOS-2412 we were seeing a weird inconsistent behavior when performing an edit action on a row in the table. On submit, the selected row would remain selected, but sometimes the pagination would reset the user back to page one. Because of this, to perform a subsequent edit the previous selection needed to be deselected first, which could mean fanning through pages to find the option. While the page resetting the pagination is an issue, we're opting to mitigate it by just forcing deselection upon saving an edit. The select column is used in these:
- DeliverableColumns: deliverable landing page, demonstration details page
- DocumentColumn: demonstration details->documents, 
- TypesColumns: demonstration details->Types, phase 8
- deliverableFileColumns: deliverable details page, cms and state files tabs.

For this, i implemented a "onSubmit" callback to the various edit dialogs across the app, feeding into it a call to resetRowSelection. Now, when submitting, the table resets to its unselected state. 


https://github.com/user-attachments/assets/3239635a-fa31-4135-ab82-775bf36f27f8



