### PR TITLE
SNYK_js_jsyaml: added ignore for snyk jsyaml

### DIFF
--- a/client/.snyk
+++ b/client/.snyk
@@ -7,6 +7,11 @@ ignore:
         reason: No clean fix available in current ESLint React plugin stack
         expires: 2026-07-14T00:00:00.000Z
         created: 2026-06-30T14:21:33.964Z
+  SNYK-JS-JSYAML-17900054:
+    - '*':
+        reason: No direct upgrade or patch available in current ESLint dependency chain
+        expires: 2026-07-23T00:00:00.000Z
+        created: 2026-07-09T00:00:00.000Z
 patch: {}
 exclude:
   global:


### PR DESCRIPTION
simply adds ignore. same snyk finding as was used on post-launch. in retrospect i shoulda just done it here and pulled into post-launch... oh well. 