### PR TITLE
Demos 2416 unselect table option after edit 2

### DIFF
--- a/client/src/components/table/Table.test.tsx
+++ b/client/src/components/table/Table.test.tsx
@@ -523,37 +523,36 @@ describe.sequential("Table Component Interactions", () => {
     });
   });
 
-  describe("Row Identity Stability", () => {
-    it("does not shift selection when rows are removed", async () => {
+  describe("row selection", () => {
+    it("clears row selection whenever table data is updated", async () => {
+      const mockTable = (data: TestType[]) => (
+        <Table<TestType>
+          columns={testColumns}
+          data={data}
+          actionButtons={(table) => {
+            const selected = table.getSelectedRowModel().rows.map((r) => r.original);
+            return (
+              <div>
+                <span data-testid="selected-count">{selected.length}</span>
+              </div>
+            );
+          }}
+        />
+      );
+
       const user = userEvent.setup();
 
-      function Wrapper() {
-        const [data, setData] = React.useState(testTableData);
+      const { rerender } = render(mockTable(testTableData));
+      await user.click(screen.getByTestId("select-row-1"));
+      expect(screen.getByTestId("selected-count")).toHaveTextContent("1");
 
-        return (
-          <>
-            <button onClick={() => setData((prev) => prev.slice(1))}>
-              Remove First
-            </button>
-            <Table columns={testColumns} data={data} />
-          </>
-        );
-      }
+      // sanity check to verify rerender preserves state normally
+      rerender(mockTable(testTableData));
+      expect(screen.getByTestId("selected-count")).toHaveTextContent("1");
 
-      render(<Wrapper />);
-
-      // Select first row checkbox
-      const firstCheckbox = screen.getByTestId(`select-row-${testTableData[0].id}`);
-      await user.click(firstCheckbox);
-
-      expect(firstCheckbox).toBeChecked();
-
-      // Remove first row
-      await user.click(screen.getByText("Remove First"));
-
-      // The new first row checkbox should NOT be checked
-      const newFirstCheckbox = screen.getByTestId(`select-row-${testTableData[1].id}`);
-      expect(newFirstCheckbox).not.toBeChecked();
+      // simulated data change
+      rerender(mockTable({ ...testTableData }));
+      expect(screen.getByTestId("selected-count")).toHaveTextContent("0");
     });
   });
 });

--- a/client/src/components/table/Table.tsx
+++ b/client/src/components/table/Table.tsx
@@ -190,15 +190,7 @@ export function Table<T extends { id: string }>({
 
   // On data update, remove rows from selection if they no longer exist in the table
   React.useEffect(() => {
-    setRowSelection((prev) => {
-      const validRowIds = new Set(table.getRowModel().rows.map((r) => r.id));
-
-      const filtered = Object.fromEntries(
-        Object.entries(prev).filter(([key]) => validRowIds.has(key))
-      );
-
-      return filtered;
-    });
+    setRowSelection({});
   }, [data]);
 
   return (

--- a/client/src/components/table/tables/DemonstrationDeliverableTable.tsx
+++ b/client/src/components/table/tables/DemonstrationDeliverableTable.tsx
@@ -47,12 +47,16 @@ export const DemonstrationDeliverableTable: React.FC<{
   );
   const actionButtons = viewMode === "demos-state-user" ? undefined : renderActionButtons;
 
-  const formattedDeliverables = sortDeliverablesByDefault(deliverables).map((deliverable) => ({
-    ...deliverable,
-    submissionDate: getLatestSubmissionDate(deliverable.deliverableActions),
-    combinedStatus: formatDeliverableStatus(deliverable),
-    combinedStatusFilter: formatDeliverableFilterStatus(deliverable),
-  }));
+  const formattedDeliverables = React.useMemo(
+    () =>
+      sortDeliverablesByDefault(deliverables).map((deliverable) => ({
+        ...deliverable,
+        submissionDate: getLatestSubmissionDate(deliverable.deliverableActions),
+        combinedStatus: formatDeliverableStatus(deliverable),
+        combinedStatusFilter: formatDeliverableFilterStatus(deliverable),
+      })),
+    [deliverables]
+  );
 
   return (
     <Table<FormattedDeliverableTableRow>

--- a/client/src/pages/DemonstrationDetail/deliverables/DeliverablesTab.test.tsx
+++ b/client/src/pages/DemonstrationDetail/deliverables/DeliverablesTab.test.tsx
@@ -6,7 +6,7 @@ import { DialogProvider } from "components/dialog/DialogContext";
 import { ADD_DELIVERABLE_SLOT_DIALOG_TITLE } from "components/dialog/deliverable";
 import { ADD_DELIVERABLE_SLOT_BUTTON_NAME, DeliverablesTab } from "./DeliverablesTab";
 import { TestProvider } from "test-utils/TestProvider";
-import { deliverableMocks } from "mock-data/deliverableMocks";
+import { deliverableMocks, MOCK_DELIVERABLE_TABLE_ROW } from "mock-data/deliverableMocks";
 
 const MOCK_PARENT_DEMONSTRATION = {
   id: "demo-1",
@@ -50,6 +50,27 @@ describe("DeliverablesTab", () => {
     const dialog = screen.getByRole("dialog");
     expect(dialog).toBeInTheDocument();
     expect(dialog).toHaveTextContent(ADD_DELIVERABLE_SLOT_DIALOG_TITLE);
+  });
+
+  it("preserves selected deliverables when the add deliverable slot dialog opens", async () => {
+    const user = userEvent.setup();
+    render(
+      <TestProvider mocks={deliverableMocks}>
+        <DialogProvider>
+          <DeliverablesTab parentDemonstration={MOCK_PARENT_DEMONSTRATION} />
+        </DialogProvider>
+      </TestProvider>
+    );
+
+    const selectedRow = await screen.findByTestId(`select-row-${MOCK_DELIVERABLE_TABLE_ROW.id}`);
+
+    await user.click(selectedRow);
+    expect(selectedRow).toBeChecked();
+
+    await user.click(screen.getByTestId(ADD_DELIVERABLE_SLOT_BUTTON_NAME));
+
+    expect(screen.getByRole("dialog")).toHaveTextContent(ADD_DELIVERABLE_SLOT_DIALOG_TITLE);
+    expect(screen.getByTestId(`select-row-${MOCK_DELIVERABLE_TABLE_ROW.id}`)).toBeChecked();
   });
 
   it("shows empty state when no demonstration deliverables are available", async () => {

--- a/client/src/pages/DemonstrationDetail/deliverables/DeliverablesTab.tsx
+++ b/client/src/pages/DemonstrationDetail/deliverables/DeliverablesTab.tsx
@@ -26,10 +26,13 @@ export const DeliverablesTab = ({
   const viewMode = rawPersonType as UserType;
   const navigate = useNavigate();
   const { data, loading, error } = useQuery<DeliverablesQueryResult>(DELIVERABLES_PAGE_QUERY);
-  const deliverables =
-    data?.deliverables.filter(
-      (deliverable) => deliverable.demonstration.id === parentDemonstration.id
-    ) ?? [];
+  const deliverables = React.useMemo(
+    () =>
+      data?.deliverables.filter(
+        (deliverable) => deliverable.demonstration.id === parentDemonstration.id
+      ) ?? [],
+    [data, parentDemonstration.id]
+  );
 
   return (
     <div className="flex flex-col">


### PR DESCRIPTION
Thanks to @tresdonicf for finding a massive simplification in how we can unselect the checkboxes on edit.  I blew up the git in my previous [PR](https://github.com/Enterprise-CMCS/demos/pull/1549) so i just recreated this one for it.

Instead of using a callback to trigger a cleaing of the checkboxes, which had to be routed to every relevent dialog, we can just modify the useEffect that we already had in Table.tsx.  Originally, that was scoped to just handling what should be selected after a delete operation, but it turns out after any change to the table data, we want to clear the selection. This vastly simplifies things, as we can just clear the selection whenever data changes. 

This did however unveil an elusive bug, where occasionally opening a dialog would clear the selection. This was happening on the Deliverables table on the demonstration details page because opening the modal would rerender the component which held the table. That component transformed the data before loading the table, so opening the dialog -> rerender tab component -> rebuild data -> unset row selections. Solution there was to memoize the data so its not rebuilt every render (we had a similar issue some time ago in one of the phases with respect to data not updating correctly on phase save).  

Anyway, this PR addresses both of those issues: checkbox behavior on save, and checkbox unintentionally getting unselected on open of the edit deliverable dialog. 

https://github.com/user-attachments/assets/524cc59b-056c-4578-8ba8-11049ad3634c

