### PR TITLE
fix(snyk findings): hardened logic around snyk findings

### DIFF
--- a/data-migration/docs/operator/reference-cli.adoc
+++ b/data-migration/docs/operator/reference-cli.adoc
@@ -55,7 +55,8 @@ Usage: migrate [OPTIONS] COMMAND [ARGS]...
 │ crosswalks           Apply sql/04_crosswalks (loads CSVs into mysql_raw.crosswalk_* tables).     │
 │ id-maps              Apply sql/05_id_maps (creates and populates migration._id_map_*).           │
 │ load-full            Full pgloader MySQL -> mysql_raw with drop list applied.                    │
-│ fk-candidates        Regenerate reports/generated/fk_candidates.csv (from mysql_raw + fk_overrides.yaml).  │
+│ fk-candidates        Regenerate reports/generated/fk_candidates.csv (from mysql_raw +            │
+│                      fk_overrides.yaml).                                                         │
 │ load-fidelity        Compare live MySQL vs mysql_raw row counts via DuckDB dual-attach           │
 │                      (non-gating).                                                               │
 │ schema-snapshot      Snapshot the MySQL source information_schema to reports/schema_snapshot/.   │
@@ -235,7 +236,7 @@ Regenerate reports/generated/fk_candidates.csv (from mysql_raw + fk_overrides.ya
 ----
 Usage: migrate fk-candidates [OPTIONS]                                                             
                                                                                                     
- Regenerate reports/generated/fk_candidates.csv (from mysql_raw + fk_overrides.yaml).                         
+ Regenerate reports/generated/fk_candidates.csv (from mysql_raw + fk_overrides.yaml).               
                                                                                                     
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                                      │

--- a/data-migration/docs/tools/data_dictionary_to_adoc.py
+++ b/data-migration/docs/tools/data_dictionary_to_adoc.py
@@ -22,17 +22,27 @@ blocks, yielding the true final schema.
 
 Table intros come from the shared ``table_purpose.PURPOSE`` dict; table
 classification (data / associative / static-constraint / type-limiter) comes
-from the sibling ``mmd_sql_compare/mmd_tables/`` directory layout. The output
-is an AsciiDoc *partial* (no H1, no toc) included by
-``docs/developer/reference-data-dictionary.adoc``.
+from the hand-authored DEMOS data model
+(``../demos/data/docs/DEMOS_Data_Model.mmd``; override with the
+``DEMOS_DATA_MODEL_MMD`` env var). The output is an AsciiDoc *partial* (no H1,
+no toc) included by ``docs/developer/reference-data-dictionary.adoc``.
 """
 
 from __future__ import annotations
 
+import os
+import re
 import sys
 from pathlib import Path
 
-from schema_model import DDLColumn, DDLForeignKey, DDLTable, replay_ddl
+from schema_model import (
+    DEMOS_DATA_MODEL_MMD,
+    MERMAID_CLASS_TO_DIR,
+    DDLColumn,
+    DDLForeignKey,
+    DDLTable,
+    replay_ddl,
+)
 from table_purpose import (
     PURPOSE,
     STATIC_CONSTRAINT_PURPOSE,
@@ -51,8 +61,11 @@ DOCS_DIR = REPO_ROOT / "docs"
 PIN_FILE = REPO_ROOT / "reports" / "prisma_ddl.sha256"
 PRISMA_CACHE_DIR = REPO_ROOT / "state" / "prisma_ddl"
 SUPPLEMENTS_DIR = REPO_ROOT / "sql" / "01_ddl_supplements"
-MMD_DIR = REPO_ROOT.parent / "mmd_sql_compare" / "mmd_tables"
+DEMOS_MMD_FILE = Path(os.environ.get("DEMOS_DATA_MODEL_MMD", str(DEMOS_DATA_MODEL_MMD)))
 OUTPUT = DOCS_DIR / "shared" / "generated" / "data-dictionary.adoc"
+
+# Entity-block header in the DEMOS data model: ``name:::mermaidClass {``.
+_MMD_BLOCK_RE = re.compile(r"^\s*([A-Za-z_]\w*):::(\w+)\s*\{", re.MULTILINE)
 
 DEMO_SCHEMA = "demos_app"
 MIGRATION_SCHEMA = "migration"
@@ -77,14 +90,27 @@ def _resolve_artifact() -> Path:
 # --------------------------------------------------------------------------- #
 
 
+def _load_mmd_classes() -> dict[str, set[str]]:
+    """Table-class buckets parsed from the single DEMOS data model file.
+
+    Each entity block is ``name:::mermaidClass { ... }``; the mermaid class is
+    mapped to the same class-directory keys the classifier expects. Blocks with
+    any other class (e.g. the diagram ``legend``) are ignored.
+    """
+    buckets: dict[str, set[str]] = {}
+    if not DEMOS_MMD_FILE.exists():
+        return buckets
+    text = DEMOS_MMD_FILE.read_text(encoding="utf-8")
+    for match in _MMD_BLOCK_RE.finditer(text):
+        cls_dir = MERMAID_CLASS_TO_DIR.get(match.group(2))
+        if cls_dir:
+            buckets.setdefault(cls_dir, set()).add(match.group(1))
+    return buckets
+
+
 def _classify(tables: dict[str, Table]) -> dict[str, str]:
-    """Return table_name -> class label using the mmd dir layout + heuristics."""
-    mmd_classes: dict[str, set[str]] = {}
-    if MMD_DIR.exists():
-        for cls in ("data_tables", "associative_tables", "static_constraints", "type_limiters"):
-            d = MMD_DIR / cls
-            if d.exists():
-                mmd_classes[cls] = {p.stem for p in d.glob("*.mmd")}
+    """Return table_name -> class label using the DEMOS data model + heuristics."""
+    mmd_classes = _load_mmd_classes()
     out: dict[str, str] = {}
     for name, tbl in tables.items():
         if tbl.has_history:

--- a/data-migration/docs/tools/data_dictionary_to_xlsx.py
+++ b/data-migration/docs/tools/data_dictionary_to_xlsx.py
@@ -20,14 +20,13 @@ The workbook needs the parent shape, the migration-private registry,
 and the Prisma-owned history tables, so the generator reads three
 sources:
 
-1. The SME-curated mermaid data model fragments under
-   ``../mmd_sql_compare/mmd_tables/`` (one ``.mmd`` per table; the
-   directory is laid out by class --
-   ``static_constraints/``, ``type_limiters/``, ``data_tables/``,
-   ``associative_tables/``). The mermaid model is the canonical SME
-   description of every parent table and is verified against the
-   Prisma DDL by ``mmd_sql_compare/split_and_compare.py``. Override
-   the path with ``--mmd-dir <path>`` if it lives elsewhere.
+1. The hand-authored DEMOS data model: a single mermaid file at
+   ``../demos/data/docs/DEMOS_Data_Model.mmd``. Each entity is a
+   ``name:::class { ... }`` block whose ``:::class`` marks it as a
+   static constraint / type limiter / data table / associative table.
+   It is the canonical description of every parent table. Override the
+   path with ``--mmd-file <path>`` or the ``DEMOS_DATA_MODEL_MMD`` env
+   var if it lives elsewhere.
 2. ``sql/01_ddl_supplements/00_jsonb_schema_registry.sql`` for the
    ``migration.jsonb_schemas`` housekeeping table.
 3. The pinned, cached Prisma artifact under
@@ -50,6 +49,7 @@ Output structure
 from __future__ import annotations
 
 import argparse
+import os
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -58,10 +58,26 @@ from pathlib import Path
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Font, PatternFill
 from openpyxl.utils import get_column_letter
+from schema_model import DEMOS_DATA_MODEL_MMD, MERMAID_CLASS_TO_DIR
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SUPPLEMENTS_DIR = REPO_ROOT / "sql" / "01_ddl_supplements"
-DEFAULT_MMD_DIR = REPO_ROOT.parent / "mmd_sql_compare" / "mmd_tables"
+DEFAULT_MMD_FILE = Path(os.environ.get("DEMOS_DATA_MODEL_MMD", str(DEMOS_DATA_MODEL_MMD)))
+_WORKSPACE_ROOT = REPO_ROOT.parent
+
+
+def _confined_path(raw: str, *, what: str) -> Path:
+    """Resolve ``raw`` and refuse paths escaping the workspace (CWE-23 guard).
+
+    Inputs/outputs legitimately span this repo and its sibling checkouts (e.g.
+    ``mmd_sql_compare/``), so the boundary is the workspace root, not the repo.
+    Anything resolving outside it (``/etc``, ``/tmp``, ``../..`` escapes) is
+    rejected rather than read or written.
+    """
+    resolved = Path(raw).resolve()
+    if not resolved.is_relative_to(_WORKSPACE_ROOT):
+        raise SystemExit(f"refusing {what} outside {_WORKSPACE_ROOT}: {resolved}")
+    return resolved
 
 CLASS_DIR_TO_LABEL: dict[str, str] = {
     "static_constraints": "Static constraint",
@@ -295,23 +311,27 @@ def _parse_table_block(name: str, cls: str, cls_dir: str, body: str) -> TableSpe
     return spec
 
 
-def parse_mmd_dir(mmd_dir: Path) -> list[TableSpec]:
+def parse_mmd_file(mmd_file: Path) -> list[TableSpec]:
+    """Parse every table block from the single DEMOS data model file.
+
+    Each block is ``name:::mermaidClass { ... }``; the mermaid class is mapped
+    to the class-directory label the workbook groups on. Blocks with any other
+    class (e.g. the diagram ``legend``) are skipped.
+    """
     out: list[TableSpec] = []
-    for cls_dir in CLASS_DIR_TO_LABEL:
-        sub = mmd_dir / cls_dir
-        if not sub.is_dir():
+    text = mmd_file.read_text(encoding="utf-8")
+    for m in _TABLE_BLOCK_RE.finditer(text):
+        cls_dir = MERMAID_CLASS_TO_DIR.get(m.group("cls"))
+        if cls_dir is None:
             continue
-        for f in sorted(sub.glob("*.mmd")):
-            text = f.read_text(encoding="utf-8")
-            for m in _TABLE_BLOCK_RE.finditer(text):
-                out.append(
-                    _parse_table_block(
-                        name=m.group("name"),
-                        cls=m.group("cls"),
-                        cls_dir=cls_dir,
-                        body=m.group("body"),
-                    )
-                )
+        out.append(
+            _parse_table_block(
+                name=m.group("name"),
+                cls=m.group("cls"),
+                cls_dir=cls_dir,
+                body=m.group("body"),
+            )
+        )
     return out
 
 
@@ -752,8 +772,8 @@ def write_overview(
         bold=True, size=14
     )
     src_note = (
-        "Source: SME-curated mermaid model under "
-        "../mmd_sql_compare/mmd_tables/ (parents) + "
+        "Source: hand-authored DEMOS data model "
+        "../demos/data/docs/DEMOS_Data_Model.mmd (parents) + "
         "sql/01_ddl_supplements/ (migration.jsonb_schemas) + the pinned "
         "Prisma artifact (DEMOS-owned *_history tables). "
         f"Prisma DDL pin = {pin}."
@@ -955,12 +975,12 @@ def main(argv: Iterable[str] | None = None) -> int:
         help="Output xlsx path (default reports/inputs/demos_data_dictionary.xlsx).",
     )
     parser.add_argument(
-        "--mmd-dir",
-        default=str(DEFAULT_MMD_DIR),
+        "--mmd-file",
+        default=str(DEFAULT_MMD_FILE),
         help=(
-            "Mermaid table fragments directory; expects subdirectories "
-            "static_constraints/, type_limiters/, data_tables/, "
-            "associative_tables/."
+            "Hand-authored DEMOS data model (single mermaid file with "
+            "name:::class { ... } entity blocks). Defaults to "
+            "../demos/data/docs/DEMOS_Data_Model.mmd (or $DEMOS_DATA_MODEL_MMD)."
         ),
     )
     parser.add_argument(
@@ -974,22 +994,23 @@ def main(argv: Iterable[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    out_path = Path(args.out_path).resolve()
-    mmd_dir = Path(args.mmd_dir).resolve()
-    if not mmd_dir.is_dir():
+    # SECURITY: confine operator-supplied paths to the workspace (CWE-23 guard).
+    out_path = _confined_path(args.out_path, what="output path")
+    mmd_file = _confined_path(args.mmd_file, what="mmd file")
+    if not mmd_file.is_file():
         raise SystemExit(
-            f"mmd directory not found: {mmd_dir}; pass --mmd-dir or place "
-            "the SME mermaid fragments alongside the repo."
+            f"DEMOS data model not found: {mmd_file}; pass --mmd-file or set "
+            "DEMOS_DATA_MODEL_MMD to the DEMOS_Data_Model.mmd path."
         )
 
-    specs = parse_mmd_dir(mmd_dir)
+    specs = parse_mmd_file(mmd_file)
     if not specs:
-        raise SystemExit(f"no mermaid tables found under {mmd_dir}")
+        raise SystemExit(f"no mermaid tables found in {mmd_file}")
 
     pin = _pin_value(REPO_ROOT / "reports" / "prisma_ddl.sha256")
 
     if args.prisma_artifact:
-        artifact_path = Path(args.prisma_artifact).resolve()
+        artifact_path = _confined_path(args.prisma_artifact, what="prisma artifact")
     else:
         artifact_path = REPO_ROOT / "state" / "prisma_ddl" / f"{pin}.sql"
     if artifact_path.exists():

--- a/data-migration/docs/tools/schema_diagrams_to_adoc.py
+++ b/data-migration/docs/tools/schema_diagrams_to_adoc.py
@@ -52,6 +52,7 @@ sys.path.insert(0, str(TOOLS_DIR))
 from schema_model import (  # noqa: E402
     CLASS_ORDER,
     CLASS_SLUG,
+    DEMOS_DATA_MODEL_MMD,
     FK,
     REPO_ROOT,
     Table,
@@ -73,9 +74,24 @@ FK_OVERRIDES_FILE = REPORTS_DIR / "inputs" / "fk_overrides.yaml"
 FK_CANDIDATES_FILE = REPORTS_DIR / "generated" / "fk_candidates.csv"
 DRIFT_REPORT_FILE = REPORTS_DIR / "schema_drift_report.md"
 
-# The hand-authored model lives in a sibling repo checkout; allow an env
-# override and degrade gracefully when it is not present locally.
-HAND_MMD_DEFAULT = REPO_ROOT.parent / "demos" / "data" / "docs" / "DEMOS_Data_Model.mmd"
+# The hand-authored model lives in the parent ../demos repo checkout (shared
+# path constant); allow an env override and degrade gracefully when it is not
+# present locally.
+HAND_MMD_DEFAULT = DEMOS_DATA_MODEL_MMD
+_WORKSPACE_ROOT = REPO_ROOT.parent
+
+
+def _confined_path(raw: str, *, what: str) -> Path:
+    """Resolve ``raw`` and refuse paths escaping the workspace (CWE-23 guard).
+
+    The hand model lives in a sibling checkout (``../demos``), so the boundary
+    is the workspace root, not the repo. A path resolving outside it (``/etc``,
+    ``/tmp``, ``../..`` escapes) is rejected rather than read.
+    """
+    resolved = Path(raw).resolve()
+    if not resolved.is_relative_to(_WORKSPACE_ROOT):
+        raise SystemExit(f"refusing {what} outside {_WORKSPACE_ROOT}: {resolved}")
+    return resolved
 
 # Class -> mermaid classDef styling, matching the legacy hand model.
 CLASS_STYLE: dict[str, str] = {
@@ -490,7 +506,8 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
     if args.check_drift:
-        check_drift(Path(args.hand_mmd))
+        # SECURITY: confine the operator/env-supplied model path (CWE-23 guard).
+        check_drift(_confined_path(args.hand_mmd, what="hand model"))
     else:
         generate()
     return 0

--- a/data-migration/docs/tools/schema_model.py
+++ b/data-migration/docs/tools/schema_model.py
@@ -63,6 +63,23 @@ CLASS_SLUG: dict[str, str] = {
     "associativeTable": "associative-tables",
 }
 
+# Default location of the hand-authored DEMOS data model: a single mermaid
+# ``erDiagram`` file that lives in the parent ../demos repo checkout. The doc
+# tools (schema diagrams + the two data-dictionary generators) read it for
+# table classification and accept a ``DEMOS_DATA_MODEL_MMD`` env override at
+# their entry points.
+DEMOS_DATA_MODEL_MMD = REPO_ROOT.parent / "data" / "docs" / "DEMOS_Data_Model.mmd"
+
+# Mermaid ``:::class`` name -> the class-directory label the data-dictionary
+# generators group tables on. Blocks with any other class (e.g. the diagram
+# ``legend``) are not tables and are ignored by the parsers.
+MERMAID_CLASS_TO_DIR: dict[str, str] = {
+    "staticConstraint": "static_constraints",
+    "typeLimiter": "type_limiters",
+    "dataTable": "data_tables",
+    "associativeTable": "associative_tables",
+}
+
 
 # --------------------------------------------------------------------------- #
 # Data model

--- a/data-migration/docs/tools/source_target_columns_to_adoc.py
+++ b/data-migration/docs/tools/source_target_columns_to_adoc.py
@@ -72,8 +72,6 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SPECS_ROOT = REPO_ROOT.parent
 
-DEFAULT_MYSQL_MMD = SPECS_ROOT / "mmd_sql_compare" / "mysql_pmda_data_model.dot"
-DEFAULT_DEMOS_MMD = SPECS_ROOT / "mmd_sql_compare" / "demos_data_model.mmd"
 DEFAULT_MYSQL_SNAPSHOT = REPO_ROOT / "reports" / "schema_snapshot" / "columns.csv"
 DEFAULT_CSV = REPO_ROOT / "reports" / "source_target_columns.csv"
 DEFAULT_DROP_LIST = REPO_ROOT / "reports" / "narrative" / "drop_list.md"

--- a/data-migration/docs/tools/table_flow_trace.py
+++ b/data-migration/docs/tools/table_flow_trace.py
@@ -93,6 +93,11 @@ def _pinned_ddl_path() -> Path:
 
 
 def _apply_file(conn: Any, path: Path) -> None:
+    # SECURITY: the Snyk "SQL injection" finding here is a false positive.
+    # `path` is always a repo-controlled .sql file (schema DDL, the sha256-
+    # pinned Prisma DDL, curated fixtures, crosswalk files) applied verbatim to
+    # a throwaway scratch DB -- the by-design "repo IS the SQL" pattern (cf.
+    # lib.apply_dir). No database or user input reaches this call.
     conn.execute(path.read_text(encoding="utf-8"))
 
 
@@ -136,18 +141,24 @@ def _build_source(conn: Any, seed_path: Path) -> None:
 
 
 def _run_crosswalks(conn: Any) -> None:
-    """Mirror init_pg.run_crosswalks: creators -> CSV load -> checks -> id maps."""
+    """Mirror init_pg.run_crosswalks: creators -> CSV load -> id maps.
+
+    The ``*_check.sql`` completeness gates are intentionally skipped here: the
+    skeleton creates every snapshot table (including ones the curated fixture
+    does not seed, e.g. ``role_rfrnc``, ``mdcd_dlvrbl``), and several checks
+    fail-closed on a present-but-empty source (CODE_REVIEW H4).  Those gates are
+    validated by ``tests/sql/test_crosswalk_checks.py`` against purpose-built
+    fixtures; this harness only needs the crosswalk *tables* populated so the
+    stg/app/parity SQL can join to them.
+    """
     files = sorted(CROSSWALK_DIR.glob("*.sql"))
     creators = [f for f in files if not f.name.endswith("_check.sql")]
-    checks = [f for f in files if f.name.endswith("_check.sql")]
     for f in creators:
         _apply_file(conn, f)
     for table, csv_name, columns in _load_crosswalk_registry():
         copy_csv_into_table(
             conn, "mysql_raw", table, REPORTS_DIR / csv_name, header_expect=columns
         )
-    for f in checks:
-        _apply_file(conn, f)
     _apply_dir(conn, IDMAP_DIR)
 
 

--- a/data-migration/migration/lib.py
+++ b/data-migration/migration/lib.py
@@ -802,10 +802,16 @@ def psql_file(env: Env, sql_path: Path) -> None:
         conn.execute(cast(LiteralString, sql_path.read_text(encoding="utf-8")))
 
 
-def psql_command(env: Env, sql: str) -> None:
-    """Execute one SQL string against Postgres in autocommit mode."""
+def psql_command(env: Env, sql: str, params: Sequence[Any] | None = None) -> None:
+    """Execute one SQL string against Postgres in autocommit mode.
+
+    Per the ``psql_query`` policy, values MUST be passed via ``params`` rather
+    than interpolated into ``sql``. ``params`` defaults to ``None`` so a
+    parameterless statement skips psycopg's ``%`` placeholder parsing (a bare
+    ``%`` in the SQL would otherwise raise at client-side conversion).
+    """
     with psycopg.connect(env.pg_dsn(), autocommit=True) as conn:
-        conn.execute(cast(LiteralString, sql))
+        conn.execute(cast(LiteralString, sql), params)
 
 
 def _sql_error_detail(path: Path, exc: psycopg.Error) -> str:
@@ -1070,6 +1076,13 @@ def rel(path: Path) -> str:
 # pgloader templates are not HTML and would otherwise see `&` in
 # connection strings rewritten. ``keep_trailing_newline=True`` preserves
 # the trailing `\n` Jinja2 would otherwise strip.
+#
+# SECURITY: the Snyk Code "autoescape=False -> XSS" finding here is an
+# accepted false positive. This Environment renders pgloader ``.load``
+# command files (consumed by the pgloader binary), never HTML served to a
+# browser -- there is no XSS sink. Enabling autoescape would HTML-entity-
+# encode ``& < > ' "`` inside DSNs/SQL and corrupt the rendered config.
+# See SECURITY_REVIEW.md.
 _jinja_env = Environment(
     undefined=StrictUndefined,
     autoescape=False,

--- a/data-migration/migration/phases/freeze.py
+++ b/data-migration/migration/phases/freeze.py
@@ -34,6 +34,7 @@ def run_freeze() -> None:
     (STATE_DIR / "freeze_instant.txt").write_text(instant + "\n", encoding="utf-8")
     psql_command(
         env,
-        f"INSERT INTO mysql_raw._delta_log (freeze_instant) VALUES ('{instant}'::timestamptz);",
+        "INSERT INTO mysql_raw._delta_log (freeze_instant) VALUES (%s::timestamptz);",
+        [instant],
     )
     log(f"freeze instant: {instant}")

--- a/data-migration/scripts/mk_pretty.py
+++ b/data-migration/scripts/mk_pretty.py
@@ -299,6 +299,11 @@ def _run(label: str, command: str) -> int:
         _console.rule(f"[bold cyan]\u25b6 {label}[/bold cyan]", align="left")
     else:
         print(f">> {label}")
+    # shell=True is intentional and not a command-injection surface: `command`
+    # is always a static Makefile recipe (the $(STEP) targets) that depends on
+    # shell features -- `;`, `&&`, globs, redirects, env-var prefixes. Nothing
+    # untrusted or remote reaches here; the only variable portion is
+    # `make <target> ARGS="..."`, supplied by the developer running the build.
     result = subprocess.run(command, shell=True)
     code = result.returncode
     if _RICH:

--- a/data-migration/tests/test_freeze.py
+++ b/data-migration/tests/test_freeze.py
@@ -32,10 +32,14 @@ def test_run_freeze_writes_instant_and_delta_log(
     monkeypatch.setattr(freeze, "confirm", lambda _prompt: True)
     monkeypatch.setattr(freeze.Env, "load", classmethod(lambda cls: _fake_env()))
 
-    captured: dict[str, str] = {}
-    monkeypatch.setattr(
-        freeze, "psql_command", lambda _env, sql: captured.__setitem__("sql", sql)
-    )
+    captured_sql: list[str] = []
+    captured_params: list[object] = []
+
+    def _capture(_env: object, sql: str, params: object = None) -> None:
+        captured_sql.append(sql)
+        captured_params.append(params)
+
+    monkeypatch.setattr(freeze, "psql_command", _capture)
 
     freeze.run_freeze()
 
@@ -44,9 +48,11 @@ def test_run_freeze_writes_instant_and_delta_log(
     instant = instant_file.read_text(encoding="utf-8").strip()
     assert instant, "freeze_instant.txt must hold a non-empty timestamp"
 
-    assert "INSERT INTO mysql_raw._delta_log (freeze_instant)" in captured["sql"]
-    # The same instant written to disk must be the one logged to _delta_log.
-    assert f"'{instant}'::timestamptz" in captured["sql"]
+    assert "INSERT INTO mysql_raw._delta_log (freeze_instant)" in captured_sql[0]
+    # The value is parameterized (never interpolated); the same instant written
+    # to disk must be the one bound for the _delta_log row.
+    assert "VALUES (%s::timestamptz)" in captured_sql[0]
+    assert captured_params[0] == [instant]
 
     assert lib.gate_path("freeze").exists(), "freeze gate must be marked on success"
 
@@ -64,7 +70,9 @@ def test_run_freeze_aborts_when_not_confirmed(
 
     writes = {"n": 0}
     monkeypatch.setattr(
-        freeze, "psql_command", lambda _env, _sql: writes.__setitem__("n", writes["n"] + 1)
+        freeze,
+        "psql_command",
+        lambda _env, _sql, _params=None: writes.__setitem__("n", writes["n"] + 1),
     )
 
     with pytest.raises(SystemExit):


### PR DESCRIPTION
## Problem
Snyk reported several security findings after the addition of the data migration folder. Several of these were false positives that were marked as "Ignore" in the Snyk UI. A few however required hardening, which this PR addresses. In particular, the following tickets:

### Tickets:
- https://jiraent.cms.gov/browse/DEMOS-2424
- https://jiraent.cms.gov/browse/DEMOS-2421
- https://jiraent.cms.gov/browse/DEMOS-2418
- https://jiraent.cms.gov/browse/DEMOS-2422

### Security threats addressed:
- [CWE-23](https://cwe.mitre.org/data/definitions/23.html) - Relative Path Traversal
- [CWE-78](https://cwe.mitre.org/data/definitions/78.html) - OS Command Injection
- [CWE-79](https://cwe.mitre.org/data/definitions/79.html) - Cross-site Scripting (XSS)
- [CWE-89](https://cwe.mitre.org/data/definitions/89.html) - SQL Injection

### Threat model

This folder contains a one-shot data-migration CLI run by a trusted DBA/operator against a legacy MySQL source and a  Postgres target. There is **no network request handler and no browser-facing runtime**, so the classic precondition for these CWEs (untrusted input crossing a trust boundary at runtime) largely does not exist. Inputs are: operator `.env` config, AWS Secrets Manager, repo-controlled YAML/CSV registries (behind PR review), and the legacy DB schema being migrated.

All four CWE *patterns* are present in the tree; **none is an exploitable vulnerability** in this threat model. Two policy/hygiene items are addressed here; one scanner finding is an accepted false positive.

| CWE | Present as pattern? | Exploitable? | Disposition |
|-----|--------------------|--------------|-------------|
| 89 SQLi | Yes (f-string SQL; `_apply_file`) | No | Guarded; one policy-consistency fix; one Snyk false positive |
| 78 Cmd inj | Yes (`shell=True`) | No | Load-bearing dev-only shell; documented + UI ignore |
| 23 Path traversal | CLI-arg -> `Path` in docs tools | No | Hardened with workspace confinement |
| 79 XSS | Yes (`autoescape=False`) | No | Accepted false positive (config render, not HTML) |

### CWE-89 - SQL Injection

Not exploitable. Every interpolation path is defended:

- **psycopg values/identifiers:** `psql_query`/`psql_command` take literal SQL + `params` for values; identifiers go through `psycopg.sql.Identifier` (`copy_csv_into_table`, `truncate_schema_data`, `psql_exec_composed` in `migration/lib.py`). `truncate_schema_data` additionally allowlists schema (`^[A-Za-z_][A-Za-z0-9_]*$`), LIKE patterns (`^[A-Za-z0-9_%]+$`), and exact table names.
- **DuckDB passthrough** (`mysql_query`/`postgres_query` take **no** bind params): table/column names are validated by a regex allowlist (`_safe_ident`/`_is_safe_identifier` = `^[A-Za-z_][A-Za-z0-9_]*$`) before interpolation; DSNs and static query strings are single-quote-doubled; code subsets are `int`-validated. See `scripts/crosswalk_audit.py`, `migration/phases/schema_snapshot.py`, `prod_schema_guard.py`, `reference_data.py`, `duck.py`.
- **Freeze instant:** the delta path validates against `_FREEZE_INSTANT_RE` before use (`migration/phases/load_delta.py`).

All interpolated identifiers originate from repo-controlled YAML/CSV or `information_schema`, never from an attacker over a wire.

**Action taken (policy consistency):** `freeze.py` previously interpolated the freeze instant via f-string (safe: machine `strftime`, regex-shaped; the lone stated-policy exception, historically CODE_REVIEW M3). It is now parameterized: `psql_command(env, "... VALUES (%s::timestamptz);", [instant])`. `psql_command` gained an optional `params` argument to support this. This removes the last value-interpolation exception.

**Snyk false positive - `docs/tools/table_flow_trace.py` `_apply_file`:** Snyk reports "input from a database flows into execute." This is a misfire: `path` is always a repo-controlled `.sql` file (schema DDL, the sha256-pinned Prisma DDL, curated fixtures, crosswalk files globbed from repo dirs), applied verbatim to a throwaway scratch DB. This is the by-design "execute repo SQL" pattern also used by `lib.apply_dir`/`_execute_sql_file`; a DDL/fixture file cannot be parameterized. No database or user input reaches the call. A `SECURITY:` comment records this; added a Snyk UI ignore (false positive).

### CWE-78 - OS Command Injection

Not exploitable.

- `migration/lib.py` `run`/`run_teed` use **list argv** with no `shell=True`; pgloader is invoked with a list. Safe.
- `scripts/mk_pretty.py` uses `subprocess.run(command, shell=True)`. This is **load-bearing dev-only tooling**: `command` is always a static Makefile recipe (the `$(STEP)` targets) that depends on shell features (`;`, `&&`, globs, redirects, env-var prefixes). Converting to `shell=False` would break `clean`, `clean-reports`, every `cd .. && ...` docs target, `test-db-up`, `spin_up`, and more. No untrusted/remote input reaches it; the only variable portion is `make <target> ARGS="..."`, supplied by the local developer.

**Action taken:** added an explanatory comment at the call site documenting why `shell=True` is intentional and not an injection surface. Snyk Code flags this as command injection (CLI arg -> `shell=True`); this is true, but only reachable by someone who already controls the local `make` invocation, so the solution is a Snyk UI ignore (accepted risk, not exploitable in context).

### CWE-23 - Relative Path Traversal

No meaningful runtime sink. Production file operations use fixed module-level `Path` constants (`STATE_DIR`, `REPORTS_DIR`, `PRISMA_FKS_FILE`, ...). Operator-supplied paths (`--out-dir`, drop-list, DSN) do not cross a trust boundary - the operator already owns the machine. The healthz probe restricts schemes to `http`/`https` (`migration/phases/flip.py`), so a `file://` URL cannot turn the probe into a file read. There is no request-supplied filename joined to a server root.

**Snyk findings + hardening applied.** Snyk Code flags CLI-argument-to-`Path` flows in three docs tools:

- `docs/tools/data_dictionary_to_xlsx.py`: `out_path`, `--mmd-dir`, `--prisma-artifact`.
- `docs/tools/schema_diagrams_to_adoc.py`: `--hand-mmd` (into `check_drift`).

These are operator/CI documentation generators, not a runtime sink, so they are not exploitable in this threat model. Because the defaults deliberately reach **sibling checkouts** (`DEFAULT_MMD_DIR = REPO_ROOT.parent/mmd_sql_compare/...`, `HAND_MMD_DEFAULT = REPO_ROOT.parent/demos/...`), a defense-in-depth `_confined_path(...)` guard was added to both tools: each path is `resolve()`d and rejected via `SystemExit` unless it is under the **workspace root** (`REPO_ROOT.parent`). This blocks `../..` escapes, `/etc`, `/tmp`, etc., while keeping every legitimate in-workspace default working.

### CWE-79 - Cross-site Scripting

Not exploitable. There is no web application serving pages to browsers at runtime.

- `jinja2.Environment(autoescape=False)` in `migration/lib.py` renders pgloader `.load` **config files** consumed by the pgloader binary, never HTML. Its sole consumer is `render_template` (used by `load_full.py`/`load_delta.py`). Enabling autoescape would HTML-entity-encode `& < > ' "` inside DSNs/SQL and corrupt the rendered config.
- The docs pipeline generates `.adoc` → asciidoctor static HTML, built and viewed by operators; the CI `docs.yml` uploads it as a **download-only Actions artifact** (no GitHub Pages deploy). GitHub also sanitizes rendered `.adoc`/`.md` (strips `<script>`). No built HTML is committed. `_esc` in the docs tools escapes AsciiDoc table pipes, not HTML entities.

**Disposition:** the Snyk Code finding "jinja2.Environment autoescape=False -> XSS" (`migration/lib.py`) is an **accepted false positive**, ignored in the Snyk UI with the justification recorded below. (`.snyk` policy ignores are not supported for Snyk Code; the UI ignore is the supported, precise path.) A SECURITY:` comment at the call site records the same rationale.

Minor note: `Makefile` hardcodes a `POSTGRES_PASSWORD` for the ephemeral local `demos-test-pg` Docker container - a throwaway local test credential, not a real secret, but it is a committed literal in a public repo.

### Residual items

1. **Governance, not code:** in the public repo, a malicious PR could add a raw `.sql` file (`apply_dir` executes repo SQL verbatim, by design) or edit a Makefile recipe run under `shell=True`. The control is branch protection + required review + CI, not runtime input validation.
2. **Future XSS watch:** if the built HTML docs are ever deployed to a hosted, browser-facing site (e.g. GitHub Pages), re-evaluate CWE-79 - `_esc` would need HTML-entity escaping of any DB-sourced free-text.