### PR TITLE
Use built-in vite path resolution on `client`

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -46,7 +46,6 @@
         "typescript-eslint": "^8.62.0",
         "vite": "^8.1.0",
         "vite-bundle-visualizer": "^1.2.1",
-        "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^4.1.9",
         "vitest-sonar-reporter": "^3.0.0"
       },
@@ -3041,13 +3040,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -5097,28 +5089,6 @@
         }
       }
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "deprecated": "unmaintained",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5308,26 +5278,6 @@
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.4.tgz",
-      "integrity": "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      },
-      "peerDependenciesMeta": {
-        "vite": {
-          "optional": true
-        }
       }
     },
     "node_modules/vite/node_modules/picomatch": {

--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,6 @@
     "typescript-eslint": "^8.62.0",
     "vite": "^8.1.0",
     "vite-bundle-visualizer": "^1.2.1",
-    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^4.1.9",
     "vitest-sonar-reporter": "^3.0.0"
   },

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,7 +1,6 @@
 /// <reference types="vitest" />
 import { execSync } from "child_process";
 import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
 
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
@@ -15,7 +14,10 @@ const getGitCommit = (): string => {
 };
 
 export const config = defineConfig({
-  plugins: [react(), tailwindcss(), tsconfigPaths()],
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    tsconfigPaths: true,
+  },
   define: {
     __GIT_COMMIT__: JSON.stringify(getGitCommit()),
   },


### PR DESCRIPTION
Been seeing this warning about how this package is no longer needed, so removing it!
<img width="1234" height="206" alt="Code_11_11_02" src="https://github.com/user-attachments/assets/1eede424-e6b4-41ac-aa67-b285d6ec1a9e" />
