### PR TITLE
Remove duplicate shared_library install

### DIFF
--- a/pipelines/Jenkinsfile.server
+++ b/pipelines/Jenkinsfile.server
@@ -122,14 +122,6 @@ stages {
             handleError(params.HANDLE_ERRORS) {
               dirCon('deployment', 'node') {
                 sh """
-                # Build shared_library first so the linked package is ready for migration tests
-                if [ -d ../shared_library ]; then
-                cd ../shared_library
-                npm ci
-                npm run build || true
-                cd -
-                fi
-
                 npm ci
                 export IS_TEST_MIGRATION="true"
                 npx tsx demosctl/index test-migration dev "temp_${env.CHANGE_ID}_${currentBuild.startTimeInMillis}"


### PR DESCRIPTION
A second install of the shared_library during a concurrently run step was causing node_modules to be removed while unit tests were running, which was causing random failures