### PR TITLE
(1/2) DEMOS-1936: Add Support for Eager Tooltips to Buttons

### DIFF
--- a/client/src/components/button/BaseButton.test.tsx
+++ b/client/src/components/button/BaseButton.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { Button } from "./Button";
+
+describe("BaseButton eagerTooltip", () => {
+  const showPopover = vi.fn();
+  const hidePopover = vi.fn();
+
+  beforeEach(() => {
+    showPopover.mockClear();
+    hidePopover.mockClear();
+    HTMLElement.prototype.showPopover = showPopover;
+    HTMLElement.prototype.hidePopover = hidePopover;
+  });
+
+  it("renders a tooltip element with the provided text", () => {
+    render(
+      <Button name="my-button" onClick={() => {}}>
+        Click me
+      </Button>
+    );
+    expect(screen.queryByRole("tooltip")).toBeNull();
+
+    render(
+      <Button name="tip-button" eagerTooltip="Helpful hint" onClick={() => {}}>
+        Hover me
+      </Button>
+    );
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Helpful hint");
+  });
+
+  it("shows the tooltip on mouse enter", () => {
+    render(
+      <Button name="tip-button" eagerTooltip="Show on hover" onClick={() => {}}>
+        Hover me
+      </Button>
+    );
+    screen.getByTestId("tip-button").dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    expect(showPopover).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the tooltip on mouse leave", () => {
+    render(
+      <Button name="tip-button" eagerTooltip="Show on hover" onClick={() => {}}>
+        Hover me
+      </Button>
+    );
+    screen.getByTestId("tip-button").dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
+    expect(hidePopover).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the tooltip on focus", () => {
+    render(
+      <Button name="tip-button" eagerTooltip="Show on focus" onClick={() => {}}>
+        Focus me
+      </Button>
+    );
+    screen.getByTestId("tip-button").dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+    expect(showPopover).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the tooltip on blur", () => {
+    render(
+      <Button name="tip-button" eagerTooltip="Show on focus" onClick={() => {}}>
+        Focus me
+      </Button>
+    );
+    screen.getByTestId("tip-button").dispatchEvent(new FocusEvent("blur", { bubbles: true }));
+    expect(hidePopover).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets aria-describedby on the button pointing to the tooltip", () => {
+    render(
+      <Button name="tip-button" eagerTooltip="Helpful hint" onClick={() => {}}>
+        Hover me
+      </Button>
+    );
+    const button = screen.getByTestId("tip-button");
+    const tooltip = screen.getByRole("tooltip");
+    expect(button.getAttribute("aria-describedby")).toBe(tooltip.id);
+  });
+
+  it("does not set aria-describedby when eagerTooltip is absent", () => {
+    render(
+      <Button name="plain-button" onClick={() => {}}>
+        No tooltip
+      </Button>
+    );
+    expect(screen.getByTestId("plain-button")).not.toHaveAttribute("aria-describedby");
+  });
+});

--- a/client/src/components/button/BaseButton.tsx
+++ b/client/src/components/button/BaseButton.tsx
@@ -22,6 +22,8 @@ disabled:text-text-placeholder
 disabled:cursor-not-allowed
 `;
 
+const NON_ALPHANUMERIC = /[^a-zA-Z0-9]/g;
+
 const getSizeClasses = (isCircle: boolean, buttonSize: ButtonSize) => {
   if (isCircle) {
     return {
@@ -72,9 +74,9 @@ export const BaseButton: React.FC<ButtonProps> = ({
 }) => {
   const sizeClasses = getSizeClasses(isCircle, size);
   const circleClasses = getCircleClasses(isCircle);
-  const uid = useId().replace(/[^a-zA-Z0-9]/g, "");
+  const uid = useId().replace(NON_ALPHANUMERIC, "");
   const anchorName = `--btn-${uid}`;
-  const tooltipId = `eager-tooltip-${uid}`;
+  const tooltipId = `tooltip-${uid}`;
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   return (

--- a/client/src/components/button/BaseButton.tsx
+++ b/client/src/components/button/BaseButton.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useId, useRef } from "react";
 import { tw } from "tags/tw";
+import { Tooltip } from "components/tooltip";
 
 export type ButtonSize = "small" | "standard" | "large";
 export type ButtonType = "button" | "submit" | "reset";
@@ -52,6 +53,7 @@ export interface ButtonProps {
   disabled?: boolean;
   isCircle?: boolean;
   tooltip?: string;
+  eagerTooltip?: string;
 }
 
 export const BaseButton: React.FC<ButtonProps> = ({
@@ -66,23 +68,38 @@ export const BaseButton: React.FC<ButtonProps> = ({
   disabled = false,
   isCircle = false,
   tooltip,
+  eagerTooltip,
 }) => {
   const sizeClasses = getSizeClasses(isCircle, size);
   const circleClasses = getCircleClasses(isCircle);
+  const uid = useId().replace(/[^a-zA-Z0-9]/g, "");
+  const anchorName = `--btn-${uid}`;
+  const tooltipId = `eager-tooltip-${uid}`;
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   return (
-    <button
-      name={name}
-      data-testid={name}
-      aria-label={ariaLabel || name}
-      type={type}
-      onClick={onClick}
-      {...(form ? { form } : {})}
-      className={`${BASE_BUTTON_STYLES} ${sizeClasses} ${circleClasses} ${className}`}
-      disabled={disabled}
-      {...(tooltip ? { title: tooltip } : {})}
-    >
-      {children}
-    </button>
+    <>
+      <button
+        ref={buttonRef}
+        name={name}
+        data-testid={name}
+        aria-label={ariaLabel || name}
+        aria-describedby={eagerTooltip ? tooltipId : undefined}
+        type={type}
+        onClick={onClick}
+        {...(form ? { form } : {})}
+        className={`${BASE_BUTTON_STYLES} ${sizeClasses} ${circleClasses} ${className}${eagerTooltip ? " [anchor-name:var(--anchor)]" : ""}`}
+        disabled={disabled}
+        {...(tooltip ? { title: tooltip } : {})}
+        {...(eagerTooltip ? { style: { "--anchor": anchorName } as React.CSSProperties } : {})}
+      >
+        {children}
+      </button>
+      {eagerTooltip && (
+        <Tooltip id={tooltipId} anchorName={anchorName} anchorRef={buttonRef}>
+          {eagerTooltip}
+        </Tooltip>
+      )}
+    </>
   );
 };

--- a/client/src/components/button/ButtonGrid.tsx
+++ b/client/src/components/button/ButtonGrid.tsx
@@ -45,7 +45,8 @@ export const ButtonGrid: React.FC = () => {
             name="test-circle-button-save"
             onClick={() => {}}
             disabled={allDisabled}
-            tooltip={allDisabled ? "Enable this button to make changes" : "Save your changes"}
+            tooltip={allDisabled ? undefined : "Save your changes"}
+            eagerTooltip={allDisabled ? "Must enable button first!" : undefined}
           >
             <SaveIcon />
           </CircleButton>
@@ -55,7 +56,8 @@ export const ButtonGrid: React.FC = () => {
             name="test-circle-button-trash"
             onClick={() => {}}
             disabled={allDisabled}
-            tooltip={allDisabled ? "Enable this button to make changes" : "Delete item"}
+            tooltip={allDisabled ? undefined : "Delete item"}
+            eagerTooltip={allDisabled ? "Must enable button first!" : undefined}
           >
             <DeleteIcon />
           </CircleButton>
@@ -88,7 +90,8 @@ export const ButtonGrid: React.FC = () => {
                 onClick={() => {}}
                 size={size}
                 disabled={allDisabled}
-                tooltip={allDisabled ? "Enable this button to make changes" : "Save your changes"}
+                tooltip={allDisabled ? undefined : "Save your changes"}
+                eagerTooltip={allDisabled ? "Must enable button first!" : undefined}
               >
                 Save
               </VariantButton>

--- a/client/src/components/button/ButtonGrid.tsx
+++ b/client/src/components/button/ButtonGrid.tsx
@@ -19,6 +19,9 @@ const variants = {
   "warning-outlined": (props: ButtonProps) => <WarningButton {...props} isOutlined={true} />,
 };
 
+const LONG_TOOLTIP_TEXT =
+  "This is a rather long tooltip text that should be wrapped when displayed in the tooltip.";
+
 export const ButtonGrid: React.FC = () => {
   const [allDisabled, setAllDisabled] = React.useState(false);
 
@@ -57,7 +60,7 @@ export const ButtonGrid: React.FC = () => {
             onClick={() => {}}
             disabled={allDisabled}
             tooltip={allDisabled ? undefined : "Delete item"}
-            eagerTooltip={allDisabled ? "Must enable button first!" : undefined}
+            eagerTooltip={allDisabled ? LONG_TOOLTIP_TEXT : undefined}
           >
             <DeleteIcon />
           </CircleButton>

--- a/client/src/components/tooltip/Tooltip.tsx
+++ b/client/src/components/tooltip/Tooltip.tsx
@@ -5,15 +5,14 @@ const TOOLTIP_STYLES = tw`
 bg-black
 text-white
 text-sm
-px-2
-py-1
+p-1
 rounded
 m-0
 border-0
+max-w-64
 [position-anchor:var(--anchor)]
 [top:anchor(bottom)]
 [left:anchor(left)]
-mt-1
 `;
 
 export const Tooltip: React.FC<{

--- a/client/src/components/tooltip/Tooltip.tsx
+++ b/client/src/components/tooltip/Tooltip.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useRef } from "react";
+import { tw } from "tags/tw";
+
+const TOOLTIP_STYLES = tw`
+bg-black
+text-white
+text-sm
+px-2
+py-1
+rounded
+m-0
+border-0
+[position-anchor:var(--anchor)]
+[top:anchor(bottom)]
+[left:anchor(left)]
+mt-1
+`;
+
+export const Tooltip: React.FC<{
+  id: string;
+  anchorName: string;
+  anchorRef: React.RefObject<HTMLElement | null>;
+  children: React.ReactNode;
+}> = ({ id, anchorName, anchorRef, children }) => {
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const anchor = anchorRef.current;
+    const popover = popoverRef.current;
+    if (!anchor || !popover) return;
+
+    const show = () => popover.showPopover();
+    const hide = () => popover.hidePopover();
+
+    anchor.addEventListener("mouseenter", show);
+    anchor.addEventListener("mouseleave", hide);
+    anchor.addEventListener("focus", show);
+    anchor.addEventListener("blur", hide);
+
+    return () => {
+      anchor.removeEventListener("mouseenter", show);
+      anchor.removeEventListener("mouseleave", hide);
+      anchor.removeEventListener("focus", show);
+      anchor.removeEventListener("blur", hide);
+    };
+  }, [anchorRef]);
+
+  return (
+    <div
+      ref={popoverRef}
+      id={id}
+      role="tooltip"
+      popover="manual"
+      className={TOOLTIP_STYLES}
+      style={{ "--anchor": anchorName } as React.CSSProperties}
+    >
+      {children}
+    </div>
+  );
+};

--- a/client/src/components/tooltip/index.ts
+++ b/client/src/components/tooltip/index.ts
@@ -1,0 +1,1 @@
+export * from "./Tooltip";


### PR DESCRIPTION
Per DEMOS-1936, this PR adds the ability to add an eager tooltip to any kind of button. It does this using relatively new technologies of the anchor positioning + popover API in order to keep the implementation clean and minimal.


https://github.com/user-attachments/assets/c5875ad3-71b0-4472-abdd-157e5ef178bc

