### PR TITLE
DEMOS-2468: added ability to arrow ^ & v w/keybrd

### DIFF
--- a/client/src/components/input/select/AutoCompleteSelect.test.tsx
+++ b/client/src/components/input/select/AutoCompleteSelect.test.tsx
@@ -6,12 +6,7 @@ import { AutoCompleteSelect, AUTOCOMPLETE_SELECT_TEST_ID } from "./AutoCompleteS
 import { Option } from "./Select";
 
 const onSelect: (value: string) => void = vi.fn();
-const scrollIntoView = vi.fn();
-
-Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
-  configurable: true,
-  value: scrollIntoView,
-});
+const scrollIntoView = vi.mocked(HTMLElement.prototype.scrollIntoView);
 
 const options: Option[] = [
   { label: "Apple", value: "apple" },
@@ -143,12 +138,29 @@ describe("AutoCompleteSelect", () => {
   it("keyboard navigation: ArrowDown/ArrowUp moves highlight", async () => {
     render(<AutoCompleteSelect value="" options={options} onSelect={onSelect} />);
     const input = screen.getByTestId(AUTOCOMPLETE_SELECT_TEST_ID);
-    input.focus();
+    fireEvent.focus(input);
     fireEvent.keyDown(input, { key: "ArrowDown" }); // index 0
     fireEvent.keyDown(input, { key: "ArrowDown" }); // index 1
     fireEvent.keyDown(input, { key: "ArrowUp" }); // index 0
     fireEvent.keyDown(input, { key: "Enter" });
     expect(onSelect).toHaveBeenCalledWith("apple");
+  });
+
+  it("uses one active highlight for mouse and keyboard navigation", () => {
+    render(<AutoCompleteSelect value="" options={options} onSelect={onSelect} />);
+    const input = screen.getByTestId(AUTOCOMPLETE_SELECT_TEST_ID);
+    fireEvent.focus(input);
+
+    fireEvent.mouseEnter(screen.getByText("Apple"));
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+
+    const optionButtons = screen.getAllByRole("option").map((option) => option.firstElementChild!);
+    expect(
+      optionButtons.some((option) => option.classList.contains("hover:bg-surface-focus"))
+    ).toBe(false);
+    expect(
+      optionButtons.filter((option) => option.classList.contains("bg-surface-focus"))
+    ).toHaveLength(1);
   });
 
   it("scrolls the active option into view during keyboard navigation", () => {

--- a/client/src/components/input/select/AutoCompleteSelect.test.tsx
+++ b/client/src/components/input/select/AutoCompleteSelect.test.tsx
@@ -6,6 +6,12 @@ import { AutoCompleteSelect, AUTOCOMPLETE_SELECT_TEST_ID } from "./AutoCompleteS
 import { Option } from "./Select";
 
 const onSelect: (value: string) => void = vi.fn();
+const scrollIntoView = vi.fn();
+
+Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+  configurable: true,
+  value: scrollIntoView,
+});
 
 const options: Option[] = [
   { label: "Apple", value: "apple" },
@@ -143,6 +149,24 @@ describe("AutoCompleteSelect", () => {
     fireEvent.keyDown(input, { key: "ArrowUp" }); // index 0
     fireEvent.keyDown(input, { key: "Enter" });
     expect(onSelect).toHaveBeenCalledWith("apple");
+  });
+
+  it("scrolls the active option into view during keyboard navigation", () => {
+    scrollIntoView.mockClear();
+    const longOptions = Array.from({ length: 20 }, (_, index) => ({
+      label: `Option ${index + 1}`,
+      value: `option-${index + 1}`,
+    }));
+
+    render(<AutoCompleteSelect value="" options={longOptions} onSelect={onSelect} />);
+    const input = screen.getByTestId(AUTOCOMPLETE_SELECT_TEST_ID);
+    input.focus();
+
+    for (let index = 0; index < 10; index += 1) {
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+    }
+
+    expect(scrollIntoView).toHaveBeenLastCalledWith({ block: "nearest" });
   });
 
   it("closes dropdown on Escape", async () => {

--- a/client/src/components/input/select/AutoCompleteSelect.tsx
+++ b/client/src/components/input/select/AutoCompleteSelect.tsx
@@ -66,6 +66,7 @@ export const AutoCompleteSelect = ({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const activeOptionRef = useRef<HTMLLIElement>(null);
 
   const closeSelect = () => {
     setIsOpen(false);
@@ -109,6 +110,10 @@ export const AutoCompleteSelect = ({
 
   const filteredOptions = filterOptions(options, filterValue);
 
+  useEffect(() => {
+    activeOptionRef.current?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (!isOpen && e.key === "ArrowDown") {
       openSelect();
@@ -135,7 +140,12 @@ export const AutoCompleteSelect = ({
       return filteredOptions.map((option, i) => {
         const isActive = i === activeIndex;
         return (
-          <li key={option.value} role="option" aria-selected={option.value === value}>
+          <li
+            key={option.value}
+            ref={isActive ? activeOptionRef : undefined}
+            role="option"
+            aria-selected={option.value === value}
+          >
             <button
               type="button"
               className={`${ITEM_CLASSES} ${isActive ? ITEM_ACTIVE_CLASSES : ""} w-full text-left`}

--- a/client/src/components/input/select/AutoCompleteSelect.tsx
+++ b/client/src/components/input/select/AutoCompleteSelect.tsx
@@ -10,7 +10,7 @@ export const AUTOCOMPLETE_SELECT_TEST_ID = "input-autocomplete-select";
 
 const ICON_CLASSES = tw`text-text-placeholder w-2 h-1`;
 const LIST_CLASSES = tw`absolute z-10 w-full bg-surface-white border border-border-fields rounded mt-0.5 max-h-56 overflow-auto shadow-sm`;
-const ITEM_CLASSES = tw`px-1 py-1 text-sm text-text-font cursor-pointer hover:bg-surface-focus`;
+const ITEM_CLASSES = tw`px-1 py-1 text-sm text-text-font cursor-pointer`;
 const ITEM_ACTIVE_CLASSES = tw`bg-surface-focus`;
 const EMPTY_CLASSES = tw`px-2 py-1 text-sm text-text-placeholder`;
 

--- a/client/vitest.setup.ts
+++ b/client/vitest.setup.ts
@@ -12,6 +12,12 @@ import React from "react";
 
 import { vi } from "vitest";
 
+// Element.scrollIntoView is not implemented by jsdom
+Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+  configurable: true,
+  value: vi.fn(),
+});
+
 // Mock HTML dialog element for tests
 // HTMLDialogElement API is not fully supported in jsdom yet, so we need these mocks
 Object.defineProperty(HTMLDialogElement.prototype, "showModal", {


### PR DESCRIPTION
i found that no dropdowns had arrow control. It would move the selector but DD would not scroll to non-visible items



https://github.com/user-attachments/assets/078e286d-a6ff-4849-9678-2c9edd774aad

This was borked everywhere apparently!
https://github.com/user-attachments/assets/3e2e0e43-7615-49a2-adfe-6f97da96eea8



