### PR TITLE
DEMOS-2469 User needs to refresh the page to see uploaded BN workbook

### DIFF
--- a/client/src/components/dialog/document/AddDocumentToDeliverableDialog.tsx
+++ b/client/src/components/dialog/document/AddDocumentToDeliverableDialog.tsx
@@ -116,11 +116,8 @@ export const AddDocumentToDeliverableDialog: React.FC<AddDocumentToDeliverableDi
       return "virus-scan-failed";
     }
 
-    // Budget Neutrality validation runs asynchronously server-side and can take far longer than a
-    // dialog should stay open (GuardDuty latency alone is unbounded). Blocking on it here left the
-    // modal spinning long after the document had already landed in the table. The same ruleset runs
-    // client-side via useBNWorkbookPreValidation before upload is permitted, so nothing is lost by
-    // letting the server-side pass complete in the background.
+    // BN validation finishes server-side on its own schedule; useBNWorkbookPreValidation already
+    // ran the same ruleset before upload, so the dialog doesn't wait on it.
     if (refetchQueries) {
       await client.refetchQueries({ include: refetchQueries });
     }

--- a/client/src/components/dialog/document/AddDocumentToDeliverableDialog.tsx
+++ b/client/src/components/dialog/document/AddDocumentToDeliverableDialog.tsx
@@ -13,10 +13,8 @@ import {
 } from "components/dialog/document/DocumentDialog";
 import { useToast } from "components/toast/ToastContext";
 import { tryUploadingFileToS3 } from "./tryUploadingFileToS3";
-import { useBNValidationStatus } from "./useBNValidationStatus";
 import { useDocumentPassedVirusScan } from "./useDocumentPassedVirusScan";
 import { useUploadDocument } from "./useUploadDocument";
-import { BN_WORKBOOK_DOCUMENT_TYPE } from "demos-server-constants";
 
 export const UPLOAD_DOCUMENT_TO_DELIVERABLE_STATE_FILES_MUTATION: TypedDocumentNode<
   {
@@ -78,7 +76,6 @@ export const AddDocumentToDeliverableDialog: React.FC<AddDocumentToDeliverableDi
     ? getCmsFileDocumentTypeSubset(documentTypeSubset)
     : documentTypeSubset;
   const { documentPassedVirusScan } = useDocumentPassedVirusScan();
-  const { waitForBNValidation } = useBNValidationStatus();
   const { uploadDocument: uploadStateDocument } = useUploadDocument(
     UPLOAD_DOCUMENT_TO_DELIVERABLE_STATE_FILES_MUTATION
   );
@@ -119,19 +116,11 @@ export const AddDocumentToDeliverableDialog: React.FC<AddDocumentToDeliverableDi
       return "virus-scan-failed";
     }
 
-    if (uploadDocumentInput.documentType === BN_WORKBOOK_DOCUMENT_TYPE) {
-      const validation = await waitForBNValidation(pendingUpload.id);
-      if (validation?.status === "Failed") {
-        const errorSummary = validation.errors.map((e) => `${e.code}: ${e.message}`).join("\n");
-        showError(
-          errorSummary
-            ? `Budget Neutrality validation failed:\n${errorSummary}`
-            : "Budget Neutrality validation failed."
-        );
-        return "bn-validation-failed";
-      }
-    }
-
+    // Budget Neutrality validation runs asynchronously server-side and can take far longer than a
+    // dialog should stay open (GuardDuty latency alone is unbounded). Blocking on it here left the
+    // modal spinning long after the document had already landed in the table. The same ruleset runs
+    // client-side via useBNWorkbookPreValidation before upload is permitted, so nothing is lost by
+    // letting the server-side pass complete in the background.
     if (refetchQueries) {
       await client.refetchQueries({ include: refetchQueries });
     }

--- a/client/src/components/dialog/document/DocumentDialog.test.tsx
+++ b/client/src/components/dialog/document/DocumentDialog.test.tsx
@@ -237,3 +237,26 @@ describe("DocumentDialog BN Workbook pre-validation", () => {
     expect(screen.getByTestId("button-confirm-upload-document")).not.toBeDisabled();
   });
 });
+
+describe("DocumentDialog upload failure handling", () => {
+  it("keeps the dialog usable when onSubmit throws", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const onSubmit = vi.fn(() => Promise.reject(new Error("Failed to fetch")));
+    const onClose = vi.fn();
+
+    renderAddDialog("General File", onSubmit, onClose);
+    selectFile("general.docx");
+    fireEvent.click(screen.getByTestId("button-confirm-upload-document"));
+
+    // A throw must not strand the dialog in "uploading", which disables both Cancel and Upload
+    // and leaves a page refresh as the only way out.
+    expect(
+      await screen.findByText(/could not be added because of an unknown problem/i)
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("button-dialog-cancel")).not.toBeDisabled();
+    expect(screen.getByTestId("button-confirm-upload-document")).not.toBeDisabled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+});

--- a/client/src/components/dialog/document/DocumentDialog.tsx
+++ b/client/src/components/dialog/document/DocumentDialog.tsx
@@ -419,9 +419,7 @@ export const DocumentDialog: React.FC<DocumentDialogProps> = ({
   };
 
   const handleUpload = async () => {
-    // Attempt to upload the document. A throw here (failed S3 PUT, mutation error, failed refetch)
-    // must never leave the dialog in "uploading" -- that state disables both Cancel and Upload, so
-    // the only way out would be a page refresh.
+    // "uploading" disables both Cancel and Upload, so a throw here must never leave it set.
     setDocumentDialogState("uploading");
     let uploadResult: DocumentUploadResult;
     try {

--- a/client/src/components/dialog/document/DocumentDialog.tsx
+++ b/client/src/components/dialog/document/DocumentDialog.tsx
@@ -419,9 +419,17 @@ export const DocumentDialog: React.FC<DocumentDialogProps> = ({
   };
 
   const handleUpload = async () => {
-    // Attempt to upload the document
+    // Attempt to upload the document. A throw here (failed S3 PUT, mutation error, failed refetch)
+    // must never leave the dialog in "uploading" -- that state disables both Cancel and Upload, so
+    // the only way out would be a page refresh.
     setDocumentDialogState("uploading");
-    const uploadResult = await onSubmit(activeDocument);
+    let uploadResult: DocumentUploadResult;
+    try {
+      uploadResult = await onSubmit(activeDocument);
+    } catch (error) {
+      console.error("Document upload failed:", error);
+      uploadResult = "unknown-error";
+    }
     setDocumentDialogState(uploadResult);
 
     // If virus scan or BN validation failed, clear the selected file so the user can choose a new one

--- a/server/src/adapters/s3/LocalS3Adapter.ts
+++ b/server/src/adapters/s3/LocalS3Adapter.ts
@@ -2,6 +2,7 @@ import { prisma, PrismaTransactionClient } from "../../prismaClient";
 import { GetPresignedDownloadUrlOptions, S3Adapter } from "../";
 import { sanitizeDownloadFileName } from "./sanitizeDownloadFileName";
 import { Prisma, DocumentPendingUpload as PrismaDocumentPendingUpload } from "@prisma/client";
+import { BN_WORKBOOK_DOCUMENT_TYPE } from "../../constants";
 
 const HOSTNAME = "LocalS3Adapter";
 const BUCKET_NAME = "local-demos-bucket";
@@ -63,6 +64,19 @@ export function createLocalS3Adapter(): S3Adapter {
             s3Path: `${HOSTNAME}/${BUCKET_NAME}/${documentPendingUpload.id}`,
           },
         });
+        // Deployed, the clean-move SQL creates this row (as "Pending") once GuardDuty clears
+        // the file. That step is bypassed here, so create it inline to satisfy the
+        // check_budget_neutrality_validation_record_exists constraint trigger on `document`.
+        if (documentData.documentTypeId === BN_WORKBOOK_DOCUMENT_TYPE) {
+          await transaction.budgetNeutralityWorkbook.create({
+            data: {
+              id: documentPendingUpload.id,
+              documentTypeId: BN_WORKBOOK_DOCUMENT_TYPE,
+              validationStatusId: "Pending",
+              validationData: {},
+            },
+          });
+        }
         return documentPendingUpload;
       };
 


### PR DESCRIPTION
The upload dialog blocked on `waitForBNValidation` — a poll of up to **60s** — while the
document row is created much earlier, right after the virus scan. So the file showed up in
the table while the modal kept spinning. QA refreshed at ~20s and reported it as stuck.

The wait did nothing anyway: an unfinished validation returned `Pending`, which isn't
`"Failed"`, so the dialog treated it as success — after burning the full 60 seconds.

## Fix

Removed the blocking BN validation wait. Flow is now mutation -> S3 PUT -> virus scan ->
refetch -> close. Validation still runs server-side; the dialog no longer waits on it.

Safe because the same ruleset already runs client-side before upload
(`useBNWorkbookPreValidation`) and disables the Upload button on failure.

Also wrapped `onSubmit` in `try`/`catch`. A throw previously left the dialog on
`uploading`, which disables both Cancel and Upload — unescapable without a refresh.

## Key changes

- `client/.../AddDocumentToDeliverableDialog.tsx` — removed the blocking BN wait
- `client/.../DocumentDialog.tsx` — `try`/`catch` so the dialog can't latch on `uploading`
- `server/.../LocalS3Adapter.ts` — local dev only; `LOCAL_SIMPLE_UPLOAD` never created the
  `budget_neutrality_workbook` row, so a constraint trigger rolled back every local BN
  upload. No production impact.