### PR TITLE
DEMOS 2087 Update references to State/Territory to name instead of ID

### DIFF
--- a/client/src/components/table/columns/DeliverableColumns.tsx
+++ b/client/src/components/table/columns/DeliverableColumns.tsx
@@ -202,7 +202,7 @@ export function DeliverableColumns({
 
   return [
     createSelectColumnDef(columnHelper),
-    columnHelper.accessor("demonstration.state.id", {
+    columnHelper.accessor("demonstration.state.name", {
       id: "stateId",
       header: "State/\u200BTerritory",
       cell: highlightCell,
@@ -215,8 +215,8 @@ export function DeliverableColumns({
           filterType: "select",
           options:
             STATES_AND_TERRITORIES.map((state) => ({
-              label: state.id,
-              value: state.id,
+              label: state.name,
+              value: state.name,
             })) ?? [],
         },
       },

--- a/client/src/components/table/columns/DemonstrationColumns.tsx
+++ b/client/src/components/table/columns/DemonstrationColumns.tsx
@@ -17,7 +17,7 @@ export function DemonstrationColumns(projectOfficerOptions: Pick<Person, "fullNa
 
   // Note, this now hosts/shares some columns with DemonstrationDeliverableTable.
   return [
-    columnHelper.accessor("state.id", {
+    columnHelper.accessor("state.name", {
       id: "stateId",
       header: "State/\u200BTerritory", // using zero width space for word break
       cell: highlightCell,
@@ -30,8 +30,8 @@ export function DemonstrationColumns(projectOfficerOptions: Pick<Person, "fullNa
           filterType: "select",
           options:
             STATES_AND_TERRITORIES.map((state) => ({
-              label: state.id,
-              value: state.id,
+              label: state.name,
+              value: state.name,
             })) ?? [],
         },
       },

--- a/client/src/components/table/tables/DeliverableTable.tsx
+++ b/client/src/components/table/tables/DeliverableTable.tsx
@@ -33,7 +33,7 @@ export type DeliverableTableRow = Omit<
 > & {
   name: string;
   demonstration: Pick<Deliverable["demonstration"], "id" | "name"> & {
-    state: Pick<State, "id">;
+    state: Pick<State, "id" | "name">;
     demonstrationTypes: {
       demonstrationTypeName: string;
       approvalStatus: "Approved" | "Unapproved";
@@ -88,6 +88,7 @@ export const DELIVERABLES_PAGE_QUERY = gql`
         name
         state {
           id
+          name
         }
         demonstrationTypes {
           demonstrationTypeName
@@ -150,6 +151,7 @@ export const STATE_USER_DELIVERABLES_PAGE_QUERY = gql`
                 name
                 state {
                   id
+                  name
                 }
                 demonstrationTypes {
                   demonstrationTypeName

--- a/client/src/components/table/tables/DemonstrationDeliverableTable.test.tsx
+++ b/client/src/components/table/tables/DemonstrationDeliverableTable.test.tsx
@@ -16,7 +16,7 @@ const baseDeliverable: Omit<DeliverableTableRow, "id" | "name" | "dueDate" | "st
   demonstration: {
     id: "demo-1",
     name: "Demo 1",
-    state: { id: "NY" },
+    state: { id: "NY", name: "New York" },
     demonstrationTypes: [],
   },
   deliverableType: "Monitoring Protocol",

--- a/client/src/components/table/tables/DemonstrationTable.test.tsx
+++ b/client/src/components/table/tables/DemonstrationTable.test.tsx
@@ -175,7 +175,7 @@ const applyProjectOfficerFilter = async (
   await user.click(officerOptionToClick!);
 };
 
-const applyStateFilter = async (user: ReturnType<typeof userEvent.setup>, stateCode: string) => {
+const applyStateFilter = async (user: ReturnType<typeof userEvent.setup>, stateName: string) => {
   // Select state filter from column dropdown
   const columnSelect = screen.getByTestId("filter-by-column");
   await user.selectOptions(columnSelect, ["stateId"]);
@@ -187,16 +187,16 @@ const applyStateFilter = async (user: ReturnType<typeof userEvent.setup>, stateC
 
   // Filter by the specified state
   const stateFilterInput = screen.getByPlaceholderText(/select state\/\u200Bterritory/i);
-  await user.type(stateFilterInput, stateCode);
+  await user.type(stateFilterInput, stateName);
 
   // Wait for dropdown and select state
   await waitFor(() => {
-    const stateOptions = screen.getAllByText(stateCode);
+    const stateOptions = screen.getAllByText(stateName);
     const stateDropdownOption = stateOptions.find((el) => el.tagName === "LI" || el.closest("li"));
     expect(stateDropdownOption).toBeInTheDocument();
   });
 
-  const stateOptions = screen.getAllByText(stateCode);
+  const stateOptions = screen.getAllByText(stateName);
   const stateOptionToClick = stateOptions.find((el) => el.tagName === "LI" || el.closest("li"));
   await user.click(stateOptionToClick!);
 };
@@ -262,11 +262,11 @@ describe("Demonstrations", () => {
       });
 
       // Verify the order: FL, MT, TX (alphabetically by state)
-      expect(rowData[0].state).toBe("FL");
+      expect(rowData[0].state).toBe("Florida");
       expect(rowData[0].title).toBe("Florida Health Innovation");
-      expect(rowData[1].state).toBe("MT");
+      expect(rowData[1].state).toBe("Montana");
       expect(rowData[1].title).toBe("Montana Medicaid Waiver");
-      expect(rowData[2].state).toBe("TX");
+      expect(rowData[2].state).toBe("Texas");
       expect(rowData[2].title).toBe("Texas Reform Initiative");
     });
 
@@ -286,12 +286,13 @@ describe("Demonstrations", () => {
 
     it("renders demonstration data correctly in table cells", () => {
       expect(screen.getByText("Montana Medicaid Waiver")).toBeInTheDocument();
-      expect(screen.getByText("MT")).toBeInTheDocument();
+      expect(screen.getByText("Montana")).toBeInTheDocument();
       expect(screen.getByText("John Doe")).toBeInTheDocument();
       expect(screen.getByText("Florida Health Innovation")).toBeInTheDocument();
-      expect(screen.getByText("FL")).toBeInTheDocument();
+      expect(screen.getByText("Florida")).toBeInTheDocument();
       expect(screen.getByText("Jane Smith")).toBeInTheDocument();
       expect(screen.getByText("Texas Reform Initiative")).toBeInTheDocument();
+      expect(screen.getByText("Texas")).toBeInTheDocument();
       expect(screen.getByText("Jim Smith")).toBeInTheDocument();
     });
 
@@ -337,7 +338,7 @@ describe("Demonstrations", () => {
 
     it("allows filtering demonstrations by column", async () => {
       await clearSearchInput(user);
-      await applyStateFilter(user, "FL");
+      await applyStateFilter(user, "Florida");
 
       await waitFor(() => {
         expect(screen.getByText("Florida Health Innovation")).toBeInTheDocument();
@@ -361,9 +362,9 @@ describe("Demonstrations", () => {
       await user.click(stateFilterInput);
 
       // Select "Montana"
-      await user.type(stateFilterInput, "MT");
+      await user.type(stateFilterInput, "Montana");
       await waitFor(async () => {
-        const mtOptions = screen.getAllByText("MT");
+        const mtOptions = screen.getAllByText("Montana");
         const mtDropdownOption = mtOptions.find((el) => el.tagName === "LI" || el.closest("li"));
         expect(mtDropdownOption).toBeInTheDocument();
         await user.click(mtDropdownOption!);
@@ -371,9 +372,9 @@ describe("Demonstrations", () => {
 
       // Select "Florida"
       await user.clear(stateFilterInput);
-      await user.type(stateFilterInput, "FL");
+      await user.type(stateFilterInput, "Florida");
       await waitFor(async () => {
-        const flOptions = screen.getAllByText("FL");
+        const flOptions = screen.getAllByText("Florida");
         const flDropdownOption = flOptions.find((el) => el.tagName === "LI" || el.closest("li"));
         expect(flDropdownOption).toBeInTheDocument();
         await user.click(flDropdownOption!);

--- a/client/src/mock-data/deliverableMocks.ts
+++ b/client/src/mock-data/deliverableMocks.ts
@@ -17,6 +17,7 @@ export const MOCK_DELIVERABLE_TABLE_ROW: DeliverableTableRow = {
     name: "Dusty Demo",
     state: {
       id: "CA",
+      name: "California",
     },
     demonstrationTypes: [],
   },
@@ -46,6 +47,7 @@ export const MOCK_DELIVERABLE_1: DeliverableDetailsManagementDeliverable = {
     expirationDate: new Date("2026-12-31"),
     state: {
       id: "CA",
+      name: "California",
     },
     demonstrationTypes: [],
   },

--- a/client/src/pages/DemonstrationDetail/DemonstrationDetailHeader.test.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetailHeader.test.tsx
@@ -168,7 +168,7 @@ describe("Demonstration Detail Header", () => {
 
     // Expected attributes in order
     const expectedAttributes = [
-      { label: "State/Territory", value: "MT" },
+      { label: "State/Territory", value: "Montana" },
       { label: "Project Officer", value: "John Doe" },
       { label: "Status", value: "Approved" },
       { label: "Effective", value: "01/01/2025" },

--- a/client/src/pages/DemonstrationDetail/DemonstrationDetailHeader.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetailHeader.tsx
@@ -22,6 +22,7 @@ export const DEMONSTRATION_HEADER_DETAILS_QUERY = gql`
       chipId
       state {
         id
+        name
       }
       primaryProjectOfficer {
         id
@@ -35,7 +36,7 @@ export type DemonstrationHeaderDetails = Pick<
   Demonstration,
   "id" | "name" | "expirationDate" | "effectiveDate" | "status" | "medicaidId" | "chipId"
 > & {
-  state: Pick<State, "id">;
+  state: Pick<State, "id" | "name">;
   primaryProjectOfficer: Pick<Person, "id" | "fullName">;
 };
 
@@ -88,7 +89,7 @@ export const DemonstrationDetailHeader: React.FC<DemonstrationDetailHeaderProps>
   }
 
   const displayFields = [
-    { label: "State/Territory", value: demonstration.state.id },
+    { label: "State/Territory", value: demonstration.state.name },
     {
       label: "Project Officer",
       value: demonstration.primaryProjectOfficer.fullName,

--- a/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
+++ b/client/src/pages/deliverables/DeliverableDetailsManagementPage.tsx
@@ -144,7 +144,7 @@ export type DeliverableDetailsManagementDeliverable = Pick<
 > & {
   allowedDocumentTypes: DocumentType[];
   demonstration: Pick<Demonstration, "id" | "name" | "expirationDate"> & {
-    state: { id: string };
+    state: { id: string, name: string };
     demonstrationTypes: {
       demonstrationTypeName: string;
       approvalStatus: "Approved" | "Unapproved";

--- a/server/src/onDemandReports/configs/applicationDetailsReportConfig.ts
+++ b/server/src/onDemandReports/configs/applicationDetailsReportConfig.ts
@@ -81,7 +81,7 @@ type ApplicationDetailsReportColumn =
 
 const applicationDetailsReportSchema = z
   .object({
-    state: z.enum(STATES_AND_TERRITORIES.map((state) => state.id)),
+    state: z.enum(STATES_AND_TERRITORIES.map((state) => state.name)),
     application_type: z.enum(APPLICATION_TYPES),
     application_title: z.string(),
     demonstration_number: z.string(),

--- a/server/src/onDemandReports/configs/applicationDetailsReportQueries.ts
+++ b/server/src/onDemandReports/configs/applicationDetailsReportQueries.ts
@@ -154,7 +154,7 @@ app_notes AS (
 )
 
 SELECT
-    demo.state_id AS state,
+    demo_state.name AS state,
     app.application_type_id AS application_type,
     app.application_title,
     demo.medicaid_id AS demonstration_number,
@@ -228,6 +228,12 @@ INNER JOIN
     demos_app.demonstration AS demo
     ON
         app.parent_demonstration_id = demo.id
+
+-- Every demonstration has a state
+INNER JOIN
+    demos_app.state AS demo_state
+    ON
+        demo.state_id = demo_state.id
 
 -- This identifies when the parent demo has CHIP
 LEFT JOIN

--- a/server/src/onDemandReports/configs/deliverableStatusReportConfig.ts
+++ b/server/src/onDemandReports/configs/deliverableStatusReportConfig.ts
@@ -49,7 +49,7 @@ type DeliverableStatusReportColumn =
 
 const deliverableStatusReportSchema = z
   .object({
-    state: z.enum(STATES_AND_TERRITORIES.map((state) => state.id)),
+    state: z.enum(STATES_AND_TERRITORIES.map((state) => state.name)),
     demonstration_title: z.string(),
     demonstration_number: z.string(),
     effective_date: usDateString,

--- a/server/src/onDemandReports/configs/deliverableStatusReportQueries.ts
+++ b/server/src/onDemandReports/configs/deliverableStatusReportQueries.ts
@@ -184,7 +184,7 @@ aggregate_private_comments AS (
 )
 
 SELECT
-    demo.state_id AS state,
+    demo_state.name AS state,
     demo.name AS demonstration_title,
     demo.medicaid_id AS demonstration_number,
     to_char(demo.effective_date AT TIME ZONE 'America/New_York', 'MM/DD/YYYY') AS effective_date,
@@ -228,6 +228,12 @@ INNER JOIN
     demos_app.demonstration AS demo
     ON
         deliv.demonstration_id = demo.id
+
+-- Every demonstration has a state
+INNER JOIN
+    demos_app.state AS demo_state
+    ON
+        demo.state_id = demo_state.id
 
 -- Primary Project Officer is guaranteed to exist
 INNER JOIN

--- a/server/src/onDemandReports/configs/demonstrationOverviewReportConfig.ts
+++ b/server/src/onDemandReports/configs/demonstrationOverviewReportConfig.ts
@@ -39,7 +39,7 @@ type DemonstrationOverviewReportColumn =
 
 export const demonstrationOverviewReportSchema = z
   .object({
-    state_territory: z.enum(STATES_AND_TERRITORIES.map((state) => state.id)),
+    state_territory: z.enum(STATES_AND_TERRITORIES.map((state) => state.name)),
     demonstration_title: z.string(),
     demonstration_number: z.string(),
     chip_id: z.string(),

--- a/server/src/onDemandReports/configs/demonstrationOverviewReportQueries.ts
+++ b/server/src/onDemandReports/configs/demonstrationOverviewReportQueries.ts
@@ -62,7 +62,7 @@ flattened_role_assignments AS (
 )
 
 SELECT
-    demo.state_id AS state_territory,
+    demo_state.name AS state_territory,
     demo.name AS demonstration_title,
     demo.medicaid_id AS demonstration_number,
     CASE WHEN demo_type.demonstration_id IS NOT NULL THEN demo.chip_id ELSE '-' END AS chip_id,
@@ -87,6 +87,12 @@ SELECT
         AS application_approval_date
 FROM
     demos_app.demonstration AS demo
+
+-- Every demonstration has a state
+INNER JOIN
+    demos_app.state AS demo_state
+    ON
+        demo.state_id = demo_state.id
 
 -- This identifies when the parent demo has CHIP
 LEFT JOIN

--- a/server/src/onDemandReports/configs/demonstrationTypesReportConfig.ts
+++ b/server/src/onDemandReports/configs/demonstrationTypesReportConfig.ts
@@ -26,7 +26,7 @@ type DemonstrationTypesReportColumn =
 
 const demonstrationTypesReportSchema = z
   .object({
-    state_territory: z.enum(STATES_AND_TERRITORIES.map((state) => state.id)),
+    state_territory: z.enum(STATES_AND_TERRITORIES.map((state) => state.name)),
     demonstration_title: z.string(),
     demonstration_number: z.string(),
     chip_id: z.string(),

--- a/server/src/onDemandReports/configs/demonstrationTypesReportQueries.ts
+++ b/server/src/onDemandReports/configs/demonstrationTypesReportQueries.ts
@@ -13,7 +13,7 @@ WITH primary_roles AS (
 )
 
 SELECT
-    demo.state_id AS state_territory,
+    demo_state.name AS state_territory,
     demo.name AS demonstration_title,
     demo.medicaid_id AS demonstration_number,
     coalesce(
@@ -44,6 +44,12 @@ INNER JOIN
     demos_app.demonstration AS demo
     ON
         demo_type.demonstration_id = demo.id
+
+-- Every demonstration has a state
+INNER JOIN
+    demos_app.state AS demo_state
+    ON
+        demo.state_id = demo_state.id
 
 -- Every demonstration has a primary project officer
 INNER JOIN


### PR DESCRIPTION
Updates State/Territory to name instead of ID in:
- Demonstration Tables
- Deliverable Tables
- Demonstration Detail Header
- Reports

<img width="1500" height="542" alt="image" src="https://github.com/user-attachments/assets/2441dec6-6b41-4c6d-b47e-e284bf7d668a" />
