### PR TITLE
DEMOS-2387 Fix underscores in downloaded file names

### DIFF
--- a/client/src/pages/DocumentDetails/DocumentDetail.test.tsx
+++ b/client/src/pages/DocumentDetails/DocumentDetail.test.tsx
@@ -12,16 +12,21 @@ import {
 
 // Mock DocumentPreview component
 vi.mock("./DocumentPreview", () => ({
-  DocumentPreview: ({ filename }: { filename: string; presignedDownloadUrl: string }) => (
-    <div data-testid="document-preview">Preview: {filename}</div>
-  ),
+  DocumentPreview: ({
+    downloadFileName,
+  }: {
+    downloadFileName: string;
+    presignedDownloadUrl: string;
+  }) => <div data-testid="document-preview">Preview: {downloadFileName}</div>,
 }));
 
+// The title keeps whatever the user typed; only the download name is sanitized.
 const mockDocument = {
   id: "doc-123",
-  name: "test-document.pdf",
+  name: 'test-document \\ / : * ? " < > |',
   createdAt: "2026-02-10T10:00:00Z",
   presignedDownloadUrl: "https://example.com/presigned-url",
+  downloadFileName: "test-document.pdf",
   application: {
     __typename: "Demonstration" as const,
     id: "demo-123",
@@ -160,8 +165,9 @@ describe("DocumentDetail", () => {
   it("renders document details successfully", async () => {
     renderDocumentDetail("doc-123", [DocumentDetailMock]);
 
+    // The heading shows the title exactly as the user saved it, invalid characters included.
     await waitFor(() => {
-      expect(screen.getByText("test-document.pdf")).toBeInTheDocument();
+      expect(screen.getByText(mockDocument.name)).toBeInTheDocument();
     });
 
     expect(screen.getByText("Test Demonstration")).toBeInTheDocument();
@@ -227,7 +233,7 @@ describe("DocumentDetailPage", () => {
     renderWithRouter();
 
     await waitFor(() => {
-      expect(screen.getByText("test-document.pdf")).toBeInTheDocument();
+      expect(screen.getByText(mockDocument.name)).toBeInTheDocument();
     });
   });
 

--- a/client/src/pages/DocumentDetails/DocumentDetail.tsx
+++ b/client/src/pages/DocumentDetails/DocumentDetail.tsx
@@ -26,7 +26,10 @@ type Extension = Pick<ServerExtension, "id" | "name"> & {
   demonstration: Demonstration;
   __typename: "Extension";
 };
-type Document = Pick<ServerDocument, "id" | "name" | "createdAt" | "presignedDownloadUrl"> & {
+type Document = Pick<
+  ServerDocument,
+  "id" | "name" | "createdAt" | "presignedDownloadUrl" | "downloadFileName"
+> & {
   application: Demonstration | Amendment | Extension;
   owner: User;
 };
@@ -37,6 +40,7 @@ export const DOCUMENT_DETAIL_QUERY: TypedDocumentNode<{ document: Document }, { 
       id
       name
       presignedDownloadUrl
+      downloadFileName
       application {
         ... on Demonstration {
           id
@@ -128,7 +132,7 @@ export const DocumentDetail: React.FC<{ documentId: string }> = ({ documentId })
       <div className="mt-2 flex-1 min-h-0">
         <DocumentPreview
           presignedDownloadUrl={document.presignedDownloadUrl}
-          filename={document.name}
+          downloadFileName={document.downloadFileName}
         />
       </div>
     </div>

--- a/client/src/pages/DocumentDetails/DocumentPreview.test.tsx
+++ b/client/src/pages/DocumentDetails/DocumentPreview.test.tsx
@@ -33,7 +33,7 @@ describe("DocumentPreview", () => {
     // Mock fetch to never resolve
     globalThis.fetch = vi.fn(() => new Promise(() => {})) as typeof fetch;
 
-    render(<DocumentPreview presignedDownloadUrl={mockPresignedUrl} filename={mockFilename} />);
+    render(<DocumentPreview presignedDownloadUrl={mockPresignedUrl} downloadFileName={mockFilename} />);
 
     expect(screen.getByText("Loading file...")).toBeInTheDocument();
   });
@@ -41,7 +41,7 @@ describe("DocumentPreview", () => {
   it("displays error when fetch fails", async () => {
     globalThis.fetch = vi.fn(() => Promise.reject(new Error("Network error"))) as typeof fetch;
 
-    render(<DocumentPreview presignedDownloadUrl={mockPresignedUrl} filename={mockFilename} />);
+    render(<DocumentPreview presignedDownloadUrl={mockPresignedUrl} downloadFileName={mockFilename} />);
 
     await waitFor(() => {
       expect(screen.getByText(/Error loading file: Network error/)).toBeInTheDocument();
@@ -56,7 +56,7 @@ describe("DocumentPreview", () => {
       } as Response)
     ) as typeof fetch;
 
-    render(<DocumentPreview presignedDownloadUrl={mockPresignedUrl} filename={mockFilename} />);
+    render(<DocumentPreview presignedDownloadUrl={mockPresignedUrl} downloadFileName={mockFilename} />);
 
     await waitFor(() => {
       expect(
@@ -81,7 +81,7 @@ describe("DocumentPreview", () => {
       mime: "application/pdf",
     });
 
-    render(<DocumentPreview presignedDownloadUrl={mockPresignedUrl} filename={mockFilename} />);
+    render(<DocumentPreview presignedDownloadUrl={mockPresignedUrl} downloadFileName={mockFilename} />);
 
     await waitFor(() => {
       const embed = document.querySelector("embed");
@@ -109,12 +109,11 @@ describe("DocumentPreview", () => {
       mime: "image/png",
     });
 
-    // The download uses the document title verbatim, consistent with what's
-    // stored and displayed elsewhere (no extension appended/slugified).
+    // The download uses the server-sanitized name, which already includes the extension.
     render(
       <DocumentPreview
         presignedDownloadUrl={mockPresignedUrl}
-        filename="Budget Neutrality Workbook Ohio"
+        downloadFileName="Budget Neutrality Workbook Ohio.xlsx"
       />
     );
 
@@ -122,7 +121,35 @@ describe("DocumentPreview", () => {
       expect(screen.getByText("Download File")).toBeInTheDocument();
       const link = screen.getByText("Download File").closest("a");
       expect(link).toHaveAttribute("href", "blob:mock-url");
-      expect(link).toHaveAttribute("download", "Budget Neutrality Workbook Ohio");
+      expect(link).toHaveAttribute("download", "Budget Neutrality Workbook Ohio.xlsx");
+    });
+  });
+
+  it("downloads with a sanitized name so the browser has nothing to replace", async () => {
+    const mockBlob = new Blob(["fake content"], { type: "application/msword" });
+
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      } as Response)
+    ) as typeof fetch;
+
+    const { fileTypeFromBlob } = await import("file-type");
+    vi.mocked(fileTypeFromBlob).mockResolvedValue({ ext: "docx", mime: "application/msword" });
+
+    // A raw title here would make the browser substitute underscores: "DEMOS-892 (3)_________".
+    render(
+      <DocumentPreview
+        presignedDownloadUrl={mockPresignedUrl}
+        downloadFileName="DEMOS-892 (3).docx"
+      />
+    );
+
+    await waitFor(() => {
+      const link = screen.getByText("Download File").closest("a");
+      expect(link).toHaveAttribute("download", "DEMOS-892 (3).docx");
+      expect(link?.getAttribute("download")).not.toContain("_");
     });
   });
 
@@ -139,7 +166,7 @@ describe("DocumentPreview", () => {
     const { fileTypeFromBlob } = await import("file-type");
     vi.mocked(fileTypeFromBlob).mockResolvedValue(undefined);
 
-    render(<DocumentPreview presignedDownloadUrl={mockPresignedUrl} filename={mockFilename} />);
+    render(<DocumentPreview presignedDownloadUrl={mockPresignedUrl} downloadFileName={mockFilename} />);
 
     await waitFor(() => {
       expect(screen.getByText("Download File")).toBeInTheDocument();
@@ -163,7 +190,7 @@ describe("DocumentPreview", () => {
       mime: "application/pdf",
     });
 
-    render(<DocumentPreview presignedDownloadUrl={mockPresignedUrl} filename={mockFilename} />);
+    render(<DocumentPreview presignedDownloadUrl={mockPresignedUrl} downloadFileName={mockFilename} />);
 
     await waitFor(() => {
       expect(fileConstructorSpy).toHaveBeenCalledWith([mockBlob], mockFilename, {

--- a/client/src/pages/DocumentDetails/DocumentPreview.tsx
+++ b/client/src/pages/DocumentDetails/DocumentPreview.tsx
@@ -4,23 +4,23 @@ import React from "react";
 
 const FilePreviewer = ({
   blob,
-  filename,
+  downloadFileName,
   mimeType,
   presignedDownloadUrl,
 }: {
   blob: Blob;
-  filename: string;
+  downloadFileName: string;
   mimeType?: string;
   presignedDownloadUrl: string;
 }) => {
-
-  const file = new File([blob], filename, { type: mimeType ?? blob.type });
+  // Sanitized server-side, so the browser has no invalid characters to underscore.
+  const file = new File([blob], downloadFileName, { type: mimeType ?? blob.type });
   const blobUrl = URL.createObjectURL(file);
 
   return mimeType == "application/pdf" ? (
     <embed src={presignedDownloadUrl} className="w-full h-full" />
   ) : (
-    <a href={blobUrl} download={filename} rel="noopener noreferrer">
+    <a href={blobUrl} download={downloadFileName} rel="noopener noreferrer">
       <Button size="large" name="button-download-file" aria-label="Download file">
         Download File
       </Button>
@@ -30,10 +30,10 @@ const FilePreviewer = ({
 
 export const DocumentPreview = ({
   presignedDownloadUrl,
-  filename,
+  downloadFileName,
 }: {
   presignedDownloadUrl: string;
-  filename: string;
+  downloadFileName: string;
 }) => {
   const [blob, setBlob] = React.useState<Blob>();
   const [mimeType, setMimeType] = React.useState<string>();
@@ -71,7 +71,7 @@ export const DocumentPreview = ({
   return (
     <FilePreviewer
       blob={blob}
-      filename={filename}
+      downloadFileName={downloadFileName}
       mimeType={mimeType}
       presignedDownloadUrl={presignedDownloadUrl}
     />

--- a/server/src/adapters/s3/AwsS3Adapter.test.ts
+++ b/server/src/adapters/s3/AwsS3Adapter.test.ts
@@ -195,6 +195,63 @@ describe("AwsS3Adapter", () => {
     });
   });
 
+  describe("getDownloadFileName", () => {
+    it("returns the sanitized name with the extension from Content-Type", async () => {
+      mockSend.mockResolvedValueOnce({ ContentType: "application/pdf" });
+      const adapter = createAWSS3Adapter();
+
+      const result = await adapter.getDownloadFileName(testKey, "Quarterly Report");
+
+      expect(HeadObjectCommand).toHaveBeenCalledExactlyOnceWith({
+        Bucket: testCleanBucket,
+        Key: testKey,
+      });
+      expect(result).toBe("Quarterly Report.pdf");
+    });
+
+    it("replaces invalid characters with a space rather than dropping them", async () => {
+      mockSend.mockResolvedValueOnce({
+        ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      });
+      const adapter = createAWSS3Adapter();
+
+      const result = await adapter.getDownloadFileName(testKey, "Budget FY25/26");
+
+      expect(result).toBe("Budget FY25 26.docx");
+    });
+
+    it("collapses the whitespace left by a run of invalid characters", async () => {
+      mockSend.mockResolvedValueOnce({
+        ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      });
+      const adapter = createAWSS3Adapter();
+
+      const result = await adapter.getDownloadFileName(testKey, 'DEMOS-892 (3) \\ / : * ? " < > |');
+
+      // No underscores — the browser never sees a character it needs to replace.
+      expect(result).toBe("DEMOS-892 (3).docx");
+      expect(result).not.toContain("_");
+    });
+
+    it("falls back to the key when the name is entirely invalid characters", async () => {
+      mockSend.mockResolvedValueOnce({ ContentType: "application/pdf" });
+      const adapter = createAWSS3Adapter();
+
+      const result = await adapter.getDownloadFileName("uuid-123", "///");
+
+      expect(result).toBe("uuid-123.pdf");
+    });
+
+    it("omits the extension when the object has no usable Content-Type", async () => {
+      mockSend.mockResolvedValueOnce({});
+      const adapter = createAWSS3Adapter();
+
+      const result = await adapter.getDownloadFileName(testKey, "No Type Here");
+
+      expect(result).toBe("No Type Here");
+    });
+  });
+
   describe("moveDocumentFromCleanToDeleted", () => {
     it("should copy document from clean to deleted bucket and delete from clean", async () => {
       const adapter = createAWSS3Adapter();

--- a/server/src/adapters/s3/AwsS3Adapter.ts
+++ b/server/src/adapters/s3/AwsS3Adapter.ts
@@ -44,7 +44,20 @@ async function getExtensionForObject(
   return contentType ? extensionForContentType(contentType) || "" : "";
 }
 
-/** Builds a Content-Disposition with a sanitized name plus the extension derived from Content-Type. */
+/** Builds the download file name: a sanitized name plus the extension derived from Content-Type. */
+async function buildDownloadFileName(
+  s3Client: S3Client,
+  bucket: string,
+  key: string,
+  fileName: string
+): Promise<string> {
+  const safeName = sanitizeDownloadFileName(fileName, key.split("/").pop() ?? key);
+
+  const extension = await getExtensionForObject(s3Client, bucket, key);
+  return extension ? `${safeName}.${extension}` : safeName;
+}
+
+/** Wraps the download file name in a Content-Disposition header value. */
 async function buildContentDisposition(
   s3Client: S3Client,
   bucket: string,
@@ -52,12 +65,9 @@ async function buildContentDisposition(
   fileName: string,
   options?: GetPresignedDownloadUrlOptions
 ): Promise<string> {
-  const safeName = sanitizeDownloadFileName(fileName, key.split("/").pop() ?? key);
+  const downloadFileName = await buildDownloadFileName(s3Client, bucket, key, fileName);
 
-  const extension = await getExtensionForObject(s3Client, bucket, key);
-  const finalName = extension ? `${safeName}.${extension}` : safeName;
-
-  return createContentDisposition(finalName, { type: options?.disposition ?? "inline" });
+  return createContentDisposition(downloadFileName, { type: options?.disposition ?? "inline" });
 }
 
 /**
@@ -97,6 +107,10 @@ export function createAWSS3Adapter(): S3Adapter {
       return await getSignedUrl(s3Client, getObjectCommand, {
         expiresIn: EXPIRATION_TIME_SECONDS,
       });
+    },
+
+    async getDownloadFileName(key: string, fileName: string): Promise<string> {
+      return await buildDownloadFileName(s3Client, cleanBucket, key, fileName);
     },
 
     async moveDocumentFromCleanToDeleted(key: string): Promise<void> {

--- a/server/src/adapters/s3/LocalS3Adapter.test.ts
+++ b/server/src/adapters/s3/LocalS3Adapter.test.ts
@@ -57,6 +57,24 @@ describe("LocalS3Adapter", () => {
     });
   });
 
+  describe("getDownloadFileName", () => {
+    it("returns the sanitized name without an extension", async () => {
+      const adapter = createLocalS3Adapter();
+
+      const result = await adapter.getDownloadFileName("uuid-123", "Budget FY25/26");
+
+      expect(result).toBe("Budget FY25 26");
+    });
+
+    it("falls back to the key when the name is entirely invalid characters", async () => {
+      const adapter = createLocalS3Adapter();
+
+      const result = await adapter.getDownloadFileName("uuid-123", "///");
+
+      expect(result).toBe("uuid-123");
+    });
+  });
+
   describe("moveDocumentFromCleanToDeleted", () => {
     it("should remove file from uploaded files set", async () => {
       const adapter = createLocalS3Adapter();

--- a/server/src/adapters/s3/LocalS3Adapter.ts
+++ b/server/src/adapters/s3/LocalS3Adapter.ts
@@ -44,6 +44,11 @@ export function createLocalS3Adapter(): S3Adapter {
       return `${key} does not exist!`;
     },
 
+    // No stored Content-Type locally, so the name comes back without an extension.
+    async getDownloadFileName(key: string, fileName: string): Promise<string> {
+      return sanitizeDownloadFileName(fileName, key.split("/").pop() ?? key);
+    },
+
     async moveDocumentFromCleanToDeleted(key: string): Promise<void> {
       uploadedFiles.delete(key);
     },

--- a/server/src/adapters/s3/S3Adapter.ts
+++ b/server/src/adapters/s3/S3Adapter.ts
@@ -14,6 +14,8 @@ export interface S3Adapter {
     fileName?: string,
     options?: GetPresignedDownloadUrlOptions
   ): Promise<string>;
+  /** The sanitized name (with extension) a download of this object should be saved as. */
+  getDownloadFileName(key: string, fileName: string): Promise<string>;
   moveDocumentFromCleanToDeleted(key: string): Promise<void>;
   uploadDocument(
     documentData: Prisma.DocumentPendingUploadCreateArgs["data"],

--- a/server/src/adapters/s3/sanitizeDownloadFileName.test.ts
+++ b/server/src/adapters/s3/sanitizeDownloadFileName.test.ts
@@ -8,8 +8,23 @@ describe("sanitizeDownloadFileName", () => {
     expect(sanitizeDownloadFileName("Quarterly Report", fallback)).toBe("Quarterly Report");
   });
 
-  it("strips characters that are invalid in file names", () => {
-    expect(sanitizeDownloadFileName('Report: Q1/Q2 "final"', fallback)).toBe("Report Q1Q2 final");
+  it("keeps characters that are valid in file names", () => {
+    const name = "Smith & Jones_final v2.1 (draft) #3, 100% approved";
+    expect(sanitizeDownloadFileName(name, fallback)).toBe(name);
+  });
+
+  it("keeps non-ASCII characters", () => {
+    expect(sanitizeDownloadFileName("Café Résumé – naïve", fallback)).toBe("Café Résumé – naïve");
+  });
+
+  it("replaces characters that are invalid in file names with a space", () => {
+    expect(sanitizeDownloadFileName("Budget FY25/26", fallback)).toBe("Budget FY25 26");
+  });
+
+  it("collapses the whitespace left behind by a run of invalid characters", () => {
+    expect(sanitizeDownloadFileName('DEMOS-892 (3) \\ / : * ? " < > |', fallback)).toBe(
+      "DEMOS-892 (3)"
+    );
   });
 
   it("trims surrounding whitespace", () => {
@@ -25,6 +40,6 @@ describe("sanitizeDownloadFileName", () => {
   });
 
   it("sanitizes the fallback itself if it contains separators", () => {
-    expect(sanitizeDownloadFileName("", "reports/on-demand/abc")).toBe("reportson-demandabc");
+    expect(sanitizeDownloadFileName("", "reports/on-demand/abc")).toBe("reports on-demand abc");
   });
 });

--- a/server/src/adapters/s3/sanitizeDownloadFileName.ts
+++ b/server/src/adapters/s3/sanitizeDownloadFileName.ts
@@ -1,12 +1,22 @@
 import sanitize from "sanitize-filename";
 
+// A space, not "", so separated tokens stay readable: "FY25/26" -> "FY25 26".
+const INVALID_CHARACTER_REPLACEMENT = " ";
+
 /** Cleans a name into a safe download file name (no extension), falling back to the UUID/key if empty. */
 export function sanitizeDownloadFileName(name: string, fallback: string): string {
-  const sanitizedName = sanitize(name).trim();
+  const sanitizedName = cleanFileName(name);
   if (sanitizedName.length > 0) {
     return sanitizedName;
   }
 
   // Rare: name was entirely invalid characters — fall back to the UUID/key.
-  return sanitize(fallback).trim();
+  return cleanFileName(fallback);
+}
+
+/** Strips characters that are invalid in file names and collapses the resulting whitespace. */
+function cleanFileName(name: string): string {
+  return sanitize(name, { replacement: INVALID_CHARACTER_REPLACEMENT })
+    .replace(/\s+/g, " ")
+    .trim();
 }

--- a/server/src/model/document/documentResolvers.test.ts
+++ b/server/src/model/document/documentResolvers.test.ts
@@ -111,6 +111,7 @@ describe("documentResolvers", () => {
   const mockS3Adapter = {
     uploadDocument: vi.fn(),
     getPresignedDownloadUrl: vi.fn(),
+    getDownloadFileName: vi.fn(),
     moveDocumentFromCleanToDeleted: vi.fn(),
   };
 
@@ -179,6 +180,24 @@ describe("documentResolvers", () => {
         document.s3Path,
         document.name
       );
+    });
+  });
+
+  describe("Document.downloadFileName", () => {
+    it("delegates to s3adapter.getDownloadFileName with the raw document name", async () => {
+      const document = {
+        s3Path: "s3/path/to/document",
+        name: 'DEMOS-892 (3) \\ / : * ? " < > |',
+      } as PrismaDocument;
+      mockS3Adapter.getDownloadFileName.mockResolvedValue("DEMOS-892 (3).docx");
+
+      const result = await documentResolvers.Document.downloadFileName(document);
+
+      expect(mockS3Adapter.getDownloadFileName).toHaveBeenCalledExactlyOnceWith(
+        document.s3Path,
+        document.name
+      );
+      expect(result).toBe("DEMOS-892 (3).docx");
     });
   });
 

--- a/server/src/model/document/documentResolvers.ts
+++ b/server/src/model/document/documentResolvers.ts
@@ -157,6 +157,8 @@ export const documentResolvers = {
     documentType: (parent: PrismaDocument): DocumentType => parent.documentTypeId as DocumentType,
     presignedDownloadUrl: (parent: PrismaDocument): Promise<string> =>
       getS3Adapter().getPresignedDownloadUrl(parent.s3Path, parent.name),
+    downloadFileName: (parent: PrismaDocument): Promise<string> =>
+      getS3Adapter().getDownloadFileName(parent.s3Path, parent.name),
     application: (parent: PrismaDocument): Promise<PrismaApplication> =>
       getApplication(parent.applicationId),
     deliverable: resolveDeliverable,

--- a/server/src/model/document/documentSchema.ts
+++ b/server/src/model/document/documentSchema.ts
@@ -32,6 +32,8 @@ export const documentSchema = gql`
     application: Application! @auth(requires: ["Access CMS Field"])
     phaseName: PhaseName @auth(requires: ["Access CMS Field"])
     presignedDownloadUrl: String! @auth(requires: ["Access CMS Field"])
+    "The sanitized file name, with extension, that this document should download as."
+    downloadFileName: String! @auth(requires: ["Access CMS Field"])
     deliverable: Deliverable @auth(requires: ["Access CMS Field"])
     deliverableSubmissionAction: DeliverableAction
     hasPendingUIPathResult: Boolean! @auth(requires: ["Access CMS Field"])
@@ -85,6 +87,7 @@ export interface Document {
   createdAt: Date;
   updatedAt: Date;
   presignedDownloadUrl: string;
+  downloadFileName: string;
   hasPendingUIPathResult: boolean;
   budgetNeutralityValidation?: BudgetNeutralityValidationResult;
 }


### PR DESCRIPTION
Downloading a Word/Excel document produced underscores in the name:

```
Document Title:  DEMOS-892 (3) \ / : * ? " < > |
Downloaded as:   DEMOS-892 (3)_________
```

Chrome adds underscores when it's handed a file name with illegal
characters. So the underscores proved our sanitizer never ran.

The server computes the download name and exposes it, so the client never builds a
file name itself.

- New `downloadFileName` field on the `Document` GraphQL type. Computed: sanitized
  `name` plus the extension from the S3 Content-Type.
- Extracted `buildDownloadFileName` in `AwsS3Adapter`, now shared by both the
  `Content-Disposition` header and the new field so they can't drift.
- The client queries that field and uses it for the download.

The heading and Title column still show the raw `name`. Only the downloaded file gets
a cleaned name.

## Why we renamed `filename` to `downloadFileName`

Just a rename, nothing behaves differently. The prop used to get the raw title and now gets the cleaned-up download name. If we left it called filename, it would be easy for someone to plug the raw title back in and bring the underscores back. The new name says what it actually holds.

## Invalid characters now become a space

They used to be dropped, which fused tokens:

| Title | Before | Now |
| --- | --- | --- |
| `Budget FY25/26` | `Budget FY2526` | `Budget FY25 26` |
| `Budget*****FY26` | `BudgetFY26` | `Budget FY26` |

Runs of invalid characters collapse to one space, and leading/trailing whitespace is
trimmed, so `DEMOS-892 (3) \ / : * ? " < > |` downloads as `DEMOS-892 (3).docx`.

Database impact: none

https://github.com/user-attachments/assets/1bdac711-086d-46fc-acf4-465d181a4085

