### PR TITLE
DEMOS-2510: adjustment in cache to fetch type tags

### DIFF
--- a/client/src/components/input/select/SelectDemonstrationType.tsx
+++ b/client/src/components/input/select/SelectDemonstrationType.tsx
@@ -39,7 +39,11 @@ export const SelectDemonstrationType = (props: SelectDemonstrationTypeProps) => 
     ...rest
   } = props;
 
-  const { loading, error, data } = useQuery(SELECT_DEMONSTRATION_TYPE_QUERY);
+  const { loading, error, data } = useQuery(SELECT_DEMONSTRATION_TYPE_QUERY, {
+    // Revalidate options on mount so newly created types are visible across workflows.
+    fetchPolicy: "cache-and-network",
+    nextFetchPolicy: "cache-first",
+  });
 
   const fetchedOptions = data?.demonstrationTypeOptions || [];
   const allOptions = [...fetchedOptions, ...createdOptions];

--- a/client/src/components/input/select/SelectDemonstrationType.tsx
+++ b/client/src/components/input/select/SelectDemonstrationType.tsx
@@ -40,7 +40,7 @@ export const SelectDemonstrationType = (props: SelectDemonstrationTypeProps) => 
   } = props;
 
   const { loading, error, data } = useQuery(SELECT_DEMONSTRATION_TYPE_QUERY, {
-    // Revalidate options on mount so newly created types are visible across workflows.
+    // retreive demos types tags between demonstration/extension/amendment workflows.
     fetchPolicy: "cache-and-network",
     nextFetchPolicy: "cache-first",
   });

--- a/client/src/components/tags/ApplicationHealthTypeTags.tsx
+++ b/client/src/components/tags/ApplicationHealthTypeTags.tsx
@@ -48,7 +48,7 @@ export const ApplicationHealthTypeTags = ({
   const { showApplyTagsDialog } = useDialog();
 
   const { data, loading, error } = useQuery(GET_APPLICATION_TAG_OPTIONS, {
-    // Keep options fresh when navigating between demonstration/amendment workflows.
+    // retreive demos types tags between demonstration/extension/amendment workflows.
     fetchPolicy: "cache-and-network",
     nextFetchPolicy: "cache-first",
   });

--- a/client/src/components/tags/ApplicationHealthTypeTags.tsx
+++ b/client/src/components/tags/ApplicationHealthTypeTags.tsx
@@ -47,7 +47,11 @@ export const ApplicationHealthTypeTags = ({
 }: ApplicationHealthTypeTagsProps) => {
   const { showApplyTagsDialog } = useDialog();
 
-  const { data, loading, error } = useQuery(GET_APPLICATION_TAG_OPTIONS);
+  const { data, loading, error } = useQuery(GET_APPLICATION_TAG_OPTIONS, {
+    // Keep options fresh when navigating between demonstration/amendment workflows.
+    fetchPolicy: "cache-and-network",
+    nextFetchPolicy: "cache-first",
+  });
 
   if (loading) return <div>Loading tags...</div>;
   if (error || !data) return <div>Error loading tags.</div>;


### PR DESCRIPTION
Amendments and Extensions have all the demo type tags without refresh from demos: demo type tags.


https://github.com/user-attachments/assets/f648a192-377f-4bbe-8739-11f8d3dcb7bf

This video shows the fixed behavior. 

A screen rec. is work a thousand words ^^

<!--
Suggested title: `DEMOS-####: Concise description` This will be used as the commit content by default
Keep this focused. Uncomment or remove sections as needed.
-->

## Steps to repro

1. Navigate to Approved Demo
2. Make sure you have an extension and/or amendment generated
3. Navigate to demo phase2
4. Click on Apply Tags btn
5. write non existing type name
6. click on Create Tag btn
7. Apply newly generated tag
8. Navigate to Amendment/Extension to phase2 (Amendments and Extensions need to exist already)
9. Click on Phase2 and Apply Tags btn
10. Verify newly generated tag is on the list
11. Actual result: newly generated tag is not in the list
12. Note: TEST env looks good. IMPL gives this issue

## Changes

What changed:

1. Added fetchPolicy: cache-and-network
2. Added nextFetchPolicy: cache-first 

-

<!-- ## Validation -->

See "Steps to repro"

<!--
- [ ] Automated tests added or updated
- [ ] Relevant automated tests pass
- [ ] Manually tested
- [ ] Testing is not applicable

Testing details:
-->

<!--
Examples:
- Tested locally using...
- Verified in Chrome, Firefox, and Safari
- Tested against the DEV environment
- Not fully testable locally because...
-->

<!-- ## Screenshots or recordings -->

<!-- Required for visible UI changes. Include before and after evidence when useful. Remove if not applicable. -->

<!-- ## Risk and rollout -->

<!-- Note migrations, configuration changes, dependencies, feature flags, deployment order, known limitations, or rollback steps. Remove for low-risk changes. -->

<!--
- Risk: Low / Medium / High
- Rollout or deployment notes: N/A
- Rollback approach: N/A
- -->

## Additional notes

<!-- Point reviewers toward areas needing special attention and identify intentional follow-up work. -->

## Automated review

- [x] Run AI Code Review <!-- The AI PR review will only run if this is checked [x] -->
