### PR TITLE
DEMOS-2362: split the demo detail query - this splits in a manner that may not be worth it. backburnering it. 

### DIFF
--- a/client/src/components/application/amendment/AmendmentWorkflow.test.tsx
+++ b/client/src/components/application/amendment/AmendmentWorkflow.test.tsx
@@ -1,14 +1,26 @@
 import React from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { AmendmentWorkflow } from "./AmendmentWorkflow";
 import { TestProvider } from "test-utils/TestProvider";
+import type { ApplicationWorkflowAmendment } from "./AmendmentWorkflow";
+
+vi.mock("components/application/phase-selector/PhaseSelector", () => ({
+  PhaseSelector: () => <div data-testid="phase-selector" />,
+}));
 
 describe("AmendmentWorkflow", () => {
   it("renders APPLICATION heading", async () => {
     render(
       <TestProvider>
-        <AmendmentWorkflow amendmentId="1" />
+        <AmendmentWorkflow
+          amendment={
+            {
+              id: "1",
+              status: "Pre-Submission",
+            } as ApplicationWorkflowAmendment
+          }
+        />
       </TestProvider>
     );
 

--- a/client/src/components/application/amendment/AmendmentWorkflow.tsx
+++ b/client/src/components/application/amendment/AmendmentWorkflow.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { ApplicationStatusBadge } from "components/badge/ApplicationStatusBadge";
-import { PhaseSelector, WorkflowApplication } from "components/application";
+import { PhaseSelector } from "../phase-selector/PhaseSelector";
+import type { WorkflowApplication } from "../types";
 import type { Amendment, DemonstrationTypeAssignment } from "demos-server";
-import { gql, useQuery } from "@apollo/client";
-import { Loading } from "components/loading/Loading";
+import { gql } from "@apollo/client";
 import { WORKFLOW_PHASE_FIELDS, WORKFLOW_DOCUMENT_FIELDS } from "fragments";
 import { Demonstration } from "pages/DemonstrationsPage";
 
@@ -65,26 +65,15 @@ export type ApplicationWorkflowAmendment = WorkflowApplication &
     };
   };
 
-export const AmendmentWorkflow = ({ amendmentId }: { amendmentId: string }) => {
-  const { data, loading, error } = useQuery<{ amendment: ApplicationWorkflowAmendment }>(
-    GET_AMENDMENT_WORKFLOW_QUERY,
-    {
-      variables: { id: amendmentId },
-    }
-  );
-
-  if (loading) return <Loading />;
-  if (error) return <p>Error Loading Amendment Workflow: {error.message}</p>;
-  if (data) {
-    return (
-      <div className="flex flex-col gap-sm p-sm">
-        <div className="flex w-full">
-          <h3 className="text-brand text-2xl font-bold">APPLICATION</h3>
-          <ApplicationStatusBadge applicationStatus={data.amendment.status} />
-        </div>
-        <hr className="text-border-rules" aria-hidden="true" />
-        <PhaseSelector application={data.amendment} workflowApplicationType="amendment" />
+export const AmendmentWorkflow = ({ amendment }: { amendment: ApplicationWorkflowAmendment }) => {
+  return (
+    <div className="flex flex-col gap-sm p-sm">
+      <div className="flex w-full">
+        <h3 className="text-brand text-2xl font-bold">APPLICATION</h3>
+        <ApplicationStatusBadge applicationStatus={amendment.status} />
       </div>
-    );
-  }
+      <hr className="text-border-rules" aria-hidden="true" />
+      <PhaseSelector application={amendment} workflowApplicationType="amendment" />
+    </div>
+  );
 };

--- a/client/src/components/application/extension/ExtensionWorkflow.test.tsx
+++ b/client/src/components/application/extension/ExtensionWorkflow.test.tsx
@@ -1,14 +1,26 @@
 import React from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ExtensionWorkflow } from "./ExtensionWorkflow";
 import { TestProvider } from "test-utils/TestProvider";
+import type { ApplicationWorkflowExtension } from "./ExtensionWorkflow";
+
+vi.mock("components/application/phase-selector/PhaseSelector", () => ({
+  PhaseSelector: () => <div data-testid="phase-selector" />,
+}));
 
 describe("ExtensionWorkflow", () => {
   it("renders APPLICATION heading", async () => {
     render(
       <TestProvider>
-        <ExtensionWorkflow extensionId="1" />
+        <ExtensionWorkflow
+          extension={
+            {
+              id: "1",
+              status: "Pre-Submission",
+            } as ApplicationWorkflowExtension
+          }
+        />
       </TestProvider>
     );
 

--- a/client/src/components/application/extension/ExtensionWorkflow.tsx
+++ b/client/src/components/application/extension/ExtensionWorkflow.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { ApplicationStatusBadge } from "components/badge/ApplicationStatusBadge";
-import { PhaseSelector, WorkflowApplication } from "components/application";
+import { PhaseSelector } from "../phase-selector/PhaseSelector";
+import type { WorkflowApplication } from "../types";
 import type { Demonstration, DemonstrationTypeAssignment, Extension } from "demos-server";
-import { gql, useQuery } from "@apollo/client";
-import { Loading } from "components/loading/Loading";
+import { gql } from "@apollo/client";
 import { WORKFLOW_PHASE_FIELDS, WORKFLOW_DOCUMENT_FIELDS } from "fragments";
 
 const EXTENSION_WORKFLOW_QUERY_NAME = "GetExtensionWorkflow";
@@ -64,26 +64,15 @@ export type ApplicationWorkflowExtension = WorkflowApplication &
     };
   };
 
-export const ExtensionWorkflow = ({ extensionId }: { extensionId: string }) => {
-  const { data, loading, error } = useQuery<{ extension: ApplicationWorkflowExtension }>(
-    GET_EXTENSION_WORKFLOW_QUERY,
-    {
-      variables: { id: extensionId },
-    }
-  );
-
-  if (loading) return <Loading />;
-  if (error) return <p>Error Loading Extension Workflow: {error.message}</p>;
-  if (data) {
-    return (
-      <div className="flex flex-col gap-sm p-sm">
-        <div className="flex w-full">
-          <h3 className="text-brand text-2xl font-bold">APPLICATION</h3>
-          <ApplicationStatusBadge applicationStatus={data.extension.status} />
-        </div>
-        <hr className="text-border-rules" aria-hidden="true" />
-        <PhaseSelector application={data.extension} workflowApplicationType="extension" />
+export const ExtensionWorkflow = ({ extension }: { extension: ApplicationWorkflowExtension }) => {
+  return (
+    <div className="flex flex-col gap-sm p-sm">
+      <div className="flex w-full">
+        <h3 className="text-brand text-2xl font-bold">APPLICATION</h3>
+        <ApplicationStatusBadge applicationStatus={extension.status} />
       </div>
-    );
-  }
+      <hr className="text-border-rules" aria-hidden="true" />
+      <PhaseSelector application={extension} workflowApplicationType="extension" />
+    </div>
+  );
 };

--- a/client/src/components/dialog/ManageContactsDialog.tsx
+++ b/client/src/components/dialog/ManageContactsDialog.tsx
@@ -14,7 +14,7 @@ import {
 } from "demos-server-constants";
 import { useDebounced } from "hooks/useDebounced";
 import {
-  DEMONSTRATION_DETAIL_QUERY,
+  DEMONSTRATION_DETAIL_SHELL_QUERY,
   GET_DEMONSTRATION_BY_ID_QUERY,
 } from "pages/DemonstrationDetail/DemonstrationDetail";
 
@@ -143,7 +143,7 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
   });
   const [setDemonstrationRoles] = useMutation(SET_DEMONSTRATION_ROLE_MUTATION, {
     refetchQueries: [
-      { query: DEMONSTRATION_DETAIL_QUERY, variables: { id: demonstrationId } },
+      { query: DEMONSTRATION_DETAIL_SHELL_QUERY, variables: { id: demonstrationId } },
       { query: GET_DEMONSTRATION_BY_ID_QUERY, variables: { id: demonstrationId } },
       { query: DEMONSTRATION_HEADER_DETAILS_QUERY, variables: { demonstrationId } },
     ],
@@ -151,7 +151,7 @@ export const ManageContactsDialog: React.FC<ManageContactsDialogProps> = ({
 
   const [unsetDemonstrationRoles] = useMutation(UNSET_DEMONSTRATION_ROLES_MUTATION, {
     refetchQueries: [
-      { query: DEMONSTRATION_DETAIL_QUERY, variables: { id: demonstrationId } },
+      { query: DEMONSTRATION_DETAIL_SHELL_QUERY, variables: { id: demonstrationId } },
       { query: GET_DEMONSTRATION_BY_ID_QUERY, variables: { id: demonstrationId } },
       { query: DEMONSTRATION_HEADER_DETAILS_QUERY, variables: { demonstrationId } },
     ],

--- a/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
+++ b/client/src/components/dialog/demonstration/EditDemonstrationDialog.tsx
@@ -10,7 +10,7 @@ import {
   Person as ServerPerson,
   DemonstrationRoleAssignment as ServerDemonstrationRoleAssignment,
 } from "demos-server";
-import { DEMONSTRATION_DETAIL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
+import { DEMONSTRATION_DETAIL_SHELL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
 import { formatDateForServer } from "util/formatDate";
 
 import { gql, TypedDocumentNode, useMutation, useQuery } from "@apollo/client";
@@ -146,7 +146,7 @@ const useUpdateDemonstration = () => {
       },
       refetchQueries: [
         {
-          query: DEMONSTRATION_DETAIL_QUERY,
+          query: DEMONSTRATION_DETAIL_SHELL_QUERY,
           variables: { id: demonstrationId },
         },
       ],

--- a/client/src/components/dialog/document/EditDocumentDialog.tsx
+++ b/client/src/components/dialog/document/EditDocumentDialog.tsx
@@ -1,7 +1,7 @@
 import { gql, useMutation, DocumentNode, TypedDocumentNode } from "@apollo/client";
 import React from "react";
 import { Document as ServerDocument, UpdateDocumentInput } from "demos-server";
-import { DEMONSTRATION_DETAIL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
+import { DEMONSTRATION_DETAIL_SHELL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
 import { DescriptionInput, TitleInput } from "./DocumentDialog";
 import { BaseDialog } from "../BaseDialog";
 import { UploadButton } from "./UploadButton";
@@ -37,7 +37,7 @@ export const isValid = (document: Document): boolean => !!document.name.trim();
 export const EditDocumentDialog: React.FC<{
   document: Document;
   refetchQueries?: DocumentNode[];
-}> = ({ document, refetchQueries = [DEMONSTRATION_DETAIL_QUERY] }) => {
+}> = ({ document, refetchQueries = [DEMONSTRATION_DETAIL_SHELL_QUERY] }) => {
   const { closeDialog } = useDialog();
   const [activeDocument, setActiveDocument] = React.useState<Document>(document);
   const { showSuccess, showError } = useToast();

--- a/client/src/components/dialog/document/RemoveDocumentDialog.test.tsx
+++ b/client/src/components/dialog/document/RemoveDocumentDialog.test.tsx
@@ -8,7 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { RemoveDocumentDialog } from "./RemoveDocumentDialog";
-import { DEMONSTRATION_DETAIL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
+import { DEMONSTRATION_DETAIL_SHELL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
 import { GET_WORKFLOW_DEMONSTRATION_QUERY } from "components/application/demonstration/DemonstrationWorkflow";
 import { DIALOG_CANCEL_BUTTON_NAME } from "components/dialog/BaseDialog";
 
@@ -77,7 +77,7 @@ describe("RemoveDocumentDialog", () => {
     await waitFor(() => {
       expect(mockQuery).toHaveBeenCalledWith({
         variables: { ids: ["test-document-id"] },
-        refetchQueries: [DEMONSTRATION_DETAIL_QUERY, GET_WORKFLOW_DEMONSTRATION_QUERY],
+        refetchQueries: [DEMONSTRATION_DETAIL_SHELL_QUERY, GET_WORKFLOW_DEMONSTRATION_QUERY],
       });
     });
   });

--- a/client/src/components/dialog/document/RemoveDocumentDialog.tsx
+++ b/client/src/components/dialog/document/RemoveDocumentDialog.tsx
@@ -1,6 +1,6 @@
 import { gql, useMutation, DocumentNode } from "@apollo/client";
 import { useToast } from "components/toast";
-import { DEMONSTRATION_DETAIL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
+import { DEMONSTRATION_DETAIL_SHELL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
 import { GET_WORKFLOW_DEMONSTRATION_QUERY } from "components/application/demonstration/DemonstrationWorkflow";
 import React, { useState } from "react";
 import { BaseDialog } from "components/dialog/BaseDialog";
@@ -20,7 +20,7 @@ export const RemoveDocumentDialog: React.FC<{
 }> = ({
   documentIds,
   onClose,
-  refetchQueries = [DEMONSTRATION_DETAIL_QUERY, GET_WORKFLOW_DEMONSTRATION_QUERY],
+  refetchQueries = [DEMONSTRATION_DETAIL_SHELL_QUERY, GET_WORKFLOW_DEMONSTRATION_QUERY],
 }) => {
   const { showSuccess, showError } = useToast();
   const [isDeleting, setIsDeleting] = useState(false);

--- a/client/src/components/dialog/document/phases/ApplicationIntakeUploadDialog.tsx
+++ b/client/src/components/dialog/document/phases/ApplicationIntakeUploadDialog.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { AddDocumentToPhaseDialog } from "components/dialog/document";
 import { DocumentType } from "demos-server";
-import { DEMONSTRATION_DETAIL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
+import { DEMONSTRATION_DETAIL_SHELL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
 import { GET_WORKFLOW_DEMONSTRATION_QUERY } from "components/application/demonstration/DemonstrationWorkflow";
 
 const DOCUMENT_TYPE_SUBSET: DocumentType[] = ["State Application", "General File"];
@@ -19,7 +19,7 @@ export const ApplicationIntakeUploadDialog: React.FC<Props> = ({ onClose, applic
       documentTypeSubset={DOCUMENT_TYPE_SUBSET}
       applicationId={applicationId}
       titleOverride="Add State Application"
-      refetchQueries={[GET_WORKFLOW_DEMONSTRATION_QUERY, DEMONSTRATION_DETAIL_QUERY]}
+      refetchQueries={[GET_WORKFLOW_DEMONSTRATION_QUERY, DEMONSTRATION_DETAIL_SHELL_QUERY]}
       phaseName="Application Intake"
     />
   );

--- a/client/src/components/dialog/document/phases/ConceptPreSubmissionUploadDialog.tsx
+++ b/client/src/components/dialog/document/phases/ConceptPreSubmissionUploadDialog.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { AddDocumentToPhaseDialog } from "components/dialog/document";
 import { DocumentType } from "demos-server";
-import { DEMONSTRATION_DETAIL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
+import { DEMONSTRATION_DETAIL_SHELL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
 import { GET_WORKFLOW_DEMONSTRATION_QUERY } from "components/application/demonstration/DemonstrationWorkflow";
 import { GET_AMENDMENT_WORKFLOW_QUERY, GET_EXTENSION_WORKFLOW_QUERY } from "components/application";
 
@@ -22,7 +22,7 @@ export const ConceptPreSubmissionUploadDialog = ({
       documentTypeSubset={DOCUMENT_TYPE_SUBSET}
       titleOverride="Pre-Submission Document"
       refetchQueries={[
-        DEMONSTRATION_DETAIL_QUERY,
+        DEMONSTRATION_DETAIL_SHELL_QUERY,
         GET_WORKFLOW_DEMONSTRATION_QUERY,
         GET_AMENDMENT_WORKFLOW_QUERY,
         GET_EXTENSION_WORKFLOW_QUERY,

--- a/client/src/components/dialog/modification/CreateAmendmentDialog.tsx
+++ b/client/src/components/dialog/modification/CreateAmendmentDialog.tsx
@@ -2,15 +2,17 @@ import React from "react";
 import { gql, useMutation } from "@apollo/client";
 import { BaseCreateModificationDialog } from "./BaseCreateModificationDialog";
 import { ModificationFormData } from "./ModificationForm";
+import { DEMONSTRATION_DETAIL_SHELL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
+import { DEMONSTRATION_AMENDMENTS_QUERY } from "pages/DemonstrationDetail/modifications/modificationQueries";
 
 export const CREATE_AMENDMENT_MUTATION = gql`
   mutation CreateAmendment($input: CreateAmendmentInput!) {
     createAmendment(input: $input) {
+      id
+      name
+      createdAt
       demonstration {
         id
-        amendments {
-          id
-        }
       }
     }
   }
@@ -29,6 +31,16 @@ export const useCreateAmendment = () => {
           signatureLevel: input.signatureLevel,
         },
       },
+      refetchQueries: [
+        {
+          query: DEMONSTRATION_DETAIL_SHELL_QUERY,
+          variables: { id: input.demonstrationId },
+        },
+        {
+          query: DEMONSTRATION_AMENDMENTS_QUERY,
+          variables: { id: input.demonstrationId },
+        },
+      ],
     });
   };
 

--- a/client/src/components/dialog/modification/CreateExtensionDialog.tsx
+++ b/client/src/components/dialog/modification/CreateExtensionDialog.tsx
@@ -2,15 +2,17 @@ import React from "react";
 import { gql, useMutation } from "@apollo/client";
 import { BaseCreateModificationDialog } from "./BaseCreateModificationDialog";
 import { ModificationFormData } from "./ModificationForm";
+import { DEMONSTRATION_DETAIL_SHELL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
+import { DEMONSTRATION_EXTENSIONS_QUERY } from "pages/DemonstrationDetail/modifications/modificationQueries";
 
 export const CREATE_EXTENSION_MUTATION = gql`
   mutation CreateExtension($input: CreateExtensionInput!) {
     createExtension(input: $input) {
+      id
+      name
+      createdAt
       demonstration {
         id
-        extensions {
-          id
-        }
       }
     }
   }
@@ -29,6 +31,16 @@ export const useCreateExtension = () => {
           signatureLevel: input.signatureLevel,
         },
       },
+      refetchQueries: [
+        {
+          query: DEMONSTRATION_DETAIL_SHELL_QUERY,
+          variables: { id: input.demonstrationId },
+        },
+        {
+          query: DEMONSTRATION_EXTENSIONS_QUERY,
+          variables: { id: input.demonstrationId },
+        },
+      ],
     });
   };
 

--- a/client/src/mock-data/demonstrationMocks.ts
+++ b/client/src/mock-data/demonstrationMocks.ts
@@ -8,7 +8,7 @@ import { GET_WORKFLOW_DEMONSTRATION_QUERY } from "components/application";
 
 import type { ApplicationStatus } from "demos-server";
 import { CreateDemonstrationInput, Demonstration } from "demos-server";
-import { DEMONSTRATION_DETAIL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
+import { DEMONSTRATION_DETAIL_SHELL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
 import { DEMONSTRATIONS_PAGE_QUERY } from "pages/DemonstrationsPage";
 
 import { MockedResponse } from "@apollo/client/testing";
@@ -31,7 +31,14 @@ import { DEMONSTRATION_HEADER_DETAILS_QUERY } from "pages/DemonstrationDetail/De
 
 export type MockDemonstration = Pick<
   Demonstration,
-  "id" | "name" | "description" | "sdgDivision" | "signatureLevel" | "currentPhaseName" | "medicaidId" | "chipId"
+  | "id"
+  | "name"
+  | "description"
+  | "sdgDivision"
+  | "signatureLevel"
+  | "currentPhaseName"
+  | "medicaidId"
+  | "chipId"
 > & {
   effectiveDate: Date;
   expirationDate: Date;
@@ -39,6 +46,8 @@ export type MockDemonstration = Pick<
   state: MockState;
   amendments: MockAmendment[];
   extensions: MockExtension[];
+  amendmentCount: number;
+  extensionCount: number;
   demonstrationTypes: MockDemonstrationTypeAssignment[];
   documents: MockDocument[];
   roles: MockDemonstrationRoleAssignment[];
@@ -62,6 +71,12 @@ export const MOCK_DEMONSTRATION: MockDemonstration = {
   extensions: mockExtensions.filter((extension) =>
     extension.name.includes("Montana Medicaid Waiver")
   ),
+  amendmentCount: mockAmendments.filter((amendment) =>
+    amendment.name.includes("Montana Medicaid Waiver")
+  ).length,
+  extensionCount: mockExtensions.filter((extension) =>
+    extension.name.includes("Montana Medicaid Waiver")
+  ).length,
   documents: mockDocuments,
   roles: [
     mockDemonstrationRoleAssignments[0],
@@ -86,7 +101,7 @@ const MOCK_DEMONSTRATION_BY_ID_QUERIES = [
   HOOK_GET_DEMONSTRATION_BY_ID_QUERY,
   GET_DEMONSTRATION_BY_ID_QUERY,
   ADD_DEMONSTRATION_TYPES_FORM_QUERY,
-  DEMONSTRATION_DETAIL_QUERY,
+  DEMONSTRATION_DETAIL_SHELL_QUERY,
   DEMONSTRATION_HEADER_DETAILS_QUERY,
 ];
 

--- a/client/src/pages/DemonstrationDetail/DemonstrationDetail.test.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetail.test.tsx
@@ -7,7 +7,7 @@ import { MockedProvider } from "@apollo/client/testing";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { DEMONSTRATION_DETAIL_QUERY, DemonstrationDetail } from "./DemonstrationDetail";
+import { DEMONSTRATION_DETAIL_SHELL_QUERY, DemonstrationDetail } from "./DemonstrationDetail";
 
 // Mock the tab components
 vi.mock("pages/DemonstrationDetail/DemonstrationTab.tsx", () => ({
@@ -31,19 +31,8 @@ const demonstrationWithModifications = {
   id: "1",
   status: "Active",
   currentPhaseName: "Phase 1",
-  amendments: [
-    {
-      id: "amendment-1",
-    },
-    {
-      id: "amendment-2",
-    },
-  ],
-  extensions: [
-    {
-      id: "extension-1",
-    },
-  ],
+  amendmentCount: 2,
+  extensionCount: 1,
   documents: [],
   roles: [],
 };
@@ -52,7 +41,7 @@ const buildDemonstrationDetailMock = (
   demonstration: typeof demonstrationWithModifications = demonstrationWithModifications
 ) => ({
   request: {
-    query: DEMONSTRATION_DETAIL_QUERY,
+    query: DEMONSTRATION_DETAIL_SHELL_QUERY,
     variables: { id: "1" },
   },
   result: {
@@ -99,8 +88,8 @@ describe("DemonstrationDetail", () => {
       buildDemonstrationDetailMock({
         ...demonstrationWithModifications,
         status: "Approved",
-        amendments: [],
-        extensions: [],
+        amendmentCount: 0,
+        extensionCount: 0,
       })
     );
 
@@ -118,8 +107,8 @@ describe("DemonstrationDetail", () => {
       buildDemonstrationDetailMock({
         ...demonstrationWithModifications,
         status: "Active",
-        amendments: [],
-        extensions: [],
+        amendmentCount: 0,
+        extensionCount: 0,
       })
     );
 

--- a/client/src/pages/DemonstrationDetail/DemonstrationDetail.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationDetail.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import {
-  Amendment,
   Demonstration,
   DemonstrationRoleAssignment,
   DemonstrationTypeAssignment,
@@ -38,8 +37,8 @@ export const GET_DEMONSTRATION_BY_ID_QUERY = gql`
   }
 `;
 
-export const DEMONSTRATION_DETAIL_QUERY = gql`
-  query DemonstrationDetailQuery($id: ID!) {
+export const DEMONSTRATION_DETAIL_SHELL_QUERY = gql`
+  query DemonstrationDetailShell($id: ID!) {
     demonstration(id: $id) {
       id
       name
@@ -51,50 +50,8 @@ export const DEMONSTRATION_DETAIL_QUERY = gql`
       state {
         id
       }
-      amendments {
-        name
-        id
-        description
-        status
-        createdAt
-        effectiveDate
-        signatureLevel
-        documents {
-          id
-          name
-          description
-          documentType
-          phaseName
-          createdAt
-          owner {
-            person {
-              fullName
-            }
-          }
-        }
-      }
-      extensions {
-        id
-        name
-        description
-        status
-        createdAt
-        effectiveDate
-        signatureLevel
-        documents {
-          id
-          name
-          description
-          documentType
-          phaseName
-          createdAt
-          owner {
-            person {
-              fullName
-            }
-          }
-        }
-      }
+      amendmentCount
+      extensionCount
       demonstrationTypes {
         demonstrationTypeName
         status
@@ -130,21 +87,13 @@ export const DEMONSTRATION_DETAIL_QUERY = gql`
   }
 `;
 
-export type DemonstrationDetailModification = Pick<
-  Amendment,
-  "id" | "name" | "description" | "status" | "createdAt" | "effectiveDate" | "signatureLevel"
-> & {
-  documents: (Pick<Document, "id" | "name" | "description" | "documentType" | "createdAt"> & {
-    owner: { person: Pick<Person, "fullName"> };
-  })[];
-};
 export type DemonstrationDetail = Pick<
   Demonstration,
   "id" | "name" | "status" | "currentPhaseName" | "effectiveDate" | "expirationDate" | "medicaidId"
 > & {
   state: Pick<State, "id">;
-  amendments: DemonstrationDetailModification[];
-  extensions: DemonstrationDetailModification[];
+  amendmentCount: number;
+  extensionCount: number;
   demonstrationTypes: Pick<
     DemonstrationTypeAssignment,
     | "demonstrationTypeName"
@@ -178,7 +127,7 @@ export const DemonstrationDetail: React.FC = () => {
   const extensionParam = getQueryParamValue(queryParams, "extension", "extensions");
 
   const { data, loading, error } = useQuery<{ demonstration: DemonstrationDetail }>(
-    DEMONSTRATION_DETAIL_QUERY,
+    DEMONSTRATION_DETAIL_SHELL_QUERY,
     {
       variables: { id: id },
     }
@@ -194,8 +143,8 @@ export const DemonstrationDetail: React.FC = () => {
     return <div>Failed to load demonstration.</div>;
   }
 
-  const amendmentCount = demonstration.amendments?.length ?? 0;
-  const extensionCount = demonstration.extensions?.length ?? 0;
+  const amendmentCount = demonstration.amendmentCount;
+  const extensionCount = demonstration.extensionCount;
   const isApproved = demonstration.status === "Approved";
   return (
     <div>
@@ -216,7 +165,6 @@ export const DemonstrationDetail: React.FC = () => {
               <AmendmentsTab
                 demonstrationId={demonstration.id}
                 medicaidId={demonstration.medicaidId}
-                amendments={demonstration.amendments}
                 selectedAmendmentId={amendmentParam || undefined}
                 canCreateModifications={isApproved}
               />
@@ -230,7 +178,6 @@ export const DemonstrationDetail: React.FC = () => {
               <ExtensionsTab
                 demonstrationId={demonstration.id}
                 medicaidId={demonstration.medicaidId}
-                extensions={demonstration.extensions}
                 selectedExtensionId={extensionParam || undefined}
                 canCreateModifications={isApproved}
               />

--- a/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
+++ b/client/src/pages/DemonstrationDetail/DemonstrationTab.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { DemonstrationWorkflow, GET_WORKFLOW_DEMONSTRATION_QUERY } from "components/application";
-import { DEMONSTRATION_DETAIL_QUERY } from "./DemonstrationDetail";
+import { DEMONSTRATION_DETAIL_SHELL_QUERY } from "./DemonstrationDetail";
 import { IconButton } from "components/button";
 import {
   AddNewIcon,
@@ -79,7 +79,7 @@ export const DemonstrationTab: React.FC<{ demonstration: DemonstrationTabDemonst
 
   const refetchApplicationWorkflow = async () => {
     await client.refetchQueries({
-      include: [DEMONSTRATION_DETAIL_QUERY, GET_WORKFLOW_DEMONSTRATION_QUERY],
+      include: [DEMONSTRATION_DETAIL_SHELL_QUERY, GET_WORKFLOW_DEMONSTRATION_QUERY],
     });
   };
 

--- a/client/src/pages/DemonstrationDetail/modifications/AmendmentsTab.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/AmendmentsTab.test.tsx
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { AmendmentsTab } from "./AmendmentsTab";
 import { ModificationTabs } from "./ModificationTabs";
-import { DemonstrationDetailModification } from "pages/DemonstrationDetail/DemonstrationDetail";
+import { MockedProvider, type MockedResponse } from "@apollo/client/testing";
+import { DEMONSTRATION_AMENDMENTS_QUERY } from "./modificationQueries";
 
 const showCreateAmendmentDialog = vi.fn();
 vi.mock("components/dialog/DialogContext", () => ({
@@ -20,55 +21,64 @@ const mockAmendments = [
   {
     id: "amendment-1",
     name: "Amendment 1",
-    description: "Description",
-    status: "Pre-Submission",
     createdAt: new Date("2024-01-01T00:00:00Z"),
-    effectiveDate: new Date("2024-02-01T00:00:00Z"),
-    signatureLevel: "OCD",
-    documents: [],
   },
-] as DemonstrationDetailModification[];
+];
 
 describe("AmendmentsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  const renderAmendmentsTab = (
-    amendments: DemonstrationDetailModification[] = [],
-    canCreateModifications = true
-  ) => {
+  const renderAmendmentsTab = (amendments = mockAmendments, canCreateModifications = true) => {
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: DEMONSTRATION_AMENDMENTS_QUERY,
+          variables: { id: "mock-demonstration-id" },
+        },
+        result: {
+          data: {
+            demonstration: {
+              id: "mock-demonstration-id",
+              amendments,
+            },
+          },
+        },
+      },
+    ];
     return render(
-      <AmendmentsTab
-        demonstrationId="mock-demonstration-id"
-        medicaidId="mock-medicaid-id"
-        amendments={amendments}
-        selectedAmendmentId="mock-amendment-id"
-        canCreateModifications={canCreateModifications}
-      />
+      <MockedProvider mocks={mocks}>
+        <AmendmentsTab
+          demonstrationId="mock-demonstration-id"
+          medicaidId="mock-medicaid-id"
+          selectedAmendmentId="mock-amendment-id"
+          canCreateModifications={canCreateModifications}
+        />
+      </MockedProvider>
     );
   };
 
   it("shows empty state message when there are no amendments", async () => {
-    renderAmendmentsTab();
+    renderAmendmentsTab([]);
 
-    expect(screen.getByText("No amendments have been added yet")).toBeInTheDocument();
+    expect(await screen.findByText("No amendments have been added yet")).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: /Amendments/i })).not.toBeInTheDocument();
     expect(ModificationTabs).not.toHaveBeenCalled();
   });
 
   it("shows centered create amendment button when there are no amendments", async () => {
-    renderAmendmentsTab();
+    renderAmendmentsTab([]);
 
-    const createButton = screen.getByRole("button", { name: /create amendment/i });
+    const createButton = await screen.findByRole("button", { name: /create amendment/i });
     expect(createButton).toBeInTheDocument();
     expect(createButton).toHaveTextContent("Create Amendment");
   });
 
   it("opens Add New Amendment modal from the empty state", async () => {
-    renderAmendmentsTab();
+    renderAmendmentsTab([]);
 
-    const createButton = screen.getByRole("button", { name: /create amendment/i });
+    const createButton = await screen.findByRole("button", { name: /create amendment/i });
     await fireEvent.click(createButton);
 
     expect(showCreateAmendmentDialog).toHaveBeenCalledWith("mock-demonstration-id");
@@ -77,7 +87,7 @@ describe("AmendmentsTab", () => {
   it("does not open Add New Amendment modal from the empty state when creation is disabled", async () => {
     renderAmendmentsTab([], false);
 
-    const createButton = screen.getByRole("button", { name: /create amendment/i });
+    const createButton = await screen.findByRole("button", { name: /create amendment/i });
     expect(createButton).toBeDisabled();
     await fireEvent.click(createButton);
 
@@ -87,13 +97,13 @@ describe("AmendmentsTab", () => {
   it("shows amendments tab title when amendments exist", async () => {
     renderAmendmentsTab(mockAmendments);
 
-    expect(screen.getByRole("heading", { name: /Amendments/i })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: /Amendments/i })).toBeInTheDocument();
   });
 
   it("shows add amendment button when amendments exist", async () => {
     renderAmendmentsTab(mockAmendments);
 
-    const addButton = screen.getByRole("button", { name: /add-new-amendment/i });
+    const addButton = await screen.findByRole("button", { name: /add-new-amendment/i });
     expect(addButton).toBeInTheDocument();
     expect(addButton).toHaveTextContent("Add Amendment");
   });
@@ -101,7 +111,7 @@ describe("AmendmentsTab", () => {
   it("opens Add New Amendment modal from the header button", async () => {
     renderAmendmentsTab(mockAmendments);
 
-    const addButton = screen.getByRole("button", { name: /add-new-amendment/i });
+    const addButton = await screen.findByRole("button", { name: /add-new-amendment/i });
     await fireEvent.click(addButton);
 
     expect(showCreateAmendmentDialog).toHaveBeenCalledWith("mock-demonstration-id");
@@ -110,7 +120,7 @@ describe("AmendmentsTab", () => {
   it("does not open Add New Amendment modal from the header button when creation is disabled", async () => {
     renderAmendmentsTab(mockAmendments, false);
 
-    const addButton = screen.getByRole("button", { name: /add-new-amendment/i });
+    const addButton = await screen.findByRole("button", { name: /add-new-amendment/i });
     expect(addButton).toBeDisabled();
     await fireEvent.click(addButton);
 
@@ -120,6 +130,7 @@ describe("AmendmentsTab", () => {
   it("passes the selected amendment to ModificationTabs when amendments exist", async () => {
     renderAmendmentsTab(mockAmendments);
 
+    await screen.findByTestId("modification-tabs");
     expect(ModificationTabs).toHaveBeenCalledWith(
       expect.objectContaining({
         items: [

--- a/client/src/pages/DemonstrationDetail/modifications/AmendmentsTab.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/AmendmentsTab.tsx
@@ -1,20 +1,37 @@
 import React from "react";
+import { useQuery } from "@apollo/client";
 import { IconButton } from "components/button";
 import { AddNewIcon } from "components/icons";
 import { useDialog } from "components/dialog/DialogContext";
-import { DemonstrationDetailModification } from "pages/DemonstrationDetail/DemonstrationDetail";
+import type { Amendment } from "demos-server";
 import { ModificationTabs } from "./ModificationTabs";
+import { DEMONSTRATION_AMENDMENTS_QUERY } from "./modificationQueries";
 
 const EMPTY_AMENDMENTS_MESSAGE = "No amendments have been added yet";
+
+type AmendmentListItem = Pick<Amendment, "id" | "name" | "createdAt">;
 
 export const AmendmentsTab: React.FC<{
   demonstrationId: string;
   medicaidId: string;
-  amendments: DemonstrationDetailModification[];
   selectedAmendmentId?: string;
   canCreateModifications: boolean;
-}> = ({ demonstrationId, medicaidId, amendments, selectedAmendmentId, canCreateModifications }) => {
+}> = ({ demonstrationId, medicaidId, selectedAmendmentId, canCreateModifications }) => {
   const { showCreateAmendmentDialog } = useDialog();
+  const { data, loading, error } = useQuery<{
+    demonstration: { amendments: AmendmentListItem[] };
+  }>(DEMONSTRATION_AMENDMENTS_QUERY, {
+    variables: { id: demonstrationId },
+  });
+  const amendments = data?.demonstration.amendments ?? [];
+
+  if (loading) {
+    return <div className="p-4">Loading amendments...</div>;
+  }
+
+  if (error) {
+    return <div className="p-4 text-red-500">Error loading amendments.</div>;
+  }
 
   if (amendments.length === 0) {
     return (

--- a/client/src/pages/DemonstrationDetail/modifications/ExtensionsTab.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ExtensionsTab.test.tsx
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { ExtensionsTab } from "./ExtensionsTab";
 import { ModificationTabs } from "./ModificationTabs";
-import { DemonstrationDetailModification } from "pages/DemonstrationDetail/DemonstrationDetail";
+import { MockedProvider, type MockedResponse } from "@apollo/client/testing";
+import { DEMONSTRATION_EXTENSIONS_QUERY } from "./modificationQueries";
 
 const showCreateExtensionDialog = vi.fn();
 vi.mock("components/dialog/DialogContext", () => ({
@@ -20,55 +21,64 @@ const mockExtensions = [
   {
     id: "extension-1",
     name: "Extension 1",
-    description: "Description",
-    status: "Pre-Submission",
     createdAt: new Date("2024-01-01T00:00:00Z"),
-    effectiveDate: new Date("2024-02-01T00:00:00Z"),
-    signatureLevel: "OCD",
-    documents: [],
   },
-] as DemonstrationDetailModification[];
+];
 
 describe("ExtensionsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  const renderExtensionsTab = (
-    extensions: DemonstrationDetailModification[] = [],
-    canCreateModifications = true
-  ) => {
+  const renderExtensionsTab = (extensions = mockExtensions, canCreateModifications = true) => {
+    const mocks: MockedResponse[] = [
+      {
+        request: {
+          query: DEMONSTRATION_EXTENSIONS_QUERY,
+          variables: { id: "mock-demonstration-id" },
+        },
+        result: {
+          data: {
+            demonstration: {
+              id: "mock-demonstration-id",
+              extensions,
+            },
+          },
+        },
+      },
+    ];
     return render(
-      <ExtensionsTab
-        demonstrationId="mock-demonstration-id"
-        medicaidId="mock-medicaid-id"
-        extensions={extensions}
-        selectedExtensionId="mock-extension-id"
-        canCreateModifications={canCreateModifications}
-      />
+      <MockedProvider mocks={mocks}>
+        <ExtensionsTab
+          demonstrationId="mock-demonstration-id"
+          medicaidId="mock-medicaid-id"
+          selectedExtensionId="mock-extension-id"
+          canCreateModifications={canCreateModifications}
+        />
+      </MockedProvider>
     );
   };
 
   it("shows empty state message when there are no extensions", async () => {
-    renderExtensionsTab();
+    renderExtensionsTab([]);
 
-    expect(screen.getByText("No extensions have been added yet")).toBeInTheDocument();
+    expect(await screen.findByText("No extensions have been added yet")).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: /Extensions/i })).not.toBeInTheDocument();
     expect(ModificationTabs).not.toHaveBeenCalled();
   });
 
   it("shows centered create extension button when there are no extensions", async () => {
-    renderExtensionsTab();
+    renderExtensionsTab([]);
 
-    const createButton = screen.getByRole("button", { name: /create extension/i });
+    const createButton = await screen.findByRole("button", { name: /create extension/i });
     expect(createButton).toBeInTheDocument();
     expect(createButton).toHaveTextContent("Create Extension");
   });
 
   it("opens Add New Extension modal from the empty state", async () => {
-    renderExtensionsTab();
+    renderExtensionsTab([]);
 
-    const createButton = screen.getByRole("button", { name: /create extension/i });
+    const createButton = await screen.findByRole("button", { name: /create extension/i });
     await fireEvent.click(createButton);
 
     expect(showCreateExtensionDialog).toHaveBeenCalledWith("mock-demonstration-id");
@@ -77,7 +87,7 @@ describe("ExtensionsTab", () => {
   it("does not open Add New Extension modal from the empty state when creation is disabled", async () => {
     renderExtensionsTab([], false);
 
-    const createButton = screen.getByRole("button", { name: /create extension/i });
+    const createButton = await screen.findByRole("button", { name: /create extension/i });
     expect(createButton).toBeDisabled();
     await fireEvent.click(createButton);
 
@@ -87,13 +97,13 @@ describe("ExtensionsTab", () => {
   it("shows extensions tab title when extensions exist", async () => {
     renderExtensionsTab(mockExtensions);
 
-    expect(screen.getByRole("heading", { name: /Extensions/i })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: /Extensions/i })).toBeInTheDocument();
   });
 
   it("shows add extension button when extensions exist", async () => {
     renderExtensionsTab(mockExtensions);
 
-    const addButton = screen.getByRole("button", { name: /add-new-extension/i });
+    const addButton = await screen.findByRole("button", { name: /add-new-extension/i });
     expect(addButton).toBeInTheDocument();
     expect(addButton).toHaveTextContent("Add Extension");
   });
@@ -101,7 +111,7 @@ describe("ExtensionsTab", () => {
   it("opens Add New Extension modal from the header button", async () => {
     renderExtensionsTab(mockExtensions);
 
-    const addButton = screen.getByRole("button", { name: /add-new-extension/i });
+    const addButton = await screen.findByRole("button", { name: /add-new-extension/i });
     await fireEvent.click(addButton);
 
     expect(showCreateExtensionDialog).toHaveBeenCalledWith("mock-demonstration-id");
@@ -110,7 +120,7 @@ describe("ExtensionsTab", () => {
   it("does not open Add New Extension modal from the header button when creation is disabled", async () => {
     renderExtensionsTab(mockExtensions, false);
 
-    const addButton = screen.getByRole("button", { name: /add-new-extension/i });
+    const addButton = await screen.findByRole("button", { name: /add-new-extension/i });
     expect(addButton).toBeDisabled();
     await fireEvent.click(addButton);
 
@@ -120,6 +130,7 @@ describe("ExtensionsTab", () => {
   it("passes the selected extension to ModificationTabs when extensions exist", async () => {
     renderExtensionsTab(mockExtensions);
 
+    await screen.findByTestId("modification-tabs");
     expect(ModificationTabs).toHaveBeenCalledWith(
       expect.objectContaining({
         items: [

--- a/client/src/pages/DemonstrationDetail/modifications/ExtensionsTab.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ExtensionsTab.tsx
@@ -1,20 +1,37 @@
 import React from "react";
+import { useQuery } from "@apollo/client";
 import { IconButton } from "components/button";
 import { AddNewIcon } from "components/icons";
 import { useDialog } from "components/dialog/DialogContext";
-import { DemonstrationDetailModification } from "pages/DemonstrationDetail/DemonstrationDetail";
+import type { Extension } from "demos-server";
 import { ModificationTabs } from "./ModificationTabs";
+import { DEMONSTRATION_EXTENSIONS_QUERY } from "./modificationQueries";
 
 const EMPTY_EXTENSIONS_MESSAGE = "No extensions have been added yet";
+
+type ExtensionListItem = Pick<Extension, "id" | "name" | "createdAt">;
 
 export const ExtensionsTab: React.FC<{
   demonstrationId: string;
   medicaidId: string;
-  extensions: DemonstrationDetailModification[];
   selectedExtensionId?: string;
   canCreateModifications: boolean;
-}> = ({ demonstrationId, medicaidId, extensions, selectedExtensionId, canCreateModifications }) => {
+}> = ({ demonstrationId, medicaidId, selectedExtensionId, canCreateModifications }) => {
   const { showCreateExtensionDialog } = useDialog();
+  const { data, loading, error } = useQuery<{
+    demonstration: { extensions: ExtensionListItem[] };
+  }>(DEMONSTRATION_EXTENSIONS_QUERY, {
+    variables: { id: demonstrationId },
+  });
+  const extensions = data?.demonstration.extensions ?? [];
+
+  if (loading) {
+    return <div className="p-4">Loading extensions...</div>;
+  }
+
+  if (error) {
+    return <div className="p-4 text-red-500">Error loading extensions.</div>;
+  }
 
   if (extensions.length === 0) {
     return (

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.test.tsx
@@ -2,9 +2,8 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { ModificationDetailsSummary } from "./ModificationDetailsSummary";
-import { ModificationItem } from "./ModificationTabs";
+import { ModificationItem } from "./ModificationTabSideNav";
 import { TestProvider } from "test-utils/TestProvider";
-import { DEMONSTRATION_DETAIL_QUERY } from "../DemonstrationDetail";
 
 const showUpdateAmendmentDialog = vi.fn();
 const showUpdateExtensionDialog = vi.fn();
@@ -21,7 +20,7 @@ describe("ModificationDetailsSummary", () => {
     vi.clearAllMocks();
   });
 
-  const mockAmendment: ModificationItem = {
+  const mockAmendment = {
     modificationType: "amendment",
     id: "mod-123",
     name: "Test Modification",
@@ -32,7 +31,7 @@ describe("ModificationDetailsSummary", () => {
     signatureLevel: "OA",
     documents: [],
     medicaidId: "demo-1",
-  };
+  } as unknown as ModificationItem;
 
   describe("Component Rendering", () => {
     it("renders the summary details header", () => {
@@ -47,7 +46,7 @@ describe("ModificationDetailsSummary", () => {
     });
 
     it("renders the correct title label ", () => {
-      const mockExtension: ModificationItem = {
+      const mockExtension = {
         modificationType: "extension",
         id: "mod-456",
         name: "Test Extension",
@@ -55,7 +54,7 @@ describe("ModificationDetailsSummary", () => {
         documents: [],
         createdAt: new Date("2024-01-01"),
         medicaidId: "demo-2",
-      };
+      } as unknown as ModificationItem;
       render(<ModificationDetailsSummary modificationItem={mockExtension} />);
       expect(screen.getByText("Extension Title")).toBeInTheDocument();
       expect(screen.getByText("Test Extension")).toBeInTheDocument();
@@ -88,28 +87,28 @@ describe("ModificationDetailsSummary", () => {
 
   describe("Conditional Rendering", () => {
     it("does not render description section when description is not provided", () => {
-      const itemWithoutDescription: ModificationItem = {
+      const itemWithoutDescription = {
         ...mockAmendment,
         description: undefined,
-      };
+      } as unknown as ModificationItem;
       render(<ModificationDetailsSummary modificationItem={itemWithoutDescription} />);
       expect(screen.queryByText("Description")).not.toBeInTheDocument();
     });
 
     it("does not render description section when description is empty string", () => {
-      const itemWithoutDescription: ModificationItem = {
+      const itemWithoutDescription = {
         ...mockAmendment,
         description: "",
-      };
+      } as unknown as ModificationItem;
       render(<ModificationDetailsSummary modificationItem={itemWithoutDescription} />);
       expect(screen.queryByText("Description")).not.toBeInTheDocument();
     });
 
     it("displays placeholder when effective date is not provided", () => {
-      const itemWithoutEffectiveDate: ModificationItem = {
+      const itemWithoutEffectiveDate = {
         ...mockAmendment,
         effectiveDate: undefined,
-      };
+      } as unknown as ModificationItem;
       render(<ModificationDetailsSummary modificationItem={itemWithoutEffectiveDate} />);
       expect(screen.getByText("--/--/----")).toBeInTheDocument();
     });
@@ -127,7 +126,7 @@ describe("ModificationDetailsSummary", () => {
     });
 
     it("renders correctly with minimal required fields only", () => {
-      const extension: ModificationItem = {
+      const extension = {
         modificationType: "extension",
         id: "mod-minimal",
         medicaidId: "demo-2",
@@ -135,7 +134,7 @@ describe("ModificationDetailsSummary", () => {
         status: "On-hold",
         documents: [],
         createdAt: new Date("2024-01-01"),
-      };
+      } as unknown as ModificationItem;
       render(<ModificationDetailsSummary modificationItem={extension} />);
       expect(screen.getByText("SUMMARY DETAILS")).toBeInTheDocument();
       expect(screen.getByText("Minimal Modification")).toBeInTheDocument();
@@ -166,15 +165,13 @@ describe("ModificationDetailsSummary", () => {
 
       fireEvent.click(editButton);
 
-      expect(showUpdateAmendmentDialog).toHaveBeenCalledWith("mod-123", [
-        DEMONSTRATION_DETAIL_QUERY,
-      ]);
+      expect(showUpdateAmendmentDialog).toHaveBeenCalledWith("mod-123");
       expect(showUpdateAmendmentDialog).toHaveBeenCalledTimes(1);
       expect(showUpdateExtensionDialog).not.toHaveBeenCalled();
     });
 
     it("calls showUpdateExtensionDialog with correct ID when clicked for extension", () => {
-      const mockExtension: ModificationItem = {
+      const mockExtension = {
         modificationType: "extension",
         id: "ext-456",
         medicaidId: "demo-2",
@@ -182,15 +179,13 @@ describe("ModificationDetailsSummary", () => {
         status: "Pre-Submission",
         documents: [],
         createdAt: new Date("2024-01-01"),
-      };
+      } as unknown as ModificationItem;
       setup(mockExtension);
       const editButton = screen.getByRole("button", { name: /button-edit-details/i });
 
       fireEvent.click(editButton);
 
-      expect(showUpdateExtensionDialog).toHaveBeenCalledWith("ext-456", [
-        DEMONSTRATION_DETAIL_QUERY,
-      ]);
+      expect(showUpdateExtensionDialog).toHaveBeenCalledWith("ext-456");
       expect(showUpdateExtensionDialog).toHaveBeenCalledTimes(1);
       expect(showUpdateAmendmentDialog).not.toHaveBeenCalled();
     });

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationDetailsSummary.tsx
@@ -1,10 +1,9 @@
 import React from "react";
-import { ModificationItem } from "./ModificationTabs";
+import { ModificationItem } from "./ModificationTabSideNav";
 import { formatDateForDisplay, getDateEst } from "util/formatDate";
 import { IconButton } from "components/button";
 import { EditIcon } from "components/icons";
 import { useDialog } from "components/dialog/DialogContext";
-import { DEMONSTRATION_DETAIL_QUERY } from "pages/DemonstrationDetail/DemonstrationDetail";
 
 const Field = ({ label, value }: { label: string; value: string }) => {
   return (
@@ -55,9 +54,9 @@ export const ModificationDetailsSummary = ({
 
   const handleEditClick = () => {
     if (modificationItem.modificationType === "amendment") {
-      showUpdateAmendmentDialog(modificationItem.id, [DEMONSTRATION_DETAIL_QUERY]);
+      showUpdateAmendmentDialog(modificationItem.id);
     } else if (modificationItem.modificationType === "extension") {
-      showUpdateExtensionDialog(modificationItem.id, [DEMONSTRATION_DETAIL_QUERY]);
+      showUpdateExtensionDialog(modificationItem.id);
     } else {
       console.error("Unknown modification type");
     }

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.test.tsx
@@ -2,8 +2,7 @@ import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ModificationTabSideNav } from "./ModificationTabSideNav";
-import { ModificationItem } from "./ModificationTabs";
+import { ModificationTabSideNav, ModificationItem } from "./ModificationTabSideNav";
 import { TestProvider } from "test-utils/TestProvider";
 import { DialogProvider } from "components/dialog/DialogContext";
 import { NON_DELIVERABLE_DOCUMENT_TYPES } from "demos-server-constants";
@@ -19,7 +18,7 @@ vi.mock("components/application", async (importOriginal) => {
 });
 
 describe("ModificationTabSideNav", () => {
-  const mockModificationItem: ModificationItem = {
+  const mockModificationItem = {
     id: "1",
     medicaidId: "demo-1",
     modificationType: "amendment",
@@ -28,7 +27,7 @@ describe("ModificationTabSideNav", () => {
     status: "Pre-Submission",
     createdAt: new Date(0),
     documents: [],
-  };
+  } as unknown as ModificationItem;
 
   const expectedTabs = [
     { label: "Application", value: "application" },
@@ -103,10 +102,10 @@ describe("ModificationTabSideNav", () => {
     });
 
     it("renders ExtensionWorkflow when modification type is extension", () => {
-      const extensionModification: ModificationItem = {
+      const extensionModification = {
         ...mockModificationItem,
         modificationType: "extension",
-      };
+      } as unknown as ModificationItem;
       setup(extensionModification);
 
       expect(screen.getByTestId("extension-workflow")).toBeInTheDocument();

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabSideNav.tsx
@@ -1,17 +1,20 @@
 import { Tab, VerticalTabs } from "layout/Tabs";
 import React from "react";
-import { ModificationItem } from "./ModificationTabs";
+import type {
+  ApplicationWorkflowAmendment,
+  ApplicationWorkflowExtension,
+} from "components/application";
 import { AddNewIcon, DetailsIcon, ListIcon, OpenFolderIcon } from "components/icons";
 import { ModificationDetailsSummary } from "./ModificationDetailsSummary";
 import {
   AmendmentWorkflow,
   ExtensionWorkflow,
-  GET_WORKFLOW_DEMONSTRATION_QUERY,
+  GET_AMENDMENT_WORKFLOW_QUERY,
+  GET_EXTENSION_WORKFLOW_QUERY,
 } from "components/application";
 import { DocumentTable } from "components/table/tables/DocumentTable";
 import { IconButton } from "components/button/IconButton";
 import { TabHeader } from "components/table/TabHeader";
-import { DEMONSTRATION_DETAIL_QUERY } from "../DemonstrationDetail";
 import { useApolloClient } from "@apollo/client/react/hooks/useApolloClient";
 import { useDialog } from "components/dialog/DialogContext";
 import { NON_DELIVERABLE_DOCUMENT_TYPES } from "demos-server-constants";
@@ -22,14 +25,21 @@ const TABS = {
   DOCUMENTS: "documents",
 };
 
+export type ModificationItem =
+  | (ApplicationWorkflowAmendment & {
+      modificationType: "amendment";
+      medicaidId: string;
+    })
+  | (ApplicationWorkflowExtension & {
+      modificationType: "extension";
+      medicaidId: string;
+    });
+
 const ModificationWorkflow = ({ modificationItem }: { modificationItem: ModificationItem }) => {
   if (modificationItem.modificationType === "amendment") {
-    return <AmendmentWorkflow key={modificationItem.id} amendmentId={modificationItem.id} />;
-  } else if (modificationItem.modificationType === "extension") {
-    return <ExtensionWorkflow key={modificationItem.id} extensionId={modificationItem.id} />;
-  } else {
-    return <div>Unsupported modification type! {modificationItem.modificationType}</div>;
+    return <AmendmentWorkflow key={modificationItem.id} amendment={modificationItem} />;
   }
+  return <ExtensionWorkflow key={modificationItem.id} extension={modificationItem} />;
 };
 
 export const ModificationTabSideNav = ({
@@ -41,7 +51,11 @@ export const ModificationTabSideNav = ({
   const client = useApolloClient();
   const refetchApplicationWorkflow = async () => {
     await client.refetchQueries({
-      include: [DEMONSTRATION_DETAIL_QUERY, GET_WORKFLOW_DEMONSTRATION_QUERY],
+      include: [
+        modificationItem.modificationType === "amendment"
+          ? GET_AMENDMENT_WORKFLOW_QUERY
+          : GET_EXTENSION_WORKFLOW_QUERY,
+      ],
     });
   };
   return (

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.test.tsx
@@ -1,26 +1,29 @@
 import React from "react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { ModificationTabs, ModificationItem } from "./ModificationTabs";
+import { ModificationTabs, ModificationListItem } from "./ModificationTabs";
 import { TestProvider } from "test-utils/TestProvider";
 import { DialogProvider } from "components/dialog/DialogContext";
 
-const createModificationItem = (overrides?: Partial<ModificationItem>): ModificationItem => {
+vi.mock("./SelectedModification", () => ({
+  SelectedModification: () => <div data-testid="selected-modification" />,
+}));
+
+const createModificationItem = (
+  overrides?: Partial<ModificationListItem>
+): ModificationListItem => {
   return {
     id: "default-id",
     medicaidId: "default-demo-id",
     modificationType: "amendment",
     name: "Default Item",
-    description: undefined,
-    status: "Pre-Submission",
     createdAt: new Date(0),
-    documents: [],
     ...overrides,
   };
 };
 
 describe("ModificationTabs Component", () => {
-  const mockItems: ModificationItem[] = [
+  const mockItems: ModificationListItem[] = [
     createModificationItem({
       id: "1",
       name: "Item 1",
@@ -99,7 +102,7 @@ describe("ModificationTabs Component", () => {
   });
 
   it("handles items without optional fields", () => {
-    const minimalItems: ModificationItem[] = [
+    const minimalItems: ModificationListItem[] = [
       createModificationItem({ id: "1", name: "Minimal Item 1" }),
       createModificationItem({ id: "2", name: "Minimal Item 2" }),
     ];
@@ -114,7 +117,7 @@ describe("ModificationTabs Component", () => {
   });
 
   it("renders tabs in newest-to-oldest order by createdAt", () => {
-    const items: ModificationItem[] = [
+    const items: ModificationListItem[] = [
       createModificationItem({
         id: "1",
         name: "First",

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { compareAsc } from "date-fns";
-import { ModificationTabSideNav } from "./ModificationTabSideNav";
-import { DemonstrationDetailModification } from "../DemonstrationDetail";
+import type { Amendment, Extension } from "demos-server";
+import { SelectedModification } from "./SelectedModification";
 
 const STYLES = {
   modificationContainer: "flex flex-col gap-2",
@@ -10,7 +10,7 @@ const STYLES = {
   selectedTab: "border-b-4 font-semibold border-border-selected",
 };
 
-export type ModificationItem = DemonstrationDetailModification & {
+export type ModificationListItem = Pick<Amendment | Extension, "id" | "name" | "createdAt"> & {
   modificationType: "amendment" | "extension";
   medicaidId: string;
 };
@@ -20,8 +20,8 @@ const ModificationTab = ({
   handleTabSelect,
   isSelected,
 }: {
-  modificationItem: ModificationItem;
-  handleTabSelect: (item: ModificationItem) => void;
+  modificationItem: ModificationListItem;
+  handleTabSelect: (item: ModificationListItem) => void;
   isSelected: boolean;
 }) => {
   const key = `modification-tab-${modificationItem.id}`;
@@ -39,7 +39,7 @@ const ModificationTab = ({
   );
 };
 
-const sortTabsNewestFirst = (items: ModificationItem[]): ModificationItem[] => {
+const sortTabsNewestFirst = (items: ModificationListItem[]): ModificationListItem[] => {
   return [...items].sort((a, b) => {
     return compareAsc(b.createdAt, a.createdAt);
   });
@@ -49,7 +49,7 @@ export const ModificationTabs = ({
   items,
   selectedItemId,
 }: {
-  items: ModificationItem[];
+  items: ModificationListItem[];
   selectedItemId?: string;
 }) => {
   if (items.length === 0) {
@@ -63,18 +63,16 @@ export const ModificationTabs = ({
     }
     return sortedItems[0]?.id || "";
   });
-  const [selectedItem, setSelectedItem] = useState<ModificationItem>(sortedItems[0]);
-
   useEffect(() => {
-    const updatedItem = sortedItems.find((item) => item.id === selectedId);
-    if (updatedItem) {
-      setSelectedItem(updatedItem);
+    if (!sortedItems.some((item) => item.id === selectedId)) {
+      setSelectedId(sortedItems[0]?.id ?? "");
     }
   }, [selectedId, sortedItems]);
 
-  const handleTabSelect = (item: ModificationItem) => {
+  const handleTabSelect = (item: ModificationListItem) => {
     setSelectedId(item.id);
   };
+  const selectedItem = sortedItems.find((item) => item.id === selectedId) ?? sortedItems[0];
 
   return (
     <div className={STYLES.modificationContainer}>
@@ -88,7 +86,13 @@ export const ModificationTabs = ({
           />
         ))}
       </div>
-      <ModificationTabSideNav modificationItem={selectedItem} />
+      {selectedItem && (
+        <SelectedModification
+          id={selectedItem.id}
+          medicaidId={selectedItem.medicaidId}
+          modificationType={selectedItem.modificationType}
+        />
+      )}
     </div>
   );
 };

--- a/client/src/pages/DemonstrationDetail/modifications/SelectedModification.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/SelectedModification.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GET_AMENDMENT_WORKFLOW_QUERY, GET_EXTENSION_WORKFLOW_QUERY } from "components/application";
+import { TestProvider } from "test-utils/TestProvider";
+import { SelectedModification } from "./SelectedModification";
+
+vi.mock("./ModificationTabSideNav", () => ({
+  ModificationTabSideNav: ({
+    modificationItem,
+  }: {
+    modificationItem: { id: string; medicaidId: string; modificationType: string };
+  }) => (
+    <div
+      data-testid="selected-modification"
+      data-id={modificationItem.id}
+      data-medicaid-id={modificationItem.medicaidId}
+      data-modification-type={modificationItem.modificationType}
+    />
+  ),
+}));
+
+const workflowResult = {
+  id: "modification-1",
+  name: "Modification One",
+  description: "Description",
+  status: "Pre-Submission",
+  currentPhaseName: "Concept",
+  clearanceLevel: "CMS (OSORA)",
+  signatureLevel: "OA",
+  effectiveDate: null,
+  demonstration: {
+    id: "demo-1",
+    status: "Approved",
+    medicaidId: "11-W-00001/1",
+    demonstrationTypes: [],
+  },
+  tags: [],
+  suggestedApplicationTags: [],
+  phases: [],
+  documents: [],
+};
+
+describe("SelectedModification", () => {
+  it.each([
+    {
+      modificationType: "amendment" as const,
+      query: GET_AMENDMENT_WORKFLOW_QUERY,
+      field: "amendment",
+    },
+    {
+      modificationType: "extension" as const,
+      query: GET_EXTENSION_WORKFLOW_QUERY,
+      field: "extension",
+    },
+  ])("loads the selected $modificationType", async ({ modificationType, query, field }) => {
+    render(
+      <TestProvider
+        mocks={[
+          {
+            request: {
+              query,
+              variables: { id: "modification-1" },
+            },
+            result: {
+              data: {
+                [field]: workflowResult,
+              },
+            },
+          },
+        ]}
+      >
+        <SelectedModification
+          id="modification-1"
+          medicaidId="11-W-00001/1"
+          modificationType={modificationType}
+        />
+      </TestProvider>
+    );
+
+    const selected = await screen.findByTestId("selected-modification");
+    expect(selected).toHaveAttribute("data-id", "modification-1");
+    expect(selected).toHaveAttribute("data-medicaid-id", "11-W-00001/1");
+    expect(selected).toHaveAttribute("data-modification-type", modificationType);
+  });
+});

--- a/client/src/pages/DemonstrationDetail/modifications/SelectedModification.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/SelectedModification.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { useQuery } from "@apollo/client";
+import {
+  GET_AMENDMENT_WORKFLOW_QUERY,
+  GET_EXTENSION_WORKFLOW_QUERY,
+  type ApplicationWorkflowAmendment,
+  type ApplicationWorkflowExtension,
+} from "components/application";
+import { Loading } from "components/loading/Loading";
+import { ModificationTabSideNav } from "./ModificationTabSideNav";
+
+type SelectedModificationProps = {
+  id: string;
+  medicaidId: string;
+  modificationType: "amendment" | "extension";
+};
+
+const SelectedAmendment = ({
+  id,
+  medicaidId,
+}: Omit<SelectedModificationProps, "modificationType">) => {
+  const { data, loading, error } = useQuery<{ amendment: ApplicationWorkflowAmendment }>(
+    GET_AMENDMENT_WORKFLOW_QUERY,
+    { variables: { id } }
+  );
+
+  if (loading) return <Loading />;
+  if (error || !data?.amendment) {
+    return <p>Error Loading Amendment Workflow: {error?.message ?? "No amendment returned."}</p>;
+  }
+
+  return (
+    <ModificationTabSideNav
+      modificationItem={{
+        ...data.amendment,
+        modificationType: "amendment",
+        medicaidId,
+      }}
+    />
+  );
+};
+
+const SelectedExtension = ({
+  id,
+  medicaidId,
+}: Omit<SelectedModificationProps, "modificationType">) => {
+  const { data, loading, error } = useQuery<{ extension: ApplicationWorkflowExtension }>(
+    GET_EXTENSION_WORKFLOW_QUERY,
+    { variables: { id } }
+  );
+
+  if (loading) return <Loading />;
+  if (error || !data?.extension) {
+    return <p>Error Loading Extension Workflow: {error?.message ?? "No extension returned."}</p>;
+  }
+
+  return (
+    <ModificationTabSideNav
+      modificationItem={{
+        ...data.extension,
+        modificationType: "extension",
+        medicaidId,
+      }}
+    />
+  );
+};
+
+export const SelectedModification = ({
+  id,
+  medicaidId,
+  modificationType,
+}: SelectedModificationProps) =>
+  modificationType === "amendment" ? (
+    <SelectedAmendment id={id} medicaidId={medicaidId} />
+  ) : (
+    <SelectedExtension id={id} medicaidId={medicaidId} />
+  );

--- a/client/src/pages/DemonstrationDetail/modifications/modificationQueries.ts
+++ b/client/src/pages/DemonstrationDetail/modifications/modificationQueries.ts
@@ -1,0 +1,27 @@
+import { gql } from "@apollo/client";
+
+export const DEMONSTRATION_AMENDMENTS_QUERY = gql`
+  query GetDemonstrationAmendments($id: ID!) {
+    demonstration(id: $id) {
+      id
+      amendments {
+        id
+        name
+        createdAt
+      }
+    }
+  }
+`;
+
+export const DEMONSTRATION_EXTENSIONS_QUERY = gql`
+  query GetDemonstrationExtensions($id: ID!) {
+    demonstration(id: $id) {
+      id
+      extensions {
+        id
+        name
+        createdAt
+      }
+    }
+  }
+`;

--- a/server/src/loaders/index.test.ts
+++ b/server/src/loaders/index.test.ts
@@ -7,6 +7,7 @@ import {
 import type { ContextUser } from "../auth";
 import { createLoaders } from ".";
 import { selectManyDemonstrations } from "../model/demonstration/queries/selectManyDemonstrations";
+import { selectDemonstrationModificationCounts } from "../model/demonstration/queries/selectDemonstrationModificationCounts";
 import { selectManyDeliverables } from "../model/deliverable/queries/selectManyDeliverables";
 import { selectManyStates } from "../model/state/queries/selectManyStates";
 import { selectManyUsers } from "../model/user/queries/selectManyUsers";
@@ -17,6 +18,12 @@ import { getManyDocuments } from "../model/document/documentData";
 vi.mock("../model/demonstration/queries/selectManyDemonstrations", () => ({
   selectManyDemonstrations: vi.fn(),
 }));
+vi.mock(
+  "../model/demonstration/queries/selectDemonstrationModificationCounts",
+  () => ({
+    selectDemonstrationModificationCounts: vi.fn(),
+  }),
+);
 vi.mock("../model/deliverable/queries/selectManyDeliverables", () => ({
   selectManyDeliverables: vi.fn(),
 }));
@@ -29,9 +36,12 @@ vi.mock("../model/user/queries/selectManyUsers", () => ({
 vi.mock("../model/person/queries/selectManyPeople", () => ({
   selectManyPeople: vi.fn(),
 }));
-vi.mock("../model/deliverableTypeDocumentType/selectDocumentTypesForDeliverableTypes", () => ({
-  selectDocumentTypesForDeliverableTypes: vi.fn(),
-}));
+vi.mock(
+  "../model/deliverableTypeDocumentType/selectDocumentTypesForDeliverableTypes",
+  () => ({
+    selectDocumentTypesForDeliverableTypes: vi.fn(),
+  }),
+);
 vi.mock("../model/document/documentData", () => ({
   getManyDocuments: vi.fn(),
 }));
@@ -63,6 +73,31 @@ describe("createLoaders", () => {
     expect(a).toEqual({ id: "a" });
     expect(b).toEqual({ id: "b" });
     expect(missing).toBeNull();
+  });
+
+  it("batches and caches demonstration modification counts", async () => {
+    vi.mocked(selectDemonstrationModificationCounts).mockResolvedValue([
+      { id: "a", amendmentCount: 2, extensionCount: 1 },
+      { id: "b", amendmentCount: 0, extensionCount: 3 },
+    ]);
+
+    const loaders = createLoaders(mockUser);
+    const [aAmendments, aExtensions, b] = await Promise.all([
+      loaders.demonstrationModificationCountsById.load("a"),
+      loaders.demonstrationModificationCountsById.load("a"),
+      loaders.demonstrationModificationCountsById.load("b"),
+    ]);
+
+    expect(
+      selectDemonstrationModificationCounts,
+    ).toHaveBeenCalledExactlyOnceWith(["a", "b"]);
+    expect(aAmendments).toEqual({
+      id: "a",
+      amendmentCount: 2,
+      extensionCount: 1,
+    });
+    expect(aExtensions).toBe(aAmendments);
+    expect(b).toEqual({ id: "b", amendmentCount: 0, extensionCount: 3 });
   });
 
   it("groups by-foreign-key loads and returns [] for keys with no rows", async () => {
@@ -116,9 +151,15 @@ describe("createLoaders", () => {
       loaders.personById.load("p1"),
     ]);
 
-    expect(selectManyUsers).toHaveBeenCalledExactlyOnceWith({ id: { in: ["u1"] } });
-    expect(selectManyStates).toHaveBeenCalledExactlyOnceWith({ id: { in: ["NC"] } });
-    expect(selectManyPeople).toHaveBeenCalledExactlyOnceWith({ id: { in: ["p1"] } });
+    expect(selectManyUsers).toHaveBeenCalledExactlyOnceWith({
+      id: { in: ["u1"] },
+    });
+    expect(selectManyStates).toHaveBeenCalledExactlyOnceWith({
+      id: { in: ["NC"] },
+    });
+    expect(selectManyPeople).toHaveBeenCalledExactlyOnceWith({
+      id: { in: ["p1"] },
+    });
   });
 
   it("threads the request user into authorization-scoped loaders and groups by foreign key", async () => {
@@ -135,7 +176,7 @@ describe("createLoaders", () => {
 
     expect(getManyDocuments).toHaveBeenCalledExactlyOnceWith(
       { applicationId: { in: ["app1", "app2"] } },
-      mockUser
+      mockUser,
     );
     expect(app1).toEqual([{ id: "doc1", applicationId: "app1" }]);
     expect(app2).toEqual([{ id: "doc2", applicationId: "app2" }]);
@@ -153,10 +194,9 @@ describe("createLoaders", () => {
       loaders.documentTypesByDeliverableTypeId.load("type2"),
     ]);
 
-    expect(selectDocumentTypesForDeliverableTypes).toHaveBeenCalledExactlyOnceWith([
-      "type1",
-      "type2",
-    ]);
+    expect(
+      selectDocumentTypesForDeliverableTypes,
+    ).toHaveBeenCalledExactlyOnceWith(["type1", "type2"]);
     expect(type1).toEqual(["General File", "Signed Approval Package"]);
     expect(type2).toEqual([]);
   });

--- a/server/src/loaders/index.ts
+++ b/server/src/loaders/index.ts
@@ -20,6 +20,10 @@ import type { DocumentType, Role, UiPathResultStatus } from "../types";
 // Batched query functions (imported from their specific files to avoid pulling
 // in resolver/barrel modules and creating import cycles).
 import { selectManyDemonstrations } from "../model/demonstration/queries/selectManyDemonstrations";
+import {
+  selectDemonstrationModificationCounts,
+  type DemonstrationModificationCounts,
+} from "../model/demonstration/queries/selectDemonstrationModificationCounts";
 import { selectManyDeliverables } from "../model/deliverable/queries/selectManyDeliverables";
 import { selectManyStates } from "../model/state/queries/selectManyStates";
 import { selectManyUsers } from "../model/user/queries/selectManyUsers";
@@ -56,7 +60,7 @@ const PENDING_TAG_SUGGESTION_STATUS = "Pending" satisfies UiPathResultStatus;
  * which the database returns rows does not matter.
  */
 function byIdLoader<T extends { id: string }>(
-  batch: (ids: string[]) => Promise<T[]>
+  batch: (ids: string[]) => Promise<T[]>,
 ): DataLoader<string, T | null> {
   return new DataLoader<string, T | null>(async (ids) => {
     const rows = await batch([...ids]);
@@ -72,7 +76,7 @@ function byIdLoader<T extends { id: string }>(
  */
 function byForeignKeyLoader<T>(
   batch: (keys: string[]) => Promise<T[]>,
-  keyOf: (row: T) => string
+  keyOf: (row: T) => string,
 ): DataLoader<string, T[]> {
   return new DataLoader<string, T[]>(async (keys) => {
     const rows = await batch([...keys]);
@@ -93,6 +97,10 @@ function byForeignKeyLoader<T>(
 export interface Loaders {
   // Single-row, keyed by primary id.
   demonstrationById: DataLoader<string, PrismaDemonstration | null>;
+  demonstrationModificationCountsById: DataLoader<
+    string,
+    DemonstrationModificationCounts | null
+  >;
   userById: DataLoader<string, PrismaUser | null>;
   stateById: DataLoader<string, PrismaState | null>;
   personById: DataLoader<string, PrismaPerson | null>;
@@ -100,14 +108,23 @@ export interface Loaders {
   // Collections, keyed by a foreign key.
   deliverablesByDemonstrationId: DataLoader<string, PrismaDeliverable[]>;
   deliverablesByCmsOwnerId: DataLoader<string, PrismaDeliverable[]>;
-  rolesByDemonstrationId: DataLoader<string, DemonstrationRoleAssignmentQueryResult[]>;
+  rolesByDemonstrationId: DataLoader<
+    string,
+    DemonstrationRoleAssignmentQueryResult[]
+  >;
   primaryProjectOfficerAssignmentsByDemonstrationId: DataLoader<
     string,
     DemonstrationRoleAssignmentQueryResult[]
   >;
   phasesByApplicationId: DataLoader<string, PrismaApplicationPhase[]>;
-  tagAssignmentsByApplicationId: DataLoader<string, ApplicationTagAssignmentQueryResult[]>;
-  suggestedTagsByApplicationId: DataLoader<string, PrismaApplicationTagSuggestion[]>;
+  tagAssignmentsByApplicationId: DataLoader<
+    string,
+    ApplicationTagAssignmentQueryResult[]
+  >;
+  suggestedTagsByApplicationId: DataLoader<
+    string,
+    PrismaApplicationTagSuggestion[]
+  >;
   demonstrationTypeAssignmentsByDemonstrationId: DataLoader<
     string,
     DemonstrationTypeTagAssignmentQueryResult[]
@@ -116,10 +133,16 @@ export interface Loaders {
     string,
     DeliverableDemonstrationTypeQueryResult[]
   >;
-  deliverableExtensionsByDeliverableId: DataLoader<string, PrismaDeliverableExtension[]>;
+  deliverableExtensionsByDeliverableId: DataLoader<
+    string,
+    PrismaDeliverableExtension[]
+  >;
   publicCommentsByDeliverableId: DataLoader<string, PrismaPublicComment[]>;
   privateCommentsByDeliverableId: DataLoader<string, PrismaPrivateComment[]>;
-  deliverableActionsByDeliverableId: DataLoader<string, SelectDeliverableActionRowResult[]>;
+  deliverableActionsByDeliverableId: DataLoader<
+    string,
+    SelectDeliverableActionRowResult[]
+  >;
   documentTypesByDeliverableTypeId: DataLoader<string, DocumentType[]>;
 
   // Authorization-scoped collections (batch functions bake in the request user's
@@ -147,23 +170,32 @@ export interface Loaders {
  */
 export function createLoaders(user: ContextUser): Loaders {
   return {
-    demonstrationById: byIdLoader((ids) => selectManyDemonstrations({ id: { in: ids } })),
+    demonstrationById: byIdLoader((ids) =>
+      selectManyDemonstrations({ id: { in: ids } }),
+    ),
+    demonstrationModificationCountsById: byIdLoader((ids) =>
+      selectDemonstrationModificationCounts(ids),
+    ),
     userById: byIdLoader((ids) => selectManyUsers({ id: { in: ids } })),
     stateById: byIdLoader((ids) => selectManyStates({ id: { in: ids } })),
     personById: byIdLoader((ids) => selectManyPeople({ id: { in: ids } })),
 
     deliverablesByDemonstrationId: byForeignKeyLoader(
-      (demonstrationIds) => selectManyDeliverables({ demonstrationId: { in: demonstrationIds } }),
-      (deliverable) => deliverable.demonstrationId
+      (demonstrationIds) =>
+        selectManyDeliverables({ demonstrationId: { in: demonstrationIds } }),
+      (deliverable) => deliverable.demonstrationId,
     ),
     deliverablesByCmsOwnerId: byForeignKeyLoader(
-      (cmsOwnerUserIds) => selectManyDeliverables({ cmsOwnerUserId: { in: cmsOwnerUserIds } }),
-      (deliverable) => deliverable.cmsOwnerUserId
+      (cmsOwnerUserIds) =>
+        selectManyDeliverables({ cmsOwnerUserId: { in: cmsOwnerUserIds } }),
+      (deliverable) => deliverable.cmsOwnerUserId,
     ),
     rolesByDemonstrationId: byForeignKeyLoader(
       (demonstrationIds) =>
-        selectManyDemonstrationRoleAssignments({ demonstrationId: { in: demonstrationIds } }),
-      (roleAssignment) => roleAssignment.demonstrationId
+        selectManyDemonstrationRoleAssignments({
+          demonstrationId: { in: demonstrationIds },
+        }),
+      (roleAssignment) => roleAssignment.demonstrationId,
     ),
     primaryProjectOfficerAssignmentsByDemonstrationId: byForeignKeyLoader(
       (demonstrationIds) =>
@@ -172,16 +204,19 @@ export function createLoaders(user: ContextUser): Loaders {
           roleId: PROJECT_OFFICER_ROLE,
           primaryDemonstrationRoleAssignment: { isNot: null },
         }),
-      (roleAssignment) => roleAssignment.demonstrationId
+      (roleAssignment) => roleAssignment.demonstrationId,
     ),
     phasesByApplicationId: byForeignKeyLoader(
-      (applicationIds) => selectManyApplicationPhases({ applicationId: { in: applicationIds } }),
-      (phase) => phase.applicationId
+      (applicationIds) =>
+        selectManyApplicationPhases({ applicationId: { in: applicationIds } }),
+      (phase) => phase.applicationId,
     ),
     tagAssignmentsByApplicationId: byForeignKeyLoader(
       (applicationIds) =>
-        selectManyApplicationTagAssignments({ applicationId: { in: applicationIds } }),
-      (tagAssignment) => tagAssignment.applicationId
+        selectManyApplicationTagAssignments({
+          applicationId: { in: applicationIds },
+        }),
+      (tagAssignment) => tagAssignment.applicationId,
     ),
     suggestedTagsByApplicationId: byForeignKeyLoader(
       (applicationIds) =>
@@ -189,38 +224,50 @@ export function createLoaders(user: ContextUser): Loaders {
           applicationId: { in: applicationIds },
           statusId: { in: [PENDING_TAG_SUGGESTION_STATUS] },
         }),
-      (suggestion) => suggestion.applicationId
+      (suggestion) => suggestion.applicationId,
     ),
     demonstrationTypeAssignmentsByDemonstrationId: byForeignKeyLoader(
       (demonstrationIds) =>
-        selectManyDemonstrationTypeTagAssignments({ demonstrationId: { in: demonstrationIds } }),
-      (assignment) => assignment.demonstrationId
+        selectManyDemonstrationTypeTagAssignments({
+          demonstrationId: { in: demonstrationIds },
+        }),
+      (assignment) => assignment.demonstrationId,
     ),
     deliverableDemonstrationTypesByDeliverableId: byForeignKeyLoader(
       (deliverableIds) =>
-        selectManyDeliverableDemonstrationTypes({ deliverableId: { in: deliverableIds } }),
-      (deliverableDemonstrationType) => deliverableDemonstrationType.deliverableId
+        selectManyDeliverableDemonstrationTypes({
+          deliverableId: { in: deliverableIds },
+        }),
+      (deliverableDemonstrationType) =>
+        deliverableDemonstrationType.deliverableId,
     ),
     deliverableExtensionsByDeliverableId: byForeignKeyLoader(
       (deliverableIds) =>
-        selectManyDeliverableExtensions({ deliverableId: { in: deliverableIds } }),
-      (extension) => extension.deliverableId
+        selectManyDeliverableExtensions({
+          deliverableId: { in: deliverableIds },
+        }),
+      (extension) => extension.deliverableId,
     ),
     publicCommentsByDeliverableId: byForeignKeyLoader(
-      (deliverableIds) => selectManyPublicComments({ deliverableId: { in: deliverableIds } }),
-      (comment) => comment.deliverableId
+      (deliverableIds) =>
+        selectManyPublicComments({ deliverableId: { in: deliverableIds } }),
+      (comment) => comment.deliverableId,
     ),
     privateCommentsByDeliverableId: byForeignKeyLoader(
-      (deliverableIds) => selectManyPrivateComments({ deliverableId: { in: deliverableIds } }),
-      (comment) => comment.deliverableId
+      (deliverableIds) =>
+        selectManyPrivateComments({ deliverableId: { in: deliverableIds } }),
+      (comment) => comment.deliverableId,
     ),
     deliverableActionsByDeliverableId: byForeignKeyLoader(
-      (deliverableIds) => selectManyDeliverableActions({ deliverableId: { in: deliverableIds } }),
-      (action) => action.deliverableId
+      (deliverableIds) =>
+        selectManyDeliverableActions({ deliverableId: { in: deliverableIds } }),
+      (action) => action.deliverableId,
     ),
     documentTypesByDeliverableTypeId: new DataLoader<string, DocumentType[]>(
       async (deliverableTypeIds) => {
-        const rows = await selectDocumentTypesForDeliverableTypes([...deliverableTypeIds]);
+        const rows = await selectDocumentTypesForDeliverableTypes([
+          ...deliverableTypeIds,
+        ]);
         const documentTypesByType = new Map<string, DocumentType[]>();
         for (const row of rows) {
           const documentType = row.documentTypeId as DocumentType;
@@ -231,21 +278,26 @@ export function createLoaders(user: ContextUser): Loaders {
             documentTypesByType.set(row.deliverableTypeId, [documentType]);
           }
         }
-        return deliverableTypeIds.map((id) => documentTypesByType.get(id) ?? []);
-      }
+        return deliverableTypeIds.map(
+          (id) => documentTypesByType.get(id) ?? [],
+        );
+      },
     ),
 
     documentsByApplicationId: byForeignKeyLoader(
-      (applicationIds) => getManyDocuments({ applicationId: { in: applicationIds } }, user),
-      (document) => document.applicationId
+      (applicationIds) =>
+        getManyDocuments({ applicationId: { in: applicationIds } }, user),
+      (document) => document.applicationId,
     ),
     amendmentsByDemonstrationId: byForeignKeyLoader(
-      (demonstrationIds) => getManyAmendments({ demonstrationId: { in: demonstrationIds } }, user),
-      (amendment) => amendment.demonstrationId
+      (demonstrationIds) =>
+        getManyAmendments({ demonstrationId: { in: demonstrationIds } }, user),
+      (amendment) => amendment.demonstrationId,
     ),
     extensionsByDemonstrationId: byForeignKeyLoader(
-      (demonstrationIds) => getManyExtensions({ demonstrationId: { in: demonstrationIds } }, user),
-      (extension) => extension.demonstrationId
+      (demonstrationIds) =>
+        getManyExtensions({ demonstrationId: { in: demonstrationIds } }, user),
+      (extension) => extension.demonstrationId,
     ),
     cmsDocumentsByDeliverableId: byForeignKeyLoader(
       (deliverableIds) =>
@@ -256,9 +308,9 @@ export function createLoaders(user: ContextUser): Loaders {
               { deliverableIsCmsAttachedFile: true },
             ],
           },
-          user
+          user,
         ),
-      (document) => document.deliverableId!
+      (document) => document.deliverableId!,
     ),
     stateDocumentsByDeliverableId: byForeignKeyLoader(
       (deliverableIds) =>
@@ -269,9 +321,9 @@ export function createLoaders(user: ContextUser): Loaders {
               { deliverableIsCmsAttachedFile: false },
             ],
           },
-          user
+          user,
         ),
-      (document) => document.deliverableId!
+      (document) => document.deliverableId!,
     ),
   };
 }

--- a/server/src/model/demonstration/demonstrationResolvers.ts
+++ b/server/src/model/demonstration/demonstrationResolvers.ts
@@ -44,7 +44,7 @@ const DEFAULT_SIGNATURE_LEVEL: SignatureLevel = "OA";
 
 export async function __createDemonstration(
   parent: unknown,
-  { input }: { input: CreateDemonstrationInput }
+  { input }: { input: CreateDemonstrationInput },
 ): Promise<PrismaDemonstration> {
   let newApplicationId: string;
   try {
@@ -75,7 +75,9 @@ export async function __createDemonstration(
       });
 
       if (!person) {
-        throw new Error(`Person with id ${input.projectOfficerUserId} not found.`);
+        throw new Error(
+          `Person with id ${input.projectOfficerUserId} not found.`,
+        );
       }
 
       await tx.demonstrationRoleAssignment.create({
@@ -102,14 +104,17 @@ export async function __createDemonstration(
   } catch (error) {
     handlePrismaError(error);
   }
-  return await getApplication(newApplicationId, { applicationTypeId: "Demonstration" });
+  return await getApplication(newApplicationId, {
+    applicationTypeId: "Demonstration",
+  });
 }
 
 export async function __updateDemonstration(
   parent: unknown,
-  { id, input }: { id: string; input: UpdateDemonstrationInput }
+  { id, input }: { id: string; input: UpdateDemonstrationInput },
 ): Promise<PrismaDemonstration> {
-  const { effectiveDate, expirationDate } = parseAndValidateEffectiveAndExpirationDates(input);
+  const { effectiveDate, expirationDate } =
+    parseAndValidateEffectiveAndExpirationDates(input);
   checkOptionalNotNullFields(["name", "projectOfficerUserId"], input);
   try {
     return await prisma().$transaction(async (tx) => {
@@ -130,7 +135,9 @@ export async function __updateDemonstration(
           select: { personTypeId: true },
         });
         if (!person) {
-          throw new Error(`Person with id ${input.projectOfficerUserId} not found.`);
+          throw new Error(
+            `Person with id ${input.projectOfficerUserId} not found.`,
+          );
         }
 
         await tx.demonstrationRoleAssignment.upsert({
@@ -179,7 +186,7 @@ export async function __updateDemonstration(
 
 export async function deleteDemonstration(
   parent: unknown,
-  { id }: { id: string }
+  { id }: { id: string },
 ): Promise<PrismaDemonstration> {
   return await prisma().$transaction(async (tx) => {
     return await deleteApplication(id, "Demonstration", tx);
@@ -187,11 +194,11 @@ export async function deleteDemonstration(
 }
 
 export async function __resolveDemonstrationPrimaryProjectOfficer(
-  parent: PrismaDemonstration
+  parent: PrismaDemonstration,
 ): Promise<PrismaPerson> {
   // It is not possible in the DB for the primary project officer not to exist
-  const primaryRoleAssignment = await prisma().primaryDemonstrationRoleAssignment.findUniqueOrThrow(
-    {
+  const primaryRoleAssignment =
+    await prisma().primaryDemonstrationRoleAssignment.findUniqueOrThrow({
       where: {
         demonstrationId_roleId: {
           demonstrationId: parent.id,
@@ -203,8 +210,7 @@ export async function __resolveDemonstrationPrimaryProjectOfficer(
           include: { person: true },
         },
       },
-    }
-  );
+    });
   return primaryRoleAssignment.demonstrationRoleAssignment.person;
 }
 
@@ -213,13 +219,15 @@ export const demonstrationResolvers = {
     demonstration: (
       parent: unknown,
       args: { id: string },
-      context: GraphQLContext
-    ): Promise<PrismaDemonstration> => getDemonstration({ id: args.id }, context.user),
+      context: GraphQLContext,
+    ): Promise<PrismaDemonstration> =>
+      getDemonstration({ id: args.id }, context.user),
     demonstrations: (
       parent: unknown,
       args: unknown,
-      context: GraphQLContext
-    ): Promise<PrismaDemonstration[]> => getManyDemonstrations({}, context.user),
+      context: GraphQLContext,
+    ): Promise<PrismaDemonstration[]> =>
+      getManyDemonstrations({}, context.user),
   },
 
   Mutation: {
@@ -232,7 +240,7 @@ export const demonstrationResolvers = {
     state: async (
       parent: PrismaDemonstration,
       args: unknown,
-      context: GraphQLContext
+      context: GraphQLContext,
     ): Promise<PrismaState> => {
       const state = await context.loaders.stateById.load(parent.stateId);
       if (!state) {
@@ -243,19 +251,51 @@ export const demonstrationResolvers = {
     documents: (
       parent: PrismaDemonstration,
       args: unknown,
-      context: GraphQLContext
-    ): Promise<PrismaDocument[]> => context.loaders.documentsByApplicationId.load(parent.id),
+      context: GraphQLContext,
+    ): Promise<PrismaDocument[]> =>
+      context.loaders.documentsByApplicationId.load(parent.id),
     amendments: (
       parent: PrismaDemonstration,
       args: unknown,
-      context: GraphQLContext
-    ): Promise<PrismaAmendment[]> => context.loaders.amendmentsByDemonstrationId.load(parent.id),
+      context: GraphQLContext,
+    ): Promise<PrismaAmendment[]> =>
+      context.loaders.amendmentsByDemonstrationId.load(parent.id),
     extensions: (
       parent: PrismaDemonstration,
       args: unknown,
-      context: GraphQLContext
-    ): Promise<PrismaExtension[]> => context.loaders.extensionsByDemonstrationId.load(parent.id),
-    sdgDivision: (parent: PrismaDemonstration): SdgDivision => parent.sdgDivisionId as SdgDivision,
+      context: GraphQLContext,
+    ): Promise<PrismaExtension[]> =>
+      context.loaders.extensionsByDemonstrationId.load(parent.id),
+    amendmentCount: async (
+      parent: PrismaDemonstration,
+      args: unknown,
+      context: GraphQLContext,
+    ): Promise<number> => {
+      const counts =
+        await context.loaders.demonstrationModificationCountsById.load(
+          parent.id,
+        );
+      if (!counts) {
+        throw new Error("No demonstration found matching the provided filter");
+      }
+      return counts.amendmentCount;
+    },
+    extensionCount: async (
+      parent: PrismaDemonstration,
+      args: unknown,
+      context: GraphQLContext,
+    ): Promise<number> => {
+      const counts =
+        await context.loaders.demonstrationModificationCountsById.load(
+          parent.id,
+        );
+      if (!counts) {
+        throw new Error("No demonstration found matching the provided filter");
+      }
+      return counts.extensionCount;
+    },
+    sdgDivision: (parent: PrismaDemonstration): SdgDivision =>
+      parent.sdgDivisionId as SdgDivision,
     signatureLevel: (parent: PrismaDemonstration): SignatureLevel =>
       parent.signatureLevelId as SignatureLevel,
     currentPhaseName: (parent: PrismaDemonstration): PhaseName =>
@@ -263,7 +303,7 @@ export const demonstrationResolvers = {
     roles: (
       parent: PrismaDemonstration,
       args: unknown,
-      context: GraphQLContext
+      context: GraphQLContext,
     ): Promise<PrismaDemonstrationRoleAssignment[]> =>
       context.loaders.rolesByDemonstrationId.load(parent.id),
     status: (parent: PrismaDemonstration): ApplicationStatus =>
@@ -271,20 +311,25 @@ export const demonstrationResolvers = {
     phases: (
       parent: PrismaDemonstration,
       args: unknown,
-      context: GraphQLContext
-    ): Promise<PrismaApplicationPhase[]> => context.loaders.phasesByApplicationId.load(parent.id),
+      context: GraphQLContext,
+    ): Promise<PrismaApplicationPhase[]> =>
+      context.loaders.phasesByApplicationId.load(parent.id),
     primaryProjectOfficer: async (
       parent: PrismaDemonstration,
       args: unknown,
-      context: GraphQLContext
+      context: GraphQLContext,
     ): Promise<PrismaPerson> => {
       const [primaryProjectOfficerAssignment] =
-        await context.loaders.primaryProjectOfficerAssignmentsByDemonstrationId.load(parent.id);
+        await context.loaders.primaryProjectOfficerAssignmentsByDemonstrationId.load(
+          parent.id,
+        );
       if (!primaryProjectOfficerAssignment) {
-        throw new Error("No demonstrationRoleAssignment found matching the provided filter");
+        throw new Error(
+          "No demonstrationRoleAssignment found matching the provided filter",
+        );
       }
       const person = await context.loaders.personById.load(
-        primaryProjectOfficerAssignment.personId
+        primaryProjectOfficerAssignment.personId,
       );
       if (!person) {
         throw new Error("No person found matching the provided filter");
@@ -296,52 +341,59 @@ export const demonstrationResolvers = {
     tags: async (
       parent: PrismaDemonstration,
       args: unknown,
-      context: GraphQLContext
+      context: GraphQLContext,
     ): Promise<Tag[]> =>
-      (await context.loaders.tagAssignmentsByApplicationId.load(parent.id)).map((assignment) => {
-        const { statusId, tagNameId } = assignment.tag;
-        return {
-          tagName: tagNameId,
-          approvalStatus: statusId as TagStatus,
-        };
-      }),
+      (await context.loaders.tagAssignmentsByApplicationId.load(parent.id)).map(
+        (assignment) => {
+          const { statusId, tagNameId } = assignment.tag;
+          return {
+            tagName: tagNameId,
+            approvalStatus: statusId as TagStatus,
+          };
+        },
+      ),
     suggestedApplicationTags: async (
       parent: PrismaDemonstration,
       args: unknown,
-      context: GraphQLContext
+      context: GraphQLContext,
     ): Promise<string[]> =>
       (await context.loaders.suggestedTagsByApplicationId.load(parent.id)).map(
-        (suggestion) => suggestion.value
+        (suggestion) => suggestion.value,
       ),
     demonstrationTypes: async (
       parent: PrismaDemonstration,
       args: unknown,
-      context: GraphQLContext
+      context: GraphQLContext,
     ): Promise<DemonstrationTypeAssignment[]> =>
-      (await context.loaders.demonstrationTypeAssignmentsByDemonstrationId.load(parent.id)).map(
-        (assignment) => {
-          const { tagNameId, tag, ...rest } = assignment;
-          return {
-            ...rest,
-            demonstrationTypeName: tagNameId,
-            status: determineDemonstrationTypeStatus(
-              assignment.effectiveDate,
-              assignment.expirationDate
-            ),
-            approvalStatus: tag.statusId as TagStatus,
-          };
-        }
-      ),
+      (
+        await context.loaders.demonstrationTypeAssignmentsByDemonstrationId.load(
+          parent.id,
+        )
+      ).map((assignment) => {
+        const { tagNameId, tag, ...rest } = assignment;
+        return {
+          ...rest,
+          demonstrationTypeName: tagNameId,
+          status: determineDemonstrationTypeStatus(
+            assignment.effectiveDate,
+            assignment.expirationDate,
+          ),
+          approvalStatus: tag.statusId as TagStatus,
+        };
+      }),
     deliverables: resolveManyDeliverables,
     chipId: async (
       parent: PrismaDemonstration,
       args: unknown,
-      context: GraphQLContext
+      context: GraphQLContext,
     ): Promise<string | null> => {
       const demonstrationTypeAssignments =
-        await context.loaders.demonstrationTypeAssignmentsByDemonstrationId.load(parent.id);
+        await context.loaders.demonstrationTypeAssignmentsByDemonstrationId.load(
+          parent.id,
+        );
       const hasChipDemonstrationType = demonstrationTypeAssignments.some(
-        (assignment) => assignment.tagNameId === CHIP_DEMONSTRATION_TYPE_TAG_NAME
+        (assignment) =>
+          assignment.tagNameId === CHIP_DEMONSTRATION_TYPE_TAG_NAME,
       );
       return hasChipDemonstrationType ? parent.chipId : null;
     },

--- a/server/src/model/demonstration/demonstrationSchema.ts
+++ b/server/src/model/demonstration/demonstrationSchema.ts
@@ -36,6 +36,8 @@ export const demonstrationSchema = gql`
     documents: [Document!]! @auth(requires: ["Access CMS Field"])
     amendments: [Amendment!]! @auth(requires: ["Access CMS Field"])
     extensions: [Extension!]! @auth(requires: ["Access CMS Field"])
+    amendmentCount: Int! @auth(requires: ["Access CMS Field"])
+    extensionCount: Int! @auth(requires: ["Access CMS Field"])
     roles: [DemonstrationRoleAssignment!]! @auth(requires: ["Access CMS Field"])
     primaryProjectOfficer: Person!
     clearanceLevel: ClearanceLevel! @auth(requires: ["Access CMS Field"])
@@ -69,9 +71,12 @@ export const demonstrationSchema = gql`
   type Mutation {
     createDemonstration(input: CreateDemonstrationInput!): Demonstration!
       @auth(requires: ["Perform CMS Action"])
-    updateDemonstration(id: ID!, input: UpdateDemonstrationInput!): Demonstration!
+    updateDemonstration(
+      id: ID!
+      input: UpdateDemonstrationInput!
+    ): Demonstration! @auth(requires: ["Perform CMS Action"])
+    deleteDemonstration(id: ID!): Demonstration!
       @auth(requires: ["Perform CMS Action"])
-    deleteDemonstration(id: ID!): Demonstration! @auth(requires: ["Perform CMS Action"])
   }
 
   type Query {
@@ -95,6 +100,8 @@ export interface Demonstration {
   documents: Document[];
   amendments: Amendment[];
   extensions: Extension[];
+  amendmentCount: number;
+  extensionCount: number;
   roles: DemonstrationRoleAssignment[];
   primaryProjectOfficer: Person;
   clearanceLevel: ClearanceLevel;

--- a/server/src/model/demonstration/queries/index.ts
+++ b/server/src/model/demonstration/queries/index.ts
@@ -1,3 +1,7 @@
 export { selectDemonstration } from "./selectDemonstration";
 export { selectDemonstrationOrThrow } from "./selectDemonstrationOrThrow";
 export { selectManyDemonstrations } from "./selectManyDemonstrations";
+export {
+  selectDemonstrationModificationCounts,
+  type DemonstrationModificationCounts,
+} from "./selectDemonstrationModificationCounts";

--- a/server/src/model/demonstration/queries/selectDemonstrationModificationCounts.test.ts
+++ b/server/src/model/demonstration/queries/selectDemonstrationModificationCounts.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { prisma } from "../../../prismaClient";
+import { selectDemonstrationModificationCounts } from "./selectDemonstrationModificationCounts";
+
+vi.mock("../../../prismaClient", () => ({
+  prisma: vi.fn(),
+}));
+
+describe("selectDemonstrationModificationCounts", () => {
+  const findMany = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(prisma).mockReturnValue({
+      demonstration: { findMany },
+    } as never);
+  });
+
+  it("selects and maps amendment and extension counts for each demonstration", async () => {
+    findMany.mockResolvedValue([
+      {
+        id: "demo-1",
+        _count: {
+          amendments: 2,
+          extensions: 3,
+        },
+      },
+    ]);
+
+    await expect(
+      selectDemonstrationModificationCounts(["demo-1"]),
+    ).resolves.toEqual([
+      {
+        id: "demo-1",
+        amendmentCount: 2,
+        extensionCount: 3,
+      },
+    ]);
+    expect(findMany).toHaveBeenCalledExactlyOnceWith({
+      where: { id: { in: ["demo-1"] } },
+      select: {
+        id: true,
+        _count: {
+          select: {
+            amendments: true,
+            extensions: true,
+          },
+        },
+      },
+    });
+  });
+});

--- a/server/src/model/demonstration/queries/selectDemonstrationModificationCounts.ts
+++ b/server/src/model/demonstration/queries/selectDemonstrationModificationCounts.ts
@@ -1,0 +1,30 @@
+import { prisma } from "../../../prismaClient";
+
+export type DemonstrationModificationCounts = {
+  id: string;
+  amendmentCount: number;
+  extensionCount: number;
+};
+
+export async function selectDemonstrationModificationCounts(
+  demonstrationIds: string[],
+): Promise<DemonstrationModificationCounts[]> {
+  const rows = await prisma().demonstration.findMany({
+    where: { id: { in: demonstrationIds } },
+    select: {
+      id: true,
+      _count: {
+        select: {
+          amendments: true,
+          extensions: true,
+        },
+      },
+    },
+  });
+
+  return rows.map((row) => ({
+    id: row.id,
+    amendmentCount: row._count.amendments,
+    extensionCount: row._count.extensions,
+  }));
+}


### PR DESCRIPTION
## Lazy-load demonstration modifications

## Summary

This is a medium, focused refactor. Keep the main Demonstration tab unchanged, but stop loading every amendment, extension, and modification document on initial page load.

Initial load becomes:

1. Demonstration shell data and modification counts.
2. Amendment or extension list when its outer tab opens.
3. Full workflow/details/documents for only the selected modification.

## Changes

- Replace `amendments` and `extensions` in the initial query with `amendmentCount` and `extensionCount`.
- Add those two GraphQL fields to `Demonstration`, backed by one request-scoped loader that obtains both relation counts.
- Apply the same CMS-field authorization as the existing collections.
- Add lightweight client queries:
  - `GetDemonstrationAmendments`: `id`, `name`, `createdAt`
  - `GetDemonstrationExtensions`: `id`, `name`, `createdAt`
- Run each list query inside its corresponding tab. The existing `Tabs` component already mounts only the selected tab, so no tab-system rewrite is needed.
- Preserve newest-first selection and URL selection such as `?amendments=<id>` and `?extensions=<id>`.

## Selected Modification

- Change `ModificationTabs` to accept lightweight list items.
- Once an item is selected, run the existing amendment or extension workflow query for that ID.
- Lift that query to a selected-modification container and pass the loaded object to:
  - Application workflow
  - Details summary
  - Documents table
- Keep documents in the workflow query because the workflow phases use them. This still limits document loading to one selected modification.
- Apollo’s normalized cache should retain previously selected modifications when switching tabs.

## Cache and Mutation Updates

- Rename the monolithic query to reflect its shell purpose and update its consumers.
- After creating a modification, refetch only the shell/count query and the matching amendment or extension list.
- Let edit mutations update normalized modification fields from their response; remove the full-detail refetch.
- After modification document or workflow changes, refetch only the selected amendment/extension workflow query.
- Replace remaining mutation references to the old monolithic query with the smallest affected shell, list, or selected-item query.

## Testing details:

Examples:
- Tested locally using...
- Verified in Chrome

Actual Unit testing:
- Verify initial page load does not request amendment lists, extension lists, or modification documents.
- Verify opening each outer tab triggers only its lightweight list query.
- Verify the newest item and URL-selected item trigger only that item’s workflow query.
- Verify empty-list states and tab counts remain correct.
- Verify switching items updates workflow, summary, and documents together.
- Verify creation updates counts and list contents; edits and uploads refresh only targeted data.
- Update GraphQL resolver tests, Apollo mocks, tab tests, and mutation-refetch expectations.
- 

https://github.com/user-attachments/assets/06953cc9-d881-45ac-ace7-dc2b9fd52314

## Risk and rollback
This is quite a change. May cause some PR conflicts. 
But easy to verify, harder to roll back as time goes on. 


## Automated review

- [ ] Run AI Code Review <!-- The AI PR review will only run if this is checked [x] -->
