### PR TITLE
(2/3) DEMOS-2386: Persist dates in first half of Application Workflow

### DIFF
--- a/client/src/components/application/phase-selector/PhaseSelector.tsx
+++ b/client/src/components/application/phase-selector/PhaseSelector.tsx
@@ -115,11 +115,7 @@ export const PhaseSelector = ({
   const renderPhase = (phaseName: PhaseName) => {
     switch (phaseName) {
       case "Concept":
-        return getConceptPhaseComponentFromApplication(
-          application,
-          workflowApplicationType,
-          setSelectedPhase
-        );
+        return getConceptPhaseComponentFromApplication(application, setSelectedPhase);
       case "Application Intake":
         return getApplicationIntakeComponentFromApplication(application, setSelectedPhase);
       case "Completeness":

--- a/client/src/components/application/phases/ApplicationIntakePhase.tsx
+++ b/client/src/components/application/phases/ApplicationIntakePhase.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useSessionStorage } from "hooks";
 
 import { gql, TypedDocumentNode, useMutation } from "@apollo/client";
 
@@ -325,7 +326,9 @@ export const ApplicationIntakePhase = ({
     REFETCH_ACTIVE_QUERIES_AFTER_SUGGESTION_UPDATE
   );
 
-  const [submittedDateOverride, setSubmittedDateOverride] = useState<string>("");
+  const [submittedDateOverride, setSubmittedDateOverride] = useSessionStorage(
+    `application-intake-submitted-date-${applicationId}`
+  );
   const [selectedSuggestedTag, setSelectedSuggestedTag] = useState<TagName | null>(null);
 
   // Calculate the dates to display based on the following rules:

--- a/client/src/components/application/phases/ConceptPhase.test.tsx
+++ b/client/src/components/application/phases/ConceptPhase.test.tsx
@@ -663,11 +663,7 @@ describe("ConceptPhase", () => {
         tags: [],
       };
 
-      const component = getConceptPhaseComponentFromApplication(
-        mockDemonstration,
-        "demonstration",
-        () => {}
-      );
+      const component = getConceptPhaseComponentFromApplication(mockDemonstration, () => {});
       expect(component).toBeDefined();
       if (component) {
         expect(component.type).toBe(ConceptPhase);
@@ -707,11 +703,7 @@ describe("ConceptPhase", () => {
         tags: [],
       };
 
-      const component = getConceptPhaseComponentFromApplication(
-        mockDemonstration,
-        "demonstration",
-        () => {}
-      );
+      const component = getConceptPhaseComponentFromApplication(mockDemonstration, () => {});
       expect(component).toBeDefined();
       if (component) {
         expect(component.type).toBe(ConceptPhase);

--- a/client/src/components/application/phases/ConceptPhase.tsx
+++ b/client/src/components/application/phases/ConceptPhase.tsx
@@ -1,15 +1,12 @@
 import React, { useEffect, useState } from "react";
+import { useSessionStorage } from "hooks";
 import { compareDesc } from "date-fns";
 
 import { tw } from "tags/tw";
 import { Button, SecondaryButton } from "components/button";
 import { ChevronRightIcon, ExportIcon } from "components/icons";
 
-import {
-  WorkflowApplication,
-  ApplicationWorkflowDocument,
-  WorkflowApplicationType,
-} from "components/application";
+import { WorkflowApplication, ApplicationWorkflowDocument } from "components/application";
 import { formatDateForServer } from "util/formatDate";
 import { DocumentList } from "./sections";
 import { useDialog } from "components/dialog/DialogContext";
@@ -62,7 +59,6 @@ export const CONCEPT_PHASE_STEP_TWO_DESCRIPTION = {
 
 export const getConceptPhaseComponentFromApplication = (
   application: WorkflowApplication,
-  workflowApplicationType: WorkflowApplicationType,
   setSelectedPhase: (phase: PhaseName) => void
 ) => {
   const conceptPhaseDocuments = application.documents.filter(
@@ -135,7 +131,9 @@ export const ConceptPhase = ({
   const { skipConceptPhase } = useSkipConceptPhase();
 
   // User can override the calculated date via the datepicker
-  const [userSubmittedDateOverride, setUserSubmittedDateOverride] = useState<string>("");
+  const [userSubmittedDateOverride, setUserSubmittedDateOverride] = useSessionStorage(
+    `concept-phase-submitted-date-${applicationId}`
+  );
   const [isFinishEnabled, setIsFinishEnabled] = useState<boolean>(false);
   const [isSkipEnabled, setIsSkipEnabled] = useState<boolean>(true);
 

--- a/client/src/components/application/phases/completeness/VerifyCompleteSection.tsx
+++ b/client/src/components/application/phases/completeness/VerifyCompleteSection.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useSessionStorage } from "hooks";
 
 import { Button, SecondaryButton } from "components/button";
 import { DatePicker } from "components/input/date/DatePicker";
@@ -86,7 +87,7 @@ export const VerifyCompleteSection = ({
   const { declareCompletenessPhaseIncomplete } = useDeclareCompletenessPhaseIncomplete();
 
   const [userSelectedStateDeemedCompleteDate, setUserSelectedStateDeemedCompleteDate] =
-    useState("");
+    useSessionStorage(`completeness-deemed-complete-date-${applicationId}`);
 
   const calculatedStateDeemedCompleteDate = calculateStateDeemedCompleteDate(
     stateDeemedCompleteDate,

--- a/client/src/components/application/phases/completeness/VerifyCompleteSection.tsx
+++ b/client/src/components/application/phases/completeness/VerifyCompleteSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { useSessionStorage } from "hooks";
 
 import { Button, SecondaryButton } from "components/button";


### PR DESCRIPTION
## Summary

Utilize the new `useSessionStorage` to ensure dates are persisted when a user navigates away from a step. 

## Changes

- Plain `useState` calls have been replaced with `useSessionStorage` as a drop-in replacement
- Removed an unused parameter from `getConceptPhaseComponentFromApplication`

## Validation

- Tested manually (screenshots attached) and existing unit tests pass

## Screen Recordings

https://github.com/user-attachments/assets/13942017-a541-4b90-b0c5-248662a878da


## Next Steps

The last PR for this work will be to implement this for the second half. Those phases use a different strategy of having the dates together in a form field so I'm strategizing about how to make the change there as simple as possible