### PR TITLE
DEMOS-2445-refactor-duckdb-connector-and-fix-logs

### DIFF
--- a/data/demos_data_tools/duckdb_connection_manager.py
+++ b/data/demos_data_tools/duckdb_connection_manager.py
@@ -2,13 +2,13 @@
 
 import os
 from logging import getLogger
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, assert_never
 
 import duckdb
 
 from logger_utils import config_logger
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from duckdb import DuckDBPyConnection as DuckConn
 
 
@@ -17,85 +17,144 @@ logger = config_logger(getLogger(__name__))
 PMDA_DDB_ATTACH_NAME = "ddb_pmda"
 DEMOS_DDB_ATTACH_NAME = "ddb_demos"
 
+type ConfigurationType = Literal["PMDA", "DEMOS"]
 
-def _load_db_configs_from_env() -> dict:
-    """Load the DB configurations from the environment.
+
+def _load_db_config_from_env(requested_config: ConfigurationType) -> dict:
+    """Load the requested DB configuration from the environment.
+
+    Args:
+        requested_config (ConfigurationType): Which DB configuration to attempt to load.
 
     Returns:
-        dict: A dictionary containing the database configuration(s).
+        dict: A dictionary containing the requested database configuration.
+
+    Raises:
+        KeyError: When loading from the environment fails due to a KeyError (missing env var).
+        RuntimeError: When loading from the environment fails for non-KeyError reasons.
     """
-    logger.info("Reading environment variables")
-    config = {
-        PMDA_DDB_ATTACH_NAME: {
-            "host": os.environ["PMDA_MYSQL_HOST"],
-            "port": os.environ["PMDA_MYSQL_PORT"],
-            "user": os.environ["PMDA_MYSQL_USER"],
-            "pwd": os.environ["PMDA_MYSQL_PWD"],
-            "db": os.environ["PMDA_MYSQL_DB"],
-        },
-        DEMOS_DDB_ATTACH_NAME: {
-            "host": os.environ["DEMOS_PGSQL_HOST"],
-            "port": os.environ["DEMOS_PGSQL_PORT"],
-            "user": os.environ["DEMOS_PGSQL_USER"],
-            "pwd": os.environ["DEMOS_PGSQL_PWD"],
-            "db": os.environ["DEMOS_PGSQL_DB"],
-            "sslmode": os.environ["DEMOS_PGSQL_SSLMODE"],
-        },
-    }
-    logger.info("Loading config from environment successfully")
+    logger.info(f"Attempting to load {requested_config} config from environment")
+
+    try:
+        if requested_config == "PMDA":
+            config = {
+                "host": os.environ["PMDA_MYSQL_HOST"],
+                "port": os.environ["PMDA_MYSQL_PORT"],
+                "user": os.environ["PMDA_MYSQL_USER"],
+                "pwd": os.environ["PMDA_MYSQL_PWD"],
+                "db": os.environ["PMDA_MYSQL_DB"],
+            }
+        elif requested_config == "DEMOS":
+            config = {
+                "host": os.environ["DEMOS_PGSQL_HOST"],
+                "port": os.environ["DEMOS_PGSQL_PORT"],
+                "user": os.environ["DEMOS_PGSQL_USER"],
+                "pwd": os.environ["DEMOS_PGSQL_PWD"],
+                "db": os.environ["DEMOS_PGSQL_DB"],
+                "sslmode": os.environ["DEMOS_PGSQL_SSLMODE"],
+            }
+        else:
+            assert_never(requested_config)
+    except KeyError:
+        err_msg = f"A KeyError occurred while loading the {requested_config} credentials from the environment."
+        logger.error(err_msg)
+        raise KeyError(err_msg) from None
+    except Exception:
+        err_msg = (
+            f"An unhandled exception occurred while loading the {requested_config} credentials from the environment."
+        )
+        logger.error(err_msg)
+        raise RuntimeError(err_msg) from None
+
+    logger.info(f"Loaded {requested_config} config from environment")
     return config
 
 
 def create_duckdb_conn() -> "DuckConn":
-    """Take the config and create a proper DuckDB connection.
+    """Create a proper DuckDB connection with an in-memory DB and extensions mounted.
+
+    Note: this no longer mounts the databases as this is done in separate functions.
 
     Returns:
-        DuckConn: A configured DuckDB connection.
+        DuckConn: An instantiated DuckDB connection.
     """
     logger.info("Creating DuckDB database")
-    config = _load_db_configs_from_env()
-
-    # In-memory DB
     conn = duckdb.connect(":memory:", config={"memory_limit": "8GB", "threads": 8})
-
-    # DEMOS PostgreSQL Connection
     conn.install_extension("postgres")
-    conn.load_extension("postgres")
-
-    ddb_demos_config = config[DEMOS_DDB_ATTACH_NAME]
-    clean_demos_pwd = ddb_demos_config["pwd"].replace("'", "''")
-    conn.execute(f"""
-        CREATE SECRET (
-            TYPE postgres,
-            HOST '{ddb_demos_config["host"]}',
-            PORT {ddb_demos_config["port"]},
-            DATABASE {ddb_demos_config["db"]},
-            USER '{ddb_demos_config["user"]}',
-            PASSWORD '{clean_demos_pwd}'
-        );
-    """)
-
-    conn.execute(f"ATTACH 'sslmode={ddb_demos_config['sslmode']}' AS {DEMOS_DDB_ATTACH_NAME} (TYPE postgres);")
-    conn.execute("SET pg_null_byte_replacement=''")  # This is necessary to handle nulls from MySQL
-    logger.info(f"Attached DEMOS PostgreSQL database AS {DEMOS_DDB_ATTACH_NAME}")
-
-    # PMDA MySQL Connection
     conn.install_extension("mysql")
+    return conn
+
+
+def attach_pmda_to_conn(conn: "DuckConn") -> "DuckConn":
+    """Attach the PMDA database to a DuckDB connection.
+
+    Args:
+        conn (DuckConn): A DuckDB connection to which the PMDA database should be attached.
+
+    Returns:
+        DuckConn: The DuckDB connection with the attached PMDA database.
+
+    Raises:
+        RuntimeError: Generally raised if any connection issues occur; done to block leaking credentials in logs.
+    """
     conn.load_extension("mysql")
-
-    ddb_pmda_config = config[PMDA_DDB_ATTACH_NAME]
+    ddb_pmda_config = _load_db_config_from_env("PMDA")
     clean_pmda_pwd = ddb_pmda_config["pwd"].replace("'", "''")
-    conn.execute(f"""
-        CREATE SECRET (
-            TYPE mysql,
-            HOST '{ddb_pmda_config["host"]}',
-            PORT {ddb_pmda_config["port"]},
-            DATABASE {ddb_pmda_config["db"]},
-            USER '{ddb_pmda_config["user"]}',
-            PASSWORD '{clean_pmda_pwd}'
-        );
-    """)
 
-    conn.execute(f"ATTACH '' AS {PMDA_DDB_ATTACH_NAME} (TYPE mysql);")
+    try:
+        conn.execute(f"""
+            CREATE SECRET (
+                TYPE mysql,
+                HOST '{ddb_pmda_config["host"]}',
+                PORT {ddb_pmda_config["port"]},
+                DATABASE {ddb_pmda_config["db"]},
+                USER '{ddb_pmda_config["user"]}',
+                PASSWORD '{clean_pmda_pwd}'
+            );
+        """)
+        conn.execute(f"ATTACH '' AS {PMDA_DDB_ATTACH_NAME} (TYPE mysql);")
+    except Exception:
+        err_msg = "An error occurred while attempting to attach the PMDA database."
+        logger.error(err_msg)
+        raise RuntimeError(err_msg) from None
+
     logger.info(f"Attached PMDA MySQL database AS {PMDA_DDB_ATTACH_NAME}")
+    return conn
+
+
+def attach_demos_to_conn(conn: "DuckConn") -> "DuckConn":
+    """Attach the DEMOS database to a DuckDB connection.
+
+    Args:
+        conn (DuckConn): A DuckDB connection to which the DEMOS database should be attached.
+
+    Returns:
+        DuckConn: The DuckDB connection with the attached DEMOS database.
+
+    Raises:
+        RuntimeError: Generally raised if any connection issues occur; done to block leaking credentials in logs.
+    """
+    conn.load_extension("postgres")
+    ddb_demos_config = _load_db_config_from_env("DEMOS")
+    clean_demos_pwd = ddb_demos_config["pwd"].replace("'", "''")
+
+    try:
+        conn.execute(f"""
+            CREATE SECRET (
+                TYPE postgres,
+                HOST '{ddb_demos_config["host"]}',
+                PORT {ddb_demos_config["port"]},
+                DATABASE {ddb_demos_config["db"]},
+                USER '{ddb_demos_config["user"]}',
+                PASSWORD '{clean_demos_pwd}'
+            );
+        """)
+        conn.execute(f"ATTACH 'sslmode={ddb_demos_config['sslmode']}' AS {DEMOS_DDB_ATTACH_NAME} (TYPE postgres);")
+        conn.execute("SET pg_null_byte_replacement=''")  # This is necessary to handle nulls from MySQL
+    except Exception:
+        err_msg = "An error occurred while attempting to attach the DEMOS database."
+        logger.error(err_msg)
+        raise RuntimeError(err_msg) from None
+
+    logger.info(f"Attached DEMOS PostgreSQL database AS {DEMOS_DDB_ATTACH_NAME}")
     return conn

--- a/data/demos_data_tools/load_staged_data_to_demos_app.py
+++ b/data/demos_data_tools/load_staged_data_to_demos_app.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, List, Literal, Set, Tuple, assert_never
 
 from dotenv import load_dotenv
 
-from duckdb_connection_manager import DEMOS_DDB_ATTACH_NAME, create_duckdb_conn
+from duckdb_connection_manager import DEMOS_DDB_ATTACH_NAME, create_duckdb_conn, attach_demos_to_conn
 from logger_utils import config_logger
 
 if TYPE_CHECKING:
@@ -385,7 +385,7 @@ def main(args: "Namespace") -> None:
         for query in generated_sql:
             logger.info(query.sql_query)
     else:
-        conn = create_duckdb_conn()
+        conn = attach_demos_to_conn(create_duckdb_conn())
         for query in generated_sql:
             logger.info(_create_log_execution_message_for_sql(query))
             conn.execute(query.sql_query)

--- a/data/demos_data_tools/logger_utils.py
+++ b/data/demos_data_tools/logger_utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 # Note these imports are done in this fashion to make the mocking easier in tests
 from logging import Formatter, StreamHandler, INFO as INFO_LOG_LEVEL
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from logging import Logger
 
 _CONFIGURED_FLAG = "_demos_data_tools_configured"

--- a/data/demos_data_tools/manage_migration_schemas.py
+++ b/data/demos_data_tools/manage_migration_schemas.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Literal
 from dotenv import load_dotenv
 
 from check_if_in_devcontainer import check_if_in_devcontainer
-from duckdb_connection_manager import DEMOS_DDB_ATTACH_NAME, create_duckdb_conn
+from duckdb_connection_manager import DEMOS_DDB_ATTACH_NAME, create_duckdb_conn, attach_demos_to_conn
 from logger_utils import config_logger
 
 if TYPE_CHECKING:
@@ -41,7 +41,7 @@ def _create_schema(conn: "DuckConn", which: MigrationSchemaType) -> None:
     """Create one of the migration schemas.
 
     Args:
-        conn (DuckConn): A DuckDB connection to the DEMOS database.
+        conn (DuckConn): A DuckDB connection with the DEMOS DB attached.
         which (MigrationSchemaType): Which schema to create (one of "raw", "staging").
     """
     match which:
@@ -61,7 +61,7 @@ def _drop_schema(conn: "DuckConn", which: MigrationSchemaType) -> None:
     """Drop one of the migration schemas.
 
     Args:
-        conn (DuckConn): A DuckDB connection to the DEMOS database.
+        conn (DuckConn): A DuckDB connection with the DEMOS DB attached.
         which (MigrationSchemaType): Which schema to drop (one of "raw", "staging").
     """
     match which:
@@ -80,7 +80,7 @@ def _drop_schema(conn: "DuckConn", which: MigrationSchemaType) -> None:
 def main(args: "Namespace") -> None:
     """Main program function."""
     check_if_in_devcontainer()
-    conn = create_duckdb_conn()
+    conn = attach_demos_to_conn(create_duckdb_conn())
     if args.action == "create":
         _create_schema(conn, args.schema)
     elif args.action == "drop":

--- a/data/demos_data_tools/migrate_files.py
+++ b/data/demos_data_tools/migrate_files.py
@@ -12,10 +12,10 @@ from typing import TYPE_CHECKING, List, TypedDict
 import boto3
 from dotenv import load_dotenv
 
-from duckdb_connection_manager import DEMOS_DDB_ATTACH_NAME, create_duckdb_conn
+from duckdb_connection_manager import DEMOS_DDB_ATTACH_NAME, create_duckdb_conn, attach_demos_to_conn
 from logger_utils import config_logger
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from duckdb import DuckDBPyConnection as DuckConn
     from mypy_boto3_s3 import S3Client
 
@@ -134,7 +134,7 @@ def migrate_file(
 
 def main() -> None:
     """Execute main program function."""
-    db_connection = create_duckdb_conn()
+    db_connection = attach_demos_to_conn(create_duckdb_conn())
     s3_client = boto3.Session().client("s3")
     copied_count = 0
     unmigrated_files = get_unmigrated_files(db_connection)
@@ -147,5 +147,5 @@ def main() -> None:
     return None
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     main()

--- a/data/demos_data_tools/pmda_exporter.py
+++ b/data/demos_data_tools/pmda_exporter.py
@@ -8,7 +8,13 @@ from typing import TYPE_CHECKING, List, Tuple
 
 from dotenv import load_dotenv
 
-from duckdb_connection_manager import DEMOS_DDB_ATTACH_NAME, PMDA_DDB_ATTACH_NAME, create_duckdb_conn
+from duckdb_connection_manager import (
+    DEMOS_DDB_ATTACH_NAME,
+    PMDA_DDB_ATTACH_NAME,
+    create_duckdb_conn,
+    attach_demos_to_conn,
+    attach_pmda_to_conn,
+)
 from logger_utils import config_logger
 
 if TYPE_CHECKING:
@@ -222,7 +228,7 @@ def main() -> None:
     """Execute main program function."""
     source_schema = os.environ["PMDA_EXPORT_SOURCE_SCHEMA"]
     target_schema = os.environ["PMDA_EXPORT_TARGET_SCHEMA"]
-    duck_conn = create_duckdb_conn()
+    duck_conn = attach_demos_to_conn(attach_pmda_to_conn(create_duckdb_conn()))
     tbl_list = get_pmda_table_list(duck_conn, source_schema)
     tbl_details = get_pmda_column_details(duck_conn, tbl_list, source_schema)
 

--- a/data/demos_data_tools/test_duckdb_connection_manager.py
+++ b/data/demos_data_tools/test_duckdb_connection_manager.py
@@ -1,6 +1,6 @@
 """A module containing tests for the duckdb_connection_manager.py file."""
 
-from unittest.mock import call
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -10,22 +10,20 @@ import duckdb_connection_manager
 class TestDuckDbConnectionManager:
     """A class for the tests for the duckdb_connection_manager.py file."""
 
-    db_conn_config = {
-        "ddb_pmda": {
-            "host": "testhost1",
-            "port": "12345",
-            "user": "fakeuser1",
-            "pwd": "fake?$'!@<&>passwd1",  # pragma: allowlist secret
-            "db": "fakedb1",
-        },
-        "ddb_demos": {
-            "host": "testhost2",
-            "port": "23456",
-            "user": "fakeuser2",
-            "pwd": "fakepasswd2",  # pragma: allowlist secret
-            "db": "fakedb2",
-            "sslmode": "prefer",
-        },
+    mock_pmda_config = {
+        "host": "testhost1",
+        "port": "12345",
+        "user": "fakeuser1",
+        "pwd": "fake?$'!@<&>passwd1",  # pragma: allowlist secret
+        "db": "fakedb1",
+    }
+    mock_demos_config = {
+        "host": "testhost2",
+        "port": "23456",
+        "user": "fakeuser2",
+        "pwd": "fakepasswd2",  # pragma: allowlist secret
+        "db": "fakedb2",
+        "sslmode": "prefer",
     }
 
     @pytest.fixture
@@ -35,55 +33,88 @@ class TestDuckDbConnectionManager:
 
     @pytest.fixture
     def mock_load_credentials(self, mocker):
-        """Patch _load_db_configs_from_env to return mock configuration."""
-        mock_loader = mocker.patch("duckdb_connection_manager._load_db_configs_from_env")
-        mock_loader.return_value = self.db_conn_config
-        return mock_loader
+        """Patch _load_db_config_from_env to prevent real env var loading."""
+        return mocker.patch("duckdb_connection_manager._load_db_config_from_env")
 
-    def test_load_db_configs_from_env(self, mocker):
+    def test__load_db_config_from_env_01(self, mocker):
         """Test duckdb_connection_manager.py functions.
 
-        ::load_db_configs_from_env
+        ::_load_db_config_from_env
 
-        ::It should build the DB config dictionary from environment variables.
+        ::It should build the PMDA config dict from environment variables.
         """
         env_vars = {
-            "PMDA_MYSQL_HOST": "envhost1",
-            "PMDA_MYSQL_PORT": "13306",
-            "PMDA_MYSQL_USER": "envuser1",
-            "PMDA_MYSQL_PWD": "envpwd1",  # pragma: allowlist secret
-            "PMDA_MYSQL_DB": "envdb1",
-            "DEMOS_PGSQL_HOST": "envhost2",
-            "DEMOS_PGSQL_PORT": "15432",
-            "DEMOS_PGSQL_USER": "envuser2",
-            "DEMOS_PGSQL_PWD": "envpwd2",  # pragma: allowlist secret
-            "DEMOS_PGSQL_DB": "envdb2",
-            "DEMOS_PGSQL_SSLMODE": "require",
+            "PMDA_MYSQL_HOST": self.mock_pmda_config["host"],
+            "PMDA_MYSQL_PORT": self.mock_pmda_config["port"],
+            "PMDA_MYSQL_USER": self.mock_pmda_config["user"],
+            "PMDA_MYSQL_PWD": self.mock_pmda_config["pwd"],
+            "PMDA_MYSQL_DB": self.mock_pmda_config["db"],
         }
         mocker.patch.dict("os.environ", env_vars)
 
-        result = duckdb_connection_manager._load_db_configs_from_env()
+        result = duckdb_connection_manager._load_db_config_from_env("PMDA")
 
-        expected = {
-            "ddb_pmda": {
-                "host": "envhost1",
-                "port": "13306",
-                "user": "envuser1",
-                "pwd": "envpwd1",  # pragma: allowlist secret
-                "db": "envdb1",
-            },
-            "ddb_demos": {
-                "host": "envhost2",
-                "port": "15432",
-                "user": "envuser2",
-                "pwd": "envpwd2",  # pragma: allowlist secret
-                "db": "envdb2",
-                "sslmode": "require",
-            },
+        assert result == self.mock_pmda_config
+
+    def test__load_db_config_from_env_02(self, mocker):
+        """Test duckdb_connection_manager.py functions.
+
+        ::_load_db_config_from_env
+
+        ::It should build the DEMOS config dict from environment variables.
+        """
+        env_vars = {
+            "DEMOS_PGSQL_HOST": self.mock_demos_config["host"],
+            "DEMOS_PGSQL_PORT": self.mock_demos_config["port"],
+            "DEMOS_PGSQL_USER": self.mock_demos_config["user"],
+            "DEMOS_PGSQL_PWD": self.mock_demos_config["pwd"],
+            "DEMOS_PGSQL_DB": self.mock_demos_config["db"],
+            "DEMOS_PGSQL_SSLMODE": self.mock_demos_config["sslmode"],
         }
-        assert result == expected
+        mocker.patch.dict("os.environ", env_vars)
 
-    def test_create_duckdb_conn_01(self, mock_duckdb_connect, mock_load_credentials):
+        result = duckdb_connection_manager._load_db_config_from_env("DEMOS")
+
+        assert result == self.mock_demos_config
+
+    def test__load_db_config_from_env_03(self, mocker):
+        """Test duckdb_connection_manager.py functions.
+
+        ::_load_db_config_from_env
+
+        ::It should raise a KeyError with a safe message when an env var is missing.
+        """
+        mocker.patch.dict("os.environ", {}, clear=True)
+
+        with pytest.raises(KeyError) as except_info:
+            duckdb_connection_manager._load_db_config_from_env("PMDA")
+
+        assert (
+            except_info.value.args[0] == "A KeyError occurred while loading the PMDA credentials from the environment."
+        )
+
+    def test__load_db_config_from_env_04(self, mocker):
+        """Test duckdb_connection_manager.py functions.
+
+        ::_load_db_config_from_env
+
+        ::It should handle other types of errors that are raised.
+        """
+        # This creates a replacement for os.environ that will throw
+        # Allows for testing
+        mock_env = MagicMock()
+        mock_env.__getitem__.side_effect = ValueError("unexpected")
+        mocker.patch.object(duckdb_connection_manager.os, "environ", new=mock_env)
+
+        with pytest.raises(RuntimeError) as except_info:
+            duckdb_connection_manager._load_db_config_from_env("DEMOS")
+
+        assert (
+            except_info.value.args[0] == "An unhandled exception occurred while loading "
+            "the DEMOS credentials from the environment."
+        )
+
+    def test_create_duckdb_conn_01(self, mock_duckdb_connect):
         """Test duckdb_connection_manager.py functions.
 
         ::create_duckdb_conn
@@ -92,10 +123,9 @@ class TestDuckDbConnectionManager:
         """
         duckdb_connection_manager.create_duckdb_conn()
 
-        mock_load_credentials.assert_called_once()
         mock_duckdb_connect.assert_called_once_with(":memory:", config={"memory_limit": "8GB", "threads": 8})
 
-    def test_create_duckdb_conn_02(self, mock_duckdb_connect, mock_load_credentials):
+    def test_create_duckdb_conn_02(self, mock_duckdb_connect):
         """Test duckdb_connection_manager.py functions.
 
         ::create_duckdb_conn
@@ -106,18 +136,71 @@ class TestDuckDbConnectionManager:
 
         mock_conn = mock_duckdb_connect.return_value
         assert mock_conn.install_extension.call_args_list == [call("postgres"), call("mysql")]
-        assert mock_conn.load_extension.call_args_list == [call("postgres"), call("mysql")]
 
-    def test_create_duckdb_conn_03(self, mock_duckdb_connect, mock_load_credentials):
+    def test_attach_pmda_to_conn_01(self, mock_load_credentials):
         """Test duckdb_connection_manager.py functions.
 
-        ::create_duckdb_conn
+        ::attach_pmda_to_conn
+
+        ::It should create a MySQL secret and escape single quotes in the password.
+        """
+        mock_conn = MagicMock()
+        mock_load_credentials.return_value = self.mock_pmda_config
+
+        duckdb_connection_manager.attach_pmda_to_conn(mock_conn)
+
+        secret_sql = mock_conn.execute.call_args_list[0].args[0]
+        assert "TYPE mysql" in secret_sql
+        assert "HOST 'testhost1'" in secret_sql
+        assert "PORT 12345" in secret_sql
+        assert "DATABASE fakedb1" in secret_sql
+        assert "USER 'fakeuser1'" in secret_sql
+        assert "PASSWORD 'fake?$''!@<&>passwd1'" in secret_sql  # pragma: allowlist secret
+
+    def test_attach_pmda_to_conn_02(self, mock_load_credentials):
+        """Test duckdb_connection_manager.py functions.
+
+        ::attach_pmda_to_conn
+
+        ::It should connect to MySQL.
+        """
+        mock_conn = MagicMock()
+        mock_load_credentials.return_value = self.mock_pmda_config
+
+        duckdb_connection_manager.attach_pmda_to_conn(mock_conn)
+
+        assert mock_conn.execute.call_args_list[1] == call("ATTACH '' AS ddb_pmda (TYPE mysql);")
+
+    def test_attach_pmda_to_conn_03(self, mock_load_credentials):
+        """Test duckdb_connection_manager.py functions.
+
+        ::attach_pmda_to_conn
+
+        ::It should raise a RuntimeError with a safe message when the connection fails.
+        """
+        mock_conn = MagicMock()
+        mock_exception_msg = "Something went wrong and this should not be logged"
+        mock_conn.execute.side_effect = Exception(mock_exception_msg)
+        mock_load_credentials.return_value = self.mock_pmda_config
+
+        with pytest.raises(RuntimeError) as except_info:
+            duckdb_connection_manager.attach_pmda_to_conn(mock_conn)
+
+        assert except_info.value.args[0] == "An error occurred while attempting to attach the PMDA database."
+        assert except_info.value.args[0] != mock_exception_msg
+
+    def test_attach_demos_to_conn_01(self, mock_load_credentials):
+        """Test duckdb_connection_manager.py functions.
+
+        ::attach_demos_to_conn
 
         ::It should create a PostgreSQL secret with the connection details.
         """
-        duckdb_connection_manager.create_duckdb_conn()
+        mock_conn = MagicMock()
+        mock_load_credentials.return_value = self.mock_demos_config
 
-        mock_conn = mock_duckdb_connect.return_value
+        duckdb_connection_manager.attach_demos_to_conn(mock_conn)
+
         secret_sql = mock_conn.execute.call_args_list[0].args[0]
         assert "TYPE postgres" in secret_sql
         assert "HOST 'testhost2'" in secret_sql
@@ -126,45 +209,35 @@ class TestDuckDbConnectionManager:
         assert "USER 'fakeuser2'" in secret_sql
         assert "PASSWORD 'fakepasswd2'" in secret_sql  # pragma: allowlist secret
 
-    def test_create_duckdb_conn_04(self, mock_duckdb_connect, mock_load_credentials):
+    def test_attach_demos_to_conn_02(self, mock_load_credentials):
         """Test duckdb_connection_manager.py functions.
 
-        ::create_duckdb_conn
-
-        ::It should create a MySQL secret and escape single quotes in the password.
-        """
-        duckdb_connection_manager.create_duckdb_conn()
-
-        mock_conn = mock_duckdb_connect.return_value
-        secret_sql = mock_conn.execute.call_args_list[3].args[0]
-        assert "TYPE mysql" in secret_sql
-        assert "HOST 'testhost1'" in secret_sql
-        assert "PORT 12345" in secret_sql
-        assert "DATABASE fakedb1" in secret_sql
-        assert "USER 'fakeuser1'" in secret_sql
-        assert "PASSWORD 'fake?$''!@<&>passwd1'" in secret_sql  # pragma: allowlist secret
-
-    def test_create_duckdb_conn_05(self, mock_duckdb_connect, mock_load_credentials):
-        """Test duckdb_connection_manager.py functions.
-
-        ::create_duckdb_conn
+        ::attach_demos_to_conn
 
         ::It should connect to PostgreSQL.
         """
-        duckdb_connection_manager.create_duckdb_conn()
+        mock_conn = MagicMock()
+        mock_load_credentials.return_value = self.mock_demos_config
 
-        mock_conn = mock_duckdb_connect.return_value
+        duckdb_connection_manager.attach_demos_to_conn(mock_conn)
+
         assert mock_conn.execute.call_args_list[1] == call("ATTACH 'sslmode=prefer' AS ddb_demos (TYPE postgres);")
         assert mock_conn.execute.call_args_list[2] == call("SET pg_null_byte_replacement=''")
 
-    def test_create_duckdb_conn_06(self, mock_duckdb_connect, mock_load_credentials):
+    def test_attach_demos_to_conn_03(self, mock_load_credentials):
         """Test duckdb_connection_manager.py functions.
 
-        ::create_duckdb_conn
+        ::attach_demos_to_conn
 
-        ::It should connect to MySQL.
+        ::It should raise a RuntimeError with a safe message when the connection fails.
         """
-        duckdb_connection_manager.create_duckdb_conn()
+        mock_conn = MagicMock()
+        mock_exception_msg = "Something went wrong and this should not be logged"
+        mock_conn.execute.side_effect = Exception(mock_exception_msg)
+        mock_load_credentials.return_value = self.mock_demos_config
 
-        mock_conn = mock_duckdb_connect.return_value
-        assert mock_conn.execute.call_args_list[4] == call("ATTACH '' AS ddb_pmda (TYPE mysql);")
+        with pytest.raises(RuntimeError) as except_info:
+            duckdb_connection_manager.attach_demos_to_conn(mock_conn)
+
+        assert except_info.value.args[0] == "An error occurred while attempting to attach the DEMOS database."
+        assert except_info.value.args[0] != mock_exception_msg

--- a/data/demos_data_tools/test_migrate_files.py
+++ b/data/demos_data_tools/test_migrate_files.py
@@ -162,12 +162,14 @@ class TestMigrateFiles:
             {"old_path": "old/2.txt", "new_path": "new/2.txt"},
         ]
         mock_create_duckdb_conn = mocker.patch("migrate_files.create_duckdb_conn", return_value=mock_conn)
+        mock_attach_demos_to_conn = mocker.patch("migrate_files.attach_demos_to_conn", return_value=mock_conn)
         mock_get_unmigrated_files = mocker.patch("migrate_files.get_unmigrated_files", return_value=test_rows)
         mock_migrate_file = mocker.patch("migrate_files.migrate_file")
 
         migrate_files.main()
 
         mock_create_duckdb_conn.assert_called_once()
+        mock_attach_demos_to_conn.assert_called_once_with(mock_conn)
         mock_boto3.Session.return_value.client.assert_called_once_with("s3")
         mock_get_unmigrated_files.assert_called_once_with(mock_conn)
         assert mock_migrate_file.call_count == 2


### PR DESCRIPTION
## Summary

This is a fix to the data migration module code that updates how we attach to DuckDB in the `duckdb_connection_manager.py` file. This version allows for the connection to be created and then have both PMDA and DEMOS attached separately. This permits working on DEMOS-related items even if the MySQL configuration is not working.

This also updates the logging to prevent the logging of credentials when a connection failure happens.

## Changes

Updates the connection process and tests. New tests not added for files that weren't covered already, but I exercised locally.

## Validation

- [X] Automated tests added or updated
- [X] Relevant automated tests pass
- [X] Manually tested
- [ ] Testing is not applicable

## Automated review

- [X] Run AI Code Review