### PR TITLE
DEMOS-2531: made keyword search non-memorable

### DIFF
--- a/client/src/components/table/KeywordSearch.test.tsx
+++ b/client/src/components/table/KeywordSearch.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Table } from "./Table";
 import { TestType, testTableData } from "./Table.test";
@@ -32,16 +32,19 @@ export const testColumns = [
   }),
 ];
 
+const renderKeywordSearch = () =>
+  render(
+    <Table<TestType>
+      keywordSearch={(table) => <KeywordSearch table={table} />}
+      columns={testColumns}
+      data={testTableData}
+      noResultsFoundMessage="No results were returned. Adjust your search and filter criteria."
+    />
+  );
+
 describe.sequential("KeywordSearch Component", () => {
   beforeEach(() => {
-    render(
-      <Table<TestType>
-        keywordSearch={(table) => <KeywordSearch table={table} />}
-        columns={testColumns}
-        data={testTableData}
-        noResultsFoundMessage="No results were returned. Adjust your search and filter criteria."
-      />
-    );
+    renderKeywordSearch();
   });
 
   describe("Initial Render", () => {
@@ -73,6 +76,15 @@ describe.sequential("KeywordSearch Component", () => {
       expect(screen.getByText("Item Three")).toBeInTheDocument();
       expect(screen.getByText("Item Four")).toBeInTheDocument();
       expect(screen.getByText("Item Five")).toBeInTheDocument();
+    });
+
+    it("clears search text when the table is remounted", async () => {
+      const user = userEvent.setup();
+      await user.type(screen.getByTestId(TEST_IDS.input), "unique");
+
+      cleanup();
+      renderKeywordSearch();
+      expect(screen.getByTestId(TEST_IDS.input)).toHaveValue("");
     });
   });
 

--- a/client/src/components/table/KeywordSearch.tsx
+++ b/client/src/components/table/KeywordSearch.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { ExitIcon, SearchIcon } from "components/icons";
 import { getInputColors, INPUT_BASE_CLASSES, LABEL_CLASSES } from "components/input/Input";
 import { useDebounced } from "hooks/useDebounced";
-import { useLocalStorage } from "hooks";
 
 import { CellContext, Row, Table } from "@tanstack/react-table";
 
@@ -12,13 +11,22 @@ export const TEST_IDS = {
   clearButton: "button-clear-search",
 };
 
-export const DEFAULT_KEYWORD_SEARCH_STORAGE_KEY = "keyword-search";
-export interface KeywordSearchProps<T> {
+type KeywordSearchStateProps =
+  | {
+      value: string;
+      onValueChange: (value: string) => void;
+    }
+  | {
+      value?: never;
+      onValueChange?: never;
+    };
+
+export type KeywordSearchProps<T> = {
   table: Table<T>;
   label?: string;
   debounceMs?: number;
   placeholder?: string;
-}
+} & KeywordSearchStateProps;
 
 export const arrIncludesAllInsensitive = <T,>(
   row: Row<T>,
@@ -70,11 +78,15 @@ export function highlightCell<TData>({
 
 export function KeywordSearch<T>({
   table,
+  value,
+  onValueChange,
   label = "Search:",
   debounceMs = 300,
   placeholder = "Search",
 }: KeywordSearchProps<T>) {
-  const [queryString, setQueryString] = useLocalStorage(DEFAULT_KEYWORD_SEARCH_STORAGE_KEY);
+  const [localQueryString, setLocalQueryString] = React.useState("");
+  const queryString = value ?? localQueryString;
+  const setQueryString = onValueChange ?? setLocalQueryString;
 
   const debouncedQueryString = useDebounced(queryString, debounceMs);
 
@@ -89,10 +101,6 @@ export function KeywordSearch<T>({
       table.setGlobalFilter("");
     }
   }, [debouncedQueryString, table]);
-
-  const onValueChange = (val: string) => {
-    setQueryString(val);
-  };
 
   const clearSearch = () => {
     setQueryString("");
@@ -112,7 +120,7 @@ export function KeywordSearch<T>({
           name={TEST_IDS.input}
           data-testid={TEST_IDS.input}
           value={queryString}
-          onChange={(e) => onValueChange(e.target.value)}
+          onChange={(e) => setQueryString(e.target.value)}
           className={`${INPUT_BASE_CLASSES} ${getInputColors("")} w-full pl-10 pr-10`}
           aria-label="Input keyword search query"
           placeholder={placeholder}

--- a/client/src/components/table/tables/DemonstrationTable.test.tsx
+++ b/client/src/components/table/tables/DemonstrationTable.test.tsx
@@ -122,7 +122,7 @@ const buildDemonstrations = (configs: TestDemoConfig[]): TestDemonstration[] => 
 };
 
 // Helper functions
-const TestDemonstrationTable: React.FC<
+const ControlledDemonstrationTable: React.FC<
   Omit<React.ComponentProps<typeof DemonstrationTable>, "searchValue" | "onSearchValueChange">
 > = (props) => {
   const [searchValue, setSearchValue] = React.useState("");
@@ -135,7 +135,7 @@ const TestDemonstrationTable: React.FC<
 const renderDemonstrations = (configs: TestDemoConfig[] = TEST_DEMO_CONFIGS) => {
   const demonstrations = buildDemonstrations(configs);
   return render(
-    <TestDemonstrationTable projectOfficerOptions={TEST_PEOPLE} demonstrations={demonstrations} />
+    <ControlledDemonstrationTable projectOfficerOptions={TEST_PEOPLE} demonstrations={demonstrations} />
   );
 };
 
@@ -227,7 +227,7 @@ describe("Demonstrations", () => {
   describe("Empty states", () => {
     it("passes correct empty message when provided", async () => {
       render(
-        <TestDemonstrationTable
+        <ControlledDemonstrationTable
           emptyRowsMessage="testEmptyRowsMessage"
           projectOfficerOptions={TEST_PEOPLE}
           demonstrations={[]}

--- a/client/src/components/table/tables/DemonstrationTable.test.tsx
+++ b/client/src/components/table/tables/DemonstrationTable.test.tsx
@@ -122,10 +122,20 @@ const buildDemonstrations = (configs: TestDemoConfig[]): TestDemonstration[] => 
 };
 
 // Helper functions
+const TestDemonstrationTable: React.FC<
+  Omit<React.ComponentProps<typeof DemonstrationTable>, "searchValue" | "onSearchValueChange">
+> = (props) => {
+  const [searchValue, setSearchValue] = React.useState("");
+
+  return (
+    <DemonstrationTable {...props} searchValue={searchValue} onSearchValueChange={setSearchValue} />
+  );
+};
+
 const renderDemonstrations = (configs: TestDemoConfig[] = TEST_DEMO_CONFIGS) => {
   const demonstrations = buildDemonstrations(configs);
   return render(
-    <DemonstrationTable projectOfficerOptions={TEST_PEOPLE} demonstrations={demonstrations} />
+    <TestDemonstrationTable projectOfficerOptions={TEST_PEOPLE} demonstrations={demonstrations} />
   );
 };
 
@@ -217,7 +227,7 @@ describe("Demonstrations", () => {
   describe("Empty states", () => {
     it("passes correct empty message when provided", async () => {
       render(
-        <DemonstrationTable
+        <TestDemonstrationTable
           emptyRowsMessage="testEmptyRowsMessage"
           projectOfficerOptions={TEST_PEOPLE}
           demonstrations={[]}

--- a/client/src/components/table/tables/DemonstrationTable.tsx
+++ b/client/src/components/table/tables/DemonstrationTable.tsx
@@ -15,6 +15,16 @@ const DEFAULT_NO_SEARCH_RESULTS_MESSAGE =
   "No results were returned. Adjust your search and filter criteria.";
 const DEFAULT_EMPTY_ROWS_MESSAGE = "No demonstrations are tracked.";
 
+type DemonstrationTableSearchProps =
+  | {
+      searchValue: string;
+      onSearchValueChange: (value: string) => void;
+    }
+  | {
+      searchValue?: never;
+      onSearchValueChange?: never;
+    };
+
 export type DemonstrationTableRow =
   | (Demonstration & { type: "demonstration" })
   | (DemonstrationAmendment & {
@@ -73,16 +83,20 @@ const applyDefaultSort = (demonstrations: Demonstration[]): Demonstration[] => {
   });
 };
 
-export const DemonstrationTable: React.FC<{
+export const DemonstrationTable: React.FC<
+  {
   demonstrations: Demonstration[];
   projectOfficerOptions: Pick<Person, "fullName">[];
   emptyRowsMessage?: string;
   noResultsFoundMessage?: string;
-}> = ({
+  } & DemonstrationTableSearchProps
+> = ({
   demonstrations,
   projectOfficerOptions,
   emptyRowsMessage = DEFAULT_EMPTY_ROWS_MESSAGE,
   noResultsFoundMessage = DEFAULT_NO_SEARCH_RESULTS_MESSAGE,
+  searchValue,
+  onSearchValueChange,
 }) => {
   const demonstrationColumns = DemonstrationColumns(projectOfficerOptions);
   const sortedDemonstrations = applyDefaultSort(demonstrations);
@@ -96,7 +110,17 @@ export const DemonstrationTable: React.FC<{
             type: "demonstration",
           }))}
           columns={demonstrationColumns}
-          keywordSearch={(table) => <KeywordSearch table={table} />}
+          keywordSearch={(table) => (
+            searchValue !== undefined && onSearchValueChange ? (
+              <KeywordSearch
+                table={table}
+                value={searchValue}
+                onValueChange={onSearchValueChange}
+              />
+            ) : (
+              <KeywordSearch table={table} />
+            )
+          )}
           columnFilter={(table) => <ColumnFilter table={table} />}
           pagination={(table) => <PaginationControls table={table} />}
           emptyRowsMessage={emptyRowsMessage}

--- a/client/src/components/table/tables/DemonstrationTable.tsx
+++ b/client/src/components/table/tables/DemonstrationTable.tsx
@@ -15,16 +15,6 @@ const DEFAULT_NO_SEARCH_RESULTS_MESSAGE =
   "No results were returned. Adjust your search and filter criteria.";
 const DEFAULT_EMPTY_ROWS_MESSAGE = "No demonstrations are tracked.";
 
-type DemonstrationTableSearchProps =
-  | {
-      searchValue: string;
-      onSearchValueChange: (value: string) => void;
-    }
-  | {
-      searchValue?: never;
-      onSearchValueChange?: never;
-    };
-
 export type DemonstrationTableRow =
   | (Demonstration & { type: "demonstration" })
   | (DemonstrationAmendment & {
@@ -42,9 +32,7 @@ export type DemonstrationTableRow =
       primaryProjectOfficer: Pick<Person, "fullName" | "id">;
     });
 
-const getSubRows = (
-  row: DemonstrationTableRow
-): DemonstrationTableRow[] | undefined => {
+const getSubRows = (row: DemonstrationTableRow): DemonstrationTableRow[] | undefined => {
   if (row.type !== "demonstration") return undefined;
   return [
     ...row.amendments.map(
@@ -83,14 +71,16 @@ const applyDefaultSort = (demonstrations: Demonstration[]): Demonstration[] => {
   });
 };
 
-export const DemonstrationTable: React.FC<
-  {
+type DemonstrationTableProps = {
   demonstrations: Demonstration[];
   projectOfficerOptions: Pick<Person, "fullName">[];
   emptyRowsMessage?: string;
   noResultsFoundMessage?: string;
-  } & DemonstrationTableSearchProps
-> = ({
+  searchValue: string;
+  onSearchValueChange: (value: string) => void;
+};
+
+export const DemonstrationTable: React.FC<DemonstrationTableProps> = ({
   demonstrations,
   projectOfficerOptions,
   emptyRowsMessage = DEFAULT_EMPTY_ROWS_MESSAGE,
@@ -111,15 +101,7 @@ export const DemonstrationTable: React.FC<
           }))}
           columns={demonstrationColumns}
           keywordSearch={(table) => (
-            searchValue !== undefined && onSearchValueChange ? (
-              <KeywordSearch
-                table={table}
-                value={searchValue}
-                onValueChange={onSearchValueChange}
-              />
-            ) : (
-              <KeywordSearch table={table} />
-            )
+            <KeywordSearch table={table} value={searchValue} onValueChange={onSearchValueChange} />
           )}
           columnFilter={(table) => <ColumnFilter table={table} />}
           pagination={(table) => <PaginationControls table={table} />}

--- a/client/src/pages/DemonstrationsPage.test.tsx
+++ b/client/src/pages/DemonstrationsPage.test.tsx
@@ -98,4 +98,19 @@ describe("DemonstrationsPage tab persistence", () => {
 
     expect(sessionStorage.getItem("selectedDemonstrationTab")).toBe("demonstrations");
   });
+
+  it("shares search between tabs but clears it after leaving the page", () => {
+    const { unmount } = render(<DemonstrationsPage />);
+    const searchInput = screen.getByLabelText(/keyword search/i);
+
+    fireEvent.change(searchInput, { target: { value: "Demo One" } });
+    fireEvent.click(screen.getByTestId("button-demonstrations"));
+
+    expect(screen.getByLabelText(/keyword search/i)).toHaveValue("Demo One");
+
+    unmount();
+    render(<DemonstrationsPage />);
+
+    expect(screen.getByLabelText(/keyword search/i)).toHaveValue("");
+  });
 });

--- a/client/src/pages/DemonstrationsPage.tsx
+++ b/client/src/pages/DemonstrationsPage.tsx
@@ -68,6 +68,7 @@ export type DemonstrationsPageQueryResult = {
 export const DemonstrationsPage: React.FC = () => {
   const { data, loading, error } =
     useQuery<DemonstrationsPageQueryResult>(DEMONSTRATIONS_PAGE_QUERY);
+  const [searchValue, setSearchValue] = React.useState("");
 
   const demonstrations = data?.demonstrations || [];
   const hasApprovedDemonstrations = demonstrations.some(
@@ -95,12 +96,16 @@ export const DemonstrationsPage: React.FC = () => {
               demonstrations={myDemonstrations}
               projectOfficerOptions={data.people}
               emptyRowsMessage="You have no assigned demonstrations at this time."
+              searchValue={searchValue}
+              onSearchValueChange={setSearchValue}
             />
           </Tab>
           <Tab label={`All Demonstrations (${demonstrations.length})`} value="demonstrations">
             <DemonstrationTable
               demonstrations={demonstrations}
               projectOfficerOptions={data.people}
+              searchValue={searchValue}
+              onSearchValueChange={setSearchValue}
             />
           </Tab>
         </HorizontalSectionTabs>


### PR DESCRIPTION
**Summary**  
Fixes keyword search state leaking between unrelated tables while preserving search across Demonstrations tabs.

**Changes**

- Removed keyword search persistence from local storage.
- Added controlled and uncontrolled search support.
- Shared search state between “My Demonstrations” and “All Demonstrations.”
- Made `DemonstrationTable` search props required.
- Added and updated tests for search behavior.

**Additional notes**  
TypeScript, ESLint, Prettier, and diff checks pass. Focused tests were blocked by a missing local Rolldown native binding.

**Automated review**

- [ ] Run AI Code Review