### PR TITLE
DEMOS-2531: Updated keyword search to not remmeber

### DIFF
--- a/client/src/components/table/KeywordSearch.test.tsx
+++ b/client/src/components/table/KeywordSearch.test.tsx
@@ -32,16 +32,20 @@ export const testColumns = [
   }),
 ];
 
+const TestTable = () => (
+  <Table<TestType>
+    keywordSearch={(table) => <KeywordSearch table={table} />}
+    columns={testColumns}
+    data={testTableData}
+    noResultsFoundMessage="No results were returned. Adjust your search and filter criteria."
+  />
+);
+
 describe.sequential("KeywordSearch Component", () => {
+  let unmount: () => void;
+
   beforeEach(() => {
-    render(
-      <Table<TestType>
-        keywordSearch={(table) => <KeywordSearch table={table} />}
-        columns={testColumns}
-        data={testTableData}
-        noResultsFoundMessage="No results were returned. Adjust your search and filter criteria."
-      />
-    );
+    ({ unmount } = render(<TestTable />));
   });
 
   describe("Initial Render", () => {
@@ -73,6 +77,19 @@ describe.sequential("KeywordSearch Component", () => {
       expect(screen.getByText("Item Three")).toBeInTheDocument();
       expect(screen.getByText("Item Four")).toBeInTheDocument();
       expect(screen.getByText("Item Five")).toBeInTheDocument();
+    });
+
+    it("does not retain the search value after remounting", async () => {
+      const user = userEvent.setup();
+      const keywordSearchInput = screen.getByTestId(TEST_IDS.input);
+
+      await user.type(keywordSearchInput, "unique");
+      expect(keywordSearchInput).toHaveValue("unique");
+
+      unmount();
+      render(<TestTable />);
+
+      expect(screen.getByTestId(TEST_IDS.input)).toHaveValue("");
     });
   });
 

--- a/client/src/components/table/KeywordSearch.tsx
+++ b/client/src/components/table/KeywordSearch.tsx
@@ -1,9 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { ExitIcon, SearchIcon } from "components/icons";
 import { getInputColors, INPUT_BASE_CLASSES, LABEL_CLASSES } from "components/input/Input";
 import { useDebounced } from "hooks/useDebounced";
-import { useLocalStorage } from "hooks";
 
 import { CellContext, Row, Table } from "@tanstack/react-table";
 
@@ -12,7 +11,6 @@ export const TEST_IDS = {
   clearButton: "button-clear-search",
 };
 
-export const DEFAULT_KEYWORD_SEARCH_STORAGE_KEY = "keyword-search";
 export interface KeywordSearchProps<T> {
   table: Table<T>;
   label?: string;
@@ -74,7 +72,7 @@ export function KeywordSearch<T>({
   debounceMs = 300,
   placeholder = "Search",
 }: KeywordSearchProps<T>) {
-  const [queryString, setQueryString] = useLocalStorage(DEFAULT_KEYWORD_SEARCH_STORAGE_KEY);
+  const [queryString, setQueryString] = useState("");
 
   const debouncedQueryString = useDebounced(queryString, debounceMs);
 


### PR DESCRIPTION
THe problem was that the search bars were memorable, And we needed them to not be memorable

<!--
Suggested title: `DEMOS-####: Concise description` This will be used as the commit content by default
Keep this focused. Uncomment or remove sections as needed.
-->

## Summary
Cleaned up the memory-related code. No tests referenced keyword-search local storage, so no test changes were needed. Storage-hook and tab-session tests remain because they cover separate functionality.
TypeScript, ESLint, Prettier, and diff checks pass.

## Changes
Added one functional state change, and one focused regression test.

- [x] Automated tests added or updated
- [x] Relevant automated tests pass
- [x] Manually tested
- [ ] Testing is not applicable

Testing details:
<!-- ## Screenshots or recordings -->
https://github.com/user-attachments/assets/ca4764f8-eed4-4a2c-9c6f-19537355833e


## Additional notes

Will close out other PR. 

## Automated review

- [x] Run AI Code Review <!-- The AI PR review will only run if this is checked [x] -->
