### PR TITLE
DEMOS-2540-add-import-of-file-registry-to-raw

### DIFF
--- a/data/migration/scripts/full_reset_and_end_to_end_run.sh
+++ b/data/migration/scripts/full_reset_and_end_to_end_run.sh
@@ -11,8 +11,8 @@ python check_if_in_devcontainer.py
 
 # Drop and recreate migration schemas entirely
 python manage_migration_schemas.py drop raw
-python manage_migration_schemas.py drop staging
 python manage_migration_schemas.py create raw
+python manage_migration_schemas.py drop staging
 python manage_migration_schemas.py create staging
 
 # Reset the database to empty
@@ -23,6 +23,12 @@ npm run dbrefresh
 # Move data from MySQL to PostgreSQL
 cd /workspaces/demos/data/demos_data_tools
 python pmda_exporter.py
+
+# Remove the PMDA S3 file list if it exists in seeds
+# Then, pull it down from S3
+cd /workspaces/demos/data/migration/stage_pmda_for_migration/seeds
+rm -f raw_pmda_s3_file_list.csv
+aws s3 cp s3://demos-prod-pmda-efs-transfer/s3_file_list.csv raw_pmda_s3_file_list.csv
 
 # Run dbt project
 cd /workspaces/demos/data/migration/stage_pmda_for_migration

--- a/data/migration/scripts/reset_from_raw.sh
+++ b/data/migration/scripts/reset_from_raw.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/zsh
-# Reset raw, staging and app
+# Reset raw, staging, and app
 # Useful to ensure you leave no prod data locally
 set -e
 
@@ -10,7 +10,7 @@ source /opt/demos-data/bin/activate
 # Not for use outside of devcontainer
 python check_if_in_devcontainer.py
 
-# Drop and recreate staging schema
+# Drop and recreate migration schemas entirely
 python manage_migration_schemas.py drop raw
 python manage_migration_schemas.py create raw
 python manage_migration_schemas.py drop staging
@@ -20,3 +20,7 @@ python manage_migration_schemas.py create staging
 cd /workspaces/demos/server
 npm run migrate:reset
 npm run dbrefresh
+
+# Remove the PMDA S3 file list if it exists in seeds
+cd /workspaces/demos/data/migration/stage_pmda_for_migration/seeds
+rm -f raw_pmda_s3_file_list.csv

--- a/data/migration/scripts/reset_from_staging.sh
+++ b/data/migration/scripts/reset_from_staging.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/zsh
-# Reset staging and app
+# Reset staging and app and download the file list
 set -e
 
 # Start in the demos_data_tools and activate the venv
@@ -17,3 +17,9 @@ python manage_migration_schemas.py create staging
 cd /workspaces/demos/server
 npm run migrate:reset
 npm run dbrefresh
+
+# Remove the PMDA S3 file list if it exists in seeds
+# Then, pull it down from S3
+cd /workspaces/demos/data/migration/stage_pmda_for_migration/seeds
+rm -f raw_pmda_s3_file_list.csv
+aws s3 cp s3://demos-prod-pmda-efs-transfer/s3_file_list.csv raw_pmda_s3_file_list.csv

--- a/data/migration/stage_pmda_for_migration/README.md
+++ b/data/migration/stage_pmda_for_migration/README.md
@@ -38,6 +38,7 @@ You can use the scripts found in `data/migration/scripts` to help set up and run
 - Copy `data/demos_data_tools/.env.example` to `data/demos_data_tools/.env` and fill in the credentials accordingly. All the Python scripts in `demos_data_tools` rely on the configuration in this `.env` file.
 - Copy `data/migration/stage_pmda_for_migration/profiles.yml.example` to `data/migration/stage_pmda_for_migration/profiles.yml` and configure the `dev` connection correctly.
 - Obtain a set of short-lived AWS credentials and put them into `~/.aws/credentials`, replacing the `[default]` section. The `devcontainer` configures these with fake credentials by default to support the `localstack` tooling; however, you will need actual credentials to connect to S3 and pull the file list from there. These generally will expire on a short timeframe, so you will need to get them regularly.
+  - Remember: the contents of `~/.aws/credentials` are overwritten whenever you rebuild your `devcontainer`, so you will need to get the keys again if you rebuild. Since they are not long-lived anyway, this is unlikely to come up frequently.
 
 ### Migration Scripts
 

--- a/data/migration/stage_pmda_for_migration/README.md
+++ b/data/migration/stage_pmda_for_migration/README.md
@@ -28,15 +28,40 @@ Try to name your tests in a descriptive manner, either by naming the file with s
 
 Contracts are enforced on the `cleaned/final` models and the documentation in `models.yml` should conform to the data types in `demos_app`. This enforcement prevents the SQL from creating incompatible data types.
 
-## Setup / Commands
+## Local Development Setup / Commands
 
-Ensure you have rebuilt your `devcontainer` recently so that the Python setup is in place. Copy `profiles.yml.example` to `profiles.yml` and configure the `dev` connection as needed. You should be able to use the local copy of the database as long as you have a copy of PMDA in `legacy_pmda_raw` (see the `demos_data_tools` package for how to get this).
+### Credentials and Configuration
 
-You will also need a staging schema to work in. On your local DB copy, run `CREATE SCHEMA legacy_pmda_staged` - this will eventually be automated as part of the `demos_data_tools` packaging.
+You can use the scripts found in `data/migration/scripts` to help set up and run things locally. You'll need to set up your credentials in a few places.
 
-Run `dbt deps` to install the packages used in this project, and then `dbt debug` to check that your setup is functioning. Once it is, you can just use `dbt build` to rebuild the project.
+- Ensure you've rebuilt your `devcontainer` recently to ensure that you have the correct Python setup (which includes `dbt`).
+- Copy `data/demos_data_tools/.env.example` to `data/demos_data_tools/.env` and fill in the credentials accordingly. All the Python scripts in `demos_data_tools` rely on the configuration in this `.env` file.
+- Copy `data/migration/stage_pmda_for_migration/profiles.yml.example` to `data/migration/stage_pmda_for_migration/profiles.yml` and configure the `dev` connection correctly.
+- Obtain a set of short-lived AWS credentials and put them into `~/.aws/credentials`, replacing the `[default]` section. The `devcontainer` configures these with fake credentials by default to support the `localstack` tooling; however, you will need actual credentials to connect to S3 and pull the file list from there. These generally will expire on a short timeframe, so you will need to get them regularly.
 
-Note that if you are editing models and you remove them, `dbt` **_does not_** clean up old tables. So you should regularly drop the contents of `legacy_pmda_staged` to ensure that you remove old tables.
+### Migration Scripts
+
+There are scripts in `data/migration/scripts` to enable common local development tasks.
+
+- `full_reset_and_end_to_end_run.sh` is a way to run the entire process end to end; since this involves pulling the raw data over from the PMDA MySQL copy, it takes longer, so you probably won't want to do this regularly. Remember, you'll need the short-lived AWS credentials for this script to work.
+- `reset_from_raw.sh` is a way to reset your local environment to a fresh state. It removes existing tables and then recreates the raw and staging schemas, resets the application database, and removes the local file containing the S3 file list.
+- `reset_from_staging.sh` is the command you'll use most often. It drops existing tables and then recreates the staging schema (where `dbt` operates), resets the application database, and removes and downloads the local file containing the S3 file list, which is loaded in as a seed (and not committed to Git).
+  - Note that if you are editing models and you remove them, `dbt` **_does not_** clean up old tables. So you should regularly clean up the contents of `legacy_pmda_staged` to ensure that you remove old tables. Running ./reset_from_staging.sh` is an easy way to do this without wiping out the raw schema and requiring a longer load of data from MySQL to PostgreSQL.
+  - Remember, like the full reset, you'll need the short-lived AWS credentials for this script to work.
+
+### Getting Started
+
+Run `dbt deps` to install the packages used in this project, and then `dbt debug` to check that your setup is functioning. Once it is, you can just use `dbt build` to rebuild the project. For your initial run, you can use `./full_reset_and_end_to_end_run.sh` since you need to make a copy of PMDA into the raw schema.
+
+### Regular Development
+
+Whenever you want to start fresh from staging without reloading the raw data, use `./reset_from_staging.sh` to do so. You'll need to do this any time you've loaded data into `demos_app` and want to try again, since otherwise, DEMOS will block duplicates of certain types of records.
+
+You can use `dbt build` to rebuild the project, which loads data into `legacy_pmda_staging`. `dbt` does a drop and reload each time, so you can just run this command as many times as you want, keeping in mind the note above about `dbt` not cleaning up old tables.
+
+When you want to load data from the staging schema into `demos_app`, use the `load_staged_data_to_demos_app.py` script in `data/demos_data_tools`.
+
+### Other Useful Commands
 
 You can use `dbt-codegen` to generate a sources.yml style file for a schema. Note that if you point directly at the existing sources.yml file, you will overwrite what is there! So be careful.
 

--- a/data/migration/stage_pmda_for_migration/models/docs/docs_pmda_s3_file_list.sql
+++ b/data/migration/stage_pmda_for_migration/models/docs/docs_pmda_s3_file_list.sql
@@ -1,0 +1,20 @@
+WITH file_names AS (
+    SELECT
+        file_path AS s3_prefix_and_file_name,
+        split_part(file_path, '/', -1) AS file_name,
+        size_bytes,
+        etag
+    FROM
+        {{ ref("raw_pmda_s3_file_list") }}
+)
+
+SELECT
+    left(s3_prefix_and_file_name, length(s3_prefix_and_file_name) - length(file_name)) AS s3_prefix,
+    file_name,
+    s3_prefix_and_file_name,
+    size_bytes,
+    etag
+FROM
+    file_names
+WHERE
+    file_name != ''

--- a/data/migration/stage_pmda_for_migration/models/models.yml
+++ b/data/migration/stage_pmda_for_migration/models/models.yml
@@ -274,7 +274,7 @@ models:
           - relationships:
               name: assert_document_owner_user_exists_in_user
               arguments:
-                to: ref('final_demos_app_user')
+                to: ref('final_demos_app_users')
                 field: id
       - name: document_type_id
         data_type: text

--- a/data/migration/stage_pmda_for_migration/models/sources.yml
+++ b/data/migration/stage_pmda_for_migration/models/sources.yml
@@ -2452,7 +2452,8 @@ sources:
             data_type: timestamp with time zone
 
       - name: mdcd_demo_aplctn_doc_rpstry_dtl
-        tags: ["source_in_use"]
+        config:
+          tags: ["source_in_use"]
         columns:
           - name: mdcd_demo_aplctn_doc_rpstry_dtl_id
             data_type: integer
@@ -2482,7 +2483,8 @@ sources:
             data_type: timestamp with time zone
 
       - name: mdcd_demo_aplctn_doc_rpstry_fil
-        tags: ["source_in_use"]
+        config:
+          tags: ["source_in_use"]
         columns:
           - name: mdcd_demo_aplctn_doc_rpstry_fil_id
             data_type: integer
@@ -2508,6 +2510,8 @@ sources:
             data_type: timestamp with time zone
 
       - name: mdcd_demo_aplctn_doc_type_rfrnc
+        config:
+          tags: ["source_in_use"]
         columns:
           - name: mdcd_demo_aplctn_doc_type_cd
             data_type: integer
@@ -3667,6 +3671,8 @@ sources:
             data_type: timestamp with time zone
 
       - name: mdcd_dlvrbl
+        config:
+          tags: ["source_in_use"]
         columns:
           - name: mdcd_dlvrbl_id
             data_type: integer
@@ -3913,6 +3919,8 @@ sources:
             data_type: smallint
 
       - name: mdcd_dlvrbl_hstry
+        config:
+          tags: ["source_in_use"]
         columns:
           - name: mdcd_dlvrbl_hstry_id
             data_type: integer
@@ -4117,6 +4125,8 @@ sources:
             data_type: smallint
 
       - name: mdcd_dlvrbl_rpt_ocrnc_rfrnc
+        config:
+          tags: ["source_in_use"]
         columns:
           - name: mdcd_dlvrbl_rpt_ocrnc_cd
             data_type: integer
@@ -4151,6 +4161,8 @@ sources:
             data_type: timestamp with time zone
 
       - name: mdcd_dlvrbl_stus_hstry
+        config:
+          tags: ["source_in_use"]
         columns:
           - name: mdcd_dlvrbl_stus_hstry_id
             data_type: integer
@@ -12008,6 +12020,8 @@ sources:
             data_type: timestamp with time zone
 
       - name: pgm_mntrg_ctgry_type_rfrnc
+        config:
+          tags: ["source_in_use"]
         columns:
           - name: pgm_mntrg_ctgry_type_cd
             data_type: integer
@@ -13153,6 +13167,8 @@ sources:
             data_type: text
 
       - name: date_type
+        config:
+          tags: ["source_in_use"]
         columns:
           - name: id
             data_type: text
@@ -13423,11 +13439,15 @@ sources:
             data_type: text
 
       - name: deliverable_type
+        config:
+          tags: ["source_in_use"]
         columns:
           - name: id
             data_type: text
 
       - name: deliverable_type_document_type
+        config:
+          tags: ["source_in_use"]
         columns:
           - name: deliverable_type_id
             data_type: text
@@ -14013,6 +14033,8 @@ sources:
             data_type: text
 
       - name: phase_document_type
+        config:
+          tags: ["source_in_use"]
         columns:
           - name: phase_id
             data_type: text
@@ -14034,6 +14056,8 @@ sources:
             data_type: text
 
       - name: phase_status
+        config:
+          tags: ["source_in_use"]
         columns:
           - name: id
             data_type: text

--- a/data/migration/stage_pmda_for_migration/seeds/.gitignore
+++ b/data/migration/stage_pmda_for_migration/seeds/.gitignore
@@ -1,0 +1,1 @@
+raw_pmda_s3_file_list.csv


### PR DESCRIPTION
## Summary

This PR adds a quick way to seed the `dbt` build with a list of the files that have been migrated from EFS into the S3 bucket from PMDA. This is done by grabbing the file that @cms-jesse creates and has stored in that bucket and dropping it into the `seeds/` folder in `dbt`, while also excluding it from the repository.

The changes to the `README.md` are relevant because to enable this, you need to override the existing `devcontainer` AWS configuration that is found in `~/.aws/credentials`. This doesn't actually cause any issues with our `localstack` configuration since it just ignores the actual values of the credentials anyway, so hopefully this doesn't introduce any friction to anyone else.

## Changes

- Tweaked and cleaned up some of the documentation to reflect current state.
- Tweaked the `sources.yml` file to make sure in-use sources were tagged properly.
- Fixed a typo in one of the tests in `models.yml`.
- Added the download of the file from S3 into the `seeds/` folder to the migration scripts and ignored the file so it does not get committed to Git.
- Added a downstream derived artifact from the seed that splits the file name from the path and removes the prefixes that do not appear to be files.

## Validation

- [ ] Automated tests added or updated
- [ ] Relevant automated tests pass
- [X] Manually tested
- [ ] Testing is not applicable

Testing details:

- Run locally on my `devcontainer` to validate functionality.

## Automated review

- [X] Run AI Code Review