### PR TITLE
DEMOS-2570: Footer Updates - Add "DEMOS Orientation Videos", Remove "FAQ"

### DIFF
--- a/client/.snyk
+++ b/client/.snyk
@@ -2,11 +2,11 @@
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-JS-BRACEEXPANSION-18313044:
+  SNYK-JS-BRACEEXPANSION-18512280:
     - '*': null
-    - reason: No clean fix available for JSDOM to upgrade WS
-    - expires: 2026-08-03T14:00:00.000Z
-    - created: 2026-07-27T14:00:00.000Z
+    - reason: Brace Expansion 5.0.9 not out for 7 days yet
+    - expires: 2026-08-08T14:00:00.000Z
+    - created: 2026-08-04T14:00:00.000Z
   SNYK-JS-NANOID-18506897:
     - '*':
         reason: No patch available

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2319,16 +2319,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/client/src/components/footer/Footer.test.tsx
+++ b/client/src/components/footer/Footer.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { useLazyQuery } from "@apollo/client";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import {
   CONTACT_US_MAILTO,
   DEMOS_ADDRESS,
@@ -9,26 +8,8 @@ import {
   REFERENCES_PATH,
 } from "./Footer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useDownloadReference } from "hooks/useDownloadReference";
 import { TestProvider } from "test-utils/TestProvider";
 import { developmentMockUser, MockUser } from "mock-data/userMocks";
-
-vi.mock("@apollo/client", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@apollo/client")>();
-
-  return {
-    ...actual,
-    useLazyQuery: vi.fn(),
-  };
-});
-
-vi.mock("hooks/useDownloadReference", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("hooks/useDownloadReference")>();
-  return {
-    ...actual,
-    useDownloadReference: vi.fn(),
-  };
-});
 
 vi.mock("config/env", async (importOriginal) => {
   const actual = await importOriginal<typeof import("config/env")>();
@@ -37,11 +18,6 @@ vi.mock("config/env", async (importOriginal) => {
     isLocalDevelopment: vi.fn(),
   };
 });
-
-type UseLazyQueryTuple = ReturnType<typeof useLazyQuery>;
-
-const fetchFaqReferenceMaterial = vi.fn();
-const downloadReference = vi.fn();
 
 const cmsUser: MockUser = {
   ...developmentMockUser,
@@ -67,15 +43,6 @@ const renderWithProviders = (currentUser: MockUser = cmsUser) =>
 
 describe("Footer Component", () => {
   beforeEach(async () => {
-    vi.clearAllMocks();
-    vi.mocked(useLazyQuery).mockReturnValue([
-      fetchFaqReferenceMaterial,
-      {},
-    ] as unknown as UseLazyQueryTuple);
-    vi.mocked(useDownloadReference).mockReturnValue({
-      downloadReference,
-      downloadReferenceAgreement: vi.fn(),
-    });
     const { isLocalDevelopment } = await import("config/env");
     vi.mocked(isLocalDevelopment).mockReturnValue(false);
   });
@@ -94,7 +61,6 @@ describe("Footer Component", () => {
     renderWithProviders();
     expect(screen.getByText(/References/i)).toBeInTheDocument();
     expect(screen.getByText(/Contact Us/i)).toBeInTheDocument();
-    expect(screen.getByText(/FAQ/i)).toBeInTheDocument();
   });
 
   it("links References to the /references page", () => {
@@ -112,29 +78,6 @@ describe("Footer Component", () => {
     expect(screen.getByRole("link", { name: /Contact Us/i })).toHaveAttribute(
       "href",
       CONTACT_US_MAILTO
-    );
-  });
-
-  it("downloads the latest FAQ reference when FAQ is clicked", async () => {
-    fetchFaqReferenceMaterial.mockResolvedValue({
-      data: {
-        references: [
-          { id: "faq-older", createdAt: new Date("2024-01-01T00:00:00.000Z") },
-          { id: "faq-latest", createdAt: new Date("2025-01-01T00:00:00.000Z") },
-        ],
-      },
-    });
-
-    renderWithProviders();
-
-    fireEvent.click(screen.getByRole("button", { name: /FAQ/i }));
-
-    await waitFor(() => expect(fetchFaqReferenceMaterial).toHaveBeenCalledTimes(1));
-    await waitFor(() =>
-      expect(downloadReference).toHaveBeenCalledWith({
-        id: "faq-latest",
-        acceptedAgreementId: null,
-      })
     );
   });
 

--- a/client/src/components/footer/Footer.test.tsx
+++ b/client/src/components/footer/Footer.test.tsx
@@ -1,11 +1,17 @@
 import React from "react";
 import { useLazyQuery } from "@apollo/client";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { CONTACT_US_MAILTO, DEMOS_ADDRESS, Footer, REFERENCES_PATH } from "./Footer";
+import {
+  CONTACT_US_MAILTO,
+  DEMOS_ADDRESS,
+  DEMOS_VIDEOS_LINK,
+  Footer,
+  REFERENCES_PATH,
+} from "./Footer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useDownloadReference } from "hooks/useDownloadReference";
-import { MockedProvider } from "@apollo/client/testing";
-import { ToastProvider } from "components/toast";
+import { TestProvider } from "test-utils/TestProvider";
+import { developmentMockUser, MockUser } from "mock-data/userMocks";
 
 vi.mock("@apollo/client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@apollo/client")>();
@@ -16,26 +22,47 @@ vi.mock("@apollo/client", async (importOriginal) => {
   };
 });
 
-vi.mock("hooks/useDownloadReference", () => ({
-  useDownloadReference: vi.fn(),
-}));
+vi.mock("hooks/useDownloadReference", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("hooks/useDownloadReference")>();
+  return {
+    ...actual,
+    useDownloadReference: vi.fn(),
+  };
+});
 
-vi.mock("config/env", () => ({
-  isLocalDevelopment: vi.fn(),
-}));
+vi.mock("config/env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("config/env")>();
+  return {
+    ...actual,
+    isLocalDevelopment: vi.fn(),
+  };
+});
 
 type UseLazyQueryTuple = ReturnType<typeof useLazyQuery>;
 
 const fetchFaqReferenceMaterial = vi.fn();
 const downloadReference = vi.fn();
 
-const renderWithProviders = () =>
+const cmsUser: MockUser = {
+  ...developmentMockUser,
+  person: { ...developmentMockUser.person, personType: "demos-cms-user" },
+};
+
+const adminUser: MockUser = {
+  ...developmentMockUser,
+  person: { ...developmentMockUser.person, personType: "demos-admin" },
+};
+
+const stateUser: MockUser = {
+  ...developmentMockUser,
+  person: { ...developmentMockUser.person, personType: "demos-state-user" },
+};
+
+const renderWithProviders = (currentUser: MockUser = cmsUser) =>
   render(
-    <MockedProvider mocks={[]}>
-      <ToastProvider>
-        <Footer />
-      </ToastProvider>
-    </MockedProvider>
+    <TestProvider currentUser={currentUser} mocks={[]}>
+      <Footer />
+    </TestProvider>
   );
 
 describe("Footer Component", () => {
@@ -125,6 +152,34 @@ describe("Footer Component", () => {
   it("displays the address", () => {
     renderWithProviders();
     expect(screen.getByText(DEMOS_ADDRESS)).toBeInTheDocument();
+  });
+
+  describe("DEMOS Orientation Videos link", () => {
+    it("is visible for CMS users", () => {
+      renderWithProviders(cmsUser);
+      expect(screen.getByRole("link", { name: /DEMOS Orientation Videos/i })).toBeInTheDocument();
+    });
+
+    it("is visible for admin users", () => {
+      renderWithProviders(adminUser);
+      expect(screen.getByRole("link", { name: /DEMOS Orientation Videos/i })).toBeInTheDocument();
+    });
+
+    it("is not visible for state users", () => {
+      renderWithProviders(stateUser);
+      expect(
+        screen.queryByRole("link", { name: /DEMOS Orientation Videos/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("points to box.com", () => {
+      renderWithProviders(cmsUser);
+      expect(screen.getByRole("link", { name: /DEMOS Orientation Videos/i })).toHaveAttribute(
+        "href",
+        DEMOS_VIDEOS_LINK
+      );
+      expect(DEMOS_VIDEOS_LINK).toContain("box.com");
+    });
   });
 
   it("displays the git commit hash in local development", async () => {

--- a/client/src/components/footer/Footer.tsx
+++ b/client/src/components/footer/Footer.tsx
@@ -55,9 +55,9 @@ const FooterLinks: React.FC = () => {
           Contact Us
         </a>
       </li>
-      |
       {isCmsOrAdmin && (
         <>
+          |
           <li>
             <a href={DEMOS_VIDEOS_LINK} className={linkStyles}>
               DEMOS Orientation Videos

--- a/client/src/components/footer/Footer.tsx
+++ b/client/src/components/footer/Footer.tsx
@@ -2,6 +2,7 @@ import { HhsLogo } from "components/brand/HhsLogo";
 import { LogoSimplified } from "components/brand/LogoSimplified";
 import { DebugOnly } from "components/debug/DebugOnly";
 import { useToast } from "components/toast";
+import { getCurrentUser } from "components/user/UserContext";
 import React from "react";
 import { tw } from "tags/tw";
 import { TypedDocumentNode, useLazyQuery } from "@apollo/client";
@@ -13,6 +14,8 @@ import { useDownloadReference } from "hooks/useDownloadReference";
 export const DEMOS_ADDRESS = "7500 Security Boulevard Baltimore, MD 21244";
 export const CONTACT_US_MAILTO = "mailto:DEMOS_Help@cms.hhs.gov";
 export const REFERENCES_PATH = "/references";
+export const DEMOS_VIDEOS_LINK =
+  "https://app.box.com/folder/405875918185?s=bu3ebr1fi8pral6hlqwrttnw4xpozgn1";
 
 const linkStyles = tw`text-blue-600 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded cursor-pointer`;
 
@@ -33,8 +36,12 @@ export const GET_FAQ_REFERENCES_QUERY: TypedDocumentNode<
 `;
 
 const FooterLinks: React.FC = () => {
+  const { currentUser } = getCurrentUser();
   const { showError } = useToast();
   const { downloadReference } = useDownloadReference();
+  const isCmsOrAdmin =
+    currentUser.person.personType === "demos-admin" ||
+    currentUser.person.personType === "demos-cms-user";
 
   const [getFaqReferenceMaterial] = useLazyQuery(GET_FAQ_REFERENCES_QUERY);
 
@@ -76,6 +83,16 @@ const FooterLinks: React.FC = () => {
         </a>
       </li>
       |
+      {isCmsOrAdmin && (
+        <>
+          <li>
+            <a href={DEMOS_VIDEOS_LINK} className={linkStyles}>
+              DEMOS Orientation Videos
+            </a>
+          </li>
+          |
+        </>
+      )}
       <li>
         <button type="button" onClick={handleFaqClick} className={linkStyles}>
           FAQ

--- a/client/src/components/footer/Footer.tsx
+++ b/client/src/components/footer/Footer.tsx
@@ -1,15 +1,12 @@
 import { HhsLogo } from "components/brand/HhsLogo";
 import { LogoSimplified } from "components/brand/LogoSimplified";
 import { DebugOnly } from "components/debug/DebugOnly";
-import { useToast } from "components/toast";
 import { getCurrentUser } from "components/user/UserContext";
 import React from "react";
 import { tw } from "tags/tw";
-import { TypedDocumentNode, useLazyQuery } from "@apollo/client";
+import { TypedDocumentNode } from "@apollo/client";
 import { Reference, TagName } from "demos-server";
 import gql from "graphql-tag";
-import { FAQ_REFERENCE_TAG } from "demos-server-constants";
-import { useDownloadReference } from "hooks/useDownloadReference";
 
 export const DEMOS_ADDRESS = "7500 Security Boulevard Baltimore, MD 21244";
 export const CONTACT_US_MAILTO = "mailto:DEMOS_Help@cms.hhs.gov";
@@ -37,33 +34,9 @@ export const GET_FAQ_REFERENCES_QUERY: TypedDocumentNode<
 
 const FooterLinks: React.FC = () => {
   const { currentUser } = getCurrentUser();
-  const { showError } = useToast();
-  const { downloadReference } = useDownloadReference();
   const isCmsOrAdmin =
     currentUser.person.personType === "demos-admin" ||
     currentUser.person.personType === "demos-cms-user";
-
-  const [getFaqReferenceMaterial] = useLazyQuery(GET_FAQ_REFERENCES_QUERY);
-
-  const handleFaqClick = async () => {
-    try {
-      const { data } = await getFaqReferenceMaterial({
-        variables: { withTag: FAQ_REFERENCE_TAG },
-      });
-      const faqReferences = data?.references;
-      if (!faqReferences || faqReferences.length === 0) {
-        showError("No FAQ reference material found.");
-        throw new Error("No FAQ reference material found.");
-      }
-      const latestFaqReference = faqReferences.sort(
-        (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
-      )[0];
-
-      await downloadReference({ id: latestFaqReference.id, acceptedAgreementId: null });
-    } catch {
-      showError("Unable to download the FAQ.");
-    }
-  };
 
   return (
     <ul
@@ -90,14 +63,8 @@ const FooterLinks: React.FC = () => {
               DEMOS Orientation Videos
             </a>
           </li>
-          |
         </>
       )}
-      <li>
-        <button type="button" onClick={handleFaqClick} className={linkStyles}>
-          FAQ
-        </button>
-      </li>
     </ul>
   );
 };


### PR DESCRIPTION
## Summary

Per DEMOS-2570 updates the Footer to include a link to the DEMOS Orientation Videos (in Box) **For CMS And Admin Users* and removes the FAQ link. There was a lot of code for the FAQ stuff!

Included a SNYK fix for `brace-expansion`

## Validation
- [X] Automated tests added or updated
- [X] Relevant automated tests pass
- [X] Manually tested

## Screenshots or recordings

https://github.com/user-attachments/assets/9fcf4c17-d7fc-4d85-afeb-f2c25160767a
