### PR TITLE
DEMOS-2540-basic-file-name-matching

### DIFF
--- a/data/migration/stage_pmda_for_migration/MIGRATION_LOGIC.md
+++ b/data/migration/stage_pmda_for_migration/MIGRATION_LOGIC.md
@@ -312,9 +312,67 @@ There's been a first-pass effort (still work in progress) on importing the submi
 
 # Documents
 
+## File Structure
+
+The PMDA system appears to have embedded some information about the specific file into the actual _path_ of the file. Profiling the contents of the production bucket where the EFS files were extracted, we see this for the file structure of the `upload/` prefix in specific.
+
+- upload
+  - appmgmtdemo
+    - docrepo
+      - (integers)
+  - deliverable
+    - cms
+      - (integers)
+    - deliverable_paper
+      - (integers)
+    - state
+      - (integers)
+  - demonstration
+    - (integers)
+    - bn_template
+      - (integers)
+    - contactReport
+    - finalDecision
+      - (integers)
+    - mrt_evaluation_design_reference_only
+      - CE
+        - (various Package.(integer) values)
+      - EandC
+        - (various Package.(integer) values)
+      - HBI
+        - (various Package.(integer) values)
+      - PRCS
+        - (various Package.(integer) values)
+      - QHP
+        - (various Package.(integer) values)
+      - SMI
+        - (various Package.(integer) values)
+      - SUD
+        - (various Package.(integer) values)
+    - mrt_historical_data
+    - mrt_point_and_click
+    - mrt_technical_specification
+      - sud
+    - mrt_technical_specification_reference_only
+      - This nests two more layers but with Package.(integer) values mostly
+    - mrt_template
+      - (integers, one empty string)
+    - postAwardForum
+      - 975 (literally the number 975)
+    - program_monitoring
+      - (integers)
+    - site_visit
+      - (integers)
+    - stc-index
+    - stc-text
+  - faq
+  - stc
+    - src
+      - (integers)
+
 ## Deliverable Documents
 
-The base for deliverable documents are the records in `mdcd_dlvrbl_fil_doc`. We select those that are not deleted (`dltd_ind = 0`), and then filter out ones where we cannot resolve an owner or a deliverable in those final sets. These are logged warnings for the testing system.
+The base for deliverable documents are the records in `mdcd_dlvrbl_fil_doc`. We select those that are not deleted (`dltd_ind = 0`), and then filter out ones where we cannot resolve an owner, or a deliverable in those final sets. These are logged warnings for the testing system. We also filter out those that we cannot resolve to known documents found in `docs_pmda_s3_file_list`. The match is made based on file name, the deliverable ID we have attempted to extract from the path, and the state or CMS file flag.
 
 To enable rapid iteration, the following short-term approaches have been taken, most of which are `#open-question` to be refined further.
 

--- a/data/migration/stage_pmda_for_migration/models/cleaned/cleaned_demos_app_application_docs.sql
+++ b/data/migration/stage_pmda_for_migration/models/cleaned/cleaned_demos_app_application_docs.sql
@@ -54,7 +54,8 @@ SELECT
     _legacy_mdcd_dlvrbl_fil_doc_id,
     _legacy_mdcd_dlvrbl_id,
     _legacy_mdcd_demo_aplctn_doc_rpstry_dtl_id,
-    _legacy_mdcd_demo_pgm_mntrg_doc_id
+    _legacy_mdcd_demo_pgm_mntrg_doc_id,
+    NULL::BIGINT AS _internal_pmda_s3_file_id
 
 FROM
     no_s3_path

--- a/data/migration/stage_pmda_for_migration/models/cleaned/cleaned_demos_app_deliverable_docs.sql
+++ b/data/migration/stage_pmda_for_migration/models/cleaned/cleaned_demos_app_deliverable_docs.sql
@@ -17,7 +17,8 @@ WITH no_s3_path AS (
         deliv_docs.mdcd_dlvrbl_fil_doc_id AS _legacy_mdcd_dlvrbl_fil_doc_id,
         deliv_docs.mdcd_dlvrbl_id AS _legacy_mdcd_dlvrbl_id,
         NULL::INTEGER AS _legacy_mdcd_demo_aplctn_doc_rpstry_dtl_id,
-        NULL::INTEGER AS _legacy_mdcd_demo_pgm_mntrg_doc_id
+        NULL::INTEGER AS _legacy_mdcd_demo_pgm_mntrg_doc_id,
+        deliv_docs.pmda_s3_file_id AS _internal_pmda_s3_file_id
 
     FROM
         {{ ref('docs_base_pmda_deliv_docs') }} AS deliv_docs
@@ -52,6 +53,7 @@ SELECT
     _legacy_mdcd_dlvrbl_fil_doc_id,
     _legacy_mdcd_dlvrbl_id,
     _legacy_mdcd_demo_aplctn_doc_rpstry_dtl_id,
-    _legacy_mdcd_demo_pgm_mntrg_doc_id
+    _legacy_mdcd_demo_pgm_mntrg_doc_id,
+    _internal_pmda_s3_file_id
 FROM
     no_s3_path

--- a/data/migration/stage_pmda_for_migration/models/cleaned/cleaned_demos_app_deliverable_docs.sql
+++ b/data/migration/stage_pmda_for_migration/models/cleaned/cleaned_demos_app_deliverable_docs.sql
@@ -28,6 +28,9 @@ WITH no_s3_path AS (
         AND deliv_docs.mdcd_dlvrbl_fil_doc_id NOT IN (
             SELECT e2.mdcd_dlvrbl_fil_doc_id FROM {{ ref('errors_deliv_docs_with_no_resolved_owner') }} AS e2
         )
+        AND deliv_docs.mdcd_dlvrbl_fil_doc_id NOT IN (
+            SELECT e3.mdcd_dlvrbl_fil_doc_id FROM {{ ref('errors_deliv_docs_with_no_matched_file') }} AS e3
+        )
 )
 
 SELECT

--- a/data/migration/stage_pmda_for_migration/models/cleaned/cleaned_demos_app_prgm_docs.sql
+++ b/data/migration/stage_pmda_for_migration/models/cleaned/cleaned_demos_app_prgm_docs.sql
@@ -49,6 +49,7 @@ SELECT
     _legacy_mdcd_dlvrbl_fil_doc_id,
     _legacy_mdcd_dlvrbl_id,
     _legacy_mdcd_demo_aplctn_doc_rpstry_dtl_id,
-    _legacy_mdcd_demo_pgm_mntrg_doc_id
+    _legacy_mdcd_demo_pgm_mntrg_doc_id,
+    NULL::BIGINT AS _internal_pmda_s3_file_id
 FROM
     no_s3_path

--- a/data/migration/stage_pmda_for_migration/models/cleaned/system/system_file_move_tracker.sql
+++ b/data/migration/stage_pmda_for_migration/models/cleaned/system/system_file_move_tracker.sql
@@ -1,0 +1,15 @@
+SELECT
+    final_docs.id AS final_document_id,
+    final_docs.s3_path AS final_document_s3_path,
+    final_docs._internal_pmda_s3_file_id,
+    s3_files.s3_prefix_and_file_name AS legacy_pmda_s3_path,
+    FALSE AS file_moved
+FROM
+    {{ ref('final_demos_app_document') }} AS final_docs
+LEFT JOIN
+    {{ ref('docs_pmda_s3_file_list') }} AS s3_files
+    ON
+        final_docs._internal_pmda_s3_file_id = s3_files.pmda_s3_file_id
+-- Filter to be removed once NOT NULL enforced by tests!
+WHERE
+    final_docs._internal_pmda_s3_file_id IS NOT NULL

--- a/data/migration/stage_pmda_for_migration/models/docs/docs_base_pmda_deliv_docs.sql
+++ b/data/migration/stage_pmda_for_migration/models/docs/docs_base_pmda_deliv_docs.sql
@@ -15,7 +15,8 @@ SELECT
     f_deliv.id AS demos_deliverable_id,
     f_deliv.demonstration_id AS demos_demonstration_id,
     f_deliv.deliverable_type_id AS demos_deliverable_type_id,
-    f_person.id AS demos_user_id
+    f_person.id AS demos_user_id,
+    s3_files.pmda_s3_file_id
 FROM
     {{ source('legacy_pmda_raw', 'mdcd_dlvrbl_fil_doc') }} AS deliv_doc
 LEFT JOIN
@@ -26,5 +27,11 @@ LEFT JOIN
     {{ ref('final_demos_app_person') }} AS f_person
     ON
         deliv_doc.user_id = f_person._legacy_users_id
+LEFT JOIN
+    {{ ref('docs_pmda_s3_file_list') }} AS s3_files
+    ON
+        deliv_doc.dlvrbl_fil_name = s3_files.file_name
+        AND deliv_doc.mdcd_dlvrbl_id = s3_files.deliv_extracted_mdcd_dlvrbl_id
+        AND deliv_doc.cmt_orgn_cd = s3_files.deliv_extracted_cmt_orgn_cd
 WHERE
     deliv_doc.dltd_ind = 0

--- a/data/migration/stage_pmda_for_migration/models/docs/docs_pmda_s3_file_list.sql
+++ b/data/migration/stage_pmda_for_migration/models/docs/docs_pmda_s3_file_list.sql
@@ -6,15 +6,55 @@ WITH file_names AS (
         etag
     FROM
         {{ ref("raw_pmda_s3_file_list") }}
+),
+
+separated_prefix AS (
+    SELECT
+        row_number() OVER () AS pmda_s3_file_id,
+        left(s3_prefix_and_file_name, length(s3_prefix_and_file_name) - length(file_name)) AS s3_prefix,
+        file_name,
+        s3_prefix_and_file_name,
+        size_bytes,
+        etag
+    FROM
+        file_names
+    WHERE
+        file_name != ''
+        AND file_name != 's3_file_list.csv'
+),
+
+with_prefix_parts AS (
+    SELECT
+        pmda_s3_file_id,
+        s3_prefix,
+        file_name,
+        s3_prefix_and_file_name,
+        split_part(s3_prefix, '/', 1) AS s3_prefix_p1,
+        split_part(s3_prefix, '/', 2) AS s3_prefix_p2,
+        split_part(s3_prefix, '/', 3) AS s3_prefix_p3,
+        split_part(s3_prefix, '/', 4) AS s3_prefix_p4,
+        split_part(s3_prefix, '/', 5) AS s3_prefix_p5,
+        split_part(s3_prefix, '/', 6) AS s3_prefix_p6,
+        split_part(s3_prefix, '/', 7) AS s3_prefix_p7,
+        size_bytes,
+        etag
+    FROM
+        separated_prefix
 )
 
 SELECT
-    left(s3_prefix_and_file_name, length(s3_prefix_and_file_name) - length(file_name)) AS s3_prefix,
+    pmda_s3_file_id,
+    s3_prefix,
     file_name,
     s3_prefix_and_file_name,
     size_bytes,
-    etag
+    etag,
+    CASE
+        WHEN s3_prefix LIKE 'upload/deliverable/%' THEN s3_prefix_p4::INTEGER
+    END AS deliv_extracted_mdcd_dlvrbl_id,
+    CASE
+        WHEN s3_prefix LIKE 'upload/deliverable/cms/%' THEN 'C'
+        WHEN s3_prefix LIKE 'upload/deliverable/state/%' THEN 'S'
+    END AS deliv_extracted_cmt_orgn_cd
 FROM
-    file_names
-WHERE
-    file_name != ''
+    with_prefix_parts

--- a/data/migration/stage_pmda_for_migration/models/errors/errors_deliv_docs_with_no_matched_file.sql
+++ b/data/migration/stage_pmda_for_migration/models/errors/errors_deliv_docs_with_no_matched_file.sql
@@ -1,0 +1,2 @@
+SELECT * FROM {{ ref('docs_base_pmda_deliv_docs') }}
+WHERE pmda_s3_file_id IS NULL

--- a/data/migration/stage_pmda_for_migration/models/models.yml
+++ b/data/migration/stage_pmda_for_migration/models/models.yml
@@ -763,6 +763,11 @@ models:
   # Document Models
   - name: docs_base_pmda_deliv_docs
     columns:
+      - name: mdcd_dlvrbl_fil_doc_id
+        data_type: integer
+        data_tests:
+          - unique:
+              name: assert_no_duplicate_mdcd_dlvrbl_fil_doc_ids_in_base_tbl
       - name: creatd_dt
         data_type: timestamptz
         data_tests:

--- a/data/migration/stage_pmda_for_migration/models/models.yml
+++ b/data/migration/stage_pmda_for_migration/models/models.yml
@@ -341,6 +341,9 @@ models:
         data_type: integer
       - name: _legacy_mdcd_demo_pgm_mntrg_doc_id
         data_type: integer
+      - name: _internal_pmda_s3_file_id
+        data_type: bigint
+        description: NOTE - should add not null and unique checks here once fully implemented
       - name: is_migrated_from_pmda
         data_type: boolean
         data_tests:
@@ -773,3 +776,20 @@ models:
         data_tests:
           - not_null:
               name: assert_no_missing_creatd_dt_in_base_pmda_deliv_docs
+
+  # System Models
+  - name: system_file_move_tracker
+    description: This table is used to track the file copy from legacy PMDA to DEMOs.
+    columns:
+      - name: _internal_pmda_s3_file_id
+        data_type: bigint
+        data_tests:
+          - unique:
+              name: assert_all_internal_pmda_file_ids_unique_in_file_move_tracker
+          - not_null:
+              name: assert_all_internal_pmda_file_ids_not_null_in_file_move_tracker
+      - name: legacy_pmda_s3_path
+        data_type: text
+        data_tests:
+          - not_null:
+              name: assert_all_legacy_s3_paths_not_null_in_file_move_tracker

--- a/data/migration/stage_pmda_for_migration/tests/assert_final_docs_and_file_move_tables_same_size.sql
+++ b/data/migration/stage_pmda_for_migration/tests/assert_final_docs_and_file_move_tables_same_size.sql
@@ -1,0 +1,26 @@
+WITH c1 AS (
+    SELECT count(*) AS doc_count
+    FROM
+        {{ ref('final_demos_app_document') }}
+    -- To be removed once files associated with all docs!
+    WHERE
+        _internal_pmda_s3_file_id IS NOT NULL
+),
+
+c2 AS (
+    SELECT count(*) AS file_move_tracker_count
+    FROM
+        {{ ref('system_file_move_tracker') }}
+)
+
+SELECT
+    c1.doc_count,
+    c2.file_move_tracker_count
+FROM
+    c1
+INNER JOIN
+    c2
+    ON
+        TRUE
+WHERE
+    c1.doc_count != c2.file_move_tracker_count

--- a/data/migration/stage_pmda_for_migration/tests/assert_no_deliv_doc_filtered_for_missing_file.sql
+++ b/data/migration/stage_pmda_for_migration/tests/assert_no_deliv_doc_filtered_for_missing_file.sql
@@ -1,0 +1,7 @@
+-- Warn in cases where a deliverable document is filtered because it can't be matched to an actual file
+
+{{ config(severity='warn') }}
+
+SELECT *
+FROM
+    {{ ref('errors_deliv_docs_with_no_matched_file') }}


### PR DESCRIPTION
## Summary

This PR adds the basics of matching S3 files in the PMDA export to specific document records within the migration, which will facilitate the actual movement of files between buckets. It is currently only targeting the deliverable documents as a general proof of concept.

## Validation

- [X] Automated tests added or updated
- [X] Relevant automated tests pass
- [X] Manually tested
- [ ] Testing is not applicable

## Automated review

- [X] Run AI Code Review