### PR TITLE
DEMOS-2540-move-deliv-docs-poc

### DIFF
--- a/data/demos_data_tools/.env.example
+++ b/data/demos_data_tools/.env.example
@@ -25,7 +25,3 @@ APP_SCHEMA=demos_app
 # S3 Settings
 PMDA_S3_BUCKET=pmda_s3_bucket
 DEMOS_S3_BUCKET=demos_s3_bucket
-AWS_ENDPOINT_URL_S3=http://localhost:4566
-
-# File Migration Settings
-FILE_MIGRATION_PRODUCTION_MODE=0

--- a/data/demos_data_tools/check_if_in_devcontainer.py
+++ b/data/demos_data_tools/check_if_in_devcontainer.py
@@ -12,7 +12,7 @@ logger = config_logger(getLogger(__name__))
 def check_if_in_devcontainer() -> None:
     """Loosely check if we are within a devcontainer, and exit if not."""
     logger.info("Checking if executing in a devcontainer")
-    is_devcontainer = os.environ.get("DEVCONTAINER") == "true"
+    is_devcontainer = os.environ.get("DEVCONTAINER", "false") == "true"
     if not is_devcontainer:
         logger.error("This tool should only be used from within the devcontainer - exiting now!")
         sys.exit(3)

--- a/data/demos_data_tools/migrate_files.py
+++ b/data/demos_data_tools/migrate_files.py
@@ -1,18 +1,14 @@
-"""Copy files between buckets on the same S3-compatible service.
-
-Rows are read from Postgres using discrete Postgres environment variables.
-The query must return: old_path and new_path.
-Only rows with `flag = true` are copied.
-"""
+"""Migrate files from PMDA to DEMOS S3 buckets based on staged data in PostgreSQL."""
 
 import os
+from dataclasses import dataclass, replace
 from logging import getLogger
-from typing import TYPE_CHECKING, List, TypedDict
+from typing import TYPE_CHECKING, List
 
 import boto3
 from dotenv import load_dotenv
 
-from duckdb_connection_manager import DEMOS_DDB_ATTACH_NAME, create_duckdb_conn, attach_demos_to_conn
+from duckdb_connection_manager import DEMOS_DDB_ATTACH_NAME, attach_demos_to_conn, create_duckdb_conn
 from logger_utils import config_logger
 
 if TYPE_CHECKING:
@@ -20,131 +16,178 @@ if TYPE_CHECKING:
     from mypy_boto3_s3 import S3Client
 
 load_dotenv()
-
-SELECT_UNMIGRATED_FILES_QUERY = f"""
-    SELECT
-        old_path, new_path
-    FROM
-        {DEMOS_DDB_ATTACH_NAME}.{os.environ["STAGING_SCHEMA"]}.system_file_migration_queue
-    WHERE
-        flag = TRUE
-"""
-MARK_FILE_MIGRATED_QUERY = f"""
-    UPDATE
-        {DEMOS_DDB_ATTACH_NAME}.{os.environ["STAGING_SCHEMA"]}.system_file_migration_queue
-    SET
-        flag = false
-    WHERE
-        old_path = $old_path
-        AND new_path = $new_path
-        AND flag = TRUE
-"""
+PMDA_S3_BUCKET = os.environ["PMDA_S3_BUCKET"]
+DEMOS_S3_BUCKET = os.environ["DEMOS_S3_BUCKET"]
+STAGING_SCHEMA = os.environ["STAGING_SCHEMA"]
 
 logger = config_logger(getLogger(__name__))
 
 
-class CopyRow(TypedDict):
-    """A queued file copy record."""
+@dataclass(frozen=True)
+class FileMigrationTrackerRecord:
+    """A file migration tracker record for a single file being migrated."""
 
-    old_path: str
-    new_path: str
+    final_document_id: str
+    final_document_s3_path: str
+    _internal_pmda_s3_file_id: int
+    legacy_pmda_s3_path: str
+    legacy_pmda_file_extension: str
+    file_mime_type: str
+    file_has_been_moved: bool
+    _local_file_has_been_moved: bool
 
 
-def get_unmigrated_files(connection: "DuckConn") -> List[CopyRow]:
-    """Read unmigrated file mappings from Postgres.
-
-    Args:
-        connection (DuckConn): The DuckDB connection with Postgres attached.
+def get_s3_client() -> "S3Client":
+    """Get an appropriate boto3 S3Client depending on environment.
 
     Returns:
-        List[CopyRow]: A list of the rows to copy.
+        S3Client: A boto3 S3Client.
     """
-    rows = connection.execute(SELECT_UNMIGRATED_FILES_QUERY).fetchall()
-    return [{"old_path": row[0], "new_path": row[1]} for row in rows]
+    is_devcontainer = os.environ.get("DEVCONTAINER", "false") == "true"
+    if is_devcontainer:
+        logger.info("Instantiating localstack S3 client")
+        s3_client = boto3.client("s3", endpoint_url="http://localstack:4566")
+    else:
+        logger.info("Instantiating regular S3 client")
+        s3_client = boto3.client("s3")
+    logger.info("S3 client instantiated")
+    return s3_client
 
 
-def mark_row_copied(connection: "DuckConn", row: CopyRow) -> None:
-    """Mark one row as copied in Postgres.
+def get_unmigrated_files(connection: "DuckConn") -> List[FileMigrationTrackerRecord]:
+    """Get a list of unmigrated files from PostgreSQL.
 
     Args:
-        connection (DuckConn): The DuckDB connection with Postgres attached.
-        row (CopyRow): The migrated row to mark as copied.
+        connection (DuckConn): The DuckDB connection with PostgreSQL attached.
+
+    Returns:
+        List[FileMigrationTrackerRecord]: A list of the unmigrated files.
     """
-    connection.execute(
-        MARK_FILE_MIGRATED_QUERY,
-        {"old_path": row["old_path"], "new_path": row["new_path"]},
-    )
-    return None
+    logger.info("Getting list of unmigrated files from PostgreSQL")
+    query = f"""
+        SELECT
+            final_document_id::TEXT,
+            final_document_s3_path,
+            _internal_pmda_s3_file_id,
+            legacy_pmda_s3_path,
+            legacy_pmda_file_extension,
+            file_mime_type,
+            file_has_been_moved,
+            FALSE AS _local_file_has_been_moved
+        FROM
+            {DEMOS_DDB_ATTACH_NAME}.{STAGING_SCHEMA}.system_file_move_tracker
+        WHERE
+            NOT file_has_been_moved;
+    """
+    query_rows = connection.execute(query).fetchall()
+    logger.info("Retrieved list of unmigrated files from database")
+    return [FileMigrationTrackerRecord(*row) for row in query_rows]
 
 
-def copy_s3_object(
-    s3_client: "S3Client",
-    source_bucket: str,
-    destination_bucket: str,
-    old_path: str,
-    new_path: str,
-) -> None:
-    """Copy one object within the same S3-compatible service.
+def _mark_file_migrated_in_db(
+    connection: "DuckConn", file_record: FileMigrationTrackerRecord
+) -> FileMigrationTrackerRecord:
+    """Mark one file migrated in PostgreSQL and return the updated record.
 
     Args:
-        s3_client (S3Client): The S3 client used to perform the copy.
-        source_bucket (str): The bucket containing the source object.
-        destination_bucket (str): The bucket receiving the copied object.
-        old_path (str): The source object key.
-        new_path (str): The destination object key.
+        connection (DuckConn): The DuckDB connection with PostgreSQL attached.
+        file_record (FileMigrationTrackerRecord): The migrated file to mark as migrated.
+
+    Returns:
+        FileMigrationTrackerRecord: The updated file record.
     """
-    s3_client.copy(
-        {"Bucket": source_bucket, "Key": old_path},
-        destination_bucket,
-        new_path,
-    )
-    return None
+    query = f"""
+        UPDATE
+            {DEMOS_DDB_ATTACH_NAME}.{STAGING_SCHEMA}.system_file_move_tracker
+        SET
+            file_has_been_moved = TRUE
+        WHERE
+            final_document_id = $final_document_id;
+    """
+    if not file_record._local_file_has_been_moved:
+        logger.warning(
+            f"Attempted to mark {file_record.final_document_id} migrated in DB "
+            "without local migration marked complete; no action was taken"
+        )
+        return file_record
+    try:
+        connection.execute(query, {"final_document_id": file_record.final_document_id})
+    except Exception as e:
+        logger.error(
+            f"Exception {e} encountered while attempting to mark {file_record.final_document_id} completed in database"
+        )
+        return file_record
+    updated_file_record = replace(file_record, file_has_been_moved=True)
+    logger.debug(f"Marked {file_record.final_document_id} as migrated in database")
+    return updated_file_record
+
+
+def _migrate_file_in_s3(s3_client: "S3Client", file_record: FileMigrationTrackerRecord) -> FileMigrationTrackerRecord:
+    """Migrate one file in S3 from PMDA to DEMOS.
+
+    Args:
+        s3_client (S3Client): The S3 client used to perform the migration.
+        file_record (FileMigrationTrackerRecord): A file to migrate.
+
+    Returns:
+        FileMigrationTrackerRecord: The updated file record.
+    """
+    try:
+        s3_client.copy(
+            {"Bucket": PMDA_S3_BUCKET, "Key": file_record.legacy_pmda_s3_path},
+            DEMOS_S3_BUCKET,
+            file_record.final_document_s3_path,
+            ExtraArgs={
+                "MetadataDirective": "REPLACE",
+                "ContentType": file_record.file_mime_type,
+            },
+        )
+    except Exception as e:
+        logger.error(f"Exception {e} encountered while attempting to move file {file_record.final_document_id} in S3")
+        return file_record
+    updated_file_record = replace(file_record, _local_file_has_been_moved=True)
+    logger.debug(f"Migrated {file_record.final_document_id} in S3 from PMDA to DEMOS")
+    return updated_file_record
 
 
 def migrate_file(
     connection: "DuckConn",
-    row: CopyRow,
     s3_client: "S3Client",
-) -> None:
-    """Copy one row from the source bucket to the destination bucket.
+    file_record: FileMigrationTrackerRecord,
+) -> FileMigrationTrackerRecord:
+    """Perform all migration steps for a single record.
 
     Args:
-        connection (DuckConn): The DuckDB connection with Postgres attached.
-        row (CopyRow): The queued row describing the source and destination keys.
-        s3_client ("S3Client"): The S3 client used to perform the copy.
+        connection (DuckConn): The DuckDB connection with PostgreSQL attached.
+        s3_client (S3Client): The S3 client used to perform the migration.
+        file_record (FileMigrationTrackerRecord): A file to migrate.
+
+    Returns:
+        FileMigrationTrackerRecord: An updated record reflecting the migration.
     """
-    source_bucket = os.environ["PMDA_S3_BUCKET"]
-    destination_bucket = os.environ["DEMOS_S3_BUCKET"]
-    if os.environ["FILE_MIGRATION_PRODUCTION_MODE"] == "1":
-        logger.info(f"Copying s3://{source_bucket}/{row['old_path']} -> s3://{destination_bucket}/{row['new_path']}")
-        copy_s3_object(
-            s3_client,
-            source_bucket,
-            destination_bucket,
-            row["old_path"],
-            row["new_path"],
-        )
-        mark_row_copied(connection, row)
-    else:
-        logger.info(
-            f"Would have copied s3://{source_bucket}/{row['old_path']} -> s3://{destination_bucket}/{row['new_path']}"
-        )
-    return None
+    updated_record = _mark_file_migrated_in_db(connection, _migrate_file_in_s3(s3_client, file_record))
+    return updated_record
 
 
 def main() -> None:
-    """Execute main program function."""
+    """Main program function."""
     db_connection = attach_demos_to_conn(create_duckdb_conn())
-    s3_client = boto3.Session().client("s3")
-    copied_count = 0
+    s3_client = get_s3_client()
     unmigrated_files = get_unmigrated_files(db_connection)
-
-    while copied_count < len(unmigrated_files):
-        logger.info(f"Processing {unmigrated_files[copied_count]['old_path']}")
-        migrate_file(db_connection, unmigrated_files[copied_count], s3_client)
-        copied_count += 1
-
-    return None
+    migration_result = [migrate_file(db_connection, s3_client, file_record) for file_record in unmigrated_files]
+    successful_files = [
+        file_record
+        for file_record in migration_result
+        if file_record._local_file_has_been_moved and file_record.file_has_been_moved
+    ]
+    failed_files = [
+        file_record
+        for file_record in migration_result
+        if not (file_record._local_file_has_been_moved and file_record.file_has_been_moved)
+    ]
+    logger.info(f"Migrated {len(successful_files)} files successfully")
+    if failed_files:
+        logger.error(f"Failed to migrate {len(failed_files)} successfully")
 
 
 if __name__ == "__main__":

--- a/data/demos_data_tools/migrate_files.py
+++ b/data/demos_data_tools/migrate_files.py
@@ -1,6 +1,7 @@
 """Migrate files from PMDA to DEMOS S3 buckets based on staged data in PostgreSQL."""
 
 import os
+import sys
 from dataclasses import dataclass, replace
 from logging import getLogger
 from typing import TYPE_CHECKING, List
@@ -187,7 +188,8 @@ def main() -> None:
     ]
     logger.info(f"Migrated {len(successful_files)} files successfully")
     if failed_files:
-        logger.error(f"Failed to migrate {len(failed_files)} successfully")
+        logger.error(f"Failed to migrate {len(failed_files)} files successfully")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/data/demos_data_tools/test_migrate_files.py
+++ b/data/demos_data_tools/test_migrate_files.py
@@ -336,8 +336,10 @@ class TestMigrateFiles:
             "migrate_files.migrate_file", side_effect=[*mock_success_results, *mock_failure_results]
         )
 
-        migrate_files.main()
+        with pytest.raises(SystemExit) as exit_info:
+            migrate_files.main()
 
+        assert exit_info.value.code == 1
         mock_create_duckdb_conn.assert_called_once()
         mock_attach_demos_to_conn.assert_called_once_with(mock_conn)
         mock_get_s3_client.assert_called_once()

--- a/data/demos_data_tools/test_migrate_files.py
+++ b/data/demos_data_tools/test_migrate_files.py
@@ -1,179 +1,352 @@
 """A module containing tests for the migrate_files.py file."""
 
 import os
-from typing import List
+from dataclasses import replace
+from textwrap import dedent
 from unittest.mock import call
 
 import pytest
 
 import migrate_files
+from duckdb_connection_manager import DEMOS_DDB_ATTACH_NAME
 
 
 class TestMigrateFiles:
     """A class for the tests for the migrate_files.py file."""
 
+    # Database return version
+    mock_row_result = [
+        (
+            "160721b7-ad29-44c9-9595-4a30ae624d06",
+            "02a8f931-1c57-421b-b106-7417fb427fa7/160721b7-ad29-44c9-9595-4a30ae624d06",
+            1,
+            "some/old/upload/121/file.xlsx.0",
+            "xlsx",
+            "xlsx-mime-type",
+            False,
+            False,
+        ),
+        (
+            "e898b7a5-8754-451f-b888-76b1d0a8475f",
+            "02a8f931-1c57-421b-b106-7417fb427fa7/e898b7a5-8754-451f-b888-76b1d0a8475f",
+            2,
+            "some/old/upload/121/file.xlsx.1",
+            "xlsx",
+            "xlsx-mime-type",
+            False,
+            False,
+        ),
+        (
+            "d95cdf17-2622-4c52-973b-2570c9763fe9",
+            "02a8f931-1c57-421b-b106-7417fb427fa7/d95cdf17-2622-4c52-973b-2570c9763fe9",
+            3,
+            "some/old/upload/121/other file names.pdf.0",
+            "pdf",
+            "pdf-mime-type",
+            False,
+            False,
+        ),
+        (
+            "afa818d7-2c2a-447a-b35b-6528ef71d477",
+            "02a8f931-1c57-421b-b106-7417fb427fa7/afa818d7-2c2a-447a-b35b-6528ef71d477",
+            4,
+            "some/old/upload/121/this is a file.docx.0",
+            "docx",
+            "docx-mime-type",
+            False,
+            False,
+        ),
+    ]
+
+    # Return transformed to dataclass
+    mock_dataclass_result = [migrate_files.FileMigrationTrackerRecord(*row) for row in mock_row_result]
+
+    @pytest.fixture
+    def mock_env_devcontainer(self, mocker):
+        """Set up a mock devcontainer environment."""
+        mocked_values = {
+            "PMDA_S3_BUCKET": "devcontainer-source-bucket",
+            "DEMOS_S3_BUCKET": "devcontainer-destination-bucket",
+            "STAGING_SCHEMA": "devcontainer-staging-schema",
+            "DEVCONTAINER": "true",
+        }
+        mocker.patch.dict(
+            os.environ,
+            mocked_values,
+            clear=True,
+        )
+        mocker.patch.object(migrate_files, "PMDA_S3_BUCKET", mocked_values["PMDA_S3_BUCKET"])
+        mocker.patch.object(migrate_files, "DEMOS_S3_BUCKET", mocked_values["DEMOS_S3_BUCKET"])
+        mocker.patch.object(migrate_files, "STAGING_SCHEMA", mocked_values["STAGING_SCHEMA"])
+        return mocked_values
+
+    @pytest.fixture
+    def mock_env_prod(self, mocker):
+        """Set up a mock prod environment."""
+        mocked_values = {
+            "PMDA_S3_BUCKET": "prod-source-bucket",
+            "DEMOS_S3_BUCKET": "prod-destination-bucket",
+            "STAGING_SCHEMA": "prod-staging-schema",
+        }
+        mocker.patch.dict(
+            os.environ,
+            mocked_values,
+            clear=True,
+        )
+        mocker.patch.object(migrate_files, "PMDA_S3_BUCKET", mocked_values["PMDA_S3_BUCKET"])
+        mocker.patch.object(migrate_files, "DEMOS_S3_BUCKET", mocked_values["DEMOS_S3_BUCKET"])
+        mocker.patch.object(migrate_files, "STAGING_SCHEMA", mocked_values["STAGING_SCHEMA"])
+        return mocked_values
+
+    @pytest.fixture
+    def mock_boto3(self, mocker):
+        """Patch the boto3 invocation and return a mocked S3 client."""
+        mock_s3_client = mocker.MagicMock()
+        mock_boto3 = mocker.patch("migrate_files.boto3")
+        mock_boto3.client.return_value = mock_s3_client
+        return {"boto3": mock_boto3, "s3_client": mock_s3_client}
+
     @pytest.fixture
     def mock_conn(self, mocker):
         """Set up a mock connection for use in testing."""
         mock_conn = mocker.MagicMock()
-        mock_row_result = [
-            ("old/1.txt", "new/1.txt"),
-            ("old/2.txt", "new/2.txt"),
-        ]
-        mock_conn.execute.return_value.fetchall.return_value = mock_row_result
         return mock_conn
 
-    @pytest.fixture
-    def mock_s3_client(self, mocker):
-        """Set up a mock S3 client for use in testing."""
-        return mocker.MagicMock()
+    def test_get_s3_client_01(self, mock_env_prod, mock_boto3):
+        """Test migrate_files.py functions.
 
-    @pytest.fixture
-    def mock_env_nonprod(self, mocker):
-        """Set the default non-prod environment variables used by the migration script."""
-        mocker.patch.dict(
-            os.environ,
-            {
-                "PMDA_S3_BUCKET": "source-bucket",
-                "DEMOS_S3_BUCKET": "destination-bucket",
-                "FILE_MIGRATION_PRODUCTION_MODE": "0",
-            },
-        )
+        ::get_s3_client
 
-    @pytest.fixture
-    def mock_env_prod(self, mocker):
-        """Set the default prod environment variables used by the migration script."""
-        mocker.patch.dict(
-            os.environ,
-            {
-                "PMDA_S3_BUCKET": "source-bucket",
-                "DEMOS_S3_BUCKET": "destination-bucket",
-                "FILE_MIGRATION_PRODUCTION_MODE": "1",
-            },
-        )
+        ::It should get a regular client when not in a devcontainer.
+        """
+        migrate_files.get_s3_client()
 
-    @pytest.fixture
-    def mock_boto3(self, mocker, mock_s3_client):
-        """Patch boto3 session creation for the migration script."""
-        mock_boto3 = mocker.patch("migrate_files.boto3")
-        mock_boto3.Session.return_value.client.return_value = mock_s3_client
-        return mock_boto3
+        mock_boto3["boto3"].client.assert_called_once_with("s3")
 
-    def test_get_unmigrated_files(self, mock_conn):
+    def test_get_s3_client_02(self, mock_env_devcontainer, mock_boto3):
+        """Test migrate_files.py functions.
+
+        ::get_s3_client
+
+        ::It should get a localstack client when in a devcontainer.
+        """
+        migrate_files.get_s3_client()
+
+        mock_boto3["boto3"].client.assert_called_once_with("s3", endpoint_url="http://localstack:4566")
+
+    def test_get_unmigrated_files(self, mock_env_devcontainer, mock_conn):
         """Test migrate_files.py functions.
 
         ::get_unmigrated_files
 
         ::It should execute the configured SQL and return fetched rows.
         """
+        mock_conn.execute.return_value.fetchall.return_value = self.mock_row_result
+        expected_query = f"""
+            SELECT
+                final_document_id::TEXT,
+                final_document_s3_path,
+                _internal_pmda_s3_file_id,
+                legacy_pmda_s3_path,
+                legacy_pmda_file_extension,
+                file_mime_type,
+                file_has_been_moved,
+                FALSE AS _local_file_has_been_moved
+            FROM
+                {DEMOS_DDB_ATTACH_NAME}.{mock_env_devcontainer["STAGING_SCHEMA"]}.system_file_move_tracker
+            WHERE
+                NOT file_has_been_moved;
+        """
+
         result = migrate_files.get_unmigrated_files(mock_conn)
 
-        mock_conn.execute.assert_called_once_with(migrate_files.SELECT_UNMIGRATED_FILES_QUERY)
-        assert result == [
-            {"old_path": "old/1.txt", "new_path": "new/1.txt"},
-            {"old_path": "old/2.txt", "new_path": "new/2.txt"},
-        ]
+        actual_query = mock_conn.execute.call_args[0][0]
+        assert dedent(actual_query) == dedent(expected_query)
+        assert result == self.mock_dataclass_result
 
-    def test_mark_row_copied(self, mock_conn):
+    def test__mark_file_migrated_in_db_01(self, mock_env_prod, mock_conn):
         """Test migrate_files.py functions.
 
-        ::mark_row_copied
+        ::_mark_file_migrated_in_db
 
-        ::It should mark the copied row.
+        ::It should mark the file if the local record shows that it has been migrated.
         """
-        test_row: migrate_files.CopyRow = {"old_path": "old/1.txt", "new_path": "new/1.txt"}
-        migrate_files.mark_row_copied(mock_conn, test_row)
-
-        mock_conn.execute.assert_called_once_with(
-            migrate_files.MARK_FILE_MIGRATED_QUERY,
-            test_row,
+        test_input = replace(self.mock_dataclass_result[0], _local_file_has_been_moved=True)
+        expected_query = f"""
+            UPDATE
+                {DEMOS_DDB_ATTACH_NAME}.{mock_env_prod["STAGING_SCHEMA"]}.system_file_move_tracker
+            SET
+                file_has_been_moved = TRUE
+            WHERE
+                final_document_id = $final_document_id;
+        """
+        expected_output = replace(
+            self.mock_dataclass_result[0],
+            file_has_been_moved=True,
+            _local_file_has_been_moved=True,
         )
 
-    def test_copy_s3_object(self, mock_s3_client):
+        result = migrate_files._mark_file_migrated_in_db(mock_conn, test_input)
+
+        actual_query = mock_conn.execute.call_args[0][0]
+        actual_params = mock_conn.execute.call_args[0][1]
+        assert dedent(actual_query) == dedent(expected_query)
+        assert actual_params == {"final_document_id": test_input.final_document_id}
+        assert result == expected_output
+
+    def test__mark_file_migrated_in_db_02(self, mock_env_prod, mock_conn):
         """Test migrate_files.py functions.
 
-        ::copy_s3_object
+        ::_mark_file_migrated_in_db
 
-        ::It should issue a server-side S3 copy request.
+        ::It should take no action if the local record does not show that it has been migrated.
         """
-        migrate_files.copy_s3_object(
-            mock_s3_client,
-            "source-bucket",
-            "destination-bucket",
-            "old/file.txt",
-            "new/file.txt",
-        )
+        test_input = self.mock_dataclass_result[0]
 
-        mock_s3_client.copy.assert_called_once_with(
-            {"Bucket": "source-bucket", "Key": "old/file.txt"},
-            "destination-bucket",
-            "new/file.txt",
-        )
+        result = migrate_files._mark_file_migrated_in_db(mock_conn, test_input)
 
-    def test_migrate_file_01(self, mocker, mock_conn, mock_s3_client, mock_env_prod, caplog):
+        mock_conn.execute.assert_not_called()
+        assert result == test_input
+
+    def test__mark_file_migrated_in_db_03(self, mock_env_prod, mock_conn, caplog):
+        """Test migrate_files.py functions.
+
+        ::_mark_file_migrated_in_db
+
+        ::It should gracefully handle when an exception occurs.
+        """
+        test_input = replace(self.mock_dataclass_result[0], _local_file_has_been_moved=True)
+        mock_conn.execute.side_effect = Exception("A bad thing has occurred!")
+
+        result = migrate_files._mark_file_migrated_in_db(mock_conn, test_input)
+        assert mock_conn.execute.was_called()
+        assert result == test_input
+        assert "A bad thing has occurred!" in caplog.text
+
+    def test__migrate_file_in_s3_01(self, mock_env_devcontainer, mock_boto3):
+        """Test migrate_files.py functions.
+
+        ::_migrate_file_in_s3
+
+        ::It should perform the copy and return an updated object.
+        """
+        test_input = self.mock_dataclass_result[2]
+
+        result = migrate_files._migrate_file_in_s3(mock_boto3["s3_client"], test_input)
+
+        mock_boto3["s3_client"].copy.assert_called_once_with(
+            {"Bucket": mock_env_devcontainer["PMDA_S3_BUCKET"], "Key": test_input.legacy_pmda_s3_path},
+            mock_env_devcontainer["DEMOS_S3_BUCKET"],
+            test_input.final_document_s3_path,
+            ExtraArgs={
+                "MetadataDirective": "REPLACE",
+                "ContentType": test_input.file_mime_type,
+            },
+        )
+        assert result == replace(test_input, _local_file_has_been_moved=True)
+
+    def test__migrate_file_in_s3_02(self, mock_env_devcontainer, mock_boto3, caplog):
+        """Test migrate_files.py functions.
+
+        ::_migrate_file_in_s3
+
+        ::It should gracefully handle an exception.
+        """
+        test_input = self.mock_dataclass_result[3]
+        mock_boto3["s3_client"].copy.side_effect = Exception("Something went wrong with S3!")
+
+        result = migrate_files._migrate_file_in_s3(mock_boto3["s3_client"], test_input)
+
+        assert result == test_input
+        assert "Something went wrong with S3!" in caplog.text
+
+    def test_migrate_file(self, mock_env_prod, mock_conn, mock_boto3, mocker):
         """Test migrate_files.py functions.
 
         ::migrate_file
 
-        ::It should copy the provided row and move the file if in production.
+        ::It should migrate the file record given.
         """
-        test_row: migrate_files.CopyRow = {"old_path": "old/1.txt", "new_path": "new/1.txt"}
-        mock_copy_s3_object = mocker.patch("migrate_files.copy_s3_object")
-        mock_mark_row_copied = mocker.patch("migrate_files.mark_row_copied")
+        test_input = self.mock_dataclass_result[1]
+        updated_test_input = replace(test_input, _local_file_has_been_moved=True)
+        mock_file_migrate_function = mocker.patch("migrate_files._migrate_file_in_s3", return_value=updated_test_input)
+        mock_db_migrate_function = mocker.patch("migrate_files._mark_file_migrated_in_db")
 
-        migrate_files.migrate_file(mock_conn, test_row, mock_s3_client)
+        migrate_files.migrate_file(mock_conn, mock_boto3["s3_client"], test_input)
 
-        mock_copy_s3_object.assert_called_once_with(
-            mock_s3_client,
-            "source-bucket",
-            "destination-bucket",
-            "old/1.txt",
-            "new/1.txt",
-        )
-        mock_mark_row_copied.assert_called_once_with(mock_conn, test_row)
-        assert "Copying s3://source-bucket/old/1.txt -> s3://destination-bucket/new/1.txt" in caplog.messages
+        mock_file_migrate_function.assert_called_once_with(mock_boto3["s3_client"], test_input)
+        mock_db_migrate_function.assert_called_once_with(mock_conn, updated_test_input)
 
-    def test_migrate_file_02(self, mocker, mock_conn, mock_s3_client, mock_env_nonprod, caplog):
-        """Test migrate_files.py functions.
-
-        ::migrate_file
-
-        ::It should not copy the provided row and not move the file if not in production.
-        """
-        test_row: migrate_files.CopyRow = {"old_path": "old/1.txt", "new_path": "new/1.txt"}
-        mock_copy_s3_object = mocker.patch("migrate_files.copy_s3_object")
-        mock_mark_row_copied = mocker.patch("migrate_files.mark_row_copied")
-
-        migrate_files.migrate_file(mock_conn, test_row, mock_s3_client)
-
-        mock_copy_s3_object.assert_not_called()
-        mock_mark_row_copied.assert_not_called()
-        assert "Would have copied s3://source-bucket/old/1.txt -> s3://destination-bucket/new/1.txt" in caplog.messages
-
-    def test_main(self, mocker, mock_conn, mock_boto3, mock_s3_client):
+    def test_main_01(self, mock_env_prod, mock_conn, mock_boto3, mocker, caplog):
         """Test migrate_files.py functions.
 
         ::main
 
-        ::It should fetch needed resources and run the migration.
+        ::It should perform the migration.
         """
-        test_rows: List[migrate_files.CopyRow] = [
-            {"old_path": "old/1.txt", "new_path": "new/1.txt"},
-            {"old_path": "old/2.txt", "new_path": "new/2.txt"},
-        ]
         mock_create_duckdb_conn = mocker.patch("migrate_files.create_duckdb_conn", return_value=mock_conn)
         mock_attach_demos_to_conn = mocker.patch("migrate_files.attach_demos_to_conn", return_value=mock_conn)
-        mock_get_unmigrated_files = mocker.patch("migrate_files.get_unmigrated_files", return_value=test_rows)
-        mock_migrate_file = mocker.patch("migrate_files.migrate_file")
+        mock_get_s3_client = mocker.patch("migrate_files.get_s3_client", return_value=mock_boto3["s3_client"])
+        mock_get_unmigrated_files = mocker.patch(
+            "migrate_files.get_unmigrated_files", return_value=self.mock_dataclass_result
+        )
+        mock_success_results = [
+            replace(result, file_has_been_moved=True, _local_file_has_been_moved=True)
+            for result in self.mock_dataclass_result
+        ]
+        mock_migrate_file = mocker.patch("migrate_files.migrate_file", side_effect=mock_success_results)
 
         migrate_files.main()
 
         mock_create_duckdb_conn.assert_called_once()
         mock_attach_demos_to_conn.assert_called_once_with(mock_conn)
-        mock_boto3.Session.return_value.client.assert_called_once_with("s3")
+        mock_get_s3_client.assert_called_once()
         mock_get_unmigrated_files.assert_called_once_with(mock_conn)
-        assert mock_migrate_file.call_count == 2
+        assert mock_migrate_file.call_count == 4
         assert mock_migrate_file.call_args_list == [
-            call(mock_conn, test_rows[0], mock_s3_client),
-            call(mock_conn, test_rows[1], mock_s3_client),
+            call(mock_conn, mock_boto3["s3_client"], self.mock_dataclass_result[0]),
+            call(mock_conn, mock_boto3["s3_client"], self.mock_dataclass_result[1]),
+            call(mock_conn, mock_boto3["s3_client"], self.mock_dataclass_result[2]),
+            call(mock_conn, mock_boto3["s3_client"], self.mock_dataclass_result[3]),
         ]
+        assert "Failed" not in caplog.text
+
+    def test_main_02(self, mock_env_prod, mock_conn, mock_boto3, mocker, caplog):
+        """Test migrate_files.py functions.
+
+        ::main
+
+        ::It should send an error message if any migrations fail.
+        """
+        mock_create_duckdb_conn = mocker.patch("migrate_files.create_duckdb_conn", return_value=mock_conn)
+        mock_attach_demos_to_conn = mocker.patch("migrate_files.attach_demos_to_conn", return_value=mock_conn)
+        mock_get_s3_client = mocker.patch("migrate_files.get_s3_client", return_value=mock_boto3["s3_client"])
+        mock_get_unmigrated_files = mocker.patch(
+            "migrate_files.get_unmigrated_files", return_value=self.mock_dataclass_result
+        )
+        mock_success_results = [
+            replace(result, file_has_been_moved=True, _local_file_has_been_moved=True)
+            for result in self.mock_dataclass_result[0:2]
+        ]
+        mock_failure_results = [
+            replace(self.mock_dataclass_result[2], file_has_been_moved=False, _local_file_has_been_moved=True),
+            replace(self.mock_dataclass_result[3], file_has_been_moved=False, _local_file_has_been_moved=False),
+        ]
+        mock_migrate_file = mocker.patch(
+            "migrate_files.migrate_file", side_effect=[*mock_success_results, *mock_failure_results]
+        )
+
+        migrate_files.main()
+
+        mock_create_duckdb_conn.assert_called_once()
+        mock_attach_demos_to_conn.assert_called_once_with(mock_conn)
+        mock_get_s3_client.assert_called_once()
+        mock_get_unmigrated_files.assert_called_once_with(mock_conn)
+        assert mock_migrate_file.call_count == 4
+        assert mock_migrate_file.call_args_list == [
+            call(mock_conn, mock_boto3["s3_client"], self.mock_dataclass_result[0]),
+            call(mock_conn, mock_boto3["s3_client"], self.mock_dataclass_result[1]),
+            call(mock_conn, mock_boto3["s3_client"], self.mock_dataclass_result[2]),
+            call(mock_conn, mock_boto3["s3_client"], self.mock_dataclass_result[3]),
+        ]
+        assert "Failed" in caplog.text

--- a/data/migration/scripts/full_reset_and_end_to_end_run.sh
+++ b/data/migration/scripts/full_reset_and_end_to_end_run.sh
@@ -34,6 +34,7 @@ aws s3 cp s3://demos-prod-pmda-efs-transfer/s3_file_list.csv raw_pmda_s3_file_li
 cd /workspaces/demos/data/migration/stage_pmda_for_migration
 dbt build
 
-# Run final step
+# Migrate files, then load data into DEMOS schema
 cd /workspaces/demos/data/demos_data_tools
+python migrate_files.py
 python load_staged_data_to_demos_app.py

--- a/data/migration/stage_pmda_for_migration/models/cleaned/system/system_file_move_tracker.sql
+++ b/data/migration/stage_pmda_for_migration/models/cleaned/system/system_file_move_tracker.sql
@@ -1,15 +1,52 @@
+WITH base_list AS (
+    SELECT
+        final_docs.id AS final_document_id,
+        final_docs.s3_path AS final_document_s3_path,
+        final_docs._internal_pmda_s3_file_id,
+        s3_files.s3_prefix_and_file_name AS legacy_pmda_s3_path
+    FROM
+        {{ ref('final_demos_app_document') }} AS final_docs
+    LEFT JOIN
+        {{ ref('docs_pmda_s3_file_list') }} AS s3_files
+        ON
+            final_docs._internal_pmda_s3_file_id = s3_files.pmda_s3_file_id
+    -- Filter to be removed once NOT NULL enforced by tests!
+    WHERE
+        final_docs._internal_pmda_s3_file_id IS NOT NULL
+),
+
+file_extensions AS (
+    SELECT
+        final_document_id,
+        final_document_s3_path,
+        _internal_pmda_s3_file_id,
+        legacy_pmda_s3_path,
+        CASE
+            WHEN
+                pg_input_is_valid(split_part(legacy_pmda_s3_path, '.', -1), 'integer')
+                THEN lower(split_part(legacy_pmda_s3_path, '.', -2))
+            ELSE lower(split_part(legacy_pmda_s3_path, '.', -1))
+        END AS legacy_pmda_file_extension
+    FROM
+        base_list
+)
+
 SELECT
-    final_docs.id AS final_document_id,
-    final_docs.s3_path AS final_document_s3_path,
-    final_docs._internal_pmda_s3_file_id,
-    s3_files.s3_prefix_and_file_name AS legacy_pmda_s3_path,
-    FALSE AS file_moved
+    final_document_id,
+    final_document_s3_path,
+    _internal_pmda_s3_file_id,
+    legacy_pmda_s3_path,
+    legacy_pmda_file_extension,
+    CASE legacy_pmda_file_extension
+        WHEN 'pdf' THEN 'application/pdf'
+        WHEN 'docx' THEN 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        WHEN 'xlsx' THEN 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        WHEN 'xlsm' THEN 'application/vnd.ms-excel.sheet.macroEnabled.12'
+        WHEN 'zip' THEN 'application/zip'
+        WHEN 'xls' THEN 'application/vnd.ms-excel'
+        WHEN 'doc' THEN 'application/msword'
+        ELSE 'application/octet-stream'
+    END AS file_mime_type,
+    FALSE AS file_has_been_moved
 FROM
-    {{ ref('final_demos_app_document') }} AS final_docs
-LEFT JOIN
-    {{ ref('docs_pmda_s3_file_list') }} AS s3_files
-    ON
-        final_docs._internal_pmda_s3_file_id = s3_files.pmda_s3_file_id
--- Filter to be removed once NOT NULL enforced by tests!
-WHERE
-    final_docs._internal_pmda_s3_file_id IS NOT NULL
+    file_extensions

--- a/data/migration/stage_pmda_for_migration/models/models.yml
+++ b/data/migration/stage_pmda_for_migration/models/models.yml
@@ -781,6 +781,11 @@ models:
   - name: system_file_move_tracker
     description: This table is used to track the file copy from legacy PMDA to DEMOs.
     columns:
+      - name: final_document_id
+        data_type: uuid
+        data_tests:
+          - unique:
+              name: assert_all_final_doc_ids_unique_in_file_move_tracker
       - name: _internal_pmda_s3_file_id
         data_type: bigint
         data_tests:


### PR DESCRIPTION
## Summary

Updates the file migration process to reflect current database / migration plan. Successfully executed locally for deliverable documents.

## Changes

- Refactored the `migrate_files.py` file to reflect the new structure in the database and to include the MIME types. Made program approach slightly more functional (mutating a record object and passing it around) but most of it is fairly similar to how we were doing it before. Also made this work seamlessly in the `devcontainer` by just checking if we are inside and if so, using the corrected `endpoint_url` argument. Updated tests throughout to reflect changes.
- Refactored the staging table where this information is stored to capture more information for us.
- Removed unused variables from the `.env.example` file.
- Small tweaks throughout.

## Validation

- [X] Automated tests added or updated
- [X] Relevant automated tests pass
- [X] Manually tested
- [ ] Testing is not applicable

Testing details:

- Validated locally by pulling the migrated documents into my `localstack` and confirming that the migration works and I can access the files afterward from the front-end. This was slightly annoying to accomplish as there are a _lot_ of files to download and load, but it does show it working fully.
  - I did have a total of _four_ files that failed. Upon checking, at least two of them failed because they exist in S3 with the exact same name but slightly different capitalization. That causes issues in MacOS, and I had to copy down and back up the files, so what happened is that those four files were dropped and then later, when my code tried to copy them, it did not work. This should not be an issue in production as we aren't moving the files via a local file system; this is entirely a gremlin of how my local environment worked. That being said, 4 files out 10992 amounts to a failure rate of 0.036% which I think is pretty good regardless. 😅

## Automated review

- [X] Run AI Code Review