### PR TITLE
DEMOS-2537: Add `demos-readonly` Role

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -62,6 +62,7 @@
     "dev:mocks:state": "VITE_MOCK_PERSON_TYPE=demos-state-user npm run dev:mocks",
     "dev:mocks:cms": "VITE_MOCK_PERSON_TYPE=demos-cms-user npm run dev:mocks",
     "dev:mocks:admin": "VITE_MOCK_PERSON_TYPE=demos-admin npm run dev:mocks",
+    "dev:mocks:readonly": "VITE_MOCK_PERSON_TYPE=demos-readonly npm run dev:mocks",
     "dev:mocks:unauth": "VITE_MOCK_PERSON_TYPE=unauth npm run dev:mocks",
     "format": "prettier --write src",
     "format:check": "prettier --check src",

--- a/client/src/components/header/CreateNewButton.test.tsx
+++ b/client/src/components/header/CreateNewButton.test.tsx
@@ -67,6 +67,22 @@ describe("CreateNewButton", () => {
     expect(screen.queryByText("Create New")).not.toBeInTheDocument();
   });
 
+  it("does not show the menu for readonly users", () => {
+    mockGetCurrentUser.mockReturnValue({
+      currentUser: {
+        ...mockUsers[0],
+        person: {
+          ...mockUsers[0].person,
+          personType: "demos-readonly",
+        },
+      },
+    });
+
+    renderCreateNewButton();
+
+    expect(screen.queryByText("Create New")).not.toBeInTheDocument();
+  });
+
   it("opens CreateDemonstrationDialog when demonstration is clicked", () => {
     mockGetCurrentUser.mockReturnValue({
       currentUser: mockUsers[0],

--- a/client/src/components/header/QuickLinks.test.tsx
+++ b/client/src/components/header/QuickLinks.test.tsx
@@ -16,6 +16,11 @@ const nonAdminUser: MockUser = {
   person: { ...developmentMockUser.person, personType: "demos-cms-user" },
 };
 
+const readonlyUser: MockUser = {
+  ...developmentMockUser,
+  person: { ...developmentMockUser.person, personType: "demos-readonly" },
+};
+
 const setup = (
   currentUser = adminUser,
   routerEntries: MemoryRouterProps["initialEntries"] = ["/"]
@@ -36,6 +41,11 @@ describe("QuickLinks", () => {
 
     it("does not render the Admin link for a non-admin user", () => {
       setup(nonAdminUser);
+      expect(screen.queryByTestId(ADMIN_LINK_NAME)).not.toBeInTheDocument();
+    });
+
+    it("does not render the Admin link for a readonly user", () => {
+      setup(readonlyUser);
       expect(screen.queryByTestId(ADMIN_LINK_NAME)).not.toBeInTheDocument();
     });
 

--- a/client/src/components/user/UserContext.test.tsx
+++ b/client/src/components/user/UserContext.test.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { getCurrentUser, isReadonly, CurrentUser } from "./UserContext";
+import { TestProvider } from "test-utils/TestProvider";
+import { developmentMockUser } from "mock-data/userMocks";
+
+describe("UserContext", () => {
+  describe("isReadonly", () => {
+    it("returns true when personType is 'demos-readonly'", () => {
+      const readonlyUser: CurrentUser = {
+        id: "user-1",
+        username: "readonly-user",
+        person: {
+          id: "person-1",
+          personType: "demos-readonly",
+          fullName: "Readonly User",
+          firstName: "Readonly",
+          lastName: "User",
+          email: "readonly@example.com",
+        },
+      };
+
+      expect(isReadonly(readonlyUser)).toBe(true);
+    });
+
+    it("returns false when personType is not 'demos-readonly'", () => {
+      const adminUser: CurrentUser = {
+        id: "user-2",
+        username: "admin-user",
+        person: {
+          id: "person-2",
+          personType: "demos-admin",
+          fullName: "Admin User",
+          firstName: "Admin",
+          lastName: "User",
+          email: "admin@example.com",
+        },
+      };
+
+      expect(isReadonly(adminUser)).toBe(false);
+    });
+
+    it("returns false when personType is 'demos-state'", () => {
+      const stateUser: CurrentUser = {
+        id: "user-3",
+        username: "state-user",
+        person: {
+          id: "person-3",
+          personType: "demos-state-user",
+          fullName: "State User",
+          firstName: "State",
+          lastName: "User",
+          email: "state@example.com",
+        },
+      };
+
+      expect(isReadonly(stateUser)).toBe(false);
+    });
+  });
+
+  describe("getCurrentUser", () => {
+    it("throws error when used outside UserProvider", () => {
+      expect(() => {
+        renderHook(() => getCurrentUser());
+      }).toThrow("getCurrentUser must be used within <UserProvider>");
+    });
+
+    it("returns context with current user when used inside UserProvider", () => {
+      const { result } = renderHook(() => getCurrentUser(), {
+        wrapper: TestProvider,
+      });
+
+      expect(result.current).toBeDefined();
+      expect(result.current.currentUser).toBeDefined();
+      expect(result.current.currentUser.id).toBe(developmentMockUser.id);
+      expect(result.current.currentUser.username).toBe(developmentMockUser.username);
+    });
+
+    it("returns user with correct structure via currentUser property", () => {
+      const { result } = renderHook(() => getCurrentUser(), {
+        wrapper: TestProvider,
+      });
+
+      const currentUser = result.current.currentUser;
+
+      expect(currentUser).toHaveProperty("id");
+      expect(currentUser).toHaveProperty("username");
+      expect(currentUser).toHaveProperty("person");
+      expect(currentUser.person).toHaveProperty("id");
+      expect(currentUser.person).toHaveProperty("personType");
+      expect(currentUser.person).toHaveProperty("fullName");
+      expect(currentUser.person).toHaveProperty("firstName");
+      expect(currentUser.person).toHaveProperty("lastName");
+      expect(currentUser.person).toHaveProperty("email");
+    });
+
+    it("returns custom user when passed via TestProvider", () => {
+      const customUser: CurrentUser = {
+        id: "custom-user-id",
+        username: "custom-username",
+        person: {
+          id: "custom-person-id",
+          personType: "demos-admin",
+          fullName: "Custom User",
+          firstName: "Custom",
+          lastName: "User",
+          email: "custom@example.com",
+        },
+      };
+
+      const { result } = renderHook(() => getCurrentUser(), {
+        wrapper: (props) => <TestProvider currentUser={customUser} {...props} />,
+      });
+
+      expect(result.current.currentUser.id).toBe("custom-user-id");
+      expect(result.current.currentUser.username).toBe("custom-username");
+      expect(result.current.currentUser.person.fullName).toBe("Custom User");
+    });
+  });
+});

--- a/client/src/components/user/UserContext.tsx
+++ b/client/src/components/user/UserContext.tsx
@@ -20,3 +20,8 @@ export function getCurrentUser() {
 
   return ctx;
 }
+
+export function isReadonly(currentUser: CurrentUser): boolean {
+  // Check if the user's personType indicates readonly status.
+  return currentUser.person.personType === "demos-readonly";
+}

--- a/client/src/mock-data/userMocks.ts
+++ b/client/src/mock-data/userMocks.ts
@@ -18,6 +18,8 @@ const getPrettyFirstName = (personType: PersonType): string => {
       return "State";
     case "demos-cms-user":
       return "CMS";
+    case "demos-readonly":
+      return "Readonly";
     default:
       return "Unknown";
   }

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -138,6 +138,9 @@ export const PERSON_TYPES = [
   "demos-cms-user",
   "demos-state-user",
   "non-user-contact",
+  // Temporary, replace when we have a real user from IDM with this role.
+  // Currently only used in mocks for DEMOS-2537
+  "demos-readonly",
 ] as const;
 
 export const USER_TYPES = ["demos-admin", "demos-cms-user", "demos-state-user"] as const;


### PR DESCRIPTION
## Summary

Adds a `PersonType` of `demos-readonly` and an accompanying `isReadonly()` function 

## Changes

- Introduces a new `PersonType` of `demos-readonly`
- Utilizes this person for a more generic `isReadonly` function
- Adds tests for `UserContext`

## Validation

- [X] Automated tests added or updated
- [X] Relevant automated tests pass
- [X] Manually tested
- [ ] Testing is not applicable

## Screenshots or recordings

https://github.com/user-attachments/assets/303bacb1-8440-4ad4-9f7e-a1748aeba5b0


## Notes

We actually get a good amount of stuff for free related to this work based on how some of these things are set up. For instance the `Create New` button already gates on an "allowlist" of person types to be able to access this.
