### PR TITLE
DEMOS-2540-improve-submission-extraction

### DIFF
--- a/data/migration/stage_pmda_for_migration/MIGRATION_LOGIC.md
+++ b/data/migration/stage_pmda_for_migration/MIGRATION_LOGIC.md
@@ -318,9 +318,20 @@ When a due date was attached to something determined to be open-ended, it was se
 
 As an initial pass, the CMS owner was set to the creator of the deliverable. If this was not resolvable, the user Elizabeth Hill was assigned as the owner. `#open-question`
 
-## Submission Date
+## Submissions / Submission Date
 
-There's been a first-pass effort (still work in progress) on importing the submission events from the database and figuring out what the due dates were at the time of the submission event. This is still in progress and needs refinement.
+Submissions were extrapolated from the deliverable files table (`mdcd_dlvrbl_fil_doc`) using an approach suggested by Zoe originally. That makes this section tightly tied with [Deliverable Documents](#deliverable-documents). A submission is defined as...
+
+Any group of files
+- for the same deliverable
+- with the same PMDA user
+- that were created within five minutes of another file in the same group.
+
+We can tune the time differently if we want; five minutes was chosen relatively arbitrarily. The advantage of this process is that it allows us to place _all_ files in a submission, and neatly sidesteps the challenge of interpreting the status history table which seems to be inconsistent.
+
+We exclude CMS files from this because CMS files cannot be part of submissions in DEMOS. If an extracted submission contains only CMS files, we do not insert it into the `deliverable_action` table as it has no state files and is therefore not a "real" submission.
+
+The submitting user was defined as the user who created the files in PMDA, with a fallback to Elizabeth Hill if needed.
 
 # Documents
 
@@ -384,7 +395,11 @@ The PMDA system appears to have embedded some information about the specific fil
 
 ## Deliverable Documents
 
-The base for deliverable documents are the records in `mdcd_dlvrbl_fil_doc`. We select those that are not deleted (`dltd_ind = 0`), and then filter out ones where we cannot resolve an owner, or a deliverable in those final sets. These are logged warnings for the testing system. We also filter out those that we cannot resolve to known documents found in `docs_pmda_s3_file_list`. The match is made based on file name, the deliverable ID we have attempted to extract from the path, and the state or CMS file flag.
+The base for deliverable documents are the records in `mdcd_dlvrbl_fil_doc`. We select those that are not deleted (`dltd_ind = 0`), and then filter out ones where we cannot resolve an owner, or a deliverable in those final sets. These are logged warnings for the testing system.
+
+We also filter out those that we cannot resolve to known documents found in `docs_pmda_s3_file_list`. The match is made based on file name, the deliverable ID we have attempted to extract from the path, and the state or CMS file flag.
+
+We derive the submissions from this result set as described in [Submissions / Submission Date](#submissions--submission-date).
 
 To enable rapid iteration, the following short-term approaches have been taken, most of which are `#open-question` to be refined further.
 
@@ -392,7 +407,6 @@ To enable rapid iteration, the following short-term approaches have been taken, 
 - The field `intrnl_cmt_txt` was assigned as the description
 - At present, all documents are being assigned as "General File". It _may_ be possible to derive some of the document types from the fields in PMDA (specifically, `bdgt_ntrlty_fil_ind`, `mntrg_rpt_fil_ind`, `mntrg_prtcl_fil_ind`, and `proc_mntrg_rpt_ind`), but the `mdcd_dlvrbl_fil_doc` table doesn't seem to have the same document type concept as other places in PMDA.
 - `cmd_orgn_cd` is used to derive CMS file vs state file; `C` for CMS, and `S` for state.
-- None of the documents are being included in submissions yet - we need to probably work backwards from the `mdcd_dlvrbl_fil_doc` table to extrapolate to submissions from that rather than the current approach of using the `stus_hstry` table per discussion with Zoe.
 
 ## Program Monitoring Documents
 

--- a/data/migration/stage_pmda_for_migration/models/cleaned/cleaned_demos_app_deliverable_action_submission_events.sql
+++ b/data/migration/stage_pmda_for_migration/models/cleaned/cleaned_demos_app_deliverable_action_submission_events.sql
@@ -8,7 +8,7 @@ WITH liz_hill AS (
 
 SELECT
     gen_random_uuid() AS id,
-    sub_evt.creatd_dt AS action_timestamp,
+    sub_evt._internal_submission_date AS action_timestamp,
     f_deliv.id AS deliverable_id,
     'Submitted Deliverable' AS action_type_id,
     'Submitted' AS old_status_id,
@@ -21,21 +21,22 @@ SELECT
     TRUE AS extension_id_optional,
     coalesce(due_date_hist.dlvrbl_due_dt, f_deliv.due_date) AS old_due_date,
     coalesce(due_date_hist.dlvrbl_due_dt, f_deliv.due_date) AS new_due_date,
-    liz_hill.id AS user_id
+    coalesce(sub_evt.demos_user_id, liz_hill.id) AS user_id,
+    sub_evt._internal_submission_id
 FROM
     {{ ref('deliverables_deliverable_submission_events') }} AS sub_evt
 
 LEFT JOIN
     {{ ref('deliverables_history_due_date_by_date_range') }} AS due_date_hist
     ON
-        sub_evt.mdcd_dlvrbl_id = due_date_hist.mdcd_dlvrbl_id
-        AND sub_evt.creatd_dt BETWEEN due_date_hist.from_time AND due_date_hist.to_time
+        sub_evt._legacy_mdcd_dlvrbl_id = due_date_hist.mdcd_dlvrbl_id
+        AND sub_evt._internal_submission_date BETWEEN due_date_hist.from_time AND due_date_hist.to_time
 
 -- Inner join acceptable here; we want actions for all the final deliverables
 INNER JOIN
     {{ ref('final_demos_app_deliverable') }} AS f_deliv
     ON
-        sub_evt.mdcd_dlvrbl_id = f_deliv._legacy_mdcd_dlvrbl_id
+        sub_evt._legacy_mdcd_dlvrbl_id = f_deliv._legacy_mdcd_dlvrbl_id
 
 -- Just putting the ID on every row
 INNER JOIN

--- a/data/migration/stage_pmda_for_migration/models/cleaned/cleaned_demos_app_deliverable_docs.sql
+++ b/data/migration/stage_pmda_for_migration/models/cleaned/cleaned_demos_app_deliverable_docs.sql
@@ -10,18 +10,29 @@ WITH no_s3_path AS (
         deliv_docs.demos_deliverable_id AS deliverable_id,
         deliv_docs.demos_deliverable_type_id AS deliverable_type_id,
         deliv_docs.cmt_orgn_cd = 'C' AS deliverable_is_cms_attached_file,
-        NULL::UUID AS deliverable_submission_action_id,
-        NULL AS deliverable_submission_action_type_id,
+        CASE
+            WHEN deliv_docs.cmt_orgn_cd = 'C' THEN NULL
+            ELSE clean_sub_evt.id
+        END AS deliverable_submission_action_id,
+        CASE
+            WHEN deliv_docs.cmt_orgn_cd = 'C' THEN NULL
+            ELSE 'Submitted Deliverable'
+        END AS deliverable_submission_action_type_id,
         deliv_docs.creatd_dt AS created_at,
         deliv_docs.creatd_dt AS updated_at,
         deliv_docs.mdcd_dlvrbl_fil_doc_id AS _legacy_mdcd_dlvrbl_fil_doc_id,
         deliv_docs.mdcd_dlvrbl_id AS _legacy_mdcd_dlvrbl_id,
         NULL::INTEGER AS _legacy_mdcd_demo_aplctn_doc_rpstry_dtl_id,
         NULL::INTEGER AS _legacy_mdcd_demo_pgm_mntrg_doc_id,
-        deliv_docs.pmda_s3_file_id AS _internal_pmda_s3_file_id
+        deliv_docs.pmda_s3_file_id AS _internal_pmda_s3_file_id,
+        deliv_docs._internal_submission_id
 
     FROM
         {{ ref('docs_base_pmda_deliv_docs') }} AS deliv_docs
+    LEFT JOIN
+        {{ ref('cleaned_demos_app_deliverable_action_submission_events') }} AS clean_sub_evt
+        ON
+            deliv_docs._internal_submission_id = clean_sub_evt._internal_submission_id
     WHERE
         deliv_docs.mdcd_dlvrbl_fil_doc_id NOT IN (
             SELECT e1.mdcd_dlvrbl_fil_doc_id FROM {{ ref('errors_deliv_docs_with_no_resolved_deliverable') }} AS e1

--- a/data/migration/stage_pmda_for_migration/models/cleaned/final/final_demos_app_deliverable_action.sql
+++ b/data/migration/stage_pmda_for_migration/models/cleaned/final/final_demos_app_deliverable_action.sql
@@ -1,7 +1,37 @@
-SELECT *
+SELECT
+    id,
+    action_timestamp,
+    deliverable_id,
+    action_type_id,
+    old_status_id,
+    new_status_id,
+    note,
+    active_extension_id,
+    due_date_change_allowed,
+    should_have_note,
+    should_have_user_id,
+    extension_id_optional,
+    old_due_date,
+    new_due_date,
+    user_id
 FROM
     {{ ref('cleaned_demos_app_deliverable_action_migration_events') }}
 UNION ALL
-SELECT *
+SELECT
+    id,
+    action_timestamp,
+    deliverable_id,
+    action_type_id,
+    old_status_id,
+    new_status_id,
+    note,
+    active_extension_id,
+    due_date_change_allowed,
+    should_have_note,
+    should_have_user_id,
+    extension_id_optional,
+    old_due_date,
+    new_due_date,
+    user_id
 FROM
     {{ ref('cleaned_demos_app_deliverable_action_submission_events') }}

--- a/data/migration/stage_pmda_for_migration/models/deliverables/deliverables_deliverable_submission_events.sql
+++ b/data/migration/stage_pmda_for_migration/models/deliverables/deliverables_deliverable_submission_events.sql
@@ -1,9 +1,26 @@
-SELECT history.*
+-- Note: something with no state documents is not considered a submission
+-- CMS documents are not part of submissions
+WITH possible_submissions AS (
+    SELECT
+        _internal_submission_id,
+        _internal_submission_date,
+        mdcd_dlvrbl_id AS _legacy_mdcd_dlvrbl_id,
+        user_id AS _legacy_mdcd_dlvrbl_fil_doc_user_id,
+        demos_deliverable_id,
+        demos_user_id,
+        sum(CASE WHEN cmt_orgn_cd = 'S' THEN 1 ELSE 0 END) AS n_state_docs
+    FROM
+        {{ ref('docs_base_pmda_deliv_docs') }}
+    GROUP BY
+        _internal_submission_id,
+        _internal_submission_date,
+        mdcd_dlvrbl_id,
+        user_id,
+        demos_deliverable_id,
+        demos_user_id
+)
+
+SELECT *
 FROM
-    {{ source('legacy_pmda_raw', 'mdcd_dlvrbl_stus_hstry') }} AS history
-WHERE
-    history.dltd_ind = 0
-    AND history.mdcd_dlvrbl_stus_cd = 3
-    AND history.mdcd_dlvrbl_id IN (
-        SELECT active.mdcd_dlvrbl_id FROM {{ ref('deliverables_active_pmda_deliverables') }} AS active
-    )
+    possible_submissions
+WHERE n_state_docs > 0

--- a/data/migration/stage_pmda_for_migration/models/deliverables/deliverables_history_due_date_by_date_range.sql
+++ b/data/migration/stage_pmda_for_migration/models/deliverables/deliverables_history_due_date_by_date_range.sql
@@ -15,7 +15,10 @@ WITH filtered_and_cleaned_history AS (
             history.mdcd_dlvrbl_id = active_deliv.mdcd_dlvrbl_id
 ),
 
-shifts AS (
+-- Need to get two different shifts
+-- One to get the time things changed
+-- One to figure out each run of the same due date
+date_shifts AS (
     SELECT
         mdcd_dlvrbl_id,
         dlvrbl_due_dt,
@@ -23,24 +26,51 @@ shifts AS (
         lead(hstry_updtd_dt, 1)
             OVER (PARTITION BY mdcd_dlvrbl_id ORDER BY hstry_updtd_dt)
             AS next_hstry_updtd_dt,
-        row_number() OVER (
-            PARTITION BY
-                mdcd_dlvrbl_id,
-                dlvrbl_due_dt
-            ORDER BY
-                hstry_updtd_dt
-        ) = 1 AS is_first_of_dlvrbl_date,
-        row_number() OVER (
-            PARTITION BY
-                mdcd_dlvrbl_id,
-                dlvrbl_due_dt
-            ORDER BY
-                hstry_updtd_dt DESC
-        ) = 1 AS is_last_of_dlvrbl_date,
-        row_number() OVER (PARTITION BY mdcd_dlvrbl_id ORDER BY hstry_updtd_dt) = 1 AS is_first_of_dlvrbl,
-        row_number() OVER (PARTITION BY mdcd_dlvrbl_id ORDER BY hstry_updtd_dt DESC) = 1 AS is_last_of_dlvrbl
+        lag(dlvrbl_due_dt, 1) OVER (PARTITION BY mdcd_dlvrbl_id ORDER BY hstry_updtd_dt) AS last_dlvrbl_due_dt
     FROM
         filtered_and_cleaned_history
+),
+
+range_groups AS (
+    SELECT
+        mdcd_dlvrbl_id,
+        dlvrbl_due_dt,
+        hstry_updtd_dt,
+        next_hstry_updtd_dt,
+        last_dlvrbl_due_dt,
+
+        -- Whenever the due date doesn't match the last one (or is null), its a new group of due dates
+        -- Taking the sum of this gives a sequential group number within each mdcd_dlvrbl_id
+        sum(CASE WHEN dlvrbl_due_dt != last_dlvrbl_due_dt OR last_dlvrbl_due_dt IS NULL THEN 1 ELSE 0 END)
+            OVER (
+                PARTITION BY
+                    mdcd_dlvrbl_id
+                ORDER BY
+                    hstry_updtd_dt
+                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            )
+            AS due_dt_range_group
+    FROM
+        date_shifts
+),
+
+-- Now, derive the first / last flags from the group variable, not the date directly
+-- Prevents issues where a due date changes and changes back
+flagged_range_groups AS (
+    SELECT
+        mdcd_dlvrbl_id,
+        dlvrbl_due_dt,
+        hstry_updtd_dt,
+        next_hstry_updtd_dt,
+        last_dlvrbl_due_dt,
+        due_dt_range_group,
+        row_number() OVER (PARTITION BY mdcd_dlvrbl_id ORDER BY hstry_updtd_dt) = 1 AS is_first_of_dlvrbl,
+        row_number() OVER (PARTITION BY mdcd_dlvrbl_id, due_dt_range_group ORDER BY hstry_updtd_dt)
+        = 1 AS is_first_of_dlvrbl_date,
+        row_number() OVER (PARTITION BY mdcd_dlvrbl_id ORDER BY hstry_updtd_dt DESC) = 1 AS is_last_of_dlvrbl,
+        row_number() OVER (PARTITION BY mdcd_dlvrbl_id, due_dt_range_group ORDER BY hstry_updtd_dt DESC)
+        = 1 AS is_last_of_dlvrbl_date
+    FROM range_groups
 ),
 
 calculated_values AS (
@@ -48,7 +78,7 @@ calculated_values AS (
         mdcd_dlvrbl_id,
         dlvrbl_due_dt,
         hstry_updtd_dt,
-        next_hstry_updtd_dt,
+        due_dt_range_group,
         CASE
             WHEN is_first_of_dlvrbl THEN '1900-01-01 00:00:00.000'::TIMESTAMP AT TIME ZONE 'America/New_York'
             WHEN is_first_of_dlvrbl_date THEN hstry_updtd_dt
@@ -57,13 +87,13 @@ calculated_values AS (
             WHEN is_last_of_dlvrbl THEN '2299-12-31 23:59:59.999'::TIMESTAMP AT TIME ZONE 'America/New_York'
             WHEN is_last_of_dlvrbl_date THEN next_hstry_updtd_dt - INTERVAL '1 ms'
         END AS to_time
-    FROM shifts
+    FROM flagged_range_groups
 )
 
 SELECT DISTINCT
     mdcd_dlvrbl_id,
     dlvrbl_due_dt,
-    first_value(from_time) OVER (PARTITION BY mdcd_dlvrbl_id, dlvrbl_due_dt ORDER BY hstry_updtd_dt) AS from_time,
-    first_value(to_time) OVER (PARTITION BY mdcd_dlvrbl_id, dlvrbl_due_dt ORDER BY hstry_updtd_dt DESC) AS to_time
+    first_value(from_time) OVER (PARTITION BY mdcd_dlvrbl_id, due_dt_range_group ORDER BY hstry_updtd_dt) AS from_time,
+    first_value(to_time) OVER (PARTITION BY mdcd_dlvrbl_id, due_dt_range_group ORDER BY hstry_updtd_dt DESC) AS to_time
 FROM
     calculated_values

--- a/data/migration/stage_pmda_for_migration/models/docs/docs_base_pmda_deliv_docs.sql
+++ b/data/migration/stage_pmda_for_migration/models/docs/docs_base_pmda_deliv_docs.sql
@@ -57,6 +57,7 @@ interval_time AS (
         base_deliv_docs
 ),
 
+-- Can tune the time here if we want to make more or less submissions
 submission_ids AS (
     SELECT
         mdcd_dlvrbl_fil_doc_id,

--- a/data/migration/stage_pmda_for_migration/models/docs/docs_base_pmda_deliv_docs.sql
+++ b/data/migration/stage_pmda_for_migration/models/docs/docs_base_pmda_deliv_docs.sql
@@ -1,37 +1,105 @@
+WITH base_deliv_docs AS (
+    SELECT
+        deliv_doc.mdcd_dlvrbl_fil_doc_id,
+        deliv_doc.mdcd_dlvrbl_id,
+        deliv_doc.doc_name,
+        deliv_doc.intrnl_cmt_txt,
+        deliv_doc.dlvrbl_fil_name,
+        deliv_doc.user_id,
+        deliv_doc.creatd_dt,
+        deliv_doc.dltd_ind,
+        deliv_doc.cmt_orgn_cd,
+        deliv_doc.bdgt_ntrlty_fil_ind,
+        deliv_doc.mntrg_rpt_fil_ind,
+        deliv_doc.mntrg_prtcl_fil_ind,
+        deliv_doc.proc_mntrg_rpt_ind,
+        f_deliv.id AS demos_deliverable_id,
+        f_deliv.demonstration_id AS demos_demonstration_id,
+        f_deliv.deliverable_type_id AS demos_deliverable_type_id,
+        f_person.id AS demos_user_id,
+        s3_files.pmda_s3_file_id
+    FROM
+        {{ source('legacy_pmda_raw', 'mdcd_dlvrbl_fil_doc') }} AS deliv_doc
+    LEFT JOIN
+        {{ ref('final_demos_app_deliverable') }} AS f_deliv
+        ON
+            deliv_doc.mdcd_dlvrbl_id = f_deliv._legacy_mdcd_dlvrbl_id
+    LEFT JOIN
+        {{ ref('final_demos_app_person') }} AS f_person
+        ON
+            deliv_doc.user_id = f_person._legacy_users_id
+    LEFT JOIN
+        {{ ref('docs_pmda_s3_file_list') }} AS s3_files
+        ON
+            deliv_doc.dlvrbl_fil_name = s3_files.file_name
+            AND deliv_doc.mdcd_dlvrbl_id = s3_files.deliv_extracted_mdcd_dlvrbl_id
+            AND deliv_doc.cmt_orgn_cd = s3_files.deliv_extracted_cmt_orgn_cd
+    WHERE
+        deliv_doc.dltd_ind = 0
+),
+
+-- Defining a submission using the deliverable documents data
+-- A submission is any group of files:
+--   for the same deliverable
+--   with the same user
+--   that were created within five minutes of another file in the same submission
+interval_time AS (
+    SELECT
+        mdcd_dlvrbl_fil_doc_id,
+        mdcd_dlvrbl_id,
+        user_id,
+        creatd_dt,
+        creatd_dt
+        - lag(creatd_dt, 1)
+            OVER (PARTITION BY mdcd_dlvrbl_id, user_id ORDER BY creatd_dt)
+            AS interval_from_prev_creatd_dt
+    FROM
+        base_deliv_docs
+),
+
+submission_ids AS (
+    SELECT
+        mdcd_dlvrbl_fil_doc_id,
+        creatd_dt,
+        sum(
+            CASE
+                WHEN interval_from_prev_creatd_dt IS NULL THEN 1
+                WHEN interval_from_prev_creatd_dt <= '5 minutes'::INTERVAL THEN 0
+                WHEN interval_from_prev_creatd_dt > '5 minutes'::INTERVAL THEN 1
+            END
+        ) OVER (ORDER BY mdcd_dlvrbl_id, user_id, creatd_dt) AS _internal_submission_id
+    FROM
+        interval_time
+)
+
 SELECT
-    deliv_doc.mdcd_dlvrbl_fil_doc_id,
-    deliv_doc.mdcd_dlvrbl_id,
-    deliv_doc.doc_name,
-    deliv_doc.intrnl_cmt_txt,
-    deliv_doc.dlvrbl_fil_name,
-    deliv_doc.user_id,
-    deliv_doc.creatd_dt,
-    deliv_doc.dltd_ind,
-    deliv_doc.cmt_orgn_cd,
-    deliv_doc.bdgt_ntrlty_fil_ind,
-    deliv_doc.mntrg_rpt_fil_ind,
-    deliv_doc.mntrg_prtcl_fil_ind,
-    deliv_doc.proc_mntrg_rpt_ind,
-    f_deliv.id AS demos_deliverable_id,
-    f_deliv.demonstration_id AS demos_demonstration_id,
-    f_deliv.deliverable_type_id AS demos_deliverable_type_id,
-    f_person.id AS demos_user_id,
-    s3_files.pmda_s3_file_id
+    base_deliv_docs.mdcd_dlvrbl_fil_doc_id,
+    base_deliv_docs.mdcd_dlvrbl_id,
+    base_deliv_docs.doc_name,
+    base_deliv_docs.intrnl_cmt_txt,
+    base_deliv_docs.dlvrbl_fil_name,
+    base_deliv_docs.user_id,
+    base_deliv_docs.creatd_dt,
+    base_deliv_docs.dltd_ind,
+    base_deliv_docs.cmt_orgn_cd,
+    base_deliv_docs.bdgt_ntrlty_fil_ind,
+    base_deliv_docs.mntrg_rpt_fil_ind,
+    base_deliv_docs.mntrg_prtcl_fil_ind,
+    base_deliv_docs.proc_mntrg_rpt_ind,
+    base_deliv_docs.demos_deliverable_id,
+    base_deliv_docs.demos_demonstration_id,
+    base_deliv_docs.demos_deliverable_type_id,
+    base_deliv_docs.demos_user_id,
+    base_deliv_docs.pmda_s3_file_id,
+    submission_ids._internal_submission_id,
+    max(submission_ids.creatd_dt)
+        OVER (PARTITION BY submission_ids._internal_submission_id)
+        AS _internal_submission_date
 FROM
-    {{ source('legacy_pmda_raw', 'mdcd_dlvrbl_fil_doc') }} AS deliv_doc
+    base_deliv_docs
+
+-- This left join should be unnecessary, but keeping it and adding a test just in case
 LEFT JOIN
-    {{ ref('final_demos_app_deliverable') }} AS f_deliv
+    submission_ids
     ON
-        deliv_doc.mdcd_dlvrbl_id = f_deliv._legacy_mdcd_dlvrbl_id
-LEFT JOIN
-    {{ ref('final_demos_app_person') }} AS f_person
-    ON
-        deliv_doc.user_id = f_person._legacy_users_id
-LEFT JOIN
-    {{ ref('docs_pmda_s3_file_list') }} AS s3_files
-    ON
-        deliv_doc.dlvrbl_fil_name = s3_files.file_name
-        AND deliv_doc.mdcd_dlvrbl_id = s3_files.deliv_extracted_mdcd_dlvrbl_id
-        AND deliv_doc.cmt_orgn_cd = s3_files.deliv_extracted_cmt_orgn_cd
-WHERE
-    deliv_doc.dltd_ind = 0
+        base_deliv_docs.mdcd_dlvrbl_fil_doc_id = submission_ids.mdcd_dlvrbl_fil_doc_id

--- a/data/migration/stage_pmda_for_migration/models/errors/errors_deliv_submissions_with_no_final_demos_deliv.sql
+++ b/data/migration/stage_pmda_for_migration/models/errors/errors_deliv_submissions_with_no_final_demos_deliv.sql
@@ -1,0 +1,2 @@
+SELECT * FROM {{ ref('deliverables_deliverable_submission_events') }}
+WHERE demos_deliverable_id IS NULL

--- a/data/migration/stage_pmda_for_migration/models/errors/errors_deliv_submissions_with_no_final_demos_user.sql
+++ b/data/migration/stage_pmda_for_migration/models/errors/errors_deliv_submissions_with_no_final_demos_user.sql
@@ -1,0 +1,2 @@
+SELECT * FROM {{ ref('deliverables_deliverable_submission_events') }}
+WHERE demos_user_id IS NULL

--- a/data/migration/stage_pmda_for_migration/models/models.yml
+++ b/data/migration/stage_pmda_for_migration/models/models.yml
@@ -906,6 +906,11 @@ models:
         data_tests:
           - not_null:
               name: assert_no_missing_creatd_dt_in_base_pmda_deliv_docs
+      - name: _internal_submission_id
+        data_type: integer
+        data_tests:
+          - not_null:
+              name: assert_no_null_computed_submission_ids_from_delivs
 
   # System Models
   - name: system_file_move_tracker

--- a/data/migration/stage_pmda_for_migration/tests/assert_no_cms_documents_in_deliverable_submissions.sql
+++ b/data/migration/stage_pmda_for_migration/tests/assert_no_cms_documents_in_deliverable_submissions.sql
@@ -1,0 +1,5 @@
+SELECT *
+FROM
+    {{ ref('final_demos_app_document') }}
+WHERE
+    deliverable_submission_action_id IS NOT NULL AND deliverable_is_cms_attached_file

--- a/data/migration/stage_pmda_for_migration/tests/assert_no_deliv_submission_filtered_for_missing_deliverable.sql
+++ b/data/migration/stage_pmda_for_migration/tests/assert_no_deliv_submission_filtered_for_missing_deliverable.sql
@@ -1,0 +1,7 @@
+-- Warn in cases where we could not link a submission to a final DEMOS deliverable
+
+{{ config(severity='warn') }}
+
+SELECT *
+FROM
+    {{ ref('errors_deliv_submissions_with_no_final_demos_deliv') }}

--- a/data/migration/stage_pmda_for_migration/tests/assert_no_deliv_submission_user_replaced_by_placeholder.sql
+++ b/data/migration/stage_pmda_for_migration/tests/assert_no_deliv_submission_user_replaced_by_placeholder.sql
@@ -1,0 +1,7 @@
+-- Warn in cases where we had to replace the submitter with Liz Hill
+
+{{ config(severity='warn') }}
+
+SELECT *
+FROM
+    {{ ref('errors_deliv_submissions_with_no_final_demos_user') }}

--- a/data/migration/stage_pmda_for_migration/tests/assert_no_null_sub_ids_for_cleaned_deliv_state_docs.sql
+++ b/data/migration/stage_pmda_for_migration/tests/assert_no_null_sub_ids_for_cleaned_deliv_state_docs.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM {{ ref('cleaned_demos_app_deliverable_docs') }}
+WHERE
+    NOT deliverable_is_cms_attached_file AND deliverable_submission_action_id IS NULL


### PR DESCRIPTION
## Summary

This refactor improves the way that submissions are extracted from PMDA. Instead of using the status history table, this uses an approach originally identified by @zoeelkins where we look at the actual files and extract submissions from that. It also fixes an issue with how the historical due dates were being calculated, and improves submission ownership by using the owner of the files in the submission.

## Changes

- Adds a CTE approach to deriving an internal submission ID to the process of getting `docs_base_pmda_deliv_docs`, which then flows through the entire system.
- Fixes the derivation in `deliverables_history_due_date_by_date_range` to properly account for times where a due date appears more than once in separate runs; I did not do this before, but it wasn't causing issues until I improved the submission calculation.
- Adds tests and updates documentation.

## Validation

- [X] Automated tests added or updated
- [X] Relevant automated tests pass
- [X] Manually tested
- [ ] Testing is not applicable

Testing details:

- DBT tests passing.
- Loaded to empty `demos_app` schema and exercised on front-end.

## Automated review

- [X] Run AI Code Review