### PR TITLE
DEMOS-2563 Responsive Display for Long Text Fields for Demonstrations

### DIFF
--- a/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
+++ b/client/src/components/application/phases/approval-summary/applicationDetailsSection.tsx
@@ -11,7 +11,7 @@ import { tw } from "tags/tw";
 import { formatDateForDisplay } from "util/formatDate";
 
 const LABEL_CLASSES = tw`text-text-font font-bold text-sm tracking-wide h-[14px] flex items-center`;
-const VALUE_CLASSES = tw`text-text-font text-base leading-relaxed h-[40px] flex items-start mt-1`;
+const VALUE_CLASSES = tw`text-text-font text-base leading-relaxed min-h-[40px] flex items-start mt-1`;
 
 export const DEMONSTRATION_SIGNATURE_LEVELS: SignatureLevel[] = ["OA"];
 export const MODIFICATION_SIGNATURE_LEVELS: SignatureLevel[] = ["OA", "OCD"];

--- a/client/src/components/table/tables/SummaryDetailsTable.tsx
+++ b/client/src/components/table/tables/SummaryDetailsTable.tsx
@@ -49,9 +49,9 @@ export const DEMONSTRATION_SUMMARY_DETAILS_QUERY = gql`
   }
 `;
 
-const FIELD_CONTAINER_CLASSES = tw`h-[62px] flex flex-col`;
+const FIELD_CONTAINER_CLASSES = tw`min-h-[62px] flex flex-col`;
 const LABEL_CLASSES = tw`text-text-font font-bold text-sm tracking-wide h-[14px] flex items-center`;
-const VALUE_CLASSES = tw`text-text-font text-base leading-relaxed h-[40px] flex items-start mt-1`;
+const VALUE_CLASSES = tw`text-text-font text-base leading-relaxed min-h-[40px] flex items-start mt-1`;
 
 const prepareDisplayData = (demonstration: Demonstration) => ({
   ...demonstration,


### PR DESCRIPTION
<!--
Suggested title: `DEMOS-####: Concise description` This will be used as the commit content by default
Keep this focused. Uncomment or remove sections as needed.
-->

## Summary

Modified static height values for fields to min-height values instead, allowing containers to grow responsively.

## Changes

Updated some tw classes from stuff like h-[40px] to min-h-[40px]
-

<!-- ## Validation -->

Modified some amendments, demos, deliverables to have grossly long field values and validated the display.

<!--
- [ ] Automated tests added or updated
- [ ] Relevant automated tests pass
- [x] Manually tested
- [ ] Testing is not applicable

Testing details:
-->

<!--
Examples:
- Tested locally using...
- Verified in Chrome, Firefox, and Safari
- Tested against the DEV environment
- Not fully testable locally because...
-->

<!-- ## Screenshots or recordings -->
before:
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/6bb18cbe-8ab5-4bf2-93ee-4d6b5c7406dd" />

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/985b7f61-ac8f-42b9-b488-055302bbdf37" />


## Additional notes

<!-- Point reviewers toward areas needing special attention and identify intentional follow-up work. -->

## Automated review

- [ ] Run AI Code Review <!-- The AI PR review will only run if this is checked [x] -->
