### PR TITLE
DEMOS-2594: updated UIPath for multiple values

### DIFF
--- a/lambdas/UIPath/db/uiPathResults.ts
+++ b/lambdas/UIPath/db/uiPathResults.ts
@@ -3,6 +3,7 @@ import type { PoolClient } from "pg";
 import { getDbPool } from "../db";
 import { ExtractionStatus } from "../fetchExtractResult";
 import {
+  DEMO_TYPE_FIELD_ID,
   getConfidence,
   getExtractedFields,
   getTextStartIndex,
@@ -33,6 +34,7 @@ const INSERT_VALUE_SQL = `insert into ${DEMOS_SCHEMA}.uipath_value
   (id, uipath_result_id, document_id, application_id, field_id, value, text_length, text_start_index, confidence, token_list, updated_at)
  values
   ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, now())`;
+const SELECT_TAG_NAMES_SQL = `select id from ${DEMOS_SCHEMA}.tag_name`;
 
 export type PersistedUiPathExtraction = {
   extractedFieldCount: number;
@@ -153,9 +155,27 @@ export async function persistFinishedUiPathExtraction(
     );
 
     const extractedFields = getExtractedFields(status);
+    let canonicalTagNames: string[] = [];
+    if (
+      extractedFields.some(
+        (field) => field.FieldId === DEMO_TYPE_FIELD_ID && !field.IsMissing,
+      )
+    ) {
+      const tagNames = await client.query<{ id: string }>(SELECT_TAG_NAMES_SQL);
+      canonicalTagNames = tagNames.rows.map((row) => row.id);
+      if (!canonicalTagNames.length) {
+        throw new Error(
+          "Cannot normalize UiPath demo_type values: no application tag names found.",
+        );
+      }
+    }
+
     const uiPathValues: PersistedUiPathValue[] = [];
     for (const field of extractedFields) {
-      const persistableValues = toPersistableFieldValues(field);
+      const persistableValues = toPersistableFieldValues(
+        field,
+        canonicalTagNames,
+      );
       if (!persistableValues.length) continue;
 
       for (const row of persistableValues) {

--- a/lambdas/UIPath/db/uiPathResults.ts
+++ b/lambdas/UIPath/db/uiPathResults.ts
@@ -34,7 +34,7 @@ const INSERT_VALUE_SQL = `insert into ${DEMOS_SCHEMA}.uipath_value
   (id, uipath_result_id, document_id, application_id, field_id, value, text_length, text_start_index, confidence, token_list, updated_at)
  values
   ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, now())`;
-const SELECT_TAG_NAMES_SQL = `select id from ${DEMOS_SCHEMA}.tag_name`;
+const SELECT_APPLICATION_TAG_NAMES_SQL = `select tag_name_id from ${DEMOS_SCHEMA}.tag where tag_type_id = 'Application'`;
 
 export type PersistedUiPathExtraction = {
   extractedFieldCount: number;
@@ -161,8 +161,10 @@ export async function persistFinishedUiPathExtraction(
         (field) => field.FieldId === DEMO_TYPE_FIELD_ID && !field.IsMissing,
       )
     ) {
-      const tagNames = await client.query<{ id: string }>(SELECT_TAG_NAMES_SQL);
-      canonicalTagNames = tagNames.rows.map((row) => row.id);
+      const tagNames = await client.query<{ tag_name_id: string }>(
+        SELECT_APPLICATION_TAG_NAMES_SQL
+      );
+      canonicalTagNames = tagNames.rows.map((row) => row.tag_name_id);
       if (!canonicalTagNames.length) {
         throw new Error(
           "Cannot normalize UiPath demo_type values: no application tag names found.",

--- a/lambdas/UIPath/runDocumentUnderstanding.test.ts
+++ b/lambdas/UIPath/runDocumentUnderstanding.test.ts
@@ -50,8 +50,8 @@ function mockSuccessfulDbQueries(
   tagNames: string[] = [],
 ) {
   mocks.queryMock.mockImplementation((sql: string) => {
-    if (sql.includes("demos_app.tag_name")) {
-      return Promise.resolve({ rows: tagNames.map((id) => ({ id })) });
+    if (sql.includes("from demos_app.tag")) {
+      return Promise.resolve({ rows: tagNames.map((tag_name_id) => ({ tag_name_id })) });
     }
 
     if (sql.includes("application_tag_suggestion_extract_field_limit")) {
@@ -333,6 +333,9 @@ describe("runDocumentUnderstanding", () => {
     await promise;
 
     expect(mocks.queryMock).toHaveBeenCalledTimes(12);
+    expect(mocks.queryMock.mock.calls[3]?.[0]).toContain(
+      "from demos_app.tag where tag_type_id = 'Application'"
+    );
     const sudInsertArgs = mocks.queryMock.mock.calls[4]?.[1];
     const bhpInsertArgs = mocks.queryMock.mock.calls[5]?.[1];
     expect(sudInsertArgs).toEqual([

--- a/lambdas/UIPath/runDocumentUnderstanding.test.ts
+++ b/lambdas/UIPath/runDocumentUnderstanding.test.ts
@@ -45,8 +45,15 @@ import { getToken } from "./getToken";
 const TEST_DOCUMENT_ID = "4cdfe542-90aa-489f-93d5-e786aaff49a2";
 const TEST_APPLICATION_ID = "app-1";
 
-function mockSuccessfulDbQueries(allowedTagSuggestionFieldIds: string[] = []) {
+function mockSuccessfulDbQueries(
+  allowedTagSuggestionFieldIds: string[] = [],
+  tagNames: string[] = [],
+) {
   mocks.queryMock.mockImplementation((sql: string) => {
+    if (sql.includes("demos_app.tag_name")) {
+      return Promise.resolve({ rows: tagNames.map((id) => ({ id })) });
+    }
+
     if (sql.includes("application_tag_suggestion_extract_field_limit")) {
       return Promise.resolve({
         rows: allowedTagSuggestionFieldIds.map((id) => ({ id })),
@@ -280,10 +287,13 @@ describe("runDocumentUnderstanding", () => {
     expect(mocks.queryMock.mock.calls.map((call) => call[0])).toContain("ROLLBACK");
   });
 
-  it("deduplicates multi-value demo_type and persists combined value", async () => {
+  it("canonicalizes and persists one value per demo_type suggestion", async () => {
     mocks.uploadDocumentMock.mockResolvedValue("doc-1");
     mocks.extractDocMock.mockResolvedValue("result-url");
-    mockSuccessfulDbQueries(["demo_type"]);
+    mockSuccessfulDbQueries(
+      ["demo_type"],
+      ["Substance Use Disorder (SUD)", "Basic Health Plan (BHP)"],
+    );
     mocks.fetchExtractionResultMock.mockResolvedValue({
       status: "Succeeded",
       Fields: [
@@ -322,29 +332,50 @@ describe("runDocumentUnderstanding", () => {
     await vi.runAllTimersAsync();
     await promise;
 
-    expect(mocks.queryMock).toHaveBeenCalledTimes(9);
-    const fieldInsertArgs = mocks.queryMock.mock.calls[3]?.[1];
-    expect(fieldInsertArgs).toEqual([
+    expect(mocks.queryMock).toHaveBeenCalledTimes(12);
+    const sudInsertArgs = mocks.queryMock.mock.calls[4]?.[1];
+    const bhpInsertArgs = mocks.queryMock.mock.calls[5]?.[1];
+    expect(sudInsertArgs).toEqual([
       expect.any(String),
       "result-1",
       TEST_DOCUMENT_ID,
       TEST_APPLICATION_ID,
       "demo_type",
-      "SUD, BHP",
-      8,
+      "Substance Use Disorder (SUD)",
+      28,
       0,
       0.5224329,
-      JSON.stringify([{ Page: 0 }, { Page: 1 }]),
+      JSON.stringify([{ Page: 0 }]),
     ]);
-    expect(mocks.queryMock.mock.calls[7]?.[0]).toContain(
-      "insert into demos_app.application_tag_suggestion_extract"
-    );
-    expect(mocks.queryMock.mock.calls[7]?.[1]).toEqual([
-      fieldInsertArgs?.[0],
+    expect(bhpInsertArgs).toEqual([
+      expect.any(String),
+      "result-1",
+      TEST_DOCUMENT_ID,
       TEST_APPLICATION_ID,
       "demo_type",
-      "SUD, BHP",
+      "Basic Health Plan (BHP)",
+      23,
+      0,
+      0.3818529,
+      JSON.stringify([{ Page: 1 }]),
+    ]);
+    expect(mocks.queryMock.mock.calls[9]?.[0]).toContain(
+      "insert into demos_app.application_tag_suggestion_extract",
+    );
+    expect(mocks.queryMock.mock.calls[9]?.[1]).toEqual([
+      sudInsertArgs?.[0],
+      TEST_APPLICATION_ID,
+      "demo_type",
+      "Substance Use Disorder (SUD)",
       1,
+      1,
+    ]);
+    expect(mocks.queryMock.mock.calls[10]?.[1]).toEqual([
+      bhpInsertArgs?.[0],
+      TEST_APPLICATION_ID,
+      "demo_type",
+      "Basic Health Plan (BHP)",
+      2,
       2,
     ]);
   });
@@ -352,7 +383,7 @@ describe("runDocumentUnderstanding", () => {
   it("throws when a tag suggestion field has no token page after committing UiPath values", async () => {
     mocks.uploadDocumentMock.mockResolvedValue("doc-1");
     mocks.extractDocMock.mockResolvedValue("result-url");
-    mockSuccessfulDbQueries(["demo_type"]);
+    mockSuccessfulDbQueries(["demo_type"], ["Substance Use Disorder (SUD)"]);
     mocks.fetchExtractionResultMock.mockResolvedValue({
       status: "Succeeded",
       Fields: [
@@ -378,10 +409,12 @@ describe("runDocumentUnderstanding", () => {
     await vi.runAllTimersAsync();
     await expectation;
 
-    expect(mocks.queryMock.mock.calls[4]?.[0]).toBe("COMMIT");
-    expect(mocks.queryMock.mock.calls[7]?.[0]).toBe("ROLLBACK");
+    expect(mocks.queryMock.mock.calls[5]?.[0]).toBe("COMMIT");
+    expect(mocks.queryMock.mock.calls[8]?.[0]).toBe("ROLLBACK");
     expect(
-      mocks.queryMock.mock.calls.some((call) => Array.isArray(call[1]) && call[1][5] === "Failed")
+      mocks.queryMock.mock.calls.some(
+        (call) => Array.isArray(call[1]) && call[1][5] === "Failed"
+      )
     ).toBe(true);
   });
 

--- a/lambdas/UIPath/uipathFields.test.ts
+++ b/lambdas/UIPath/uipathFields.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  warn: vi.fn(),
+}));
+
+vi.mock("./log", () => ({
+  log: { warn: mocks.warn },
+}));
+
+import { toPersistableFieldValues } from "./uipathFields";
+
+const TAG_NAMES = [
+  "Basic Health Plan (BHP)",
+  "Dental",
+  "Long-Term Services and Supports (LTSS)",
+  "ReEntry",
+  "Substance Use Disorder (SUD)",
+];
+
+describe("toPersistableFieldValues", () => {
+  beforeEach(() => {
+    mocks.warn.mockReset();
+  });
+
+  it("splits, canonicalizes, and deduplicates a comma-delimited demo_type list", () => {
+    const fieldValues = toPersistableFieldValues(
+      {
+        FieldId: "demo_type",
+        FieldName: "demo_type",
+        Values: [
+          {
+            Value:
+              "Substance Use Disorder (SUD),, ReEntry, Substance Use Disorder (SUD), (LTSS),, Dental",
+            Confidence: 0.8,
+            Reference: { TokenList: [{ Page: 2 }] },
+          },
+        ],
+      },
+      TAG_NAMES,
+    );
+
+    expect(fieldValues.map((value) => value.valueText)).toEqual([
+      "Substance Use Disorder (SUD)",
+      "ReEntry",
+      "Long-Term Services and Supports (LTSS)",
+      "Dental",
+    ]);
+    expect(
+      fieldValues.every((value) => value.fieldValue.Confidence === 0.8),
+    ).toBe(true);
+  });
+
+  it("accepts string arrays and keeps metadata from the highest-confidence duplicate", () => {
+    const lowConfidenceValue = {
+      Value: ["SUD", " BHP ", ""],
+      Confidence: 0.25,
+      Reference: { TokenList: [{ Page: 0 }] },
+    };
+    const highConfidenceValue = {
+      UnformattedValue: ["sud"],
+      Confidence: 0.9,
+      Reference: { TokenList: [{ Page: 3 }] },
+    };
+
+    const fieldValues = toPersistableFieldValues(
+      {
+        FieldId: "demo_type",
+        FieldName: "demo_type",
+        Values: [lowConfidenceValue, highConfidenceValue],
+      },
+      TAG_NAMES,
+    );
+
+    expect(fieldValues.map((value) => value.valueText)).toEqual([
+      "Substance Use Disorder (SUD)",
+      "Basic Health Plan (BHP)",
+    ]);
+    expect(fieldValues[0]?.fieldValue).toBe(highConfidenceValue);
+    expect(fieldValues[1]?.fieldValue).toBe(lowConfidenceValue);
+  });
+
+  it("logs and skips unknown or ambiguous tag aliases", () => {
+    const fieldValues = toPersistableFieldValues(
+      {
+        FieldId: "demo_type",
+        FieldName: "demo_type",
+        Values: [{ Value: "Dental, Unknown Tag, DUP" }],
+      },
+      [...TAG_NAMES, "First Duplicate (DUP)", "Second Duplicate (DUP)"],
+    );
+
+    expect(fieldValues.map((value) => value.valueText)).toEqual(["Dental"]);
+    expect(mocks.warn).toHaveBeenCalledTimes(2);
+    expect(mocks.warn).toHaveBeenCalledWith(
+      { fieldId: "demo_type", value: "Unknown Tag" },
+      "Skipping unknown or ambiguous UiPath tag suggestion",
+    );
+    expect(mocks.warn).toHaveBeenCalledWith(
+      { fieldId: "demo_type", value: "DUP" },
+      "Skipping unknown or ambiguous UiPath tag suggestion",
+    );
+  });
+});

--- a/lambdas/UIPath/uipathFields.ts
+++ b/lambdas/UIPath/uipathFields.ts
@@ -1,11 +1,11 @@
 import { ExtractionStatus } from "./fetchExtractResult";
 import { log } from "./log";
 
-const DEMO_TYPE_FIELD_ID = "demo_type";
+export const DEMO_TYPE_FIELD_ID = "demo_type";
 
 export interface UiPathFieldValue {
-  Value?: string;
-  UnformattedValue?: string;
+  Value?: string | string[];
+  UnformattedValue?: string | string[];
   Confidence?: number;
   Reference?: {
     TextLength?: number;
@@ -74,39 +74,132 @@ export function getTokenList(value: UiPathFieldValue): unknown[] {
   return Array.isArray(tokenList) ? tokenList : [];
 }
 
-function coerceValueText(value: UiPathFieldValue): string | null {
+function coerceValueTexts(value: UiPathFieldValue): string[] {
   const text = value.UnformattedValue ?? value.Value;
-  if (typeof text !== "string") {
-    return null;
+  if (typeof text === "string") {
+    return [text.trim()].filter(Boolean);
   }
 
-  return text.trim();
+  if (Array.isArray(text)) {
+    return text
+      .filter((item): item is string => typeof item === "string")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  return [];
 }
 
-export function toPersistableFieldValues(field: UiPathField): PersistableFieldValue[] {
+function normalizeTagLookupKey(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+type CanonicalTagLookup = {
+  exactNames: Map<string, string>;
+  aliases: Map<string, string | null>;
+};
+
+function buildCanonicalTagLookup(
+  tagNames: readonly string[],
+): CanonicalTagLookup {
+  const exactNames = new Map<string, string>();
+  const aliasesByKey = new Map<string, Set<string>>();
+
+  const addAlias = (key: string, tagName: string) => {
+    const candidates = aliasesByKey.get(key) ?? new Set<string>();
+    candidates.add(tagName);
+    aliasesByKey.set(key, candidates);
+  };
+
+  for (const tagName of tagNames) {
+    exactNames.set(normalizeTagLookupKey(tagName), tagName);
+
+    for (const match of tagName.matchAll(/\(([^()]+)\)/g)) {
+      const alias = match[1]?.trim();
+      if (!alias) continue;
+      addAlias(normalizeTagLookupKey(alias), tagName);
+      addAlias(normalizeTagLookupKey(`(${alias})`), tagName);
+    }
+  }
+
+  return {
+    exactNames,
+    aliases: new Map(
+      Array.from(aliasesByKey, ([key, candidates]) => [
+        key,
+        candidates.size === 1
+          ? (candidates.values().next().value ?? null)
+          : null,
+      ]),
+    ),
+  };
+}
+
+function resolveCanonicalTagName(
+  lookup: CanonicalTagLookup,
+  value: string,
+): string | null {
+  const key = normalizeTagLookupKey(value);
+  return lookup.exactNames.get(key) ?? lookup.aliases.get(key) ?? null;
+}
+
+function toDemoTypeCandidates(value: UiPathFieldValue): string[] {
+  return coerceValueTexts(value).flatMap((text) =>
+    text
+      .split(",")
+      .map((candidate) => candidate.trim())
+      .filter(Boolean),
+  );
+}
+
+export function toPersistableFieldValues(
+  field: UiPathField,
+  canonicalTagNames: readonly string[] = [],
+): PersistableFieldValue[] {
   if (field.IsMissing) return [];
   if (!field.FieldId || !field.FieldName) return [];
   const values = field.Values ?? [];
   const fieldType = field.FieldType || "Text";
+  const isDemoType = field.FieldId === DEMO_TYPE_FIELD_ID;
+  const canonicalTagLookup = isDemoType
+    ? buildCanonicalTagLookup(canonicalTagNames)
+    : null;
 
   const persistableValues: PersistableFieldValue[] = [];
   for (const fieldValue of values) {
     try {
-      const valueText = coerceValueText(fieldValue);
-      if (!valueText) continue;
-      persistableValues.push({
-        FieldId: field.FieldId,
-        FieldName: field.FieldName,
-        FieldType: fieldType,
-        valueText,
-        fieldValue,
-      });
+      const valueTexts = isDemoType
+        ? toDemoTypeCandidates(fieldValue)
+        : coerceValueTexts(fieldValue);
+      for (const valueText of valueTexts) {
+        const canonicalValue = canonicalTagLookup
+          ? resolveCanonicalTagName(canonicalTagLookup, valueText)
+          : null;
+        if (isDemoType && !canonicalValue) {
+          log.warn(
+            { fieldId: field.FieldId, value: valueText },
+            "Skipping unknown or ambiguous UiPath tag suggestion",
+          );
+          continue;
+        }
+
+        persistableValues.push({
+          FieldId: field.FieldId,
+          FieldName: field.FieldName,
+          FieldType: fieldType,
+          valueText: canonicalValue ?? valueText,
+          fieldValue,
+        });
+      }
     } catch (error) {
-      log.warn({ error, fieldId: field.FieldId }, "Skipping invalid UiPath field value");
+      log.warn(
+        { error, fieldId: field.FieldId },
+        "Skipping invalid UiPath field value",
+      );
     }
   }
 
-  if (field.FieldId !== DEMO_TYPE_FIELD_ID || persistableValues.length <= 1) {
+  if (!isDemoType || persistableValues.length <= 1) {
     return persistableValues;
   }
 
@@ -114,35 +207,14 @@ export function toPersistableFieldValues(field: UiPathField): PersistableFieldVa
   for (const persistableValue of persistableValues) {
     const key = persistableValue.valueText.toUpperCase();
     const existing = bestByValue.get(key);
-    if (!existing || getConfidence(persistableValue.fieldValue) > getConfidence(existing.fieldValue)) {
+    if (
+      !existing ||
+      getConfidence(persistableValue.fieldValue) >
+        getConfidence(existing.fieldValue)
+    ) {
       bestByValue.set(key, persistableValue);
     }
   }
 
-  const uniqueValues = Array.from(bestByValue.values());
-  if (uniqueValues.length <= 1) {
-    return uniqueValues;
-  }
-
-  uniqueValues.sort((a, b) => getConfidence(b.fieldValue) - getConfidence(a.fieldValue));
-  const combinedValueText = uniqueValues.map((value) => value.valueText).join(", ");
-  const maxConfidence = Math.max(...uniqueValues.map((value) => getConfidence(value.fieldValue)));
-  const sample = uniqueValues[0];
-  if (!sample) return [];
-
-  return [
-    {
-      FieldId: sample.FieldId,
-      FieldName: sample.FieldName,
-      FieldType: sample.FieldType,
-      valueText: combinedValueText,
-      fieldValue: {
-        Value: combinedValueText,
-        Confidence: maxConfidence,
-        SelectedValues: uniqueValues.map((value) => value.valueText),
-        RawValues: uniqueValues.map((value) => value.fieldValue),
-        TokenList: uniqueValues.flatMap((value) => getTokenList(value.fieldValue)),
-      },
-    },
-  ];
+  return Array.from(bestByValue.values());
 }


### PR DESCRIPTION
This breaks down the multiple values smushed together into sepearate values. 

<img width="936" height="318" alt="Screenshot 2026-08-10 at 14 03 04" src="https://github.com/user-attachments/assets/d0ce689a-171f-46c8-bb15-1c049012eccb" />

<img width="1052" height="398" alt="Screenshot 2026-08-10 at 16 44 44" src="https://github.com/user-attachments/assets/b2271df8-0c80-42ba-b64a-6cf8d095a7d9" />


## Summary

Instead of JOINiNG the multiple values. We do not. I was prepared for multiple values, but they never happened until this latest model. 

## Changes
Improved existing mechanism for creating multiple rows. This was like 1/2 in place, this is hte completion of that work. 


<!--
- [ ] Automated tests added or updated
- [ ] Relevant automated tests pass
- [ ] Manually tested
- [ ] Testing is not applicable

Testing details:
-->

<!--
Examples:
- Tested locally using...
- Verified in Chrome, Firefox, and Safari
- Tested against the DEV environment
- Not fully testable locally because...
-->

## Risk
Very little. This was giving the multiple results as 1 string and now we are fixing it. I would say broken is probably better than working incorrectly. And working properly is better than it not working. 


## Automated review

- [x] Run AI Code Review <!-- The AI PR review will only run if this is checked [x] -->
