### PR TITLE
hotfix/report-generation-timeout

### DIFF
--- a/server/src/model/onDemandReport/onDemandReportResolvers.ts
+++ b/server/src/model/onDemandReport/onDemandReportResolvers.ts
@@ -23,30 +23,36 @@ export const onDemandReportResolvers = {
       const reportId = randomUUID();
       const s3Adapter = getS3Adapter();
       try {
-        uploadedReportPaths = await prisma().$transaction(async (tx) => {
-          const reportResults = await runOnDemandReport(args.reportType, tx);
-          const generatedDate = getEasternNow();
-          const formattedReport = await formatOnDemandReportInExcel(
-            args.reportType,
-            reportResults,
-            { requestId: reportId, requestTimestamp: generatedDate["Current Time"] }
-          );
-          const fileS3Path = await s3Adapter.uploadOnDemandReport(reportId, formattedReport);
-          const generatedFileName = generateOnDemandReportFileName(args.reportType, generatedDate);
-          await insertOnDemandReport(
-            {
-              id: reportId,
-              s3Path: fileS3Path,
-              generatedFileName: generatedFileName + ".xlsx",
-              requestingUserId: context.user.id,
-              reportTypeId: args.reportType,
-              statusId: "Available",
-              reportGeneratedAt: generatedDate["Current Time"].easternTZDate,
-            },
-            tx
-          );
-          return [fileS3Path, generatedFileName];
-        });
+        uploadedReportPaths = await prisma().$transaction(
+          async (tx) => {
+            const reportResults = await runOnDemandReport(args.reportType, tx);
+            const generatedDate = getEasternNow();
+            const formattedReport = await formatOnDemandReportInExcel(
+              args.reportType,
+              reportResults,
+              { requestId: reportId, requestTimestamp: generatedDate["Current Time"] }
+            );
+            const fileS3Path = await s3Adapter.uploadOnDemandReport(reportId, formattedReport);
+            const generatedFileName = generateOnDemandReportFileName(
+              args.reportType,
+              generatedDate
+            );
+            await insertOnDemandReport(
+              {
+                id: reportId,
+                s3Path: fileS3Path,
+                generatedFileName: generatedFileName + ".xlsx",
+                requestingUserId: context.user.id,
+                reportTypeId: args.reportType,
+                statusId: "Available",
+                reportGeneratedAt: generatedDate["Current Time"].easternTZDate,
+              },
+              tx
+            );
+            return [fileS3Path, generatedFileName];
+          },
+          { timeout: 30000 }
+        );
       } catch (error) {
         await s3Adapter.deleteOnDemandReport(reportId).catch((cleanupError) => {
           const cleanupErrorMessage =


### PR DESCRIPTION
## Summary

Increases the transaction timeout period for the transaction used to generate on-demand reports, since they were taking too long for the default of 5000ms.

## Changes

Milliseconds go up.

## Validation

- [ ] Automated tests added or updated
- [X] Relevant automated tests pass
- [ ] Manually tested
- [ ] Testing is not applicable

## Automated review

- [X] Run AI Code Review