### PR TITLE
Hotfix/non unique key

### DIFF
--- a/client/src/components/input/select/AutoCompleteMultiselect.tsx
+++ b/client/src/components/input/select/AutoCompleteMultiselect.tsx
@@ -154,7 +154,11 @@ export const AutoCompleteMultiselect = ({
               filtered.map((opt, i) => {
                 const isActive = i === activeIndex;
                 return (
-                  <li key={opt.value} role="option" aria-selected={selected.includes(opt.value)}>
+                  <li
+                    key={`${opt.value}-${i}`}
+                    role="option"
+                    aria-selected={selected.includes(opt.value)}
+                  >
                     <label
                       className={`${ITEM_CLASSES} ${isActive ? ITEM_ACTIVE_CLASSES : ""} flex items-center cursor-pointer`}
                       style={{ cursor: isDisabled ? "not-allowed" : "pointer" }}


### PR DESCRIPTION
Couple different points of issues here that we should probably have a deeper fix/story for. This just fixes it in the simplest way. 

main issue: 
duplicated values in the keys of the dropdown causes those elements to not be properly referenced in react, making them not disappear/reappear when the options are filtered. 

Solution:
added the loop index to the key to make it always unique

1) We are not filtering the people by person type, so state users or even non-user contacts show up in this dropdown
2) we are not removing duplicates. This was the core of the issue; some users in PMDA had both non-user-contact accounts and accounts of another type. Because of this we end up with duplicates. We will need a ticket specifically for dealing with this, but will reach out to Migration team in the meantime to see if this is truly a PMDA data issue or something up in the migration. 
3) the value of the dropdown options are the plaintext name of the users. This is likely fine, but another way to prevent duplicated keys would be to use the uuid as the option value.

## Automated review

- [x] Run AI Code Review <!-- The AI PR review will only run if this is checked [x] -->
