### PR TITLE
DEMOS-2573: Add Horizontal Scroll to Modification Tabs

### DIFF
--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.test.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.test.tsx
@@ -162,4 +162,23 @@ describe("ModificationTabs Component", () => {
     expect(tab1Button).toHaveAttribute("aria-selected", "false");
     expect(tab2Button).toHaveAttribute("aria-selected", "true");
   });
+
+  it("enables horizontal scrolling with many items", () => {
+    const manyItems = Array.from({ length: 20 }, (_, i) =>
+      createModificationItem({ id: `${i}`, name: `Item ${i}` })
+    );
+
+    const { container } = render(
+      <DialogProvider>
+        <TestProvider>
+          <ModificationTabs items={manyItems} />
+        </TestProvider>
+      </DialogProvider>
+    );
+
+    const tabList = container.querySelector(".overflow-x-auto");
+    expect(tabList).not.toBeNull();
+    expect(tabList).toHaveClass("overflow-x-auto");
+    expect(tabList).toHaveClass("flex-nowrap");
+  });
 });

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.tsx
@@ -5,8 +5,9 @@ import { DemonstrationDetailModification } from "../DemonstrationDetail";
 
 const STYLES = {
   modificationContainer: "flex flex-col gap-2",
-  tabList: "flex flex-row gap-1 border-b border-border-rules overflow-x-auto flex-nowrap",
-  tab: "cursor-pointer p-0.5 font-normal",
+  tabList:
+    "flex flex-row gap-1 border-b border-border-rules overflow-x-auto flex-nowrap scrollbar-thin",
+  tab: "cursor-pointer p-0.5 font-normal min-w-[240px] truncate",
   selectedTab: "border-b-4 font-semibold border-border-selected",
 };
 

--- a/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.tsx
+++ b/client/src/pages/DemonstrationDetail/modifications/ModificationTabs.tsx
@@ -5,7 +5,7 @@ import { DemonstrationDetailModification } from "../DemonstrationDetail";
 
 const STYLES = {
   modificationContainer: "flex flex-col gap-2",
-  tabList: "flex flex-row gap-1 border-b border-border-rules",
+  tabList: "flex flex-row gap-1 border-b border-border-rules overflow-x-auto flex-nowrap",
   tab: "cursor-pointer p-0.5 font-normal",
   selectedTab: "border-b-4 font-semibold border-border-selected",
 };


### PR DESCRIPTION
## Summary

Adds a horizontal scrollbar to the modification tabs when there are enough modifications to warrant it. Does not show the scrollbar otherwise.

## Validation

- [X] Automated tests added or updated
- [X] Relevant automated tests pass
- [X] Manually tested
- [ ] Testing is not applicable

## Screenshots or recordings

https://github.com/user-attachments/assets/31cba88d-87ad-48a3-91a7-133f81c0cd1f

<img width="2082" height="1429" alt="chrome_11_25_38" src="https://github.com/user-attachments/assets/3f288997-4165-4569-af31-a9a098ae7ab9" />

 ## Risk and rollout

- Risk: Low