### PR TITLE
(1/4) DEMOS-2535: Readonly User in Application Workflow - Infrastructure & Concept Phase

### DIFF
--- a/client/src/components/application/phases/ConceptPhase.test.tsx
+++ b/client/src/components/application/phases/ConceptPhase.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { TZDate } from "@date-fns/tz";
 import { TestProvider } from "test-utils/TestProvider";
+import { readonlyMockUser, cmsMockUser, MockUser } from "mock-data/userMocks";
 
 import {
   ConceptPhase,
@@ -72,11 +73,11 @@ const DEFAULT_PROPS: ConceptPhaseProps = {
 };
 
 describe("ConceptPhase", () => {
-  const setup = (props: Partial<ConceptPhaseProps> = {}) => {
+  const setup = (props: Partial<ConceptPhaseProps> = {}, currentUser?: MockUser) => {
     const renderComponent = (newProps: Partial<ConceptPhaseProps>) => {
       const finalProps = { ...DEFAULT_PROPS, ...newProps };
       return (
-        <TestProvider>
+        <TestProvider currentUser={currentUser}>
           <DialogProvider>
             <ConceptPhase {...finalProps} />
           </DialogProvider>
@@ -718,6 +719,50 @@ describe("ConceptPhase", () => {
       });
       const dateInput = screen.getByTestId(DATE_PICKER_NAME) as HTMLInputElement;
       expect(dateInput.value).toBe("2024-01-10");
+    });
+  });
+
+  describe("Readonly User Behavior", () => {
+    it("hides upload button for readonly users", () => {
+      setup({ documents: [] }, readonlyMockUser);
+
+      const uploadButton = screen.queryByTestId(UPLOAD_BUTTON_NAME);
+      expect(uploadButton).not.toBeInTheDocument();
+    });
+
+    it("hides finish button for readonly users", () => {
+      setup({ documents: [MOCK_DOCUMENT] }, readonlyMockUser);
+
+      const finishButton = screen.queryByTestId(FINISH_BUTTON_NAME);
+      expect(finishButton).not.toBeInTheDocument();
+    });
+
+    it("hides skip button for readonly users", () => {
+      setup({ documents: [] }, readonlyMockUser);
+
+      const skipButton = screen.queryByTestId(SKIP_BUTTON_NAME);
+      expect(skipButton).not.toBeInTheDocument();
+    });
+
+    it("disables date picker for readonly users", () => {
+      setup({ documents: [MOCK_DOCUMENT] }, readonlyMockUser);
+
+      const dateInput = screen.getByTestId(DATE_PICKER_NAME);
+      expect(dateInput).toBeDisabled();
+    });
+
+    it("shows upload button for non-readonly users", () => {
+      setup({ documents: [] }, cmsMockUser);
+
+      const uploadButton = screen.getByTestId(UPLOAD_BUTTON_NAME);
+      expect(uploadButton).toBeInTheDocument();
+    });
+
+    it("enables date picker for non-readonly users", () => {
+      setup({ documents: [MOCK_DOCUMENT], phaseStatus: "Started" }, cmsMockUser);
+
+      const dateInput = screen.getByTestId(DATE_PICKER_NAME);
+      expect(dateInput).not.toBeDisabled();
     });
   });
 });

--- a/client/src/components/application/phases/ConceptPhase.tsx
+++ b/client/src/components/application/phases/ConceptPhase.tsx
@@ -20,6 +20,7 @@ import {
   useSkipConceptPhase,
 } from "components/application/phase-status/phaseCompletionQueries";
 import { TZDate } from "@date-fns/tz/date";
+import { getCurrentUser, isReadonly } from "components/user/UserContext";
 
 const STYLES = {
   pane: tw`bg-white`,
@@ -129,6 +130,7 @@ export const ConceptPhase = ({
   const { setApplicationDate } = useSetApplicationDate();
   const { completePhase } = useCompletePhase();
   const { skipConceptPhase } = useSkipConceptPhase();
+  const { currentUser } = getCurrentUser();
 
   // User can override the calculated date via the datepicker
   const [userSubmittedDateOverride, setUserSubmittedDateOverride] = useSessionStorage(
@@ -138,6 +140,7 @@ export const ConceptPhase = ({
   const [isSkipEnabled, setIsSkipEnabled] = useState<boolean>(true);
 
   const isPhaseFinalized = phaseStatus === "Completed" || phaseStatus === "Skipped";
+  const isReadonlyUser = isReadonly(currentUser);
 
   // Calculate the submitted date based on documents
   const calculatedSubmittedDate = calculatePresubmissionDate(
@@ -223,6 +226,7 @@ export const ConceptPhase = ({
       </p>
 
       <SecondaryButton
+        isHidden={isReadonlyUser}
         onClick={() => showConceptPreSubmissionDocumentUploadDialog(applicationId)}
         size="small"
         name={UPLOAD_BUTTON_NAME}
@@ -245,23 +249,22 @@ export const ConceptPhase = ({
       </p>
 
       <div className="space-y-4">
-        <div>
-          <DatePicker
-            name={DATE_PICKER_NAME}
-            label={"Concept Paper Submitted Date" satisfies DateType}
-            value={submittedDate}
-            onChange={(newDate) => {
-              setUserSubmittedDateOverride(newDate);
-            }}
-            isRequired={documents.length > 0}
-            getValidationMessage={getDateValidationMessage}
-            isDisabled={isPhaseFinalized}
-          />
-        </div>
+        <DatePicker
+          name={DATE_PICKER_NAME}
+          label={"Concept Paper Submitted Date" satisfies DateType}
+          value={submittedDate}
+          onChange={(newDate) => {
+            setUserSubmittedDateOverride(newDate);
+          }}
+          isRequired={documents.length > 0}
+          getValidationMessage={getDateValidationMessage}
+          isDisabled={isPhaseFinalized || isReadonlyUser}
+        />
       </div>
 
       <div className={STYLES.actions}>
         <SecondaryButton
+          isHidden={isReadonlyUser}
           name={SKIP_BUTTON_NAME}
           aria-label="Skip this section"
           onClick={onSkip}
@@ -271,6 +274,7 @@ export const ConceptPhase = ({
           <ChevronRightIcon />
         </SecondaryButton>
         <Button
+          isHidden={isReadonlyUser}
           name={FINISH_BUTTON_NAME}
           aria-label="Finish this section"
           onClick={onFinish}

--- a/client/src/components/button/BaseButton.tsx
+++ b/client/src/components/button/BaseButton.tsx
@@ -74,11 +74,12 @@ export const BaseButton: React.FC<ButtonProps> = ({
   tooltip,
   eagerTooltip,
 }) => {
+  const uid = useId().replace(NON_ALPHANUMERIC, "");
+
   if (isHidden) return null;
 
   const sizeClasses = getSizeClasses(isCircle, size);
   const circleClasses = getCircleClasses(isCircle);
-  const uid = useId().replace(NON_ALPHANUMERIC, "");
   const anchorName = `--btn-${uid}`;
   const tooltipId = `tooltip-${uid}`;
   const buttonRef = useRef<HTMLButtonElement>(null);

--- a/client/src/components/button/BaseButton.tsx
+++ b/client/src/components/button/BaseButton.tsx
@@ -54,6 +54,7 @@ export interface ButtonProps {
   size?: ButtonSize;
   disabled?: boolean;
   isCircle?: boolean;
+  isHidden?: boolean;
   tooltip?: string;
   eagerTooltip?: string;
 }
@@ -69,9 +70,12 @@ export const BaseButton: React.FC<ButtonProps> = ({
   size = "standard",
   disabled = false,
   isCircle = false,
+  isHidden = false,
   tooltip,
   eagerTooltip,
 }) => {
+  if (isHidden) return null;
+
   const sizeClasses = getSizeClasses(isCircle, size);
   const circleClasses = getCircleClasses(isCircle);
   const uid = useId().replace(NON_ALPHANUMERIC, "");

--- a/client/src/components/button/BaseButton.tsx
+++ b/client/src/components/button/BaseButton.tsx
@@ -75,6 +75,7 @@ export const BaseButton: React.FC<ButtonProps> = ({
   eagerTooltip,
 }) => {
   const uid = useId().replace(NON_ALPHANUMERIC, "");
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   if (isHidden) return null;
 
@@ -82,7 +83,6 @@ export const BaseButton: React.FC<ButtonProps> = ({
   const circleClasses = getCircleClasses(isCircle);
   const anchorName = `--btn-${uid}`;
   const tooltipId = `tooltip-${uid}`;
-  const buttonRef = useRef<HTMLButtonElement>(null);
 
   return (
     <>

--- a/client/src/mock-data/demonstrationMocks.ts
+++ b/client/src/mock-data/demonstrationMocks.ts
@@ -22,6 +22,7 @@ import { MockDocument, mockDocuments } from "./documentMocks";
 import { MockExtension, mockExtensions } from "./extensionMocks";
 import { mockPeople, MockPerson } from "./personMocks";
 import { MockState, mockStates } from "./stateMocks";
+import { MOCK_PHASES } from "./workflowMocks";
 import {
   MOCK_DEMONSTRATION_TYPE_ASSIGNMENTS,
   MockDemonstrationTypeAssignment,
@@ -31,7 +32,14 @@ import { DEMONSTRATION_HEADER_DETAILS_QUERY } from "pages/DemonstrationDetail/De
 
 export type MockDemonstration = Pick<
   Demonstration,
-  "id" | "name" | "description" | "sdgDivision" | "signatureLevel" | "currentPhaseName" | "medicaidId" | "chipId"
+  | "id"
+  | "name"
+  | "description"
+  | "sdgDivision"
+  | "signatureLevel"
+  | "currentPhaseName"
+  | "medicaidId"
+  | "chipId"
 > & {
   effectiveDate: Date;
   expirationDate: Date;
@@ -110,7 +118,10 @@ export const demonstrationMocks: MockedResponse[] = [
     },
     result: {
       data: {
-        demonstration: { ...MOCK_DEMONSTRATION, phases: [] },
+        demonstration: {
+          ...MOCK_DEMONSTRATION,
+          phases: MOCK_PHASES,
+        },
       },
     },
     maxUsageCount: Number.POSITIVE_INFINITY,

--- a/client/src/mock-data/userMocks.ts
+++ b/client/src/mock-data/userMocks.ts
@@ -44,7 +44,7 @@ export const developmentMockUser: MockUser = {
 // Common test user variants for component testing
 export const readonlyMockUser: MockUser = {
   ...developmentMockUser,
-  // Note ths will change to `demos-restricted-cms-user when this role is changed to that.
+  // Note this will change to `demos-restricted-cms-user` when this role is changed to that.
   person: { ...developmentMockUser.person, personType: "demos-readonly" },
 };
 

--- a/client/src/mock-data/userMocks.ts
+++ b/client/src/mock-data/userMocks.ts
@@ -41,6 +41,18 @@ export const developmentMockUser: MockUser = {
   },
 };
 
+// Common test user variants for component testing
+export const readonlyMockUser: MockUser = {
+  ...developmentMockUser,
+  // Note ths will change to `demos-restricted-cms-user when this role is changed to that.
+  person: { ...developmentMockUser.person, personType: "demos-readonly" },
+};
+
+export const cmsMockUser: MockUser = {
+  ...developmentMockUser,
+  person: { ...developmentMockUser.person, personType: "demos-cms-user" },
+};
+
 export const mockUsers: MockUser[] = [
   { id: "1", username: "john.doe", person: mockPeople[0] },
   { id: "2", username: "jane.smith", person: mockPeople[1] },

--- a/client/src/mock-data/workflowMocks.ts
+++ b/client/src/mock-data/workflowMocks.ts
@@ -2,6 +2,17 @@ import { MockedResponse } from "@apollo/client/testing";
 import { GET_AMENDMENT_WORKFLOW_QUERY } from "components/application/amendment/AmendmentWorkflow";
 import { GET_EXTENSION_WORKFLOW_QUERY } from "components/application/extension/ExtensionWorkflow";
 
+export const MOCK_PHASES = [
+  { phaseName: "Concept", phaseStatus: "Not Started", phaseDates: [] },
+  { phaseName: "Application Intake", phaseStatus: "Not Started", phaseDates: [] },
+  { phaseName: "Completeness", phaseStatus: "Not Started", phaseDates: [] },
+  { phaseName: "Federal Comment", phaseStatus: "Not Started", phaseDates: [] },
+  { phaseName: "SDG Preparation", phaseStatus: "Not Started", phaseDates: [] },
+  { phaseName: "Review", phaseStatus: "Not Started", phaseDates: [] },
+  { phaseName: "Approval Package", phaseStatus: "Not Started", phaseDates: [] },
+  { phaseName: "Approval Summary", phaseStatus: "Not Started", phaseDates: [] },
+] as const;
+
 export const workflowMocks: MockedResponse[] = [
   {
     request: {
@@ -27,7 +38,7 @@ export const workflowMocks: MockedResponse[] = [
               fullName: "John Doe",
             },
           },
-          phases: [],
+          phases: MOCK_PHASES,
           tags: [],
           documents: [],
         },
@@ -59,7 +70,7 @@ export const workflowMocks: MockedResponse[] = [
               fullName: "John Doe",
             },
           },
-          phases: [],
+          phases: MOCK_PHASES,
           tags: [],
           documents: [],
         },

--- a/client/src/router/DemosRouter.tsx
+++ b/client/src/router/DemosRouter.tsx
@@ -20,7 +20,11 @@ import { RequireRole } from "./RequireRole";
 import { PersonType } from "demos-server";
 import { ReferencesPage } from "pages/references/ReferencesPage";
 
-const DEMONSTRATION_ACCESS_ROLES: PersonType[] = ["demos-admin", "demos-cms-user"];
+const DEMONSTRATION_ACCESS_ROLES: PersonType[] = [
+  "demos-admin",
+  "demos-cms-user",
+  "demos-readonly",
+];
 
 const HomePage = () => {
   const { currentUser } = getCurrentUser();


### PR DESCRIPTION
## Summary

Per DEMOS-2535 this PR implements the first part of implementing the view for the readonly user in the application workflow.

## Changes

- Fix some mocks behavior for `npm run dev:mocks` as well as add a couple of mocked users.
- Add an `isHidden` prop to our `<BaseButton>` component in order to hide them while keeping the JSX clean
- Hide and disable components in the concept phase where appropriate per requirements for readonly role

## Validation

- [X] Automated tests added or updated
- [X] Relevant automated tests pass
- [X] Manually tested

## Screenshots or recordings

<img width="3699" height="1514" alt="firefox_10_16_00" src="https://github.com/user-attachments/assets/37f9ad9e-d4de-43c9-99db-14de133184fb" />
<img width="3719" height="1851" alt="firefox_10_42_53" src="https://github.com/user-attachments/assets/f89c59ea-2a60-42f0-aaea-1a564e4f36f7" />


## Additional notes

`demos-readonly` is used here though this will change to `demos-restricted-cms-user` with #1704 - small change

## Automated review

- [X] Run AI Code Review <!-- The AI PR review will only run if this is checked [x] -->
